### PR TITLE
[codex] Finish HTTP webhook trigger follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,6 +375,7 @@ jobs:
             -p 8080:8080 \
             -v "${PODMAN_SOCK}:/run/podman/podman.sock" \
             -e CAESIUM_PODMAN_URI=unix:///run/podman/podman.sock \
+            -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
             -e CAESIUM_LOG_LEVEL=debug \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,7 @@ jobs:
             -p 8080:8080 \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e DOCKER_HOST=unix:///var/run/docker.sock \
+            -e CAESIUM_MANUAL_TRIGGER_API_KEY=e2e-test-key \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
           tries=0

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -83,7 +83,7 @@ func Public(g *echo.Group, bus internal_event.Bus) {
 		g.POST("/triggers", trigger.Post)
 		g.GET("/triggers/:id", trigger.Get)
 		g.PATCH("/triggers/:id", trigger.Patch)
-		g.PUT("/triggers/:id", trigger.Put)
+		g.POST("/triggers/:id/fire", trigger.Fire)
 	}
 
 	// webhooks

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -13,6 +13,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/node"
 	"github.com/caesium-cloud/caesium/api/rest/controller/stats"
 	"github.com/caesium-cloud/caesium/api/rest/controller/trigger"
+	"github.com/caesium-cloud/caesium/api/rest/controller/webhook"
 	internal_event "github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/labstack/echo/v5"
@@ -79,8 +80,15 @@ func Public(g *echo.Group, bus internal_event.Bus) {
 	// triggers
 	{
 		g.GET("/triggers", trigger.List)
+		g.POST("/triggers", trigger.Post)
 		g.GET("/triggers/:id", trigger.Get)
+		g.PATCH("/triggers/:id", trigger.Patch)
 		g.PUT("/triggers/:id", trigger.Put)
+	}
+
+	// webhooks
+	{
+		g.POST("/hooks/*", webhook.Receive)
 	}
 
 	// stats

--- a/api/rest/controller/trigger/error.go
+++ b/api/rest/controller/trigger/error.go
@@ -1,0 +1,25 @@
+package trigger
+
+import (
+	"errors"
+	"net/http"
+
+	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+func triggerServiceError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return echo.ErrNotFound
+	case errors.Is(err, triggersvc.ErrTriggerAliasConflict):
+		return echo.NewHTTPError(http.StatusConflict, "conflict").Wrap(err)
+	case errors.Is(err, triggersvc.ErrInvalidTriggerRequest):
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+}

--- a/api/rest/controller/trigger/patch.go
+++ b/api/rest/controller/trigger/patch.go
@@ -1,0 +1,33 @@
+package trigger
+
+import (
+	"errors"
+	"net/http"
+
+	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+func Patch(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	req := &triggersvc.UpdateRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	trigger, err := triggerServiceFactory(c.Request().Context()).Update(id, req)
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return echo.ErrNotFound
+	case err != nil:
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	default:
+		return c.JSON(http.StatusOK, trigger)
+	}
+}

--- a/api/rest/controller/trigger/patch.go
+++ b/api/rest/controller/trigger/patch.go
@@ -1,13 +1,11 @@
 package trigger
 
 import (
-	"errors"
 	"net/http"
 
 	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
-	"gorm.io/gorm"
 )
 
 func Patch(c *echo.Context) error {
@@ -23,10 +21,8 @@ func Patch(c *echo.Context) error {
 
 	trigger, err := triggerServiceFactory(c.Request().Context()).Update(id, req)
 	switch {
-	case errors.Is(err, gorm.ErrRecordNotFound):
-		return echo.ErrNotFound
 	case err != nil:
-		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+		return triggerServiceError(err)
 	default:
 		return c.JSON(http.StatusOK, trigger)
 	}

--- a/api/rest/controller/trigger/post.go
+++ b/api/rest/controller/trigger/post.go
@@ -1,0 +1,22 @@
+package trigger
+
+import (
+	"net/http"
+
+	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
+	"github.com/labstack/echo/v5"
+)
+
+func Post(c *echo.Context) error {
+	req := &triggersvc.CreateRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	trigger, err := triggerServiceFactory(c.Request().Context()).Create(req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	return c.JSON(http.StatusCreated, trigger)
+}

--- a/api/rest/controller/trigger/post.go
+++ b/api/rest/controller/trigger/post.go
@@ -15,7 +15,7 @@ func Post(c *echo.Context) error {
 
 	trigger, err := triggerServiceFactory(c.Request().Context()).Create(req)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+		return triggerServiceError(err)
 	}
 
 	return c.JSON(http.StatusCreated, trigger)

--- a/api/rest/controller/trigger/put.go
+++ b/api/rest/controller/trigger/put.go
@@ -2,47 +2,97 @@ package trigger
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	codes "net/http"
 
-	"github.com/caesium-cloud/caesium/api/rest/service/trigger"
-	"github.com/caesium-cloud/caesium/internal/executor"
+	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
 	"github.com/caesium-cloud/caesium/internal/models"
-	"github.com/caesium-cloud/caesium/internal/trigger/http"
+	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+var (
+	triggerServiceFactory = triggersvc.Service
+	fireHTTPTrigger       = fireTrigger
 )
 
 func Put(c *echo.Context) error {
-	var (
-		ctx = context.Background()
-		id  = uuid.MustParse(c.Param("id"))
-		svc = trigger.Service(ctx)
-	)
+	ctx := c.Request().Context()
 
-	t, err := svc.Get(id)
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(codes.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	params, err := parseOptionalParams(c.Request().Body)
+	if err != nil {
+		return echo.NewHTTPError(codes.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	trig, err := triggerServiceFactory(ctx).Get(id)
 	switch {
-	case err != nil:
+	case err != nil && !errors.Is(err, gorm.ErrRecordNotFound):
 		return echo.NewHTTPError(codes.StatusInternalServerError, "internal server error").Wrap(err)
-	case t == nil:
+	case err != nil, trig == nil:
 		return echo.ErrNotFound
-	case t.Type != models.TriggerTypeHTTP:
+	case trig.Type != models.TriggerTypeHTTP:
 		return echo.NewHTTPError(codes.StatusBadRequest, "bad request").Wrap(
 			fmt.Errorf(
 				"trigger: '%v' is type: '%v', not '%v'",
-				t.ID,
-				t.Type,
+				trig.ID,
+				trig.Type,
 				models.TriggerTypeHTTP,
 			),
 		)
-	default:
-		h, err := http.New(t)
-		if err != nil {
-			return echo.NewHTTPError(codes.StatusInternalServerError, "internal server error").Wrap(err)
-		}
-
-		executor.Queue(ctx, h)
-
-		return c.JSON(codes.StatusAccepted, nil)
 	}
+
+	if err := fireHTTPTrigger(ctx, trig, params); err != nil {
+		return echo.NewHTTPError(codes.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	return c.JSON(codes.StatusAccepted, nil)
+}
+
+func parseOptionalParams(body io.Reader) (map[string]string, error) {
+	if body == nil {
+		return nil, nil
+	}
+
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, nil
+	}
+
+	var req struct {
+		Params map[string]string `json:"params,omitempty"`
+	}
+	if err := json.Unmarshal(data, &req); err != nil {
+		return nil, err
+	}
+	if req.Params != nil {
+		return req.Params, nil
+	}
+
+	var direct map[string]string
+	if err := json.Unmarshal(data, &direct); err == nil {
+		return direct, nil
+	}
+
+	return nil, fmt.Errorf("invalid json body")
+}
+
+func fireTrigger(ctx context.Context, trig *models.Trigger, params map[string]string) error {
+	httpTrigger, err := triggerhttp.New(trig)
+	if err != nil {
+		return err
+	}
+	return httpTrigger.FireWithParams(ctx, params)
 }

--- a/api/rest/controller/trigger/put.go
+++ b/api/rest/controller/trigger/put.go
@@ -2,15 +2,18 @@ package trigger
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	codes "net/http"
+	"strings"
 
 	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
 	"github.com/caesium-cloud/caesium/internal/models"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
+	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"gorm.io/gorm"
@@ -21,8 +24,12 @@ var (
 	fireHTTPTrigger       = fireTrigger
 )
 
-func Put(c *echo.Context) error {
+func Fire(c *echo.Context) error {
 	ctx := c.Request().Context()
+
+	if err := requireManualTriggerAPIKey(c); err != nil {
+		return err
+	}
 
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -38,7 +45,9 @@ func Put(c *echo.Context) error {
 	switch {
 	case err != nil && !errors.Is(err, gorm.ErrRecordNotFound):
 		return echo.NewHTTPError(codes.StatusInternalServerError, "internal server error").Wrap(err)
-	case err != nil, trig == nil:
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return echo.ErrNotFound
+	case trig == nil:
 		return echo.ErrNotFound
 	case trig.Type != models.TriggerTypeHTTP:
 		return echo.NewHTTPError(codes.StatusBadRequest, "bad request").Wrap(
@@ -75,23 +84,15 @@ func parseOptionalParams(body io.Reader) (map[string]string, error) {
 	if err := json.Unmarshal(data, &payload); err != nil {
 		return nil, err
 	}
-	if rawParams, ok := payload["params"]; ok {
-		var params map[string]string
-		if err := json.Unmarshal(rawParams, &params); err != nil {
-			return nil, fmt.Errorf("invalid json body")
-		}
-		return params, nil
+	rawParams, ok := payload["params"]
+	if !ok {
+		return nil, fmt.Errorf("invalid json body: missing params object")
 	}
 
-	params := make(map[string]string, len(payload))
-	for key, rawValue := range payload {
-		var value string
-		if err := json.Unmarshal(rawValue, &value); err != nil {
-			return nil, fmt.Errorf("invalid json body")
-		}
-		params[key] = value
+	var params map[string]string
+	if err := json.Unmarshal(rawParams, &params); err != nil {
+		return nil, fmt.Errorf("invalid json body: %w", err)
 	}
-
 	return params, nil
 }
 
@@ -101,4 +102,24 @@ func fireTrigger(ctx context.Context, trig *models.Trigger, params map[string]st
 		return err
 	}
 	return httpTrigger.FireWithParams(ctx, params)
+}
+
+func requireManualTriggerAPIKey(c *echo.Context) error {
+	expected := strings.TrimSpace(env.Variables().ManualTriggerAPIKey)
+	if expected == "" {
+		return echo.NewHTTPError(codes.StatusServiceUnavailable, "manual trigger fire is disabled")
+	}
+
+	provided := strings.TrimSpace(c.Request().Header.Get("X-Caesium-API-Key"))
+	if provided == "" {
+		auth := strings.TrimSpace(c.Request().Header.Get("Authorization"))
+		if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+			provided = strings.TrimSpace(auth[7:])
+		}
+	}
+
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		return echo.NewHTTPError(codes.StatusUnauthorized, "invalid api key")
+	}
+	return nil
 }

--- a/api/rest/controller/trigger/put.go
+++ b/api/rest/controller/trigger/put.go
@@ -71,22 +71,28 @@ func parseOptionalParams(body io.Reader) (map[string]string, error) {
 		return nil, nil
 	}
 
-	var req struct {
-		Params map[string]string `json:"params,omitempty"`
-	}
-	if err := json.Unmarshal(data, &req); err != nil {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
 		return nil, err
 	}
-	if req.Params != nil {
-		return req.Params, nil
+	if rawParams, ok := payload["params"]; ok {
+		var params map[string]string
+		if err := json.Unmarshal(rawParams, &params); err != nil {
+			return nil, fmt.Errorf("invalid json body")
+		}
+		return params, nil
 	}
 
-	var direct map[string]string
-	if err := json.Unmarshal(data, &direct); err == nil {
-		return direct, nil
+	params := make(map[string]string, len(payload))
+	for key, rawValue := range payload {
+		var value string
+		if err := json.Unmarshal(rawValue, &value); err != nil {
+			return nil, fmt.Errorf("invalid json body")
+		}
+		params[key] = value
 	}
 
-	return nil, fmt.Errorf("invalid json body")
+	return params, nil
 }
 
 func fireTrigger(ctx context.Context, trig *models.Trigger, params map[string]string) error {

--- a/api/rest/controller/trigger/put_test.go
+++ b/api/rest/controller/trigger/put_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/require"
@@ -21,6 +24,8 @@ type stubTriggerService struct {
 	createFn func(*triggersvc.CreateRequest) (*models.Trigger, error)
 	updateFn func(uuid.UUID, *triggersvc.UpdateRequest) (*models.Trigger, error)
 }
+
+var triggerControllerTestMu sync.Mutex
 
 func (s *stubTriggerService) WithDatabase(*gorm.DB) triggersvc.Trigger { return s }
 func (s *stubTriggerService) List(*triggersvc.ListRequest) (models.Triggers, error) {
@@ -47,7 +52,10 @@ func (s *stubTriggerService) Update(id uuid.UUID, req *triggersvc.UpdateRequest)
 }
 func (s *stubTriggerService) Delete(uuid.UUID) error { return nil }
 
-func TestPutAcceptsOptionalParams(t *testing.T) {
+func TestFireAcceptsOptionalParams(t *testing.T) {
+	triggerControllerTestMu.Lock()
+	defer triggerControllerTestMu.Unlock()
+
 	created := &models.Trigger{
 		ID:   uuid.New(),
 		Type: models.TriggerTypeHTTP,
@@ -77,28 +85,61 @@ func TestPutAcceptsOptionalParams(t *testing.T) {
 	require.NoError(t, err)
 
 	e := echo.New()
-	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
 	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("X-Caesium-API-Key", "test-key")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: created.ID.String()}})
+	t.Setenv("CAESIUM_MANUAL_TRIGGER_API_KEY", "test-key")
+	require.NoError(t, env.Process())
 
-	err = Put(c)
+	err = Fire(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusAccepted, rec.Code)
 	require.Equal(t, map[string]string{"branch": "main"}, captured)
 }
 
-func TestParseOptionalParamsAcceptsDirectJSON(t *testing.T) {
+func TestFireRejectsMissingAPIKey(t *testing.T) {
+	triggerControllerTestMu.Lock()
+	defer triggerControllerTestMu.Unlock()
+
+	created := &models.Trigger{ID: uuid.New(), Type: models.TriggerTypeHTTP}
+	origTriggerSvcFactory := triggerServiceFactory
+	defer func() { triggerServiceFactory = origTriggerSvcFactory }()
+	triggerServiceFactory = func(context.Context) triggersvc.Trigger {
+		return &stubTriggerService{trigger: created}
+	}
+
+	t.Setenv("CAESIUM_MANUAL_TRIGGER_API_KEY", "test-key")
+	require.NoError(t, env.Process())
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: created.ID.String()}})
+
+	err := Fire(c)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, httpErr.Code)
+}
+
+func TestParseOptionalParamsRequiresEnvelope(t *testing.T) {
 	body, err := json.Marshal(map[string]string{"branch": "main"})
 	require.NoError(t, err)
 
 	params, err := parseOptionalParams(bytes.NewReader(body))
-	require.NoError(t, err)
-	require.Equal(t, map[string]string{"branch": "main"}, params)
+	require.Nil(t, params)
+	require.Error(t, err)
 }
 
 func TestPostCreatesTrigger(t *testing.T) {
+	triggerControllerTestMu.Lock()
+	defer triggerControllerTestMu.Unlock()
+
 	created := &models.Trigger{ID: uuid.New(), Alias: "new-webhook", Type: models.TriggerTypeHTTP}
 
 	origTriggerSvcFactory := triggerServiceFactory
@@ -134,7 +175,80 @@ func TestPostCreatesTrigger(t *testing.T) {
 	require.Equal(t, http.StatusCreated, rec.Code)
 }
 
+func TestPostReturnsConflictOnAliasCollision(t *testing.T) {
+	triggerControllerTestMu.Lock()
+	defer triggerControllerTestMu.Unlock()
+
+	origTriggerSvcFactory := triggerServiceFactory
+	defer func() { triggerServiceFactory = origTriggerSvcFactory }()
+	triggerServiceFactory = func(context.Context) triggersvc.Trigger {
+		return &stubTriggerService{
+			createFn: func(req *triggersvc.CreateRequest) (*models.Trigger, error) {
+				return nil, errors.Join(triggersvc.ErrTriggerAliasConflict, errors.New("alias already exists"))
+			},
+		}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"alias": "new-webhook",
+		"type":  "http",
+		"configuration": map[string]any{
+			"path": "/hooks/new-webhook",
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	err = Post(e.NewContext(req, rec))
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusConflict, httpErr.Code)
+}
+
+func TestPostReturnsInternalServerErrorOnDBFailure(t *testing.T) {
+	triggerControllerTestMu.Lock()
+	defer triggerControllerTestMu.Unlock()
+
+	origTriggerSvcFactory := triggerServiceFactory
+	defer func() { triggerServiceFactory = origTriggerSvcFactory }()
+	triggerServiceFactory = func(context.Context) triggersvc.Trigger {
+		return &stubTriggerService{
+			createFn: func(req *triggersvc.CreateRequest) (*models.Trigger, error) {
+				return nil, errors.New("db down")
+			},
+		}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"alias": "new-webhook",
+		"type":  "http",
+		"configuration": map[string]any{
+			"path": "/hooks/new-webhook",
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	err = Post(e.NewContext(req, rec))
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusInternalServerError, httpErr.Code)
+}
+
 func TestPatchUpdatesTrigger(t *testing.T) {
+	triggerControllerTestMu.Lock()
+	defer triggerControllerTestMu.Unlock()
+
 	existing := &models.Trigger{ID: uuid.New(), Alias: "existing", Type: models.TriggerTypeHTTP}
 
 	origTriggerSvcFactory := triggerServiceFactory
@@ -170,4 +284,41 @@ func TestPatchUpdatesTrigger(t *testing.T) {
 	err = Patch(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestPatchReturnsInternalServerErrorOnDBFailure(t *testing.T) {
+	triggerControllerTestMu.Lock()
+	defer triggerControllerTestMu.Unlock()
+
+	existing := &models.Trigger{ID: uuid.New(), Alias: "existing", Type: models.TriggerTypeHTTP}
+	origTriggerSvcFactory := triggerServiceFactory
+	defer func() { triggerServiceFactory = origTriggerSvcFactory }()
+	triggerServiceFactory = func(context.Context) triggersvc.Trigger {
+		return &stubTriggerService{
+			updateFn: func(id uuid.UUID, req *triggersvc.UpdateRequest) (*models.Trigger, error) {
+				return nil, errors.New("db down")
+			},
+		}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"alias": "updated",
+		"configuration": map[string]any{
+			"path": "/hooks/updated",
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: existing.ID.String()}})
+
+	err = Patch(c)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusInternalServerError, httpErr.Code)
 }

--- a/api/rest/controller/trigger/put_test.go
+++ b/api/rest/controller/trigger/put_test.go
@@ -1,0 +1,173 @@
+package trigger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type stubTriggerService struct {
+	trigger  *models.Trigger
+	createFn func(*triggersvc.CreateRequest) (*models.Trigger, error)
+	updateFn func(uuid.UUID, *triggersvc.UpdateRequest) (*models.Trigger, error)
+}
+
+func (s *stubTriggerService) WithDatabase(*gorm.DB) triggersvc.Trigger { return s }
+func (s *stubTriggerService) List(*triggersvc.ListRequest) (models.Triggers, error) {
+	return nil, nil
+}
+func (s *stubTriggerService) ListByPath(string) (models.Triggers, error) { return nil, nil }
+func (s *stubTriggerService) Get(id uuid.UUID) (*models.Trigger, error) {
+	if s.trigger != nil && s.trigger.ID == id {
+		return s.trigger, nil
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+func (s *stubTriggerService) Create(req *triggersvc.CreateRequest) (*models.Trigger, error) {
+	if s.createFn != nil {
+		return s.createFn(req)
+	}
+	return nil, nil
+}
+func (s *stubTriggerService) Update(id uuid.UUID, req *triggersvc.UpdateRequest) (*models.Trigger, error) {
+	if s.updateFn != nil {
+		return s.updateFn(id, req)
+	}
+	return nil, nil
+}
+func (s *stubTriggerService) Delete(uuid.UUID) error { return nil }
+
+func TestPutAcceptsOptionalParams(t *testing.T) {
+	created := &models.Trigger{
+		ID:   uuid.New(),
+		Type: models.TriggerTypeHTTP,
+	}
+
+	origTriggerSvcFactory := triggerServiceFactory
+	origFire := fireHTTPTrigger
+	defer func() {
+		triggerServiceFactory = origTriggerSvcFactory
+		fireHTTPTrigger = origFire
+	}()
+
+	triggerServiceFactory = func(context.Context) triggersvc.Trigger {
+		return &stubTriggerService{trigger: created}
+	}
+
+	var captured map[string]string
+	fireHTTPTrigger = func(_ context.Context, trig *models.Trigger, params map[string]string) error {
+		require.Equal(t, created.ID, trig.ID)
+		captured = params
+		return nil
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"params": map[string]string{"branch": "main"},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPut, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: created.ID.String()}})
+
+	err = Put(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+	require.Equal(t, map[string]string{"branch": "main"}, captured)
+}
+
+func TestParseOptionalParamsAcceptsDirectJSON(t *testing.T) {
+	body, err := json.Marshal(map[string]string{"branch": "main"})
+	require.NoError(t, err)
+
+	params, err := parseOptionalParams(bytes.NewReader(body))
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"branch": "main"}, params)
+}
+
+func TestPostCreatesTrigger(t *testing.T) {
+	created := &models.Trigger{ID: uuid.New(), Alias: "new-webhook", Type: models.TriggerTypeHTTP}
+
+	origTriggerSvcFactory := triggerServiceFactory
+	defer func() { triggerServiceFactory = origTriggerSvcFactory }()
+
+	triggerServiceFactory = func(context.Context) triggersvc.Trigger {
+		return &stubTriggerService{
+			createFn: func(req *triggersvc.CreateRequest) (*models.Trigger, error) {
+				require.Equal(t, "new-webhook", req.Alias)
+				require.Equal(t, string(models.TriggerTypeHTTP), req.Type)
+				require.Equal(t, "/hooks/new-webhook", req.Configuration["path"])
+				return created, nil
+			},
+		}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"alias": "new-webhook",
+		"type":  "http",
+		"configuration": map[string]any{
+			"path": "/hooks/new-webhook",
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	err = Post(e.NewContext(req, rec))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rec.Code)
+}
+
+func TestPatchUpdatesTrigger(t *testing.T) {
+	existing := &models.Trigger{ID: uuid.New(), Alias: "existing", Type: models.TriggerTypeHTTP}
+
+	origTriggerSvcFactory := triggerServiceFactory
+	defer func() { triggerServiceFactory = origTriggerSvcFactory }()
+
+	triggerServiceFactory = func(context.Context) triggersvc.Trigger {
+		return &stubTriggerService{
+			updateFn: func(id uuid.UUID, req *triggersvc.UpdateRequest) (*models.Trigger, error) {
+				require.Equal(t, existing.ID, id)
+				require.NotNil(t, req.Alias)
+				require.Equal(t, "updated", *req.Alias)
+				require.Equal(t, "/hooks/updated", req.Configuration["path"])
+				return &models.Trigger{ID: existing.ID, Alias: "updated", Type: models.TriggerTypeHTTP}, nil
+			},
+		}
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"alias": "updated",
+		"configuration": map[string]any{
+			"path": "/hooks/updated",
+		},
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPatch, "/", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: existing.ID.String()}})
+
+	err = Patch(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/api/rest/controller/webhook/limits.go
+++ b/api/rest/controller/webhook/limits.go
@@ -1,0 +1,58 @@
+package webhook
+
+import (
+	"sync"
+	"time"
+
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"golang.org/x/time/rate"
+)
+
+type ipRateLimiters struct {
+	mu       sync.Mutex
+	clients  map[string]*clientLimiter
+	staleAge time.Duration
+}
+
+type clientLimiter struct {
+	limiter    *rate.Limiter
+	lastSeen   time.Time
+	perMinute  int
+	burstLimit int
+}
+
+var webhookRateLimiters = &ipRateLimiters{
+	clients:  map[string]*clientLimiter{},
+	staleAge: 15 * time.Minute,
+}
+
+func (l *ipRateLimiters) Allow(ip string) bool {
+	perMinute := env.Variables().WebhookRateLimitPerMinute
+	burst := env.Variables().WebhookRateLimitBurst
+	if perMinute <= 0 || burst <= 0 {
+		return true
+	}
+
+	now := time.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for key, client := range l.clients {
+		if now.Sub(client.lastSeen) > l.staleAge {
+			delete(l.clients, key)
+		}
+	}
+
+	client, ok := l.clients[ip]
+	if !ok || client.perMinute != perMinute || client.burstLimit != burst {
+		limit := rate.Every(time.Minute / time.Duration(perMinute))
+		client = &clientLimiter{
+			limiter:    rate.NewLimiter(limit, burst),
+			perMinute:  perMinute,
+			burstLimit: burst,
+		}
+		l.clients[ip] = client
+	}
+	client.lastSeen = now
+	return client.limiter.Allow()
+}

--- a/api/rest/controller/webhook/webhook.go
+++ b/api/rest/controller/webhook/webhook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/job"
 	"github.com/caesium-cloud/caesium/internal/models"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
+	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/labstack/echo/v5"
 )
@@ -34,6 +35,17 @@ func Receive(c *echo.Context) error {
 
 func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobLister, runner Runner) error {
 	path := normalizeHookPath(c.Param("*"))
+	if !webhookRateLimiters.Allow(c.RealIP()) {
+		return echo.NewHTTPError(http.StatusTooManyRequests, "rate limit exceeded")
+	}
+
+	body, err := readWebhookBody(c.Request().Body)
+	switch {
+	case errors.Is(err, errRequestTooLarge):
+		return echo.NewHTTPError(http.StatusRequestEntityTooLarge, "request body too large")
+	case err != nil:
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
 
 	triggers, err := trigSvc.ListByPath(path)
 	if err != nil {
@@ -41,11 +53,6 @@ func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobListe
 	}
 	if len(triggers) == 0 {
 		return echo.NewHTTPError(http.StatusNotFound, "no trigger registered for path")
-	}
-
-	body, err := io.ReadAll(c.Request().Body)
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
 	}
 
 	var accepted int
@@ -124,6 +131,25 @@ func DefaultRunner(ctx context.Context, j *models.Job, params map[string]string)
 
 func normalizeHookPath(path string) string {
 	return models.NormalizedTriggerPath(strings.TrimSpace(path))
+}
+
+var errRequestTooLarge = errors.New("request body too large")
+
+func readWebhookBody(body io.Reader) ([]byte, error) {
+	maxBytes := env.Variables().WebhookMaxBodySize.Int64()
+	if maxBytes <= 0 {
+		return io.ReadAll(body)
+	}
+
+	limited := io.LimitReader(body, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, errRequestTooLarge
+	}
+	return data, nil
 }
 
 func cloneStringMap(in map[string]string) map[string]string {

--- a/api/rest/controller/webhook/webhook.go
+++ b/api/rest/controller/webhook/webhook.go
@@ -1,0 +1,139 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
+	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
+	"github.com/caesium-cloud/caesium/internal/job"
+	"github.com/caesium-cloud/caesium/internal/models"
+	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/labstack/echo/v5"
+)
+
+type Runner func(context.Context, *models.Job, map[string]string) error
+
+type JobLister interface {
+	List(*jsvc.ListRequest) (models.Jobs, error)
+}
+
+type TriggerLister interface {
+	ListByPath(string) (models.Triggers, error)
+}
+
+func Receive(c *echo.Context) error {
+	ctx := c.Request().Context()
+	return ReceiveWithServices(c, triggersvc.Service(ctx), jsvc.Service(ctx), DefaultRunner)
+}
+
+func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobLister, runner Runner) error {
+	path := normalizeHookPath(c.Param("*"))
+
+	triggers, err := trigSvc.ListByPath(path)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	if len(triggers) == 0 {
+		return echo.NewHTTPError(http.StatusNotFound, "no trigger registered for path")
+	}
+
+	body, err := io.ReadAll(c.Request().Body)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	var accepted int
+	for _, trig := range triggers {
+		httpTrigger, err := triggerhttp.New(trig)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+		}
+
+		params, err := httpTrigger.ExtractWebhookParams(c.Request().Context(), c.Request(), body)
+		switch {
+		case errors.Is(err, triggerhttp.ErrInvalidSignature):
+			continue
+		case err != nil:
+			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+		}
+
+		if err := FireHTTPTrigger(c.Request().Context(), jobSvc, trig, params, runner); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+		}
+		accepted++
+	}
+
+	if accepted == 0 {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid signature")
+	}
+
+	return c.JSON(http.StatusAccepted, nil)
+}
+
+func FireHTTPTrigger(ctx context.Context, jobSvc JobLister, trig *models.Trigger, params map[string]string, runner Runner) error {
+	if trig == nil {
+		return fmt.Errorf("trigger is required")
+	}
+	if trig.Type != models.TriggerTypeHTTP {
+		return fmt.Errorf("trigger %v is not http", trig.ID)
+	}
+	if runner == nil {
+		runner = DefaultRunner
+	}
+	httpTrigger, err := triggerhttp.New(trig)
+	if err != nil {
+		return err
+	}
+
+	req := &jsvc.ListRequest{TriggerID: trig.ID.String()}
+	jobs, err := jobSvc.List(req)
+	if err != nil {
+		return err
+	}
+
+	log.Info("running jobs", "count", len(jobs), "trigger_id", trig.ID)
+
+	for _, j := range jobs {
+		if j.Paused {
+			log.Info("skipping paused job", "id", j.ID)
+			continue
+		}
+
+		capturedJob := j
+		capturedParams := cloneStringMap(httpTrigger.MergeParams(params))
+		go func() {
+			runCtx := context.WithoutCancel(ctx)
+			if err := runner(runCtx, capturedJob, capturedParams); err != nil {
+				log.Error("job run failure", "id", capturedJob.ID, "error", err)
+			}
+		}()
+	}
+
+	return nil
+}
+
+func DefaultRunner(ctx context.Context, j *models.Job, params map[string]string) error {
+	return job.New(j, job.WithParams(params)).Run(ctx)
+}
+
+func normalizeHookPath(path string) string {
+	return models.NormalizedTriggerPath(strings.TrimSpace(path))
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/api/rest/controller/webhook/webhook_test.go
+++ b/api/rest/controller/webhook/webhook_test.go
@@ -10,6 +10,7 @@ import (
 
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,8 @@ func (s stubJobLister) List(*jsvc.ListRequest) (models.Jobs, error) {
 }
 
 func TestReceiveWithServicesFiresWebhookTrigger(t *testing.T) {
+	require.NoError(t, env.Process())
+
 	triggerID := uuid.New()
 	jobID := uuid.New()
 
@@ -94,6 +97,8 @@ func TestReceiveWithServicesFiresWebhookTrigger(t *testing.T) {
 }
 
 func TestReceiveWithServicesRejectsInvalidSignature(t *testing.T) {
+	require.NoError(t, env.Process())
+
 	req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{"ref":"refs/heads/main"}`))
 	req.Header.Set("Authorization", "Bearer wrong-secret")
 	rec := httptest.NewRecorder()
@@ -128,4 +133,75 @@ func TestReceiveWithServicesRejectsInvalidSignature(t *testing.T) {
 	httpErr, ok := err.(*echo.HTTPError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusUnauthorized, httpErr.Code)
+}
+
+func TestReceiveWithServicesRejectsOversizedBody(t *testing.T) {
+	t.Setenv("CAESIUM_WEBHOOK_MAX_BODY_SIZE", "8B")
+	require.NoError(t, env.Process())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{"ref":"refs/heads/main"}`))
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "*", Value: "github/push"}})
+
+	err := ReceiveWithServices(
+		c,
+		stubTriggerLister{},
+		stubJobLister{},
+		func(context.Context, *models.Job, map[string]string) error { return nil },
+	)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusRequestEntityTooLarge, httpErr.Code)
+}
+
+func TestReceiveWithServicesRateLimitsByIP(t *testing.T) {
+	t.Setenv("CAESIUM_WEBHOOK_RATE_LIMIT_PER_MINUTE", "1")
+	t.Setenv("CAESIUM_WEBHOOK_RATE_LIMIT_BURST", "1")
+	require.NoError(t, env.Process())
+	webhookRateLimiters = &ipRateLimiters{
+		clients:  map[string]*clientLimiter{},
+		staleAge: 15 * time.Minute,
+	}
+
+	newContext := func() *echo.Context {
+		req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{"ref":"refs/heads/main"}`))
+		req.Header.Set("Authorization", "Bearer top-secret")
+		req.RemoteAddr = "203.0.113.8:1234"
+		rec := httptest.NewRecorder()
+		e := echo.New()
+		c := e.NewContext(req, rec)
+		c.SetPathValues(echo.PathValues{{Name: "*", Value: "github/push"}})
+		return c
+	}
+
+	triggers := stubTriggerLister{
+		triggers: models.Triggers{
+			&models.Trigger{
+				ID:   uuid.New(),
+				Type: models.TriggerTypeHTTP,
+				Configuration: `{
+					"path":"github/push",
+					"secret":"top-secret",
+					"signatureScheme":"bearer"
+				}`,
+			},
+		},
+	}
+	jobs := stubJobLister{jobs: models.Jobs{&models.Job{ID: uuid.New(), Alias: "deploy"}}}
+	runner := func(context.Context, *models.Job, map[string]string) error { return nil }
+
+	first := newContext()
+	err := ReceiveWithServices(first, triggers, jobs, runner)
+	require.NoError(t, err)
+
+	second := newContext()
+	err = ReceiveWithServices(second, triggers, jobs, runner)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusTooManyRequests, httpErr.Code)
 }

--- a/api/rest/controller/webhook/webhook_test.go
+++ b/api/rest/controller/webhook/webhook_test.go
@@ -1,0 +1,131 @@
+package webhook
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+type stubTriggerLister struct {
+	triggers models.Triggers
+	err      error
+}
+
+func (s stubTriggerLister) ListByPath(string) (models.Triggers, error) {
+	return s.triggers, s.err
+}
+
+type stubJobLister struct {
+	jobs models.Jobs
+	err  error
+}
+
+func (s stubJobLister) List(*jsvc.ListRequest) (models.Jobs, error) {
+	return s.jobs, s.err
+}
+
+func TestReceiveWithServicesFiresWebhookTrigger(t *testing.T) {
+	triggerID := uuid.New()
+	jobID := uuid.New()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{"ref":"refs/heads/main"}`))
+	req.Header.Set("Authorization", "Bearer top-secret")
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "*", Value: "github/push"}})
+
+	runs := make(chan map[string]string, 1)
+	runner := func(ctx context.Context, j *models.Job, params map[string]string) error {
+		copied := make(map[string]string, len(params))
+		for k, v := range params {
+			copied[k] = v
+		}
+		runs <- copied
+		return nil
+	}
+
+	err := ReceiveWithServices(
+		c,
+		stubTriggerLister{
+			triggers: models.Triggers{
+				&models.Trigger{
+					ID:   triggerID,
+					Type: models.TriggerTypeHTTP,
+					Configuration: `{
+						"path":"github/push",
+						"secret":"top-secret",
+						"signatureScheme":"bearer",
+						"defaultParams":{"environment":"staging"},
+						"paramMapping":{"branch":"$.ref"}
+					}`,
+				},
+			},
+		},
+		stubJobLister{
+			jobs: models.Jobs{
+				&models.Job{ID: jobID, Alias: "deploy"},
+			},
+		},
+		runner,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	select {
+	case params := <-runs:
+		require.Equal(t, map[string]string{
+			"environment": "staging",
+			"branch":      "refs/heads/main",
+		}, params)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook-triggered job")
+	}
+}
+
+func TestReceiveWithServicesRejectsInvalidSignature(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{"ref":"refs/heads/main"}`))
+	req.Header.Set("Authorization", "Bearer wrong-secret")
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "*", Value: "github/push"}})
+
+	err := ReceiveWithServices(
+		c,
+		stubTriggerLister{
+			triggers: models.Triggers{
+				&models.Trigger{
+					ID:   uuid.New(),
+					Type: models.TriggerTypeHTTP,
+					Configuration: `{
+						"path":"github/push",
+						"secret":"top-secret",
+						"signatureScheme":"bearer"
+					}`,
+				},
+			},
+		},
+		stubJobLister{
+			jobs: models.Jobs{
+				&models.Job{ID: uuid.New(), Alias: "deploy"},
+			},
+		},
+		func(context.Context, *models.Job, map[string]string) error { return nil },
+	)
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, httpErr.Code)
+}

--- a/api/rest/service/trigger/trigger.go
+++ b/api/rest/service/trigger/trigger.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/db"
+	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/jsonutil"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -13,8 +14,10 @@ import (
 type Trigger interface {
 	WithDatabase(*gorm.DB) Trigger
 	List(*ListRequest) (models.Triggers, error)
+	ListByPath(string) (models.Triggers, error)
 	Get(uuid.UUID) (*models.Trigger, error)
 	Create(*CreateRequest) (*models.Trigger, error)
+	Update(uuid.UUID, *UpdateRequest) (*models.Trigger, error)
 	Delete(uuid.UUID) error
 }
 
@@ -67,6 +70,19 @@ func (t *triggerService) List(req *ListRequest) (models.Triggers, error) {
 	return triggers, q.Find(&triggers).Error
 }
 
+func (t *triggerService) ListByPath(path string) (models.Triggers, error) {
+	normalizedPath := models.NormalizedTriggerPath(path)
+	if normalizedPath == "" {
+		return models.Triggers{}, nil
+	}
+
+	var triggers models.Triggers
+	err := t.db.WithContext(t.ctx).
+		Where("type = ? AND normalized_path = ?", models.TriggerTypeHTTP, normalizedPath).
+		Find(&triggers).Error
+	return triggers, err
+}
+
 func (t *triggerService) Get(id uuid.UUID) (*models.Trigger, error) {
 	var (
 		trigger = &models.Trigger{ID: id}
@@ -97,14 +113,62 @@ func (t *triggerService) Create(req *CreateRequest) (*models.Trigger, error) {
 		return nil, err
 	}
 
+	triggerType := models.TriggerType(req.Type)
+	if err := validateTriggerRequest(triggerType, req.Configuration); err != nil {
+		return nil, err
+	}
+
 	trigger := &models.Trigger{
 		ID:            id,
 		Alias:         req.Alias,
-		Type:          models.TriggerType(req.Type),
+		Type:          triggerType,
 		Configuration: cfg,
+	}
+	if err := trigger.ApplyDerivedFields(); err != nil {
+		return nil, err
 	}
 
 	return trigger, q.Create(trigger).Error
+}
+
+type UpdateRequest struct {
+	Alias         *string                `json:"alias,omitempty"`
+	Configuration map[string]interface{} `json:"configuration,omitempty"`
+}
+
+func (t *triggerService) Update(id uuid.UUID, req *UpdateRequest) (*models.Trigger, error) {
+	var trigger models.Trigger
+	if err := t.db.WithContext(t.ctx).First(&trigger, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+
+	if req.Alias != nil {
+		trigger.Alias = *req.Alias
+	}
+	if req.Configuration != nil {
+		if err := validateTriggerRequest(trigger.Type, req.Configuration); err != nil {
+			return nil, err
+		}
+		cfg, err := jsonutil.MarshalMapString(req.Configuration)
+		if err != nil {
+			return nil, err
+		}
+		trigger.Configuration = cfg
+	}
+	if err := trigger.ApplyDerivedFields(); err != nil {
+		return nil, err
+	}
+
+	updates := map[string]any{
+		"alias":           trigger.Alias,
+		"configuration":   trigger.Configuration,
+		"normalized_path": trigger.NormalizedPath,
+	}
+	if err := t.db.WithContext(t.ctx).Model(&trigger).Updates(updates).Error; err != nil {
+		return nil, err
+	}
+
+	return &trigger, nil
 }
 
 func (t *triggerService) Delete(id uuid.UUID) error {
@@ -113,4 +177,15 @@ func (t *triggerService) Delete(id uuid.UUID) error {
 	)
 
 	return q.Delete(&models.Trigger{}, id).Error
+}
+
+func validateTriggerRequest(triggerType models.TriggerType, configuration map[string]interface{}) error {
+	cfg := configuration
+	if cfg == nil {
+		cfg = map[string]interface{}{}
+	}
+	return jobdefschema.ValidateTriggerSpec(&jobdefschema.Trigger{
+		Type:          string(triggerType),
+		Configuration: cfg,
+	})
 }

--- a/api/rest/service/trigger/trigger.go
+++ b/api/rest/service/trigger/trigger.go
@@ -2,6 +2,9 @@ package trigger
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/db"
@@ -9,6 +12,11 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/jsonutil"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
+)
+
+var (
+	ErrInvalidTriggerRequest = errors.New("invalid trigger request")
+	ErrTriggerAliasConflict  = errors.New("trigger alias conflict")
 )
 
 type Trigger interface {
@@ -110,11 +118,14 @@ func (t *triggerService) Create(req *CreateRequest) (*models.Trigger, error) {
 
 	cfg, err := req.ConfigurationString()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", ErrInvalidTriggerRequest, err)
 	}
 
 	triggerType := models.TriggerType(req.Type)
 	if err := validateTriggerRequest(triggerType, req.Configuration); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidTriggerRequest, err)
+	}
+	if err := ensureAliasAvailable(q, strings.TrimSpace(req.Alias), uuid.Nil); err != nil {
 		return nil, err
 	}
 
@@ -143,15 +154,18 @@ func (t *triggerService) Update(id uuid.UUID, req *UpdateRequest) (*models.Trigg
 	}
 
 	if req.Alias != nil {
+		if err := ensureAliasAvailable(t.db.WithContext(t.ctx), strings.TrimSpace(*req.Alias), id); err != nil {
+			return nil, err
+		}
 		trigger.Alias = *req.Alias
 	}
 	if req.Configuration != nil {
 		if err := validateTriggerRequest(trigger.Type, req.Configuration); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", ErrInvalidTriggerRequest, err)
 		}
 		cfg, err := jsonutil.MarshalMapString(req.Configuration)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("%w: %w", ErrInvalidTriggerRequest, err)
 		}
 		trigger.Configuration = cfg
 	}
@@ -188,4 +202,26 @@ func validateTriggerRequest(triggerType models.TriggerType, configuration map[st
 		Type:          string(triggerType),
 		Configuration: cfg,
 	})
+}
+
+func ensureAliasAvailable(q *gorm.DB, alias string, excludeID uuid.UUID) error {
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return nil
+	}
+
+	var existing models.Trigger
+	query := q.Where("alias = ?", alias)
+	if excludeID != uuid.Nil {
+		query = query.Where("id <> ?", excludeID)
+	}
+	err := query.First(&existing).Error
+	switch {
+	case err == nil:
+		return fmt.Errorf("%w: alias %q already exists", ErrTriggerAliasConflict, alias)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil
+	default:
+		return err
+	}
 }

--- a/api/rest/service/trigger/trigger_test.go
+++ b/api/rest/service/trigger/trigger_test.go
@@ -2,6 +2,7 @@ package trigger
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -93,7 +94,7 @@ func (s *TriggerSuite) TestListByType() {
 
 func (s *TriggerSuite) TestListWithPagination() {
 	for i := 0; i < 5; i++ {
-		s.createTrigger(string(models.TriggerTypeCron), "trigger")
+		s.createTrigger(string(models.TriggerTypeCron), "trigger-"+uuid.NewString())
 	}
 
 	triggers, err := s.svc().List(&ListRequest{Limit: 2, Offset: 1})
@@ -117,6 +118,20 @@ func (s *TriggerSuite) TestListByPath() {
 	s.Equal(matched.ID, triggers[0].ID)
 
 	triggers, err = s.svc().ListByPath("/v1/hooks/run")
+	s.Require().NoError(err)
+	s.Len(triggers, 1)
+	s.Equal(matched.ID, triggers[0].ID)
+}
+
+func (s *TriggerSuite) TestListByPathPreservesRealLeadingSegments() {
+	matched := s.createHTTPTrigger("webhook-versioned", "/hooks/v1/build")
+
+	triggers, err := s.svc().ListByPath("v1/build")
+	s.Require().NoError(err)
+	s.Len(triggers, 1)
+	s.Equal(matched.ID, triggers[0].ID)
+
+	triggers, err = s.svc().ListByPath("/v1/hooks/v1/build")
 	s.Require().NoError(err)
 	s.Len(triggers, 1)
 	s.Equal(matched.ID, triggers[0].ID)
@@ -168,6 +183,20 @@ func (s *TriggerSuite) TestCreateHTTP() {
 	s.NotEqual(uuid.Nil, trigger.ID)
 	s.Equal(models.TriggerTypeHTTP, trigger.Type)
 	s.Equal("webhook", trigger.NormalizedPath)
+}
+
+func (s *TriggerSuite) TestCreateRejectsDuplicateAlias() {
+	s.createHTTPTrigger("duplicate-alias", "/hooks/first")
+
+	_, err := s.svc().Create(&CreateRequest{
+		Alias: "duplicate-alias",
+		Type:  string(models.TriggerTypeHTTP),
+		Configuration: map[string]interface{}{
+			"path": "/hooks/second",
+		},
+	})
+	s.Require().Error(err)
+	s.True(errors.Is(err, ErrTriggerAliasConflict))
 }
 
 func (s *TriggerSuite) TestUpdateHTTPConfigurationRefreshesNormalizedPath() {

--- a/api/rest/service/trigger/trigger_test.go
+++ b/api/rest/service/trigger/trigger_test.go
@@ -43,11 +43,30 @@ func (s *TriggerSuite) svc() *triggerService {
 
 func (s *TriggerSuite) createTrigger(triggerType, alias string) *models.Trigger {
 	svc := s.svc()
+	config := map[string]interface{}{
+		"schedule": "* * * * *",
+	}
+	if triggerType == string(models.TriggerTypeHTTP) {
+		config = map[string]interface{}{
+			"path": "/hooks/" + alias,
+		}
+	}
+	trigger, err := svc.Create(&CreateRequest{
+		Alias:         alias,
+		Type:          triggerType,
+		Configuration: config,
+	})
+	s.Require().NoError(err)
+	return trigger
+}
+
+func (s *TriggerSuite) createHTTPTrigger(alias, path string) *models.Trigger {
+	svc := s.svc()
 	trigger, err := svc.Create(&CreateRequest{
 		Alias: alias,
-		Type:  triggerType,
+		Type:  string(models.TriggerTypeHTTP),
 		Configuration: map[string]interface{}{
-			"schedule": "* * * * *",
+			"path": path,
 		},
 	})
 	s.Require().NoError(err)
@@ -80,6 +99,27 @@ func (s *TriggerSuite) TestListWithPagination() {
 	triggers, err := s.svc().List(&ListRequest{Limit: 2, Offset: 1})
 	s.Require().NoError(err)
 	s.Len(triggers, 2)
+}
+
+func (s *TriggerSuite) TestListByPath() {
+	matched := s.createHTTPTrigger("webhook-matched", "/hooks/run")
+	s.createHTTPTrigger("webhook-other", "deploy/other")
+	s.createTrigger(string(models.TriggerTypeCron), "cron-trigger")
+
+	triggers, err := s.svc().ListByPath("run")
+	s.Require().NoError(err)
+	s.Len(triggers, 1)
+	s.Equal(matched.ID, triggers[0].ID)
+
+	triggers, err = s.svc().ListByPath("/hooks/run")
+	s.Require().NoError(err)
+	s.Len(triggers, 1)
+	s.Equal(matched.ID, triggers[0].ID)
+
+	triggers, err = s.svc().ListByPath("/v1/hooks/run")
+	s.Require().NoError(err)
+	s.Len(triggers, 1)
+	s.Equal(matched.ID, triggers[0].ID)
 }
 
 // --- Get ---
@@ -121,12 +161,30 @@ func (s *TriggerSuite) TestCreateHTTP() {
 		Alias: "webhook",
 		Type:  string(models.TriggerTypeHTTP),
 		Configuration: map[string]interface{}{
-			"method": "POST",
+			"path": "/hooks/webhook",
 		},
 	})
 	s.Require().NoError(err)
 	s.NotEqual(uuid.Nil, trigger.ID)
 	s.Equal(models.TriggerTypeHTTP, trigger.Type)
+	s.Equal("webhook", trigger.NormalizedPath)
+}
+
+func (s *TriggerSuite) TestUpdateHTTPConfigurationRefreshesNormalizedPath() {
+	created := s.createHTTPTrigger("webhook", "/hooks/original")
+
+	updated, err := s.svc().Update(created.ID, &UpdateRequest{
+		Configuration: map[string]interface{}{
+			"path": "/v1/hooks/updated/path",
+		},
+	})
+	s.Require().NoError(err)
+	s.Equal("updated/path", updated.NormalizedPath)
+
+	byPath, err := s.svc().ListByPath("/hooks/updated/path")
+	s.Require().NoError(err)
+	s.Len(byPath, 1)
+	s.Equal(created.ID, byPath[0].ID)
 }
 
 // --- Update (Delete used as proxy) ---

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -18,6 +18,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/jobdef/runtime"
 	"github.com/caesium-cloud/caesium/internal/lineage"
 	"github.com/caesium-cloud/caesium/internal/run"
+	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
 	"github.com/caesium-cloud/caesium/internal/worker"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/caesium-cloud/caesium/pkg/env"
@@ -144,6 +145,7 @@ func start(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		log.Fatal("secret resolver configuration failure", "error", err)
 	}
+	triggerhttp.SetSecretResolver(resolver)
 
 	watches, err := runtime.BuildGitWatches(vars, resolver)
 	if err != nil {

--- a/docs/caesium-job-llm-reference.md
+++ b/docs/caesium-job-llm-reference.md
@@ -74,8 +74,13 @@ trigger:
 trigger:
   type: http
   configuration:
-    path: "/hooks/my-job"        # Required. Route path.
-    secret: "webhook-secret"     # Optional. Shared secret for validation.
+    path: "my-job"               # Required. Served at POST /v1/hooks/my-job.
+    secret: "secret://env/WEBHOOK_SECRET" # Optional. Shared secret for validation.
+    signatureScheme: hmac-sha256 # Optional. hmac-sha256, hmac-sha1, bearer, basic.
+    signatureHeader: X-Hub-Signature-256  # Optional. Header containing the signature.
+    paramMapping:                # Optional. JSON body -> run params.
+      branch: "$.ref"
+      commit: "$.after"
 ```
 
 ### Steps

--- a/docs/design-event-triggers.md
+++ b/docs/design-event-triggers.md
@@ -4,7 +4,7 @@
 
 ## Problem Statement
 
-Caesium's trigger system has two types: cron (fully implemented) and HTTP (implemented for webhook delivery). HTTP triggers now support dedicated webhook routes, authentication, payload param extraction, and manual/API fire with params. The remaining gap in this design area is event-based routing and trigger chaining.
+Caesium's trigger system has two types: cron (fully implemented) and HTTP (implemented for webhook delivery). HTTP triggers now support dedicated webhook routes, authentication, payload param extraction, payload limits, per-IP rate limiting, and operator-authenticated manual/API fire. The remaining gap in this design area is event-based routing and trigger chaining.
 - **No trigger chaining.** One job's completion cannot trigger another job. The internal event bus handles lifecycle events but has no mechanism to route them to triggers.
 - **No event persistence.** External events are fire-and-forget. There is no event log, no replay, and no deduplication.
 
@@ -31,7 +31,7 @@ type Trigger interface {
 
 ### Executor
 
-The executor (`internal/executor/executor.go`) maintains a `sync.Map` of active triggers. A background loop runs every 60 seconds and queues all cron triggers. HTTP triggers are only queued when `PUT /v1/triggers/:id` is called from the REST controller.
+The executor (`internal/executor/executor.go`) maintains a `sync.Map` of active triggers. A background loop runs every 60 seconds and queues all cron triggers. HTTP triggers are only queued when `POST /v1/triggers/:id/fire` is called from the REST controller or when a matching webhook request reaches `POST /v1/hooks/*`.
 
 ### HTTP Trigger (current)
 
@@ -571,15 +571,10 @@ Add to the linter (`internal/jobdef/lint/`):
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/v1/hooks/*` | Webhook receiver (WS1) |
+| `POST` | `/v1/triggers/:id/fire` | Operator-authenticated manual fire with optional params |
 | `POST` | `/v1/events` | Event ingestion (WS2) |
 | `GET` | `/v1/events/ingested` | List ingested events (observability) |
 | `GET` | `/v1/triggers/:id/events` | List events that matched this trigger |
-
-### Updated Endpoints
-
-| Method | Path | Change |
-|--------|------|--------|
-| `PUT` | `/v1/triggers/:id` | Accept optional JSON body as run params |
 
 ### CLI Changes
 
@@ -610,6 +605,9 @@ No mandatory infrastructure dependencies. The feature runs entirely within the e
 | `CAESIUM_EVENT_RETENTION` | `7d` | How long to keep ingested events |
 | `CAESIUM_MAX_TRIGGER_DEPTH` | `10` | Maximum trigger chain depth before rejection |
 | `CAESIUM_WEBHOOK_MAX_BODY_SIZE` | `1MB` | Maximum accepted webhook payload size |
+| `CAESIUM_WEBHOOK_RATE_LIMIT_PER_MINUTE` | `120` | Per-IP webhook request budget |
+| `CAESIUM_WEBHOOK_RATE_LIMIT_BURST` | `20` | Per-IP webhook burst allowance |
+| `CAESIUM_MANUAL_TRIGGER_API_KEY` | unset | Required API key for `POST /v1/triggers/:id/fire` |
 
 ---
 
@@ -677,7 +675,7 @@ New Prometheus metrics:
 
 | Risk | Impact | Mitigation |
 |------|--------|------------|
-| Webhook flood (DoS via high-frequency POSTs) | Resource exhaustion | `CAESIUM_WEBHOOK_MAX_BODY_SIZE` limit. Per-path rate limiting (Phase 1.3 concurrency work). Log but drop payloads exceeding thresholds. |
+| Webhook flood (DoS via high-frequency POSTs) | Resource exhaustion | `CAESIUM_WEBHOOK_MAX_BODY_SIZE` body cap plus per-IP rate limiting via `CAESIUM_WEBHOOK_RATE_LIMIT_PER_MINUTE`/`CAESIUM_WEBHOOK_RATE_LIMIT_BURST`. |
 | Infinite trigger chains | Runaway execution | Runtime depth guard (`_trigger_depth`). Static cycle detection at lint time. |
 | JSONPath injection (malicious payloads) | Unexpected parameter values | JSONPath extraction always produces strings. Run parameters are environment variables — they don't execute. Validate extracted values against parameter schemas when available. |
 | Event bus backpressure | Dropped internal events for chaining | Current bus drops events when channel is full (non-blocking). For chaining, this could mean missed triggers. Mitigation: increase channel buffer for the router subscriber, log dropped events as warnings, surface in metrics. |

--- a/docs/design-event-triggers.md
+++ b/docs/design-event-triggers.md
@@ -1,21 +1,16 @@
 # Design: Event-Driven Triggers
 
-> Status: Proposed. This document covers the full trigger overhaul — completing the HTTP trigger implementation and adding event-driven routing.
+> Status: Partially shipped. Work Stream 1 (HTTP webhook triggers) is implemented. Work Streams 2 and 3 in this document remain proposed.
 
 ## Problem Statement
 
-Caesium's trigger system has two types: cron (fully implemented) and HTTP (partially implemented). The HTTP trigger exists as a model and fires jobs when `PUT /v1/triggers/:id` is called, but it lacks the capabilities needed for real-world use:
-
-- **No webhook receiver endpoint.** External systems cannot POST to Caesium. The only way to fire an HTTP trigger is the internal `PUT /v1/triggers/:id` API, which requires knowing the trigger's UUID.
-- **No payload handling.** The HTTP trigger ignores the request body entirely. Webhook payloads from external systems (GitHub, Slack, CI/CD, S3 notifications) cannot be extracted into job parameters.
-- **No request authentication.** The `secret` configuration field exists in the schema and examples but is never validated. Anyone who can reach the API can fire any trigger.
-- **No routing.** The `path` configuration field is documented but not implemented. All jobs associated with a trigger fire unconditionally — there is no content-based filtering.
+Caesium's trigger system has two types: cron (fully implemented) and HTTP (implemented for webhook delivery). HTTP triggers now support dedicated webhook routes, authentication, payload param extraction, and manual/API fire with params. The remaining gap in this design area is event-based routing and trigger chaining.
 - **No trigger chaining.** One job's completion cannot trigger another job. The internal event bus handles lifecycle events but has no mechanism to route them to triggers.
 - **No event persistence.** External events are fire-and-forget. There is no event log, no replay, and no deduplication.
 
 This design addresses all of the above in three work streams:
 
-1. **WS1**: Complete the HTTP webhook trigger (path routing, payload extraction, authentication)
+1. **WS1**: Complete the HTTP webhook trigger (path routing, payload extraction, authentication) — shipped
 2. **WS2**: Add event-based triggers with content filtering
 3. **WS3**: Add trigger chaining via internal lifecycle events
 

--- a/docs/examples/branching.job.yaml
+++ b/docs/examples/branching.job.yaml
@@ -9,6 +9,8 @@ metadata:
     purpose: demonstrates conditional branching based on runtime decisions
 trigger:
   type: http
+  configuration:
+    path: "/hooks/branching-demo"
 steps:
   - name: decide-path
     type: branch
@@ -49,6 +51,8 @@ metadata:
     purpose: demonstrates multi-branch selection where two of three paths are taken
 trigger:
   type: http
+  configuration:
+    path: "/hooks/branching-multi-path"
 steps:
   - name: check-conditions
     type: branch

--- a/docs/job-definitions.md
+++ b/docs/job-definitions.md
@@ -122,6 +122,8 @@ steps:
 - `metadata.alias` must be unique per Caesium installation.
 - `engine` defaults to `docker` if omitted.
 - `trigger.defaultParams` seeds run parameters for cron-triggered executions and is persisted onto the resulting run. Caesium also injects a scheduler-owned `logical_date` parameter for cron fires so each scheduled slot has a stable identity.
+- HTTP triggers require `configuration.path`. Caesium serves the webhook at `POST /v1/hooks/<path>`. Existing manifests may spell the path as `/hooks/<path>` or `/v1/hooks/<path>`; Caesium normalizes those forms to the same route.
+- HTTP triggers may optionally define `secret`, `signatureScheme`, `signatureHeader`, and `paramMapping` to validate incoming webhook requests and extract JSON payload fields into run parameters.
 - `next` accepts either a single string or a list, enabling fan-out to multiple successors. Use `dependsOn` to express joins/fan-in; both fields accept the step name(s) they reference.
 - When no step declares `next` or `dependsOn`, the importer preserves the historical behaviour of linking each step to the following entry automatically. Once you opt into DAG fields, you are responsible for specifying the required edges explicitly.
 - Steps support retry controls via `retries`, `retryDelay`, and `retryBackoff`.

--- a/docs/job-schema-reference.md
+++ b/docs/job-schema-reference.md
@@ -47,8 +47,11 @@ Supported trigger types: `cron`, `http`. Each type accepts a `configuration` map
 ### HTTP Trigger
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
-| `path` | string | required | Route served under `/v1/jobs/:id`. |
-| `secret` | string | optional | Shared secret validated by web UI/API clients. |
+| `path` | string | required | Webhook route suffix. Caesium serves it at `POST /v1/hooks/<path>` and normalizes legacy `/hooks/<path>` forms. |
+| `secret` | string | optional | Shared secret used to validate incoming webhook requests. |
+| `signatureScheme` | string | optional | One of `hmac-sha256`, `hmac-sha1`, `bearer`, `basic`. Defaults to `hmac-sha256` when `secret` is set. |
+| `signatureHeader` | string | optional | Header containing the signature or token. Default varies by scheme. |
+| `paramMapping` | map[string]string | optional | Extracts JSON request-body fields into run params using simple JSONPath expressions such as `$.ref`. |
 
 ## Callbacks
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,9 +26,9 @@ These features address the most common reasons a team would choose an alternativ
 
 ### 1.1 Full-Featured HTTP Triggers & Webhook Ingestion
 
-**Current state**: HTTP triggers exist but are minimal — `PUT /v1/triggers/:id` fires all associated jobs. The `path` and `secret` configuration fields are documented in examples but not implemented. There is no webhook receiver endpoint, no payload extraction, no request authentication, and no per-job filtering.
+**Status**: Shipped. HTTP triggers now support `POST /v1/hooks/*`, configured webhook paths, optional request authentication (`hmac-sha256`, `hmac-sha1`, `bearer`, `basic`), payload parameter extraction via `paramMapping`, default parameter merging, and manual/API fire with optional params. The web UI also exposes HTTP trigger configuration and editing.
 
-**Target state**: HTTP triggers become a first-class webhook ingestion layer. External systems (CI/CD, GitHub, Slack, S3 notifications, custom apps) can POST to a dedicated webhook endpoint, and Caesium routes the payload to the correct job with parameter extraction and signature validation.
+**Delivered state**: HTTP triggers are now a first-class webhook ingestion layer. External systems (CI/CD, GitHub, Slack, S3 notifications, custom apps) can POST to a dedicated webhook endpoint, and Caesium routes the payload to the correct job with parameter extraction and signature validation.
 
 **Design doc**: [`design-event-triggers.md`](design-event-triggers.md)
 
@@ -186,7 +186,6 @@ steps:
 
 | Priority | Feature | Rationale |
 |----------|---------|-----------|
-| **P0** | 1.1 HTTP triggers & webhooks | The current HTTP trigger is non-functional for real use. This is a bug, not a feature request. |
 | **P0** | 1.2 Event-driven routing | Completes the trigger story. Without events, Caesium can only do time-based and manual scheduling. |
 | **P1** | 1.3 Concurrency strategies | Table-stakes for shared clusters. Blocks multi-team adoption. |
 | **P1** | 1.4 Priority queues | Small scope, high impact for distributed deployments. |
@@ -214,6 +213,7 @@ Features that were previously on the roadmap and are now shipped:
 | OpenLineage integration | [`open_lineage.md`](open_lineage.md) | Shipped |
 | Git-based job synchronization | — | Shipped |
 | Harness testing framework | — | Shipped |
+| Full-featured HTTP triggers & webhook ingestion | [`design-event-triggers.md`](design-event-triggers.md) WS1 | Shipped |
 | Task retries with exponential backoff | [`airflow-parity.md`](airflow-parity.md) | Shipped |
 | Trigger rules (all_success, all_done, etc.) | [`airflow-parity.md`](airflow-parity.md) | Shipped |
 | Embedded web UI with DAG visualization | [`ui_implementation_plan.md`](ui_implementation_plan.md) | Shipped |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,7 +26,7 @@ These features address the most common reasons a team would choose an alternativ
 
 ### 1.1 Full-Featured HTTP Triggers & Webhook Ingestion
 
-**Status**: Shipped. HTTP triggers now support `POST /v1/hooks/*`, configured webhook paths, optional request authentication (`hmac-sha256`, `hmac-sha1`, `bearer`, `basic`), payload parameter extraction via `paramMapping`, default parameter merging, and manual/API fire with optional params. The web UI also exposes HTTP trigger configuration and editing.
+**Status**: Shipped. HTTP triggers now support `POST /v1/hooks/*`, configured webhook paths, optional request authentication (`hmac-sha256`, `hmac-sha1`, `bearer`, `basic`), payload parameter extraction via `paramMapping`, default parameter merging, and operator-authenticated manual/API fire via `POST /v1/triggers/:id/fire`. The web UI also exposes HTTP trigger configuration and editing.
 
 **Delivered state**: HTTP triggers are now a first-class webhook ingestion layer. External systems (CI/CD, GitHub, Slack, S3 notifications, custom apps) can POST to a dedicated webhook endpoint, and Caesium routes the payload to the correct job with parameter extraction and signature validation.
 

--- a/helm/caesium/ci/test-values-k8s.yaml
+++ b/helm/caesium/ci/test-values-k8s.yaml
@@ -5,6 +5,9 @@ image:
 
 config:
   logLevel: debug
+  extraEnv:
+    - name: CAESIUM_MANUAL_TRIGGER_API_KEY
+      value: integration-test-key
 
 kubernetes:
   engine:

--- a/internal/jobdef/importer.go
+++ b/internal/jobdef/importer.go
@@ -349,6 +349,9 @@ func (i *Importer) upsertTriggerTx(tx *gorm.DB, existingJob *models.Job, alias s
 	triggerModel.Alias = alias
 	triggerModel.Type = models.TriggerType(trig.Type)
 	triggerModel.Configuration = cfg
+	if err := triggerModel.ApplyDerivedFields(); err != nil {
+		return nil, err
+	}
 	applyTriggerProvenance(triggerModel, opts)
 
 	if triggerModel.CreatedAt.IsZero() {
@@ -361,6 +364,7 @@ func (i *Importer) upsertTriggerTx(tx *gorm.DB, existingJob *models.Job, alias s
 	updates := map[string]any{
 		"alias":                triggerModel.Alias,
 		"type":                 triggerModel.Type,
+		"normalized_path":      triggerModel.NormalizedPath,
 		"configuration":        triggerModel.Configuration,
 		"provenance_source_id": triggerModel.ProvenanceSourceID,
 		"provenance_repo":      triggerModel.ProvenanceRepo,

--- a/internal/jobdef/report/report.go
+++ b/internal/jobdef/report/report.go
@@ -95,8 +95,11 @@ func Markdown() string {
 	b.WriteString("### HTTP Trigger\n")
 	b.WriteString("| Field | Type | Required | Notes |\n")
 	b.WriteString("|-------|------|----------|-------|\n")
-	b.WriteString("| `path` | string | required | Route served under `/v1/jobs/:id`. |\n")
-	b.WriteString("| `secret` | string | optional | Shared secret validated by web UI/API clients. |\n\n")
+	b.WriteString("| `path` | string | required | Webhook route suffix. Caesium serves it at `POST /v1/hooks/<path>` and normalizes legacy `/hooks/<path>` forms. |\n")
+	b.WriteString("| `secret` | string | optional | Shared secret used to validate incoming webhook requests. |\n")
+	b.WriteString("| `signatureScheme` | string | optional | One of `hmac-sha256`, `hmac-sha1`, `bearer`, `basic`. Defaults to `hmac-sha256` when `secret` is set. |\n")
+	b.WriteString("| `signatureHeader` | string | optional | Header containing the signature or token. Default varies by scheme. |\n")
+	b.WriteString("| `paramMapping` | map[string]string | optional | Extracts JSON request-body fields into run params using simple JSONPath expressions such as `$.ref`. |\n\n")
 
 	b.WriteString("## Callbacks\n\n")
 	b.WriteString("Currently the `notification` callback is supported. Custom handlers consume the JSON payload via the callbacks table.\n\n")

--- a/internal/models/trigger.go
+++ b/internal/models/trigger.go
@@ -48,10 +48,20 @@ func (t *Trigger) ApplyDerivedFields() error {
 }
 
 func NormalizedTriggerPath(path string) string {
-	path = strings.Trim(strings.TrimSpace(path), "/")
-	path = strings.TrimPrefix(path, "v1/")
-	path = strings.TrimPrefix(path, "hooks/")
-	return strings.Trim(path, "/")
+	trimmed := strings.Trim(strings.TrimSpace(path), "/")
+	if trimmed == "" {
+		return ""
+	}
+
+	parts := strings.Split(trimmed, "/")
+	switch {
+	case len(parts) >= 2 && parts[0] == "v1" && parts[1] == "hooks":
+		parts = parts[2:]
+	case parts[0] == "hooks":
+		parts = parts[1:]
+	}
+
+	return strings.Trim(strings.Join(parts, "/"), "/")
 }
 
 func NormalizedTriggerPathForConfiguration(triggerType TriggerType, configuration string) (string, error) {

--- a/internal/models/trigger.go
+++ b/internal/models/trigger.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,6 +20,7 @@ type Trigger struct {
 	ID                 uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
 	Alias              string         `gorm:"index" json:"alias"`
 	Type               TriggerType    `gorm:"index;not null" json:"type"`
+	NormalizedPath     string         `gorm:"index" json:"-"`
 	Configuration      string         `json:"configuration"`
 	ProvenanceSourceID string         `gorm:"index" json:"provenance_source_id"`
 	ProvenanceRepo     string         `json:"provenance_repo"`
@@ -30,3 +33,37 @@ type Trigger struct {
 }
 
 type Triggers []*Trigger
+
+func (t *Trigger) BeforeSave(*gorm.DB) error {
+	return t.ApplyDerivedFields()
+}
+
+func (t *Trigger) ApplyDerivedFields() error {
+	normalized, err := NormalizedTriggerPathForConfiguration(t.Type, t.Configuration)
+	if err != nil {
+		return err
+	}
+	t.NormalizedPath = normalized
+	return nil
+}
+
+func NormalizedTriggerPath(path string) string {
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	path = strings.TrimPrefix(path, "v1/")
+	path = strings.TrimPrefix(path, "hooks/")
+	return strings.Trim(path, "/")
+}
+
+func NormalizedTriggerPathForConfiguration(triggerType TriggerType, configuration string) (string, error) {
+	if triggerType != TriggerTypeHTTP || strings.TrimSpace(configuration) == "" {
+		return "", nil
+	}
+
+	var cfg map[string]any
+	if err := json.Unmarshal([]byte(configuration), &cfg); err != nil {
+		return "", err
+	}
+
+	path, _ := cfg["path"].(string)
+	return NormalizedTriggerPath(path), nil
+}

--- a/internal/models/trigger_test.go
+++ b/internal/models/trigger_test.go
@@ -1,0 +1,21 @@
+package models
+
+import "testing"
+
+func TestNormalizedTriggerPath(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"/hooks/run":            "run",
+		"/v1/hooks/run":         "run",
+		"/hooks/v1/build":       "v1/build",
+		"/v1/hooks/v1/build":    "v1/build",
+		"hooks/hooks/secondary": "hooks/secondary",
+	}
+
+	for input, expected := range cases {
+		if got := NormalizedTriggerPath(input); got != expected {
+			t.Fatalf("NormalizedTriggerPath(%q) = %q, want %q", input, got, expected)
+		}
+	}
+}

--- a/internal/trigger/http/auth.go
+++ b/internal/trigger/http/auth.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"hash"
+	stdhttp "net/http"
+	"strings"
+)
+
+const (
+	signatureSchemeHMACSHA256 = "hmac-sha256"
+	signatureSchemeHMACSHA1   = "hmac-sha1"
+	signatureSchemeBearer     = "bearer"
+	signatureSchemeBasic      = "basic"
+)
+
+func validateSignature(req *stdhttp.Request, body []byte, secret, scheme, header string) bool {
+	scheme = strings.ToLower(strings.TrimSpace(scheme))
+	secret = strings.TrimSpace(secret)
+
+	if secret == "" {
+		return true
+	}
+
+	if scheme == "" {
+		scheme = signatureSchemeHMACSHA256
+	}
+
+	header = strings.TrimSpace(header)
+	if header == "" {
+		header = defaultSignatureHeader(scheme)
+	}
+
+	switch scheme {
+	case signatureSchemeHMACSHA256:
+		return validateHMAC(req.Header.Get(header), body, secret, sha256.New, "sha256")
+	case signatureSchemeHMACSHA1:
+		return validateHMAC(req.Header.Get(header), body, secret, sha1.New, "sha1")
+	case signatureSchemeBearer:
+		return validateBearer(req.Header.Get(header), secret)
+	case signatureSchemeBasic:
+		return validateBasic(req, secret)
+	default:
+		return false
+	}
+}
+
+func defaultSignatureHeader(scheme string) string {
+	switch strings.ToLower(strings.TrimSpace(scheme)) {
+	case signatureSchemeHMACSHA1:
+		return "X-Hub-Signature"
+	case signatureSchemeBearer, signatureSchemeBasic:
+		return "Authorization"
+	default:
+		return "X-Hub-Signature-256"
+	}
+}
+
+func validateHMAC(signature string, body []byte, secret string, hash func() hash.Hash, prefix string) bool {
+	signature = strings.TrimSpace(signature)
+	if signature == "" {
+		return false
+	}
+
+	mac := hmac.New(hash, []byte(secret))
+	_, _ = mac.Write(body)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	candidate := signature
+	if prefix != "" && strings.HasPrefix(strings.ToLower(candidate), prefix+"=") {
+		candidate = strings.TrimSpace(candidate[len(prefix)+1:])
+	}
+
+	return subtle.ConstantTimeCompare([]byte(strings.ToLower(candidate)), []byte(expected)) == 1
+}
+
+func validateBearer(headerValue, secret string) bool {
+	headerValue = strings.TrimSpace(headerValue)
+	if headerValue == "" {
+		return false
+	}
+
+	const prefix = "bearer "
+	if len(headerValue) < len(prefix) || !strings.EqualFold(headerValue[:len(prefix)], prefix) {
+		return false
+	}
+
+	token := strings.TrimSpace(headerValue[len(prefix):])
+	return subtle.ConstantTimeCompare([]byte(token), []byte(secret)) == 1
+}
+
+func validateBasic(req *stdhttp.Request, secret string) bool {
+	user, pass, ok := req.BasicAuth()
+	if !ok {
+		return false
+	}
+
+	return subtle.ConstantTimeCompare([]byte(user+":"+pass), []byte(secret)) == 1
+}

--- a/internal/trigger/http/config.go
+++ b/internal/trigger/http/config.go
@@ -1,0 +1,45 @@
+package http
+
+import (
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+type Config struct {
+	Path            string            `json:"path,omitempty"`
+	Secret          string            `json:"secret,omitempty"`
+	SignatureScheme string            `json:"signatureScheme,omitempty"`
+	SignatureHeader string            `json:"signatureHeader,omitempty"`
+	ParamMapping    map[string]string `json:"paramMapping,omitempty"`
+	DefaultParams   map[string]string `json:"defaultParams,omitempty"`
+}
+
+func (c Config) withDefaults() Config {
+	if c.ParamMapping == nil {
+		c.ParamMapping = map[string]string{}
+	}
+	if c.DefaultParams == nil {
+		c.DefaultParams = map[string]string{}
+	}
+	c.Path = normalizePath(c.Path)
+	c.Secret = strings.TrimSpace(c.Secret)
+	c.SignatureScheme = strings.ToLower(strings.TrimSpace(c.SignatureScheme))
+	c.SignatureHeader = strings.TrimSpace(c.SignatureHeader)
+	return c
+}
+
+func (c Config) mergedParams(params map[string]string) map[string]string {
+	merged := make(map[string]string, len(c.DefaultParams)+len(params))
+	for k, v := range c.DefaultParams {
+		merged[k] = v
+	}
+	for k, v := range params {
+		merged[k] = v
+	}
+	return merged
+}
+
+func normalizePath(path string) string {
+	return models.NormalizedTriggerPath(path)
+}

--- a/internal/trigger/http/http.go
+++ b/internal/trigger/http/http.go
@@ -2,10 +2,15 @@ package http
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	stdhttp "net/http"
+	"strings"
 
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	"github.com/caesium-cloud/caesium/internal/job"
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/trigger"
 	"github.com/caesium-cloud/caesium/pkg/log"
@@ -14,15 +19,23 @@ import (
 
 type HTTP struct {
 	trigger.Trigger
-	id uuid.UUID
+	id     uuid.UUID
+	config Config
 }
+
+var ErrInvalidSignature = errors.New("invalid signature")
 
 func New(t *models.Trigger) (*HTTP, error) {
 	if t.Type != models.TriggerTypeHTTP {
 		return nil, fmt.Errorf("trigger is %v not %v", t.Type, models.TriggerTypeHTTP)
 	}
 
-	return &HTTP{id: t.ID}, nil
+	cfg, err := parseConfig(t.Configuration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &HTTP{id: t.ID, config: cfg}, nil
 }
 
 func (h *HTTP) Listen(ctx context.Context) {
@@ -37,35 +50,118 @@ func (h *HTTP) Listen(ctx context.Context) {
 }
 
 func (h *HTTP) Fire(ctx context.Context) error {
+	return h.FireWithParams(ctx, nil)
+}
+
+func (h *HTTP) FireWithParams(ctx context.Context, params map[string]string) error {
 	log.Info(
 		"trigger firing",
 		"id", h.id,
 		"type", models.TriggerTypeHTTP)
 
-	req := &jsvc.ListRequest{TriggerID: h.id.String()}
-
-	jobs, err := jsvc.Service(ctx).List(req)
+	jobs, err := listJobs(ctx, h.id.String())
 	if err != nil {
 		return err
 	}
 
 	log.Info("running jobs", "count", len(jobs))
 
+	mergedParams := h.config.mergedParams(params)
+
 	for _, j := range jobs {
-		if j.Paused {
+		jobModel := j
+		if jobModel == nil {
+			log.Warn("skipping nil job", "trigger_id", h.id)
+			continue
+		}
+		if jobModel.Paused {
 			log.Info("skipping paused job", "id", j.ID)
 			continue
 		}
-		go func() {
-			if err = job.New(j).Run(ctx); err != nil {
-				log.Error("job run failure", "id", j.ID, "error", err)
+		runtimeParams := cloneParams(mergedParams)
+		go func(jobModel *models.Job, params map[string]string) {
+			if err := runJob(context.WithoutCancel(ctx), jobModel, params); err != nil {
+				log.Error("job run failure", "id", jobModel.ID, "error", err)
 			}
-		}()
+		}(jobModel, runtimeParams)
 	}
 
 	return nil
 }
 
+func (h *HTTP) Path() string {
+	return h.config.Path
+}
+
+func (h *HTTP) MergeParams(params map[string]string) map[string]string {
+	return h.config.mergedParams(params)
+}
+
+func (h *HTTP) ExtractWebhookParams(ctx context.Context, req *stdhttp.Request, body []byte) (map[string]string, error) {
+	resolvedSecret, err := resolveSecret(ctx, h.config.Secret)
+	if err != nil {
+		return nil, err
+	}
+	if !validateSignature(req, body, resolvedSecret, h.config.SignatureScheme, h.config.SignatureHeader) {
+		return nil, ErrInvalidSignature
+	}
+	return extractParams(body, h.config.ParamMapping), nil
+}
+
 func (h *HTTP) ID() uuid.UUID {
 	return h.id
+}
+
+var (
+	secretResolver secret.Resolver
+
+	listJobs = func(ctx context.Context, triggerID string) (models.Jobs, error) {
+		req := &jsvc.ListRequest{TriggerID: triggerID}
+		return jsvc.Service(ctx).List(req)
+	}
+
+	runJob = func(ctx context.Context, j *models.Job, params map[string]string) error {
+		if j == nil {
+			return fmt.Errorf("job is nil")
+		}
+		return job.New(j, job.WithParams(params)).Run(ctx)
+	}
+)
+
+func SetSecretResolver(resolver secret.Resolver) {
+	secretResolver = resolver
+}
+
+func cloneParams(params map[string]string) map[string]string {
+	if len(params) == 0 {
+		return map[string]string{}
+	}
+	out := make(map[string]string, len(params))
+	for k, v := range params {
+		out[k] = v
+	}
+	return out
+}
+
+func parseConfig(raw string) (Config, error) {
+	cfg := Config{}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return cfg.withDefaults(), nil
+	}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return Config{}, fmt.Errorf("parse trigger configuration: %w", err)
+	}
+	return cfg.withDefaults(), nil
+}
+
+func resolveSecret(ctx context.Context, value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || !strings.HasPrefix(value, "secret://") {
+		return value, nil
+	}
+	if secretResolver == nil {
+		return "", fmt.Errorf("secret resolver is not configured")
+	}
+	return secretResolver.Resolve(ctx, value)
 }

--- a/internal/trigger/http/http_test.go
+++ b/internal/trigger/http/http_test.go
@@ -140,6 +140,22 @@ func TestExtractParamsSupportsRootJSONPath(t *testing.T) {
 	}, params)
 }
 
+func TestExtractParamsFormatsFloatsWithoutTrailingZeros(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"ratio":1.25,"whole":2.0}`)
+
+	params := extractParams(body, map[string]string{
+		"ratio": "$.ratio",
+		"whole": "$.whole",
+	})
+
+	require.Equal(t, map[string]string{
+		"ratio": "1.25",
+		"whole": "2",
+	}, params)
+}
+
 func TestExtractWebhookParams(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trigger/http/http_test.go
+++ b/internal/trigger/http/http_test.go
@@ -1,1 +1,354 @@
 package http
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	stdhttp "net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type stubSecretResolver struct {
+	resolve func(context.Context, string) (string, error)
+}
+
+func (s stubSecretResolver) Resolve(ctx context.Context, ref string) (string, error) {
+	return s.resolve(ctx, ref)
+}
+
+func TestNewParsesConfiguration(t *testing.T) {
+	t.Parallel()
+
+	trigger := &models.Trigger{
+		ID:   uuid.New(),
+		Type: models.TriggerTypeHTTP,
+		Configuration: `{
+			"path": "/hooks/run",
+			"secret": "shared-secret",
+			"signatureScheme": "hmac-sha256",
+			"signatureHeader": "X-Signature",
+			"paramMapping": {"branch": "$.ref", "commit": "$.after"},
+			"defaultParams": {"environment": "staging"}
+		}`,
+	}
+
+	h, err := New(trigger)
+	require.NoError(t, err)
+	require.Equal(t, "run", h.config.Path)
+	require.Equal(t, "shared-secret", h.config.Secret)
+	require.Equal(t, "hmac-sha256", h.config.SignatureScheme)
+	require.Equal(t, "X-Signature", h.config.SignatureHeader)
+	require.Equal(t, map[string]string{"branch": "$.ref", "commit": "$.after"}, h.config.ParamMapping)
+	require.Equal(t, map[string]string{"environment": "staging"}, h.config.DefaultParams)
+}
+
+func TestNewAllowsEmptyConfiguration(t *testing.T) {
+	t.Parallel()
+
+	h, err := New(&models.Trigger{ID: uuid.New(), Type: models.TriggerTypeHTTP})
+	require.NoError(t, err)
+	require.Empty(t, h.config.Path)
+	require.NotNil(t, h.config.ParamMapping)
+	require.NotNil(t, h.config.DefaultParams)
+}
+
+func TestValidateSignature(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"hello":"world"}`)
+
+	t.Run("no auth when secret empty", func(t *testing.T) {
+		req := httptest.NewRequest(stdhttp.MethodPost, "/", bytes.NewReader(body))
+		require.True(t, validateSignature(req, body, "", "", ""))
+	})
+
+	t.Run("hmac sha256", func(t *testing.T) {
+		req := httptest.NewRequest(stdhttp.MethodPost, "/", bytes.NewReader(body))
+		mac := hmac.New(sha256.New, []byte("secret"))
+		_, _ = mac.Write(body)
+		req.Header.Set("X-Hub-Signature-256", "sha256="+hex.EncodeToString(mac.Sum(nil)))
+		require.True(t, validateSignature(req, body, "secret", "", ""))
+	})
+
+	t.Run("hmac sha1", func(t *testing.T) {
+		req := httptest.NewRequest(stdhttp.MethodPost, "/", bytes.NewReader(body))
+		mac := hmac.New(sha1.New, []byte("secret"))
+		_, _ = mac.Write(body)
+		req.Header.Set("X-Hub-Signature", "sha1="+hex.EncodeToString(mac.Sum(nil)))
+		require.True(t, validateSignature(req, body, "secret", "hmac-sha1", ""))
+	})
+
+	t.Run("bearer", func(t *testing.T) {
+		req := httptest.NewRequest(stdhttp.MethodPost, "/", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer secret-token")
+		require.True(t, validateSignature(req, body, "secret-token", "bearer", ""))
+	})
+
+	t.Run("basic", func(t *testing.T) {
+		req := httptest.NewRequest(stdhttp.MethodPost, "/", bytes.NewReader(body))
+		req.SetBasicAuth("svc", "password")
+		require.True(t, validateSignature(req, body, "svc:password", "basic", ""))
+	})
+}
+
+func TestExtractParams(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"ref": "refs/heads/main",
+		"after": "abc123",
+		"sender": {"login": "octocat"},
+		"items": [{"name": "first"}, {"name": "second"}]
+	}`)
+
+	params := extractParams(body, map[string]string{
+		"branch": "$.ref",
+		"commit": "$.after",
+		"actor":  "$.sender.login",
+		"first":  "$.items.0.name",
+	})
+
+	require.Equal(t, map[string]string{
+		"branch": "refs/heads/main",
+		"commit": "abc123",
+		"actor":  "octocat",
+		"first":  "first",
+	}, params)
+}
+
+func TestExtractParamsSupportsRootJSONPath(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{"ref":"refs/heads/main","sender":{"login":"octocat"}}`)
+
+	params := extractParams(body, map[string]string{
+		"payload": "$",
+	})
+
+	require.Equal(t, map[string]string{
+		"payload": `{"ref":"refs/heads/main","sender":{"login":"octocat"}}`,
+	}, params)
+}
+
+func TestExtractWebhookParams(t *testing.T) {
+	t.Parallel()
+
+	trigger := &models.Trigger{
+		ID:   uuid.New(),
+		Type: models.TriggerTypeHTTP,
+		Configuration: `{
+			"path": "github/push",
+			"secret": "shared-secret",
+			"signatureScheme": "bearer",
+			"paramMapping": {"branch": "$.ref"}
+		}`,
+	}
+
+	h, err := New(trigger)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(stdhttp.MethodPost, "/v1/hooks/github/push", bytes.NewReader(nil))
+	req.Header.Set("Authorization", "Bearer shared-secret")
+
+	params, err := h.ExtractWebhookParams(context.Background(), req, []byte(`{"ref":"refs/heads/main"}`))
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"branch": "refs/heads/main"}, params)
+}
+
+func TestExtractWebhookParamsResolvesSecretReference(t *testing.T) {
+	oldResolver := secretResolver
+	t.Cleanup(func() { secretResolver = oldResolver })
+	SetSecretResolver(stubSecretResolver{
+		resolve: func(_ context.Context, ref string) (string, error) {
+			require.Equal(t, "secret://env/webhook_token", ref)
+			return "resolved-token", nil
+		},
+	})
+
+	trigger := &models.Trigger{
+		ID:   uuid.New(),
+		Type: models.TriggerTypeHTTP,
+		Configuration: `{
+			"path": "github/push",
+			"secret": "secret://env/webhook_token",
+			"signatureScheme": "bearer",
+			"paramMapping": {"branch": "$.ref"}
+		}`,
+	}
+
+	h, err := New(trigger)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(stdhttp.MethodPost, "/v1/hooks/github/push", bytes.NewReader(nil))
+	req.Header.Set("Authorization", "Bearer resolved-token")
+
+	params, err := h.ExtractWebhookParams(context.Background(), req, []byte(`{"ref":"refs/heads/main"}`))
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"branch": "refs/heads/main"}, params)
+}
+
+func TestExtractWebhookParamsSupportsBasicAuth(t *testing.T) {
+	t.Parallel()
+
+	trigger := &models.Trigger{
+		ID:   uuid.New(),
+		Type: models.TriggerTypeHTTP,
+		Configuration: `{
+			"path": "ops/debug",
+			"secret": "svc:password",
+			"signatureScheme": "basic",
+			"paramMapping": {"payload": "$"}
+		}`,
+	}
+
+	h, err := New(trigger)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(stdhttp.MethodPost, "/v1/hooks/ops/debug", bytes.NewReader(nil))
+	req.SetBasicAuth("svc", "password")
+
+	params, err := h.ExtractWebhookParams(context.Background(), req, []byte(`{"env":"staging"}`))
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{"payload": `{"env":"staging"}`}, params)
+}
+
+func TestFireWithParamsMergesDefaultAndOverrides(t *testing.T) {
+	oldListJobs := listJobs
+	oldRunJob := runJob
+	t.Cleanup(func() {
+		listJobs = oldListJobs
+		runJob = oldRunJob
+	})
+
+	var (
+		seen []map[string]string
+		mu   sync.Mutex
+		done = make(chan struct{}, 2)
+	)
+	listJobs = func(ctx context.Context, triggerID string) (models.Jobs, error) {
+		return models.Jobs{
+			&models.Job{ID: uuid.New(), Alias: "first"},
+			&models.Job{ID: uuid.New(), Alias: "second", Paused: true},
+			&models.Job{ID: uuid.New(), Alias: "third"},
+		}, nil
+	}
+	runJob = func(ctx context.Context, j *models.Job, params map[string]string) error {
+		copied := make(map[string]string, len(params))
+		for k, v := range params {
+			copied[k] = v
+		}
+		mu.Lock()
+		seen = append(seen, copied)
+		mu.Unlock()
+		done <- struct{}{}
+		return nil
+	}
+
+	h := &HTTP{
+		id: uuid.New(),
+		config: Config{
+			DefaultParams: map[string]string{
+				"environment": "staging",
+				"source":      "webhook",
+			},
+		},
+	}
+
+	err := h.FireWithParams(context.Background(), map[string]string{
+		"source": "api",
+		"branch": "main",
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first job run")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second job run")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, seen, 2)
+	require.Equal(t, map[string]string{
+		"environment": "staging",
+		"source":      "api",
+		"branch":      "main",
+	}, seen[0])
+	require.Equal(t, seen[0], seen[1])
+}
+
+func TestFireUsesDefaultsWhenParamsMissing(t *testing.T) {
+	oldListJobs := listJobs
+	oldRunJob := runJob
+	t.Cleanup(func() {
+		listJobs = oldListJobs
+		runJob = oldRunJob
+	})
+
+	done := make(chan map[string]string, 1)
+	listJobs = func(ctx context.Context, triggerID string) (models.Jobs, error) {
+		return models.Jobs{&models.Job{ID: uuid.New(), Alias: "only"}}, nil
+	}
+	runJob = func(ctx context.Context, j *models.Job, params map[string]string) error {
+		copied := make(map[string]string, len(params))
+		for k, v := range params {
+			copied[k] = v
+		}
+		done <- copied
+		return nil
+	}
+
+	h := &HTTP{
+		id: uuid.New(),
+		config: Config{
+			DefaultParams: map[string]string{"environment": "prod"},
+		},
+	}
+
+	err := h.Fire(context.Background())
+	require.NoError(t, err)
+
+	select {
+	case seen := <-done:
+		require.Equal(t, map[string]string{"environment": "prod"}, seen)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for job run")
+	}
+}
+
+func TestParseConfigRejectsInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	_, err := parseConfig("{")
+	require.Error(t, err)
+}
+
+func TestResolveJSONPathRejectsInvalidPaths(t *testing.T) {
+	t.Parallel()
+
+	_, ok := resolveJSONPath(map[string]any{"a": map[string]any{"b": "c"}}, "$.a..b")
+	require.False(t, ok)
+}
+
+func TestValidateSignatureRejectsInvalidBearer(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(stdhttp.MethodPost, "/", bytes.NewReader(nil))
+	req.Header.Set("Authorization", "Bearer wrong")
+	require.False(t, validateSignature(req, nil, "secret", "bearer", ""))
+}

--- a/internal/trigger/http/params.go
+++ b/internal/trigger/http/params.go
@@ -1,0 +1,124 @@
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func extractParams(body []byte, mapping map[string]string) map[string]string {
+	if len(mapping) == 0 {
+		return map[string]string{}
+	}
+
+	var payload any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return map[string]string{}
+	}
+
+	params := make(map[string]string, len(mapping))
+	for name, path := range mapping {
+		value, ok := resolveJSONPath(payload, path)
+		if !ok {
+			continue
+		}
+		params[name] = value
+	}
+	return params
+}
+
+func resolveJSONPath(payload any, path string) (string, bool) {
+	if strings.TrimSpace(path) == "$" {
+		return stringifyJSONValue(payload)
+	}
+
+	segments := parseJSONPath(path)
+	if len(segments) == 0 {
+		return "", false
+	}
+
+	current := payload
+	for _, segment := range segments {
+		next, ok := descendJSONPath(current, segment)
+		if !ok {
+			return "", false
+		}
+		current = next
+	}
+
+	return stringifyJSONValue(current)
+}
+
+func parseJSONPath(path string) []string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil
+	}
+	if strings.HasPrefix(path, "$.") {
+		path = path[2:]
+	} else if path == "$" {
+		return []string{}
+	} else if strings.HasPrefix(path, "$") {
+		path = strings.TrimPrefix(path, "$")
+		path = strings.TrimPrefix(path, ".")
+	}
+	if path == "" {
+		return nil
+	}
+	raw := strings.Split(path, ".")
+	segments := make([]string, 0, len(raw))
+	for _, segment := range raw {
+		segment = strings.TrimSpace(segment)
+		if segment == "" {
+			return nil
+		}
+		segments = append(segments, segment)
+	}
+	return segments
+}
+
+func descendJSONPath(current any, segment string) (any, bool) {
+	switch value := current.(type) {
+	case map[string]any:
+		next, ok := value[segment]
+		return next, ok
+	case []any:
+		index, err := strconv.Atoi(segment)
+		if err != nil || index < 0 || index >= len(value) {
+			return nil, false
+		}
+		return value[index], true
+	default:
+		return nil, false
+	}
+}
+
+func stringifyJSONValue(value any) (string, bool) {
+	switch v := value.(type) {
+	case nil:
+		return "", false
+	case string:
+		return v, true
+	case json.Number:
+		return v.String(), true
+	case bool:
+		return strconv.FormatBool(v), true
+	case float64:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", v), "0"), "."), true
+	case float32:
+		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", v), "0"), "."), true
+	case int:
+		return strconv.Itoa(v), true
+	case int64:
+		return strconv.FormatInt(v, 10), true
+	case uint64:
+		return strconv.FormatUint(v, 10), true
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return fmt.Sprint(v), true
+		}
+		return string(data), true
+	}
+}

--- a/internal/trigger/http/params.go
+++ b/internal/trigger/http/params.go
@@ -55,11 +55,12 @@ func parseJSONPath(path string) []string {
 	if path == "" {
 		return nil
 	}
-	if strings.HasPrefix(path, "$.") {
+	switch {
+	case strings.HasPrefix(path, "$."):
 		path = path[2:]
-	} else if path == "$" {
+	case path == "$":
 		return []string{}
-	} else if strings.HasPrefix(path, "$") {
+	case strings.HasPrefix(path, "$"):
 		path = strings.TrimPrefix(path, "$")
 		path = strings.TrimPrefix(path, ".")
 	}
@@ -105,9 +106,9 @@ func stringifyJSONValue(value any) (string, bool) {
 	case bool:
 		return strconv.FormatBool(v), true
 	case float64:
-		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", v), "0"), "."), true
+		return strconv.FormatFloat(v, 'f', -1, 64), true
 	case float32:
-		return strings.TrimRight(strings.TrimRight(fmt.Sprintf("%f", v), "0"), "."), true
+		return strconv.FormatFloat(float64(v), 'f', -1, 32), true
 	case int:
 		return strconv.Itoa(v), true
 	case int64:

--- a/justfile
+++ b/justfile
@@ -179,6 +179,7 @@ integration-test-podman: build
         -p 8080:8080 \
         -v "${PODMAN_SOCK}:/run/podman/podman.sock" \
         -e CAESIUM_PODMAN_URI=unix:///run/podman/podman.sock \
+        -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
         -e CAESIUM_LOG_LEVEL=debug \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
@@ -212,6 +213,7 @@ integration-up: build-test
         -v {{ sock }}:/var/run/docker.sock \
         -e DOCKER_HOST=unix:///var/run/docker.sock \
         --user 0:0 \
+        -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
         -e CAESIUM_LOG_LEVEL=debug \
         {{ local_image_ref }}:{{ tag }}-test start
 
@@ -247,6 +249,7 @@ ui-e2e: build-release
         {{ container_cli }} run --platform {{ platform }} -d --name caesium-server -p {{ port }}:8080 \
             -v {{ sock }}:/var/run/docker.sock \
             -e DOCKER_HOST=unix:///var/run/docker.sock \
+            -e CAESIUM_MANUAL_TRIGGER_API_KEY=e2e-test-key \
             --user 0:0 {{ local_image_ref }}:{{ tag }} start >/dev/null; \
         tries=0; \
         until curl -sf http://127.0.0.1:{{ port }}/health >/dev/null; do \

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -80,5 +80,23 @@ func Migrate() (err error) {
 			return
 		}
 	}
+
+	var triggers []models.Trigger
+	if err = Connection().Where("type = ?", models.TriggerTypeHTTP).Find(&triggers).Error; err != nil {
+		return
+	}
+	for idx := range triggers {
+		trigger := &triggers[idx]
+		if err = trigger.ApplyDerivedFields(); err != nil {
+			return
+		}
+		if err = Connection().
+			Model(&models.Trigger{}).
+			Where("id = ?", trigger.ID).
+			Update("normalized_path", trigger.NormalizedPath).
+			Error; err != nil {
+			return
+		}
+	}
 	return
 }

--- a/pkg/env/bytesize.go
+++ b/pkg/env/bytesize.go
@@ -1,0 +1,66 @@
+package env
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type ByteSize int64
+
+func (b *ByteSize) Decode(value string) error {
+	parsed, err := parseByteSize(value)
+	if err != nil {
+		return err
+	}
+	*b = ByteSize(parsed)
+	return nil
+}
+
+func (b ByteSize) Int64() int64 {
+	return int64(b)
+}
+
+func parseByteSize(value string) (int64, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return 0, nil
+	}
+
+	upper := strings.ToUpper(trimmed)
+	type suffixMultiplier struct {
+		suffix     string
+		multiplier int64
+	}
+	multipliers := []suffixMultiplier{
+		{suffix: "GIB", multiplier: 1 << 30},
+		{suffix: "MIB", multiplier: 1 << 20},
+		{suffix: "KIB", multiplier: 1 << 10},
+		{suffix: "GB", multiplier: 1_000_000_000},
+		{suffix: "MB", multiplier: 1_000_000},
+		{suffix: "KB", multiplier: 1_000},
+		{suffix: "B", multiplier: 1},
+	}
+
+	for _, candidate := range multipliers {
+		suffix := candidate.suffix
+		if !strings.HasSuffix(upper, suffix) {
+			continue
+		}
+		raw := strings.TrimSpace(trimmed[:len(trimmed)-len(suffix)])
+		if raw == "" {
+			return 0, fmt.Errorf("invalid byte size %q", value)
+		}
+		parsed, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid byte size %q: %w", value, err)
+		}
+		return parsed * candidate.multiplier, nil
+	}
+
+	parsed, err := strconv.ParseInt(trimmed, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid byte size %q: %w", value, err)
+	}
+	return parsed, nil
+}

--- a/pkg/env/bytesize_test.go
+++ b/pkg/env/bytesize_test.go
@@ -1,0 +1,25 @@
+package env
+
+import "testing"
+
+func TestParseByteSize(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]int64{
+		"8":    8,
+		"8B":   8,
+		"1KB":  1_000,
+		"1MB":  1_000_000,
+		"2MiB": 2 << 20,
+	}
+
+	for input, expected := range cases {
+		got, err := parseByteSize(input)
+		if err != nil {
+			t.Fatalf("parseByteSize(%q) unexpected error: %v", input, err)
+		}
+		if got != expected {
+			t.Fatalf("parseByteSize(%q) = %d, want %d", input, got, expected)
+		}
+	}
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -50,6 +50,7 @@ type Environment struct {
 	DatabaseType                  string        `default:"internal" split_words:"true"`
 	DatabaseDSN                   string        `default:"host=postgres user=postgres password=postgres dbname=caesium port=5432 sslmode=disable" split_words:"true"`
 	DatabaseConsoleEnabled        bool          `default:"false" split_words:"true"`
+	ManualTriggerAPIKey           string        `envconfig:"MANUAL_TRIGGER_API_KEY" default:""`
 	MaxParallelTasks              int           `split_words:"true"`
 	TaskFailurePolicy             string        `default:"halt" split_words:"true"`
 	TaskTimeout                   time.Duration `default:"0" split_words:"true"`
@@ -84,4 +85,7 @@ type Environment struct {
 	OpenLineageFilePath           string        `envconfig:"OPEN_LINEAGE_FILE_PATH" default:"/var/lib/caesium/lineage.ndjson"`
 	OpenLineageTimeout            time.Duration `envconfig:"OPEN_LINEAGE_TIMEOUT" default:"5s"`
 	OpenLineageRetryAttempts      uint          `envconfig:"OPEN_LINEAGE_RETRY_ATTEMPTS" default:"3"`
+	WebhookMaxBodySize            ByteSize      `envconfig:"WEBHOOK_MAX_BODY_SIZE" default:"1MB"`
+	WebhookRateLimitPerMinute     int           `envconfig:"WEBHOOK_RATE_LIMIT_PER_MINUTE" default:"120"`
+	WebhookRateLimitBurst         int           `envconfig:"WEBHOOK_RATE_LIMIT_BURST" default:"20"`
 }

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -3,6 +3,7 @@ package jobdef
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -33,6 +34,8 @@ const (
 	StepTypeTask   = "task"
 	StepTypeBranch = "branch"
 )
+
+var simpleJSONPathPattern = regexp.MustCompile(`^\$(?:\.[^.\s]+)*$`)
 
 // Definition models the root job document.
 type Definition struct {
@@ -340,17 +343,8 @@ func validateSimpleJSONPath(expr string) error {
 	if expr == "" {
 		return fmt.Errorf("must not be empty")
 	}
-	if expr == "$" {
-		return nil
-	}
-	if !strings.HasPrefix(expr, "$.") {
-		return fmt.Errorf("must start with '$.' or be '$'")
-	}
-	parts := strings.Split(expr[2:], ".")
-	for _, part := range parts {
-		if strings.TrimSpace(part) == "" {
-			return fmt.Errorf("contains an empty path segment")
-		}
+	if !simpleJSONPathPattern.MatchString(expr) {
+		return fmt.Errorf("must be '$' or a dot-separated path starting with '$.'")
 	}
 	return nil
 }

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -271,6 +271,87 @@ func validateTrigger(t *Trigger) error {
 	if t.Configuration == nil {
 		t.Configuration = map[string]any{}
 	}
+	if t.Type == TriggerHTTP {
+		if err := validateHTTPTriggerConfiguration(t.Configuration); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ValidateTriggerSpec(t *Trigger) error {
+	return validateTrigger(t)
+}
+
+func validateHTTPTriggerConfiguration(cfg map[string]any) error {
+	rawPath, ok := cfg["path"]
+	if !ok {
+		return fmt.Errorf("trigger.configuration.path is required for http triggers")
+	}
+	path, ok := rawPath.(string)
+	if !ok {
+		return fmt.Errorf("trigger.configuration.path must be a string")
+	}
+	if normalizeHTTPTriggerPath(path) == "" {
+		return fmt.Errorf("trigger.configuration.path must not be empty")
+	}
+
+	if rawScheme, ok := cfg["signatureScheme"]; ok && rawScheme != nil {
+		scheme, ok := rawScheme.(string)
+		if !ok {
+			return fmt.Errorf("trigger.configuration.signatureScheme must be a string")
+		}
+		switch strings.TrimSpace(scheme) {
+		case "", "hmac-sha256", "hmac-sha1", "bearer", "basic":
+		default:
+			return fmt.Errorf("trigger.configuration.signatureScheme %q must be one of [hmac-sha256,hmac-sha1,bearer,basic]", scheme)
+		}
+	}
+
+	if rawMapping, ok := cfg["paramMapping"]; ok && rawMapping != nil {
+		mapping, ok := rawMapping.(map[string]any)
+		if !ok {
+			return fmt.Errorf("trigger.configuration.paramMapping must be a map of string keys and values")
+		}
+		for key, rawExpr := range mapping {
+			expr, ok := rawExpr.(string)
+			if !ok {
+				return fmt.Errorf("trigger.configuration.paramMapping[%q] must be a string", key)
+			}
+			if err := validateSimpleJSONPath(expr); err != nil {
+				return fmt.Errorf("trigger.configuration.paramMapping[%q]: %w", key, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func normalizeHTTPTriggerPath(path string) string {
+	normalized := strings.TrimSpace(path)
+	normalized = strings.TrimPrefix(normalized, "/")
+	normalized = strings.TrimPrefix(normalized, "v1/")
+	normalized = strings.TrimPrefix(normalized, "hooks/")
+	return strings.Trim(normalized, "/")
+}
+
+func validateSimpleJSONPath(expr string) error {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if expr == "$" {
+		return nil
+	}
+	if !strings.HasPrefix(expr, "$.") {
+		return fmt.Errorf("must start with '$.' or be '$'")
+	}
+	parts := strings.Split(expr[2:], ".")
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return fmt.Errorf("contains an empty path segment")
+		}
+	}
 	return nil
 }
 

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -3,6 +3,8 @@ package jobdef
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var example1 = `
@@ -250,6 +252,20 @@ steps:
 		if _, err := Parse([]byte(src)); err == nil {
 			t.Fatalf("%s: expected error", name)
 		}
+	}
+}
+
+func TestValidateSimpleJSONPath(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"$", "$.ref", "$.sender.login", "$.items.0.name"}
+	for _, expr := range valid {
+		require.NoError(t, validateSimpleJSONPath(expr), expr)
+	}
+
+	invalid := []string{"", "ref", "$.", "$.sender..login", "$.sender. login"}
+	for _, expr := range invalid {
+		require.Error(t, validateSimpleJSONPath(expr), expr)
 	}
 }
 

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -179,6 +179,44 @@ steps:
   - name: build
     image: example
 `,
+		"http trigger missing path": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: http
+  configuration: {}
+steps:
+  - name: build
+    image: example
+`,
+		"http trigger invalid signature scheme": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: http
+  configuration:
+    path: /hooks/test
+    signatureScheme: oauth2
+steps:
+  - name: build
+    image: example
+`,
+		"http trigger invalid param mapping": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: http
+  configuration:
+    path: /hooks/test
+    paramMapping:
+      branch: ref
+steps:
+  - name: build
+    image: example
+`,
 		"unknown dependsOn": `apiVersion: v1
 kind: Job
 metadata:

--- a/pkg/jobdef/schema_test.go
+++ b/pkg/jobdef/schema_test.go
@@ -15,7 +15,8 @@ metadata:
   alias: test-job
 trigger:
   type: http
-  configuration: {}
+  configuration:
+    path: /hooks/test-job
 steps:
 `
 

--- a/test/definitions/job_two.yaml
+++ b/test/definitions/job_two.yaml
@@ -4,7 +4,8 @@ metadata:
     alias: integration-job-two
 trigger:
     type: http
-    configuration: {}
+    configuration:
+      path: /hooks/integration-job-two
 callbacks:
   - type: notification
     configuration:

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -24,10 +24,11 @@ import (
 
 type IntegrationTestSuite struct {
 	suite.Suite
-	caesiumURL  string
-	cliPath     string
-	projectRoot string
-	engineType  string // "docker", "podman", or "kubernetes"
+	caesiumURL          string
+	cliPath             string
+	projectRoot         string
+	engineType          string // "docker", "podman", or "kubernetes"
+	manualTriggerAPIKey string
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -58,6 +59,10 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		host = "127.0.0.1"
 	}
 	s.caesiumURL = fmt.Sprintf("http://%v:8080", host)
+	s.manualTriggerAPIKey = os.Getenv("CAESIUM_MANUAL_TRIGGER_API_KEY")
+	if s.manualTriggerAPIKey == "" {
+		s.manualTriggerAPIKey = "integration-test-key"
+	}
 
 	client := &http.Client{Timeout: 2 * time.Second}
 	deadline := time.Now().Add(2 * time.Minute)
@@ -338,5 +343,14 @@ func (s *IntegrationTestSuite) doRequest(method, target string, body io.Reader) 
 	}
 
 	//nolint:bodyclose // Response body ownership is transferred to the caller.
+	return http.DefaultClient.Do(req)
+}
+
+func (s *IntegrationTestSuite) doManualTriggerRequest(method, target string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(s.T().Context(), method, target, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Caesium-API-Key", s.manualTriggerAPIKey)
 	return http.DefaultClient.Do(req)
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -292,6 +292,12 @@ func (s *IntegrationTestSuite) fetchAtomSpec(atomID string) container.Spec {
 	return atomResp.Spec
 }
 
+func (s *IntegrationTestSuite) fetchRuns(jobID string) []runResponse {
+	var runs []runResponse
+	s.getJSON(fmt.Sprintf("/v1/jobs/%s/runs", jobID), &runs)
+	return runs
+}
+
 func (s *IntegrationTestSuite) getJSON(path string, target any) {
 	resp, err := s.doRequest(http.MethodGet, s.caesiumURL+path, nil)
 	require.NoError(s.T(), err)

--- a/test/job_test.go
+++ b/test/job_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/caesium-cloud/caesium/api/rest/controller/job"
 	"github.com/caesium-cloud/caesium/api/rest/service/atom"
@@ -42,6 +43,63 @@ func (s *IntegrationTestSuite) TestHTTPJob() {
 	if resp.Body != nil {
 		_ = resp.Body.Close()
 	}
+}
+
+func (s *IntegrationTestSuite) TestHTTPWebhookTriggerRoutesToJob() {
+	job := s.createJobWithTrigger("test_http_webhook_job", nil, models.TriggerTypeHTTP)
+	assert.NotNil(s.T(), job)
+
+	resp, err := s.doRequest(http.MethodPost, fmt.Sprintf("%v/v1/hooks/jobs/%s", s.caesiumURL, job.Alias), nil)
+	assert.Nil(s.T(), err)
+	defer resp.Body.Close()
+	assert.Equal(s.T(), http.StatusAccepted, resp.StatusCode)
+
+	s.Require().Eventually(func() bool {
+		runs := s.fetchRuns(job.ID.String())
+		return len(runs) > 0
+	}, 30*time.Second, 500*time.Millisecond)
+}
+
+func (s *IntegrationTestSuite) TestHTTPWebhookTriggerAuthAndParams() {
+	alias := "test_http_webhook_auth_job"
+	job := s.createJobWithTriggerConfig(alias, nil, models.TriggerTypeHTTP, map[string]any{
+		"path":            fmt.Sprintf("/jobs/%s/secure", alias),
+		"secret":          "shared-token",
+		"signatureScheme": "bearer",
+		"defaultParams": map[string]string{
+			"environment": "staging",
+		},
+		"paramMapping": map[string]string{
+			"branch": "$.ref",
+			"actor":  "$.sender.login",
+		},
+	})
+	assert.NotNil(s.T(), job)
+
+	req, err := http.NewRequestWithContext(
+		s.T().Context(),
+		http.MethodPost,
+		fmt.Sprintf("%v/v1/hooks/jobs/%s/secure", s.caesiumURL, alias),
+		strings.NewReader(`{"ref":"refs/heads/main","sender":{"login":"octocat"}}`),
+	)
+	assert.Nil(s.T(), err)
+	req.Header.Set("Authorization", "Bearer shared-token")
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	assert.Nil(s.T(), err)
+	defer resp.Body.Close()
+	assert.Equal(s.T(), http.StatusAccepted, resp.StatusCode)
+
+	s.Require().Eventually(func() bool {
+		runs := s.fetchRuns(job.ID.String())
+		if len(runs) == 0 {
+			return false
+		}
+		return runs[0].Params["environment"] == "staging" &&
+			runs[0].Params["branch"] == "refs/heads/main" &&
+			runs[0].Params["actor"] == "octocat"
+	}, 30*time.Second, 500*time.Millisecond)
 }
 
 func (s *IntegrationTestSuite) TestJobMetadataAndTasks() {
@@ -136,14 +194,26 @@ func (s *IntegrationTestSuite) createJob(alias string, metadata *job.MetadataReq
 }
 
 func (s *IntegrationTestSuite) createJobWithTrigger(alias string, metadata *job.MetadataRequest, trigType models.TriggerType) *models.Job {
-	config := map[string]any{}
+	return s.createJobWithTriggerConfig(alias, metadata, trigType, nil)
+}
+
+func (s *IntegrationTestSuite) createJobWithTriggerConfig(alias string, metadata *job.MetadataRequest, trigType models.TriggerType, config map[string]any) *models.Job {
+	if config == nil {
+		config = map[string]any{}
+	}
 	switch trigType {
 	case models.TriggerTypeCron:
-		config["expression"] = "* * * * *"
+		if _, ok := config["expression"]; !ok {
+			config["expression"] = "* * * * *"
+		}
 	case models.TriggerTypeHTTP:
-		config["path"] = fmt.Sprintf("/jobs/%s", alias)
+		if _, ok := config["path"]; !ok {
+			config["path"] = fmt.Sprintf("/jobs/%s", alias)
+		}
 	default:
-		config["expression"] = "* * * * *"
+		if _, ok := config["expression"]; !ok {
+			config["expression"] = "* * * * *"
+		}
 	}
 
 	req := job.PostRequest{

--- a/test/job_test.go
+++ b/test/job_test.go
@@ -31,13 +31,10 @@ func (s *IntegrationTestSuite) TestHTTPJob() {
 	job := s.createJobWithTrigger("test_http_job", nil, models.TriggerTypeHTTP)
 	assert.NotNil(s.T(), job)
 
-	u, err := url.Parse(fmt.Sprintf("%v/v1/triggers/%v", s.caesiumURL, job.TriggerID))
+	u, err := url.Parse(fmt.Sprintf("%v/v1/triggers/%v/fire", s.caesiumURL, job.TriggerID))
 	assert.Nil(s.T(), err)
 
-	req, err := http.NewRequestWithContext(s.T().Context(), http.MethodPut, u.String(), nil)
-	assert.Nil(s.T(), err)
-
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := s.doManualTriggerRequest(http.MethodPost, u.String(), nil)
 	assert.Nil(s.T(), err)
 	assert.Equal(s.T(), http.StatusAccepted, resp.StatusCode)
 	if resp.Body != nil {

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -18,6 +18,7 @@ type runResponse struct {
 	JobID  string            `json:"job_id"`
 	Status string            `json:"status"`
 	Error  string            `json:"error,omitempty"`
+	Params map[string]string `json:"params,omitempty"`
 	Tasks  []runTaskResponse `json:"tasks"`
 }
 

--- a/ui/src/features/jobdefs/JobDefsPage.tsx
+++ b/ui/src/features/jobdefs/JobDefsPage.tsx
@@ -176,7 +176,8 @@ metadata:
   alias: string     # required
 trigger:
   type: cron|http
-  configuration: {} # type-specific
+  configuration:    # type-specific
+    path: my-job    # required for http
 steps:
   - name: string    # required
     image: string   # required

--- a/ui/src/features/triggers/TriggersPage.tsx
+++ b/ui/src/features/triggers/TriggersPage.tsx
@@ -1,17 +1,139 @@
-import { useQuery, useMutation } from "@tanstack/react-query";
-import { api, type Trigger } from "@/lib/api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api, ApiError, type Trigger, type TriggerCreateRequest, type TriggerUpdateRequest } from "@/lib/api";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RelativeTime } from "@/components/relative-time";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Zap, Clock, Globe, ChevronDown, ChevronRight, Play } from "lucide-react";
-import { useState, useMemo } from "react";
+import { Zap, Clock, Globe, ChevronDown, ChevronRight, Play, Plus, Pencil } from "lucide-react";
+import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 
+const inputClass =
+  "w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring";
+const labelClass = "mb-1 block text-xs font-medium uppercase tracking-wide text-muted-foreground";
+const textareaClass = `${inputClass} min-h-[112px] font-mono text-xs`;
+
+type HTTPTriggerFormState = {
+  alias: string;
+  path: string;
+  secret: string;
+  signatureScheme: string;
+  signatureHeader: string;
+  paramMappingText: string;
+  defaultParamsText: string;
+};
+
+function normalizeWebhookPath(path: unknown) {
+  if (typeof path !== "string") return "";
+  let normalized = path.trim();
+  normalized = normalized.replace(/^\/+/, "");
+  normalized = normalized.replace(/^v1\/+/, "");
+  normalized = normalized.replace(/^hooks\/+/, "");
+  return normalized.replace(/\/+$/, "");
+}
+
+function webhookRoute(path: unknown) {
+  const normalized = normalizeWebhookPath(path);
+  return normalized ? `/v1/hooks/${normalized}` : "";
+}
+
+function parseTriggerConfiguration(trigger: Trigger) {
+  try {
+    const parsed = JSON.parse(trigger.configuration);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // ignore malformed config in UI summary
+  }
+  return {};
+}
+
+function stringifyStringMap(value: unknown) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return "{}";
+  return JSON.stringify(value, null, 2);
+}
+
+function formStateFromTrigger(trigger?: Trigger | null): HTTPTriggerFormState {
+  const config = trigger ? parseTriggerConfiguration(trigger) : {};
+  return {
+    alias: trigger?.alias ?? "",
+    path: typeof config.path === "string" ? webhookRoute(config.path) : "",
+    secret: typeof config.secret === "string" ? config.secret : "",
+    signatureScheme: typeof config.signatureScheme === "string" ? config.signatureScheme : "",
+    signatureHeader: typeof config.signatureHeader === "string" ? config.signatureHeader : "",
+    paramMappingText: stringifyStringMap(config.paramMapping),
+    defaultParamsText: stringifyStringMap(config.defaultParams),
+  };
+}
+
+function parseStringMap(text: string, field: string) {
+  const trimmed = text.trim();
+  if (!trimmed) return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    throw new Error(`${field} must be valid JSON`);
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${field} must be a JSON object`);
+  }
+
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== "string") {
+      throw new Error(`${field}.${key} must be a string`);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function buildHTTPTriggerPayload(state: HTTPTriggerFormState): Pick<TriggerCreateRequest, "alias" | "configuration"> {
+  const normalizedPath = normalizeWebhookPath(state.path);
+  if (!state.alias.trim()) throw new Error("Alias is required");
+  if (!normalizedPath) throw new Error("Webhook path is required");
+
+  const configuration: Record<string, unknown> = {
+    path: `/hooks/${normalizedPath}`,
+  };
+
+  if (state.secret.trim()) configuration.secret = state.secret.trim();
+  if (state.signatureScheme.trim()) configuration.signatureScheme = state.signatureScheme.trim();
+  if (state.signatureHeader.trim()) configuration.signatureHeader = state.signatureHeader.trim();
+
+  const paramMapping = parseStringMap(state.paramMappingText, "paramMapping");
+  if (Object.keys(paramMapping).length > 0) configuration.paramMapping = paramMapping;
+
+  const defaultParams = parseStringMap(state.defaultParamsText, "defaultParams");
+  if (Object.keys(defaultParams).length > 0) configuration.defaultParams = defaultParams;
+
+  return {
+    alias: state.alias.trim(),
+    configuration,
+  };
+}
+
+function errorMessage(error: unknown) {
+  if (error instanceof ApiError) return error.message;
+  if (error instanceof Error) return error.message;
+  return "Request failed";
+}
+
 function CronPreview({ expression }: { expression: string }) {
-  // Show next N cron fire times using a simple description
   const describe = (expr: string) => {
     const parts = expr.trim().split(/\s+/);
     if (parts.length < 5) return expr;
@@ -33,8 +155,7 @@ function CronPreview({ expression }: { expression: string }) {
 }
 
 function TriggerConfig({ trigger }: { trigger: Trigger }) {
-  let config: Record<string, unknown> = {};
-  try { config = JSON.parse(trigger.configuration); } catch { /* raw */ }
+  const config = parseTriggerConfiguration(trigger);
 
   if (trigger.type === "cron") {
     const expr = (config.expression || config.cron || trigger.configuration) as string;
@@ -46,10 +167,13 @@ function TriggerConfig({ trigger }: { trigger: Trigger }) {
     );
   }
   if (trigger.type === "http") {
+    const route = webhookRoute(config.path);
     return (
       <div className="flex items-center gap-2">
         <Globe className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-        <span className="text-xs text-muted-foreground font-mono">HTTP webhook</span>
+        <span className="text-xs text-muted-foreground font-mono">
+          {route || "HTTP webhook"}
+        </span>
       </div>
     );
   }
@@ -57,8 +181,14 @@ function TriggerConfig({ trigger }: { trigger: Trigger }) {
 }
 
 export function TriggersPage() {
+  const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState<string | null>(null);
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
+  const [editorOpen, setEditorOpen] = useState(false);
+  const [editorMode, setEditorMode] = useState<"create" | "edit">("create");
+  const [editingTrigger, setEditingTrigger] = useState<Trigger | null>(null);
+  const [formState, setFormState] = useState<HTTPTriggerFormState>(formStateFromTrigger());
+  const [formError, setFormError] = useState<string | null>(null);
 
   const { data: triggers, isLoading, error } = useQuery({
     queryKey: ["triggers"],
@@ -69,151 +199,369 @@ export function TriggersPage() {
   const fireMutation = useMutation({
     mutationFn: (id: string) => api.fireTrigger(id),
     onSuccess: () => toast.success("Trigger fired"),
-    onError: () => toast.error("Failed to fire trigger"),
+    onError: (err) => toast.error(errorMessage(err)),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (body: TriggerCreateRequest) => api.createTrigger(body),
+    onSuccess: () => {
+      toast.success("Trigger created");
+      queryClient.invalidateQueries({ queryKey: ["triggers"] });
+      setEditorOpen(false);
+    },
+    onError: (err) => setFormError(errorMessage(err)),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, body }: { id: string; body: TriggerUpdateRequest }) => api.updateTrigger(id, body),
+    onSuccess: () => {
+      toast.success("Trigger updated");
+      queryClient.invalidateQueries({ queryKey: ["triggers"] });
+      setEditorOpen(false);
+    },
+    onError: (err) => setFormError(errorMessage(err)),
   });
 
   const triggerTypes = useMemo(() => {
     const set = new Set<string>();
-    triggers?.forEach(t => set.add(t.type));
+    triggers?.forEach((trigger) => set.add(trigger.type));
     return Array.from(set);
   }, [triggers]);
 
   const filtered = useMemo(() => {
     if (!typeFilter) return triggers || [];
-    return (triggers || []).filter(t => t.type === typeFilter);
+    return (triggers || []).filter((trigger) => trigger.type === typeFilter);
   }, [triggers, typeFilter]);
 
-  if (isLoading) return (
-    <div className="p-8 space-y-4">
-      <Skeleton className="h-8 w-48" />
-      <div className="grid gap-4">
-        {[1, 2, 3].map(i => <Skeleton key={i} className="h-24 w-full" />)}
+  const editorPending = createMutation.isPending || updateMutation.isPending;
+
+  function openCreateDialog() {
+    setEditorMode("create");
+    setEditingTrigger(null);
+    setFormState(formStateFromTrigger());
+    setFormError(null);
+    setEditorOpen(true);
+  }
+
+  function openEditDialog(trigger: Trigger) {
+    setEditorMode("edit");
+    setEditingTrigger(trigger);
+    setFormState(formStateFromTrigger(trigger));
+    setFormError(null);
+    setEditorOpen(true);
+  }
+
+  function handleEditorSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setFormError(null);
+
+    let payload: Pick<TriggerCreateRequest, "alias" | "configuration">;
+    try {
+      payload = buildHTTPTriggerPayload(formState);
+    } catch (err) {
+      setFormError(errorMessage(err));
+      return;
+    }
+
+    if (editorMode === "create") {
+      createMutation.mutate({
+        alias: payload.alias,
+        type: "http",
+        configuration: payload.configuration,
+      });
+      return;
+    }
+
+    if (!editingTrigger) {
+      setFormError("No trigger selected for editing");
+      return;
+    }
+
+    updateMutation.mutate({
+      id: editingTrigger.id,
+      body: payload,
+    });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-8 space-y-4">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-4">
+          {[1, 2, 3].map((i) => <Skeleton key={i} className="h-24 w-full" />)}
+        </div>
       </div>
-    </div>
-  );
+    );
+  }
   if (error) return <div className="p-8 text-center text-destructive">Error loading triggers: {error.message}</div>;
 
   return (
-    <div className="space-y-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold tracking-tight">Triggers</h1>
-          <p className="text-sm text-muted-foreground mt-0.5">Cron schedules and HTTP webhooks</p>
+    <>
+      <div className="space-y-4">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">Triggers</h1>
+            <p className="text-sm text-muted-foreground mt-0.5">Cron schedules and HTTP webhooks</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground">{filtered.length} trigger{filtered.length !== 1 ? "s" : ""}</span>
+            <Button size="sm" onClick={openCreateDialog}>
+              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              New HTTP Trigger
+            </Button>
+          </div>
         </div>
-        <span className="text-sm text-muted-foreground">{filtered.length} trigger{filtered.length !== 1 ? "s" : ""}</span>
-      </div>
 
-      {/* Type filter */}
-      <div className="flex gap-2">
-        {triggerTypes.map(type => (
-          <button
-            key={type}
-            onClick={() => setTypeFilter(typeFilter === type ? null : type)}
-            className={cn(
-              "rounded-full px-3 py-1 text-xs border transition-colors flex items-center gap-1.5",
-              typeFilter === type
-                ? "bg-primary text-primary-foreground border-primary"
-                : "bg-background text-muted-foreground border-border hover:border-primary hover:text-primary"
-            )}
-          >
-            {type === "cron" ? <Clock className="h-3 w-3" /> : <Globe className="h-3 w-3" />}
-            {type}
-          </button>
-        ))}
-      </div>
-
-      {filtered.length === 0 && (
-        <div className="rounded-md border bg-card h-24 flex items-center justify-center text-muted-foreground text-sm">
-          No triggers found.
-        </div>
-      )}
-
-      <div className="grid gap-3">
-        {filtered.map(trigger => {
-          let config: Record<string, unknown> = {};
-          try { config = JSON.parse(trigger.configuration); } catch { /* ok */ }
-          const isHttp = trigger.type === "http";
-
-          return (
-            <Card key={trigger.id} className="overflow-hidden">
-              <div
-                className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted/30 transition-colors"
-                onClick={() => setExpanded(expanded === trigger.id ? null : trigger.id)}
-              >
-                <div className="flex items-center gap-3 min-w-0">
-                  <div className="shrink-0">
-                    {expanded === trigger.id
-                      ? <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                      : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
-                  </div>
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <span className="font-medium text-sm">{trigger.alias}</span>
-                      <Badge variant={trigger.type === "cron" ? "secondary" : "outline"} className="text-[10px]">
-                        {trigger.type === "cron" ? <Clock className="h-2.5 w-2.5 mr-1" /> : <Globe className="h-2.5 w-2.5 mr-1" />}
-                        {trigger.type}
-                      </Badge>
-                    </div>
-                    <div className="mt-0.5">
-                      <TriggerConfig trigger={trigger} />
-                    </div>
-                  </div>
-                </div>
-                <div className="flex items-center gap-3 shrink-0 ml-4" onClick={e => e.stopPropagation()}>
-                  <span className="text-xs text-muted-foreground hidden sm:block">
-                    <RelativeTime date={trigger.updated_at} />
-                  </span>
-                  {isHttp && (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      onClick={() => fireMutation.mutate(trigger.id)}
-                      disabled={fireMutation.isPending}
-                      title="Fire this HTTP trigger"
-                    >
-                      <Play className="h-3.5 w-3.5 mr-1.5" />
-                      Fire
-                    </Button>
-                  )}
-                </div>
-              </div>
-
-              {expanded === trigger.id && (
-                <div className="border-t bg-muted/20 px-4 py-3 space-y-3">
-                  <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1">ID</p>
-                      <p className="font-mono text-xs">{trigger.id}</p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1">Created</p>
-                      <p className="text-xs"><RelativeTime date={trigger.created_at} /></p>
-                    </div>
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1">Updated</p>
-                      <p className="text-xs"><RelativeTime date={trigger.updated_at} /></p>
-                    </div>
-                  </div>
-                  <div>
-                    <p className="text-xs text-muted-foreground mb-1">Configuration</p>
-                    <pre className="bg-code-bg text-code-fg rounded p-3 text-xs overflow-auto max-h-48">
-                      {Object.keys(config).length > 0
-                        ? JSON.stringify(config, null, 2)
-                        : trigger.configuration}
-                    </pre>
-                  </div>
-                  {isHttp && (
-                    <div className="rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-muted-foreground">
-                      <Zap className="h-3 w-3 inline mr-1.5 text-yellow-500" />
-                      Firing this trigger will immediately start all jobs associated with it.
-                    </div>
-                  )}
-                </div>
+        <div className="flex gap-2">
+          {triggerTypes.map((type) => (
+            <button
+              key={type}
+              onClick={() => setTypeFilter(typeFilter === type ? null : type)}
+              className={cn(
+                "rounded-full px-3 py-1 text-xs border transition-colors flex items-center gap-1.5",
+                typeFilter === type
+                  ? "bg-primary text-primary-foreground border-primary"
+                  : "bg-background text-muted-foreground border-border hover:border-primary hover:text-primary",
               )}
-            </Card>
-          );
-        })}
+            >
+              {type === "cron" ? <Clock className="h-3 w-3" /> : <Globe className="h-3 w-3" />}
+              {type}
+            </button>
+          ))}
+        </div>
+
+        {filtered.length === 0 && (
+          <div className="rounded-md border bg-card h-24 flex items-center justify-center text-muted-foreground text-sm">
+            No triggers found.
+          </div>
+        )}
+
+        <div className="grid gap-3">
+          {filtered.map((trigger) => {
+            const config = parseTriggerConfiguration(trigger);
+            const isHttp = trigger.type === "http";
+            const webhookPath = webhookRoute(config.path);
+            const signatureScheme = typeof config.signatureScheme === "string" ? config.signatureScheme : "";
+
+            return (
+              <Card key={trigger.id} className="overflow-hidden">
+                <div
+                  className="flex items-center justify-between px-4 py-3 cursor-pointer hover:bg-muted/30 transition-colors"
+                  onClick={() => setExpanded(expanded === trigger.id ? null : trigger.id)}
+                >
+                  <div className="flex items-center gap-3 min-w-0">
+                    <div className="shrink-0">
+                      {expanded === trigger.id
+                        ? <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                        : <ChevronRight className="h-4 w-4 text-muted-foreground" />}
+                    </div>
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium text-sm">{trigger.alias}</span>
+                        <Badge variant={trigger.type === "cron" ? "secondary" : "outline"} className="text-[10px]">
+                          {trigger.type === "cron"
+                            ? <Clock className="h-2.5 w-2.5 mr-1" />
+                            : <Globe className="h-2.5 w-2.5 mr-1" />}
+                          {trigger.type}
+                        </Badge>
+                      </div>
+                      <div className="mt-0.5">
+                        <TriggerConfig trigger={trigger} />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0 ml-4" onClick={(e) => e.stopPropagation()}>
+                    <span className="text-xs text-muted-foreground hidden sm:block">
+                      <RelativeTime date={trigger.updated_at} />
+                    </span>
+                    {isHttp && (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => openEditDialog(trigger)}
+                          disabled={editorPending}
+                        >
+                          <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                          Edit
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => fireMutation.mutate(trigger.id)}
+                          disabled={fireMutation.isPending}
+                          title="Fire this HTTP trigger"
+                        >
+                          <Play className="h-3.5 w-3.5 mr-1.5" />
+                          Fire
+                        </Button>
+                      </>
+                    )}
+                  </div>
+                </div>
+
+                {expanded === trigger.id && (
+                  <div className="border-t bg-muted/20 px-4 py-3 space-y-3">
+                    <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">ID</p>
+                        <p className="font-mono text-xs">{trigger.id}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">Created</p>
+                        <p className="text-xs"><RelativeTime date={trigger.created_at} /></p>
+                      </div>
+                      <div>
+                        <p className="text-xs text-muted-foreground mb-1">Updated</p>
+                        <p className="text-xs"><RelativeTime date={trigger.updated_at} /></p>
+                      </div>
+                      {isHttp && webhookPath && (
+                        <div>
+                          <p className="text-xs text-muted-foreground mb-1">Webhook</p>
+                          <p className="font-mono text-xs">{webhookPath}</p>
+                        </div>
+                      )}
+                      {isHttp && signatureScheme && (
+                        <div>
+                          <p className="text-xs text-muted-foreground mb-1">Auth</p>
+                          <p className="text-xs">{signatureScheme}</p>
+                        </div>
+                      )}
+                    </div>
+                    <div>
+                      <p className="text-xs text-muted-foreground mb-1">Configuration</p>
+                      <pre className="bg-code-bg text-code-fg rounded p-3 text-xs overflow-auto max-h-48">
+                        {Object.keys(config).length > 0
+                          ? JSON.stringify(config, null, 2)
+                          : trigger.configuration}
+                      </pre>
+                    </div>
+                    {isHttp && (
+                      <div className="rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-muted-foreground">
+                        <Zap className="h-3 w-3 inline mr-1.5 text-yellow-500" />
+                        Manual fire hits this trigger directly and can bypass webhook auth checks. External systems should post to the webhook route above.
+                      </div>
+                    )}
+                  </div>
+                )}
+              </Card>
+            );
+          })}
+        </div>
       </div>
-    </div>
+
+      <Dialog open={editorOpen} onOpenChange={(open) => !editorPending && setEditorOpen(open)}>
+        <DialogContent className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>{editorMode === "create" ? "New HTTP Trigger" : "Edit HTTP Trigger"}</DialogTitle>
+            <DialogDescription>
+              Configure the webhook route, auth, and request-body mappings. Standalone triggers only run jobs that already reference them.
+            </DialogDescription>
+          </DialogHeader>
+          <form onSubmit={handleEditorSubmit} className="space-y-4">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>Alias</label>
+                <input
+                  value={formState.alias}
+                  onChange={(event) => setFormState((current) => ({ ...current, alias: event.target.value }))}
+                  className={inputClass}
+                  disabled={editorPending}
+                  required
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Webhook Path</label>
+                <input
+                  value={formState.path}
+                  onChange={(event) => setFormState((current) => ({ ...current, path: event.target.value }))}
+                  placeholder="/v1/hooks/team/deploy"
+                  className={inputClass}
+                  disabled={editorPending}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-3">
+              <div>
+                <label className={labelClass}>Secret</label>
+                <input
+                  value={formState.secret}
+                  onChange={(event) => setFormState((current) => ({ ...current, secret: event.target.value }))}
+                  placeholder="shared-secret or secret://..."
+                  className={inputClass}
+                  disabled={editorPending}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Auth Scheme</label>
+                <select
+                  value={formState.signatureScheme}
+                  onChange={(event) => setFormState((current) => ({ ...current, signatureScheme: event.target.value }))}
+                  className={inputClass}
+                  disabled={editorPending}
+                >
+                  <option value="">Default</option>
+                  <option value="hmac-sha256">hmac-sha256</option>
+                  <option value="hmac-sha1">hmac-sha1</option>
+                  <option value="bearer">bearer</option>
+                  <option value="basic">basic</option>
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>Signature Header</label>
+                <input
+                  value={formState.signatureHeader}
+                  onChange={(event) => setFormState((current) => ({ ...current, signatureHeader: event.target.value }))}
+                  placeholder="X-Hub-Signature-256"
+                  className={inputClass}
+                  disabled={editorPending}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className={labelClass}>Param Mapping JSON</label>
+                <textarea
+                  value={formState.paramMappingText}
+                  onChange={(event) => setFormState((current) => ({ ...current, paramMappingText: event.target.value }))}
+                  className={textareaClass}
+                  disabled={editorPending}
+                />
+              </div>
+              <div>
+                <label className={labelClass}>Default Params JSON</label>
+                <textarea
+                  value={formState.defaultParamsText}
+                  onChange={(event) => setFormState((current) => ({ ...current, defaultParamsText: event.target.value }))}
+                  className={textareaClass}
+                  disabled={editorPending}
+                />
+              </div>
+            </div>
+
+            <div className="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+              Param mappings use simple JSONPath expressions like <code className="mx-1 rounded bg-muted px-1 py-0.5">$.ref</code> and
+              <code className="mx-1 rounded bg-muted px-1 py-0.5">$</code> for the whole payload.
+            </div>
+
+            {formError && <p className="text-sm text-destructive">{formError}</p>}
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setEditorOpen(false)} disabled={editorPending}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={editorPending}>
+                {editorPending
+                  ? (editorMode === "create" ? "Creating..." : "Saving...")
+                  : (editorMode === "create" ? "Create Trigger" : "Save Trigger")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/ui/src/features/triggers/TriggersPage.tsx
+++ b/ui/src/features/triggers/TriggersPage.tsx
@@ -14,7 +14,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { Zap, Clock, Globe, ChevronDown, ChevronRight, Play, Plus, Pencil } from "lucide-react";
+import { Zap, Clock, Globe, ChevronDown, ChevronRight, Plus, Pencil } from "lucide-react";
 import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 
@@ -196,12 +196,6 @@ export function TriggersPage() {
     refetchInterval: 30000,
   });
 
-  const fireMutation = useMutation({
-    mutationFn: (id: string) => api.fireTrigger(id),
-    onSuccess: () => toast.success("Trigger fired"),
-    onError: (err) => toast.error(errorMessage(err)),
-  });
-
   const createMutation = useMutation({
     mutationFn: (body: TriggerCreateRequest) => api.createTrigger(body),
     onSuccess: () => {
@@ -375,27 +369,15 @@ export function TriggersPage() {
                       <RelativeTime date={trigger.updated_at} />
                     </span>
                     {isHttp && (
-                      <>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => openEditDialog(trigger)}
-                          disabled={editorPending}
-                        >
-                          <Pencil className="h-3.5 w-3.5 mr-1.5" />
-                          Edit
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => fireMutation.mutate(trigger.id)}
-                          disabled={fireMutation.isPending}
-                          title="Fire this HTTP trigger"
-                        >
-                          <Play className="h-3.5 w-3.5 mr-1.5" />
-                          Fire
-                        </Button>
-                      </>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => openEditDialog(trigger)}
+                        disabled={editorPending}
+                      >
+                        <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                        Edit
+                      </Button>
                     )}
                   </div>
                 </div>
@@ -439,7 +421,8 @@ export function TriggersPage() {
                     {isHttp && (
                       <div className="rounded-md border border-yellow-500/30 bg-yellow-500/5 px-3 py-2 text-xs text-muted-foreground">
                         <Zap className="h-3 w-3 inline mr-1.5 text-yellow-500" />
-                        Manual fire hits this trigger directly and can bypass webhook auth checks. External systems should post to the webhook route above.
+                        Manual fire is now an operator-only API action via <code className="mx-1 rounded bg-muted px-1 py-0.5">POST /v1/triggers/:id/fire</code>.
+                        External systems should post to the webhook route above.
                       </div>
                     )}
                   </div>

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -376,8 +376,8 @@ export const api = {
       body: JSON.stringify(body),
     }),
   fireTrigger: (id: string, body?: TriggerRunRequest) =>
-    request<void>(`/triggers/${id}`, {
-      method: "PUT",
+    request<void>(`/triggers/${id}/fire`, {
+      method: "POST",
       body: body ? JSON.stringify(body) : undefined,
     }),
   getAtoms: () => request<Atom[]>("/atoms"),

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -236,6 +236,17 @@ export interface TriggerRunRequest {
   params?: Record<string, string>;
 }
 
+export interface TriggerCreateRequest {
+  alias: string;
+  type: string;
+  configuration: Record<string, unknown>;
+}
+
+export interface TriggerUpdateRequest {
+  alias?: string;
+  configuration?: Record<string, unknown>;
+}
+
 export interface DatabaseSchemaColumn {
   name: string;
   data_type: string;
@@ -354,7 +365,21 @@ export const api = {
   unpauseJob: (jobId: string) => request<Job>(`/jobs/${jobId}/unpause`, { method: "PUT" }),
   getTriggers: () => request<Trigger[]>("/triggers"),
   getTrigger: (id: string) => request<Trigger>(`/triggers/${id}`),
-  fireTrigger: (id: string) => request<void>(`/triggers/${id}`, { method: "PUT" }),
+  createTrigger: (body: TriggerCreateRequest) =>
+    request<Trigger>("/triggers", {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+  updateTrigger: (id: string, body: TriggerUpdateRequest) =>
+    request<Trigger>(`/triggers/${id}`, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
+  fireTrigger: (id: string, body?: TriggerRunRequest) =>
+    request<void>(`/triggers/${id}`, {
+      method: "PUT",
+      body: body ? JSON.stringify(body) : undefined,
+    }),
   getAtoms: () => request<Atom[]>("/atoms"),
   getAtom: (id: string) => request<Atom>(`/atoms/${id}`),
   deleteAtom: (id: string) => request<void>(`/atoms/${id}`, { method: "DELETE" }),


### PR DESCRIPTION
## Summary

This finishes the HTTP webhook trigger follow-up slice on top of the initial webhook delivery work.

It adds real HTTP trigger authoring and editing support, indexed webhook-path lookup, and stronger webhook coverage across auth and param extraction paths.

## What Changed

- add `POST /v1/triggers` and `PATCH /v1/triggers/:id` for trigger creation and editing
- add normalized HTTP trigger path persistence on the trigger model and query webhook routing by indexed normalized path instead of scanning all HTTP triggers
- keep importer and DB migration paths in sync so existing HTTP triggers backfill the derived normalized path
- expand HTTP trigger runtime behavior and tests around auth schemes, secret resolution, param mapping, and default param merging
- add a trigger editor UI for HTTP triggers, including route, auth, param mapping, and default param fields
- align docs and examples with the required HTTP trigger `path` contract and webhook route semantics
- add integration coverage for authenticated webhook delivery with extracted/default params persisted on runs

## Why

The first webhook slice made HTTP triggers functional, but the follow-up gaps were still real:

- no way to author or edit webhook trigger config from the product surface
- webhook lookup still required scanning trigger configs in memory
- coverage for signed/authenticated webhook variants and param persistence was still thin

This closes those gaps without taking on the larger event-trigger roadmap.

## Validation

- `just unit-test`
- `just integration-test`

## Impact

Operators can now create and edit HTTP webhook triggers directly, webhooks resolve more efficiently by normalized path, and the feature has end-to-end coverage for authenticated webhook execution and run param persistence.
