### PR TITLE
CGO Linking for scratch Docker Image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -43,8 +43,8 @@ steps:
   image: plugins/docker
   settings:
     repo: caesiumcloud/caesium
+    tags: ${DRONE_COMMIT_SHA:0:7}
     dockerfile: build/Dockerfile
-    auto_tag: true
     username:
       from_secret: docker_username
     password:

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ caesium
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+coverage.txt
 
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,15 +5,24 @@ RUN apk update
 RUN apk add --no-cache git g++
 
 # Download Go dependencies
-WORKDIR $GOPATH/src/github.com/caesium-cloud/caesium
+WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 
 # Build binary
 COPY . .
-RUN GOOS=linux GOARCH=amd64 go build -o /go/bin/caesium
+ENV CGO_ENABLED=1 \
+    GOOS=linux \
+    GOARCH=amd64
+RUN go build
+
+# Link for CGO
+WORKDIR /dist
+RUN cp /build/caesium .
+RUN ldd caesium | tr -s '[:blank:]' '\n' | grep '^/' | \
+    xargs -I % sh -c 'mkdir -p $(dirname ./%); cp % ./%;'
 
 # Package for lightweight deployment
 FROM scratch
-COPY --from=builder /go/bin/caesium /go/bin/caesium
-ENTRYPOINT ["/go/bin/caesium"]
+COPY --chown=0:0 --from=builder /dist /
+ENTRYPOINT ["/caesium"]

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,0 +1,15 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type IntegrationTestSuite struct {
+	suite.Suite
+}
+
+func TestIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(IntegrationTestSuite))
+}


### PR DESCRIPTION
Because we have incorporated [go-sqlite3](https://github.com/mattn/go-sqlite3), we now have a dependency on CGO. As a result, the binary we build also needs the dynamically linked C libraries to be put into the scratch container with it.

I also made the Drone CI build the container every time to make sure it doesn't fail, added an empty integration test file for the future, and added `coverage.txt` to `.gitignore` because it should be there.