### PR TITLE
Added start of authentication and authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,12 +226,13 @@ The embedded UI exposes a few optional power-user surfaces:
 
 ## API Reference
 
-The server exposes REST on port `8080`. GraphQL is available at `GET /gql` only when `CAESIUM_AUTH_MODE=none`; when API-key auth is enabled, authentication in this release applies to the REST API and embedded UI only, and webhook delivery continues to use per-trigger webhook signature configuration rather than bearer tokens.
+The server exposes REST on port `8080`. GraphQL is available at `GET /gql` only when `CAESIUM_AUTH_MODE=none`; when API-key auth is enabled, authentication in this release applies to the REST API, `/metrics`, and embedded UI only, and webhook delivery continues to use per-trigger webhook signature configuration rather than bearer tokens. The UI determines whether login is required through the explicit `GET /auth/status` endpoint rather than probing protected resources.
 
 | Endpoint | Purpose |
 |---|---|
 | `GET /health` | Health check |
-| `GET /metrics` | Prometheus metrics |
+| `GET /auth/status` | Report whether API-key auth is enabled for the UI |
+| `GET /metrics` | Prometheus metrics (viewer auth required when `CAESIUM_AUTH_MODE=api-key`) |
 | `GET /gql` | GraphQL endpoint when `CAESIUM_AUTH_MODE=none` |
 | `GET /v1/jobs` | List jobs |
 | `GET /v1/jobs/:id` | Get one job |
@@ -255,6 +256,8 @@ The server exposes REST on port `8080`. GraphQL is available at `GET /gql` only 
 | `GET /v1/nodes/:address/workers` | Inspect worker state for one node |
 
 The log and database console endpoints are intentionally gated by environment variables because they are operator-facing debugging features rather than default public APIs.
+
+For the auth management CLI, prefer supplying credentials through `CAESIUM_API_KEY`; the `--api-key` flag remains available but is visible in process listings.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="https://hub.docker.com/r/caesiumcloud/caesium/"><img src="https://img.shields.io/docker/pulls/caesiumcloud/caesium?style=plastic" alt="Docker Pulls"></a>
 </p>
 
-Caesium lets you define jobs as declarative YAML DAGs, run them on Docker, Podman, or Kubernetes, and operate them through a REST API, GraphQL endpoint, Prometheus metrics, and an embedded React UI.
+Caesium lets you define jobs as declarative YAML DAGs, run them on Docker, Podman, or Kubernetes, and operate them through a REST API, Prometheus metrics, an embedded React UI, and an optional GraphQL endpoint when API-key auth is disabled.
 
 ## Local Developer Experience
 
@@ -226,13 +226,13 @@ The embedded UI exposes a few optional power-user surfaces:
 
 ## API Reference
 
-The server exposes REST on port `8080` plus GraphQL at `GET /gql`.
+The server exposes REST on port `8080`. GraphQL is available at `GET /gql` only when `CAESIUM_AUTH_MODE=none`; when API-key auth is enabled, authentication in this release applies to the REST API and embedded UI only, and webhook delivery continues to use per-trigger webhook signature configuration rather than bearer tokens.
 
 | Endpoint | Purpose |
 |---|---|
 | `GET /health` | Health check |
 | `GET /metrics` | Prometheus metrics |
-| `GET /gql` | GraphQL endpoint |
+| `GET /gql` | GraphQL endpoint when `CAESIUM_AUTH_MODE=none` |
 | `GET /v1/jobs` | List jobs |
 | `GET /v1/jobs/:id` | Get one job |
 | `GET /v1/jobs/:id/tasks` | List persisted task definitions for a job |

--- a/api/api.go
+++ b/api/api.go
@@ -3,19 +3,25 @@ package api
 import (
 	"context"
 	"fmt"
+	"net"
+	"strings"
 
 	"github.com/caesium-cloud/caesium/api/gql"
 	"github.com/caesium-cloud/caesium/api/rest/bind"
+	"github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/labstack/echo-contrib/v5/echoprometheus"
 	"github.com/labstack/echo/v5"
 )
 
 // Start launches Caesium's API.
-func Start(ctx context.Context, bus event.Bus) error {
+func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) error {
 	e := echo.New()
+	vars := env.Variables()
+	configureIPExtractor(e, vars)
 
 	// health
 	e.GET("/health", Health)
@@ -26,18 +32,72 @@ func Start(ctx context.Context, bus event.Bus) error {
 	e.GET("/metrics", echoprometheus.NewHandler())
 
 	// REST
-	bind.All(e.Group("/v1"), bus)
+	bind.All(e.Group("/v1"), bus, authSvc, auditor, limiter)
 
-	// GraphQL
-	e.GET("/gql", gql.Handler())
+	registerGraphQL(e, vars)
 
 	// Embedded web UI
 	RegisterUI(e)
 
 	sc := echo.StartConfig{
-		Address: fmt.Sprintf(":%v", env.Variables().Port),
+		Address: fmt.Sprintf(":%v", vars.Port),
 	}
 	return sc.Start(ctx, e)
+}
+
+func registerGraphQL(e *echo.Echo, vars env.Environment) {
+	if vars.AuthMode == "none" {
+		e.GET("/gql", gql.Handler())
+		return
+	}
+
+	log.Info("graphql endpoint disabled while authentication is enabled")
+}
+
+func configureIPExtractor(e *echo.Echo, vars env.Environment) {
+	trusted := parseTrustedProxyRanges(vars.TrustedProxies)
+	if len(trusted) == 0 {
+		e.IPExtractor = echo.ExtractIPDirect()
+		return
+	}
+
+	options := []echo.TrustOption{
+		echo.TrustLoopback(false),
+		echo.TrustLinkLocal(false),
+		echo.TrustPrivateNet(false),
+	}
+	for _, ipNet := range trusted {
+		options = append(options, echo.TrustIPRange(ipNet))
+	}
+	e.IPExtractor = echo.ExtractIPFromXFFHeader(options...)
+}
+
+func parseTrustedProxyRanges(raw string) []*net.IPNet {
+	parts := strings.Split(raw, ",")
+	ranges := make([]*net.IPNet, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		if _, ipNet, err := net.ParseCIDR(part); err == nil {
+			ranges = append(ranges, ipNet)
+			continue
+		}
+
+		if ip := net.ParseIP(part); ip != nil {
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			ranges = append(ranges, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+			continue
+		}
+
+		log.Warn("ignoring invalid trusted proxy entry", "value", part)
+	}
+	return ranges
 }
 
 func Shutdown() error {

--- a/api/api.go
+++ b/api/api.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"strings"
 
 	"github.com/caesium-cloud/caesium/api/gql"
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	"github.com/caesium-cloud/caesium/api/rest/bind"
 	"github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/caesium-cloud/caesium/internal/event"
@@ -25,11 +27,11 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 
 	// health
 	e.GET("/health", Health)
+	e.GET("/auth/status", authStatus(vars))
 
 	// metrics
-	metrics.Register()
 	e.Use(echoprometheus.NewMiddleware("caesium"))
-	e.GET("/metrics", echoprometheus.NewHandler())
+	registerMetrics(e, vars, authSvc, auditor, limiter)
 
 	// REST
 	bind.All(e.Group("/v1"), bus, authSvc, auditor, limiter)
@@ -43,6 +45,26 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 		Address: fmt.Sprintf(":%v", vars.Port),
 	}
 	return sc.Start(ctx, e)
+}
+
+func authStatus(vars env.Environment) echo.HandlerFunc {
+	return func(c *echo.Context) error {
+		return c.JSON(http.StatusOK, map[string]bool{
+			"enabled": vars.AuthMode == "api-key",
+		})
+	}
+}
+
+func registerMetrics(e *echo.Echo, vars env.Environment, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) {
+	metrics.Register()
+
+	handler := echoprometheus.NewHandler()
+	if vars.AuthMode == "api-key" && authSvc != nil {
+		e.GET("/metrics", handler, authmw.Auth(authSvc, auditor, limiter))
+		return
+	}
+
+	e.GET("/metrics", handler)
 }
 
 func registerGraphQL(e *echo.Echo, vars env.Environment) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,7 +24,7 @@ func TestRegisterGraphQLSkippedWhenAuthEnabled(t *testing.T) {
 }
 
 func hasRoute(e *echo.Echo, method, path string) bool {
-	for _, route := range e.Routes() {
+	for _, route := range e.Router().Routes() {
 		if route.Method == method && route.Path == path {
 			return true
 		}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,9 +1,15 @@
 package api
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/require"
@@ -21,6 +27,81 @@ func TestRegisterGraphQLSkippedWhenAuthEnabled(t *testing.T) {
 	registerGraphQL(e, env.Environment{AuthMode: "api-key"})
 
 	require.False(t, hasRoute(e, http.MethodGet, "/gql"))
+}
+
+func TestAuthStatusReflectsAuthMode(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		rec := performRequest(t, authStatus(env.Environment{AuthMode: "api-key"}), http.MethodGet, "/auth/status")
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var body map[string]bool
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		require.True(t, body["enabled"])
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		rec := performRequest(t, authStatus(env.Environment{AuthMode: "none"}), http.MethodGet, "/auth/status")
+
+		require.Equal(t, http.StatusOK, rec.Code)
+		var body map[string]bool
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+		require.False(t, body["enabled"])
+	})
+}
+
+func TestRegisterMetricsPublicWhenAuthDisabled(t *testing.T) {
+	e := echo.New()
+	registerMetrics(e, env.Environment{AuthMode: "none"}, nil, nil, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "caesium_")
+}
+
+func TestRegisterMetricsProtectedWhenAuthEnabled(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := iauth.NewService(db)
+	auditor := iauth.NewAuditLogger(db)
+	limiter := iauth.NewRateLimiter(5, time.Minute)
+
+	resp, err := svc.CreateKey(&iauth.CreateKeyRequest{
+		Role:      models.RoleViewer,
+		CreatedBy: "seed",
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	registerMetrics(e, env.Environment{AuthMode: "api-key"}, svc, auditor, limiter)
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	req.Header.Set("Authorization", "Bearer "+resp.Plaintext)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "caesium_")
+}
+
+func performRequest(t *testing.T, handler echo.HandlerFunc, method, path string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	e := echo.New()
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err := handler(c)
+	require.NoError(t, err)
+	return rec
 }
 
 func hasRoute(e *echo.Echo, method, path string) bool {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterGraphQLWhenAuthDisabled(t *testing.T) {
+	e := echo.New()
+	registerGraphQL(e, env.Environment{AuthMode: "none"})
+
+	require.True(t, hasRoute(e, http.MethodGet, "/gql"))
+}
+
+func TestRegisterGraphQLSkippedWhenAuthEnabled(t *testing.T) {
+	e := echo.New()
+	registerGraphQL(e, env.Environment{AuthMode: "api-key"})
+
+	require.False(t, hasRoute(e, http.MethodGet, "/gql"))
+}
+
+func hasRoute(e *echo.Echo, method, path string) bool {
+	for _, route := range e.Routes() {
+		if route.Method == method && route.Path == path {
+			return true
+		}
+	}
+	return false
+}

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -1,0 +1,293 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/labstack/echo/v5"
+)
+
+// ContextKeyAuth is the key used to store the authenticated API key in the Echo context.
+const ContextKeyAuth = "auth"
+
+// uuidPattern matches UUID path segments for route normalisation.
+var uuidPattern = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+var namedParamPattern = regexp.MustCompile(`:[^/]+`)
+
+// skipPaths lists exact paths that never require authentication.
+var skipPaths = map[string]bool{
+	"/health": true,
+}
+
+// Auth returns Echo middleware that enforces API key authentication and RBAC.
+func Auth(svc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c *echo.Context) error {
+			path := c.Request().URL.Path
+
+			// Skip auth for explicitly public paths.
+			if skipPaths[path] {
+				return next(c)
+			}
+
+			ip := c.RealIP()
+
+			// Rate limit check before doing any work.
+			if limiter.IsLimited(ip) {
+				metrics.AuthFailuresTotal.WithLabelValues("rate_limited").Inc()
+				retryAfter := limiter.RetryAfter(ip)
+				c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+				return echo.NewHTTPError(http.StatusTooManyRequests, "too many failed authentication attempts")
+			}
+
+			// Extract bearer token.
+			token := extractBearerToken(c)
+			if token == "" {
+				metrics.AuthFailuresTotal.WithLabelValues("missing").Inc()
+				return echo.NewHTTPError(http.StatusUnauthorized, "missing authorization header")
+			}
+
+			// Validate the API key.
+			key, err := svc.ValidateKey(token)
+			if err != nil {
+				reason := classifyAuthError(err)
+				metrics.AuthFailuresTotal.WithLabelValues(reason).Inc()
+
+				limited := limiter.RecordFailure(ip)
+				logAuditFailure(auditor.Log(auth.AuditEntry{
+					Actor:    tokenPrefix(token),
+					Action:   auth.ActionAuthDenied,
+					SourceIP: ip,
+					Outcome:  auth.OutcomeDenied,
+					Metadata: map[string]interface{}{
+						"reason": reason,
+						"method": c.Request().Method,
+						"path":   path,
+					},
+				}))
+
+				if limited {
+					retryAfter := limiter.RetryAfter(ip)
+					c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+					return echo.NewHTTPError(http.StatusTooManyRequests, "too many failed authentication attempts")
+				}
+
+				return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired api key")
+			}
+
+			// Determine the required role for this endpoint.
+			routePath := normalisePath(c)
+			required, ok := auth.RequiredRole(c.Request().Method, routePath)
+			if !ok {
+				return denyAccess(c, auditor, key.KeyPrefix, key.Role, routePath, "unknown_route", "")
+			}
+
+			if !auth.HasRole(key.Role, required) {
+				return denyAccess(c, auditor, key.KeyPrefix, key.Role, routePath, "insufficient_role", required)
+			}
+
+			// Store authenticated identity in context for downstream handlers.
+			scopeContext, err := authorizeScope(c, svc, key, routePath)
+			if err != nil {
+				if he, ok := err.(*echo.HTTPError); ok && he.Code == http.StatusForbidden {
+					return denyAccess(c, auditor, key.KeyPrefix, key.Role, routePath, "insufficient_scope", required)
+				}
+				return err
+			}
+
+			c.Set(ContextKeyAuth, key)
+			metrics.AuthKeyAgeSeconds.Observe(time.Since(key.CreatedAt).Seconds())
+
+			if err := next(c); err != nil {
+				return err
+			}
+
+			metrics.AuthRequestsTotal.WithLabelValues("success", string(key.Role), c.Request().Method, routePath).Inc()
+			logSuccessfulAction(auditor, c, key, routePath, scopeContext)
+			return nil
+		}
+	}
+}
+
+// extractBearerToken extracts the token from the Authorization header.
+func extractBearerToken(c *echo.Context) string {
+	header := c.Request().Header.Get("Authorization")
+	if header == "" {
+		return ""
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
+		return ""
+	}
+	return strings.TrimSpace(parts[1])
+}
+
+// normalisePath returns the Echo route pattern (with :param placeholders)
+// so RBAC policy lookup works for parametric routes. Falls back to replacing
+// UUID segments in the raw path.
+func normalisePath(c *echo.Context) string {
+	ri := c.RouteInfo()
+	path := ri.Path
+	if path == "" {
+		path = uuidPattern.ReplaceAllString(c.Request().URL.Path, ":id")
+	}
+	return namedParamPattern.ReplaceAllString(path, ":id")
+}
+
+// tokenPrefix returns a safe display prefix for logging, never the full key.
+func tokenPrefix(token string) string {
+	if len(token) > 13 {
+		return token[:13]
+	}
+	return token
+}
+
+// classifyAuthError maps validation errors to metric label values.
+func classifyAuthError(err error) string {
+	switch err {
+	case auth.ErrKeyNotFound:
+		return "invalid"
+	case auth.ErrKeyExpired:
+		return "expired"
+	case auth.ErrKeyRevoked:
+		return "revoked"
+	default:
+		log.Error("unexpected auth validation error", "error", err)
+		return "error"
+	}
+}
+
+func denyAccess(
+	c *echo.Context,
+	auditor *auth.AuditLogger,
+	actor string,
+	keyRole models.Role,
+	routePath string,
+	reason string,
+	required models.Role,
+) error {
+	metrics.AuthRequestsTotal.WithLabelValues("denied", string(keyRole), c.Request().Method, routePath).Inc()
+
+	metadata := map[string]interface{}{
+		"reason":     reason,
+		"method":     c.Request().Method,
+		"path":       routePath,
+		"key_role":   string(keyRole),
+		"policy_key": c.Request().Method + " " + routePath,
+	}
+	if required != "" {
+		metadata["required_role"] = string(required)
+	}
+
+	logAuditFailure(auditor.Log(auth.AuditEntry{
+		Actor:    actor,
+		Action:   auth.ActionAuthDenied,
+		SourceIP: c.RealIP(),
+		Outcome:  auth.OutcomeDenied,
+		Metadata: metadata,
+	}))
+	return echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+}
+
+func logSuccessfulAction(
+	auditor *auth.AuditLogger,
+	c *echo.Context,
+	key *models.APIKey,
+	routePath string,
+	scopeContext *scopeAuditContext,
+) {
+	action := auditActionForRoute(c.Request().Method, routePath)
+	if action == "" {
+		return
+	}
+
+	if resp, err := echo.UnwrapResponse(c.Response()); err == nil && resp.Status >= http.StatusBadRequest {
+		return
+	}
+
+	entry := auth.AuditEntry{
+		Actor:    key.KeyPrefix,
+		Action:   action,
+		SourceIP: c.RealIP(),
+		Outcome:  auth.OutcomeSuccess,
+		Metadata: map[string]interface{}{
+			"method": c.Request().Method,
+			"path":   routePath,
+		},
+	}
+
+	if scopeContext != nil && len(scopeContext.jobAliases) > 0 {
+		entry.ResourceType = "job"
+		entry.ResourceID = scopeContext.jobAliases[0]
+		entry.Metadata["job_aliases"] = append([]string(nil), scopeContext.jobAliases...)
+	}
+
+	switch action {
+	case auth.ActionJobdefApply:
+		entry.ResourceType = "job_definition"
+	case auth.ActionCachePrune:
+		entry.ResourceType = "cache"
+	case auth.ActionCacheDelete:
+		entry.ResourceType = "cache"
+	}
+
+	logAuditFailure(auditor.Log(entry))
+}
+
+func auditActionForRoute(method, routePath string) string {
+	switch method + " " + routePath {
+	case "POST /v1/jobs":
+		return auth.ActionJobCreate
+	case "DELETE /v1/jobs/:id":
+		return auth.ActionJobDelete
+	case "PUT /v1/jobs/:id/pause":
+		return auth.ActionJobPause
+	case "PUT /v1/jobs/:id/unpause":
+		return auth.ActionJobUnpause
+	case "POST /v1/jobs/:id/run":
+		return auth.ActionRunTrigger
+	case "POST /v1/jobs/:id/runs/:id/retry":
+		return auth.ActionRunRetry
+	case "POST /v1/jobs/:id/backfill":
+		return auth.ActionBackfill
+	case "PUT /v1/jobs/:id/backfills/:id/cancel":
+		return auth.ActionBackfill
+	case "POST /v1/jobdefs/apply":
+		return auth.ActionJobdefApply
+	case "POST /v1/cache/prune":
+		return auth.ActionCachePrune
+	case "DELETE /v1/jobs/:id/cache":
+		return auth.ActionCacheDelete
+	case "DELETE /v1/jobs/:id/cache/:id":
+		return auth.ActionCacheDelete
+	default:
+		return ""
+	}
+}
+
+func logAuditFailure(err error) {
+	if err != nil {
+		log.Warn("failed to write audit log", "error", err)
+	}
+}
+
+// GetAuthKey extracts the authenticated API key from the Echo context.
+// Returns nil if no key is present (e.g. unauthenticated endpoints).
+func GetAuthKey(c *echo.Context) *models.APIKey {
+	v := c.Get(ContextKeyAuth)
+	if v == nil {
+		return nil
+	}
+	key, ok := v.(*models.APIKey)
+	if !ok {
+		return nil
+	}
+	return key
+}

--- a/api/middleware/auth_scope.go
+++ b/api/middleware/auth_scope.go
@@ -1,0 +1,194 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+// ContextKeyAllowedJobAliases stores the scoped job aliases available to list endpoints.
+const ContextKeyAllowedJobAliases = "auth.allowed_job_aliases"
+
+type scopeAuditContext struct {
+	jobAliases []string
+}
+
+// GetAllowedJobAliases returns the scoped aliases injected by the auth middleware.
+func GetAllowedJobAliases(c *echo.Context) []string {
+	v := c.Get(ContextKeyAllowedJobAliases)
+	if v == nil {
+		return nil
+	}
+	aliases, ok := v.([]string)
+	if !ok {
+		return nil
+	}
+	return append([]string(nil), aliases...)
+}
+
+func authorizeScope(c *echo.Context, svc *auth.Service, key *models.APIKey, routePath string) (*scopeAuditContext, error) {
+	scopeJobs, err := auth.ScopeJobs(key.Scope)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+	}
+	if len(scopeJobs) == 0 {
+		return &scopeAuditContext{}, nil
+	}
+
+	state := &scopeAuditContext{}
+
+	switch routePath {
+	case "/v1/jobs":
+		switch c.Request().Method {
+		case http.MethodGet:
+			c.Set(ContextKeyAllowedJobAliases, append([]string(nil), scopeJobs...))
+			return state, nil
+		case http.MethodPost:
+			aliases, err := parseJobAliasesForScope(c)
+			if err != nil {
+				return nil, echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+			}
+			if len(aliases) != 1 || !auth.CheckScope(key.Scope, aliases[0]) {
+				return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+			}
+			state.jobAliases = aliases
+			return state, nil
+		}
+	case "/v1/jobdefs/apply":
+		aliases, prune, err := parseApplyAliasesForScope(c)
+		if err != nil {
+			return nil, echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+		}
+		if prune {
+			return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+		}
+		for _, alias := range aliases {
+			if !auth.CheckScope(key.Scope, alias) {
+				return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+			}
+		}
+		state.jobAliases = aliases
+		return state, nil
+	}
+
+	if strings.HasPrefix(routePath, "/v1/jobs/:id") {
+		jobAlias, err := resolveScopedJobAlias(c, svc, routePath)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, echo.ErrNotFound
+			}
+			return nil, echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+		}
+		if !auth.CheckScope(key.Scope, jobAlias) {
+			return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+		}
+		state.jobAliases = []string{jobAlias}
+		return state, nil
+	}
+
+	return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+}
+
+func resolveScopedJobAlias(c *echo.Context, svc *auth.Service, routePath string) (string, error) {
+	ctx := c.Request().Context()
+
+	switch {
+	case strings.Contains(routePath, "/runs/:id/"):
+		runID, err := uuid.Parse(c.Param("run_id"))
+		if err != nil {
+			return "", err
+		}
+		return svc.JobAliasByRunID(ctx, runID)
+	case strings.Contains(routePath, "/runs/:id"):
+		runID, err := uuid.Parse(c.Param("run_id"))
+		if err != nil {
+			return "", err
+		}
+		return svc.JobAliasByRunID(ctx, runID)
+	case strings.Contains(routePath, "/backfills/:id"):
+		backfillID, err := uuid.Parse(c.Param("backfill_id"))
+		if err != nil {
+			return "", err
+		}
+		return svc.JobAliasByBackfillID(ctx, backfillID)
+	default:
+		jobID, err := uuid.Parse(c.Param("id"))
+		if err != nil {
+			return "", err
+		}
+		return svc.JobAliasByID(ctx, jobID)
+	}
+}
+
+func parseJobAliasesForScope(c *echo.Context) ([]string, error) {
+	var payload struct {
+		Alias string `json:"alias"`
+	}
+	if err := decodeScopedBody(c, &payload); err != nil {
+		return nil, err
+	}
+	alias := strings.TrimSpace(payload.Alias)
+	if alias == "" {
+		return nil, errors.New("alias is required")
+	}
+	return []string{alias}, nil
+}
+
+func parseApplyAliasesForScope(c *echo.Context) ([]string, bool, error) {
+	var payload struct {
+		Definitions []struct {
+			Metadata struct {
+				Alias string `json:"alias"`
+			} `json:"metadata"`
+		} `json:"definitions"`
+		Prune bool `json:"prune"`
+	}
+	if err := decodeScopedBody(c, &payload); err != nil {
+		return nil, false, err
+	}
+
+	aliases := make([]string, 0, len(payload.Definitions))
+	for _, def := range payload.Definitions {
+		alias := strings.TrimSpace(def.Metadata.Alias)
+		if alias == "" {
+			return nil, false, errors.New("definition metadata.alias is required")
+		}
+		aliases = append(aliases, alias)
+	}
+	return aliases, payload.Prune, nil
+}
+
+func decodeScopedBody(c *echo.Context, target interface{}) error {
+	bodyBytes, err := readAndRestoreBody(c)
+	if err != nil {
+		return err
+	}
+	if len(bodyBytes) == 0 {
+		return io.EOF
+	}
+	return json.Unmarshal(bodyBytes, target)
+}
+
+func readAndRestoreBody(c *echo.Context) ([]byte, error) {
+	req := c.Request()
+	if req.Body == nil {
+		return nil, nil
+	}
+
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+	req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+	c.SetRequest(req)
+	return bodyBytes, nil
+}

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -1,0 +1,500 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupAuth(t *testing.T) (*gorm.DB, *auth.Service, *auth.AuditLogger, *auth.RateLimiter, string) {
+	t.Helper()
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+	key := createKey(t, svc, models.RoleAdmin, nil)
+
+	return db, svc, auditor, limiter, key
+}
+
+func createKey(t *testing.T, svc *auth.Service, role models.Role, scope *models.KeyScope) string {
+	t.Helper()
+
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      role,
+		Scope:     scope,
+		CreatedBy: "test",
+	})
+	require.NoError(t, err)
+
+	return resp.Plaintext
+}
+
+func seedJobFixtures(t *testing.T, db *gorm.DB, alias string) (uuid.UUID, uuid.UUID, uuid.UUID) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	triggerID := uuid.New()
+	jobID := uuid.New()
+	runID := uuid.New()
+	backfillID := uuid.New()
+
+	require.NoError(t, db.Create(&models.Trigger{
+		ID:            triggerID,
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"cron":"0 * * * *"}`,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}).Error)
+
+	require.NoError(t, db.Create(&models.Job{
+		ID:        jobID,
+		Alias:     alias,
+		TriggerID: triggerID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+
+	require.NoError(t, db.Create(&models.Backfill{
+		ID:            backfillID,
+		JobID:         jobID,
+		Status:        string(models.BackfillStatusRunning),
+		Start:         now,
+		End:           now.Add(time.Hour),
+		MaxConcurrent: 1,
+		Reprocess:     string(models.ReprocessNone),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}).Error)
+
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:          runID,
+		JobID:       jobID,
+		BackfillID:  &backfillID,
+		TriggerID:   triggerID,
+		TriggerType: string(models.TriggerTypeCron),
+		Status:      "running",
+		StartedAt:   now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}).Error)
+
+	return jobID, runID, backfillID
+}
+
+func callMiddleware(
+	t *testing.T,
+	svc *auth.Service,
+	auditor *auth.AuditLogger,
+	limiter *auth.RateLimiter,
+	req *http.Request,
+	route *echo.RouteInfo,
+	pathValues echo.PathValues,
+	next echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
+	t.Helper()
+
+	if next == nil {
+		next = func(c *echo.Context) error {
+			return c.String(http.StatusOK, "ok")
+		}
+	}
+
+	e := echo.New()
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if route != nil {
+		pv := append(echo.PathValues(nil), pathValues...)
+		c.InitializeRoute(route, &pv)
+	}
+
+	handler := authmw.Auth(svc, auditor, limiter)(next)
+	err := handler(c)
+	return rec, err
+}
+
+func TestMiddlewareSkipsHealthEndpoint(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	rec, err := callMiddleware(t, svc, auditor, limiter, req, nil, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareRejectsMissingAuth(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestMiddlewareRejectsInvalidToken(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer csk_live_invalid123")
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestMiddlewareAcceptsValidToken(t *testing.T) {
+	_, svc, auditor, limiter, key := setupAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareStoresAuthInContext(t *testing.T) {
+	_, svc, auditor, limiter, key := setupAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	var capturedKey *models.APIKey
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet},
+		nil,
+		func(c *echo.Context) error {
+			capturedKey = authmw.GetAuthKey(c)
+			return c.String(http.StatusOK, "ok")
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, capturedKey)
+	require.Equal(t, models.RoleAdmin, capturedKey.Role)
+}
+
+func TestMiddlewareRejectsExpiredKey(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+
+	past := time.Now().UTC().Add(-time.Hour)
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleAdmin,
+		CreatedBy: "test",
+		ExpiresAt: &past,
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+resp.Plaintext)
+	_, err = callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestMiddlewareRejectsRevokedKey(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleAdmin,
+		CreatedBy: "test",
+	})
+	require.NoError(t, err)
+	require.NoError(t, svc.RevokeKey(resp.Key.ID))
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+resp.Plaintext)
+	_, err = callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestMiddlewareRejectsBadAuthorizationFormat(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestMiddlewareRateLimiting(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(2, time.Minute)
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+		req.Header.Set("Authorization", "Bearer csk_live_badkey")
+		_, _ = callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer csk_live_badkey")
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusTooManyRequests, he.Code)
+}
+
+func TestMiddlewareRBACViewerCannotWrite(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+	key := createKey(t, svc, models.RoleViewer, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	req = httptest.NewRequest(http.MethodPost, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err = callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodPost}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestMiddlewareNormalisesNamedRouteParams(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleViewer, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/job-1/runs/run-2", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs/:id/runs/:run_id", Method: http.MethodGet},
+		echo.PathValues{
+			{Name: "id", Value: "job-1"},
+			{Name: "run_id", Value: "run-2"},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareRejectsUnknownProtectedRoute(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleAdmin, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/unknown", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/unknown", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestMiddlewareScopedListInjectsAliases(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleViewer, &models.KeyScope{Jobs: []string{"alpha", "beta"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	var aliases []string
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet},
+		nil,
+		func(c *echo.Context) error {
+			aliases = authmw.GetAllowedJobAliases(c)
+			return c.String(http.StatusOK, "ok")
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{"alpha", "beta"}, aliases)
+}
+
+func TestMiddlewareScopedJobRouteAllowsInScopeAlias(t *testing.T) {
+	db, svc, auditor, limiter, _ := setupAuth(t)
+	jobID, _, _ := seedJobFixtures(t, db, "alpha")
+	key := createKey(t, svc, models.RoleViewer, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/"+jobID.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs/:id", Method: http.MethodGet},
+		echo.PathValues{{Name: "id", Value: jobID.String()}},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareScopedJobRouteRejectsOutOfScopeAlias(t *testing.T) {
+	db, svc, auditor, limiter, _ := setupAuth(t)
+	jobID, _, _ := seedJobFixtures(t, db, "alpha")
+	key := createKey(t, svc, models.RoleViewer, &models.KeyScope{Jobs: []string{"beta"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/"+jobID.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs/:id", Method: http.MethodGet},
+		echo.PathValues{{Name: "id", Value: jobID.String()}},
+		nil,
+	)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestMiddlewareScopedRunRouteAllowsInScopeAlias(t *testing.T) {
+	db, svc, auditor, limiter, _ := setupAuth(t)
+	jobID, runID, _ := seedJobFixtures(t, db, "alpha")
+	key := createKey(t, svc, models.RoleViewer, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs/"+jobID.String()+"/runs/"+runID.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs/:id/runs/:run_id", Method: http.MethodGet},
+		echo.PathValues{
+			{Name: "id", Value: jobID.String()},
+			{Name: "run_id", Value: runID.String()},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareScopedCreateRejectsOutOfScopeAlias(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleOperator, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs", strings.NewReader(`{"alias":"beta"}`))
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodPost}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestMiddlewareScopedJobdefApplyRejectsPrune(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleOperator, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/jobdefs/apply",
+		strings.NewReader(`{"definitions":[{"metadata":{"alias":"alpha"}}],"prune":true}`),
+	)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/jobdefs/apply", Method: http.MethodPost}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestMiddlewareScopedGlobalRouteRejected(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleViewer, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/stats", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(t, svc, auditor, limiter, req, &echo.RouteInfo{Path: "/v1/stats", Method: http.MethodGet}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestGetAuthKeyReturnsNilWhenNotSet(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	key := authmw.GetAuthKey(c)
+	require.Nil(t, key)
+}

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -1,7 +1,9 @@
 package bind
 
 import (
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	"github.com/caesium-cloud/caesium/api/rest/controller/atom"
+	authctrl "github.com/caesium-cloud/caesium/api/rest/controller/auth"
 	"github.com/caesium-cloud/caesium/api/rest/controller/backfill"
 	"github.com/caesium-cloud/caesium/api/rest/controller/database"
 	"github.com/caesium-cloud/caesium/api/rest/controller/event"
@@ -14,16 +16,32 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/stats"
 	"github.com/caesium-cloud/caesium/api/rest/controller/trigger"
 	"github.com/caesium-cloud/caesium/api/rest/controller/webhook"
+	"github.com/caesium-cloud/caesium/internal/auth"
 	internal_event "github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/labstack/echo/v5"
 )
 
-func All(g *echo.Group, bus internal_event.Bus) {
-	Public(g, bus)
+var webhookHandler = webhook.Receive
+
+// All binds all routes to the given group, optionally with auth middleware.
+func All(g *echo.Group, bus internal_event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) {
+	bindWebhooks(g)
+
+	protected := g.Group("")
+	if env.Variables().AuthMode == "api-key" {
+		protected.Use(authmw.Auth(authSvc, auditor, limiter))
+		if authSvc != nil {
+			authctrl.Dependencies.Service = authSvc
+			authctrl.Dependencies.Auditor = auditor
+			bindAuth(protected)
+		}
+	}
+
+	Protected(protected, bus)
 }
 
-func Public(g *echo.Group, bus internal_event.Bus) {
+func Protected(g *echo.Group, bus internal_event.Bus) {
 	// events
 	{
 		ctrl := event.New(bus)
@@ -86,11 +104,6 @@ func Public(g *echo.Group, bus internal_event.Bus) {
 		g.POST("/triggers/:id/fire", trigger.Fire)
 	}
 
-	// webhooks
-	{
-		g.POST("/hooks/*", webhook.Receive)
-	}
-
 	// stats
 	{
 		g.GET("/stats", stats.Get)
@@ -113,4 +126,16 @@ func Public(g *echo.Group, bus internal_event.Bus) {
 	{
 		g.GET("/nodes/:address/workers", node.Workers)
 	}
+}
+
+func bindWebhooks(g *echo.Group) {
+	g.POST("/hooks/*", webhookHandler)
+}
+
+func bindAuth(g *echo.Group) {
+	g.GET("/auth/keys", authctrl.ListKeys)
+	g.POST("/auth/keys", authctrl.CreateKey)
+	g.POST("/auth/keys/:id/revoke", authctrl.RevokeKey)
+	g.POST("/auth/keys/:id/rotate", authctrl.RotateKey)
+	g.GET("/auth/audit", authctrl.QueryAudit)
 }

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -32,9 +32,7 @@ func All(g *echo.Group, bus internal_event.Bus, authSvc *auth.Service, auditor *
 	if env.Variables().AuthMode == "api-key" {
 		protected.Use(authmw.Auth(authSvc, auditor, limiter))
 		if authSvc != nil {
-			authctrl.Dependencies.Service = authSvc
-			authctrl.Dependencies.Auditor = auditor
-			bindAuth(protected)
+			bindAuth(protected, authctrl.New(authSvc, auditor))
 		}
 	}
 
@@ -132,10 +130,10 @@ func bindWebhooks(g *echo.Group) {
 	g.POST("/hooks/*", webhookHandler)
 }
 
-func bindAuth(g *echo.Group) {
-	g.GET("/auth/keys", authctrl.ListKeys)
-	g.POST("/auth/keys", authctrl.CreateKey)
-	g.POST("/auth/keys/:id/revoke", authctrl.RevokeKey)
-	g.POST("/auth/keys/:id/rotate", authctrl.RotateKey)
-	g.GET("/auth/audit", authctrl.QueryAudit)
+func bindAuth(g *echo.Group, controller *authctrl.Controller) {
+	g.GET("/auth/keys", controller.ListKeys)
+	g.POST("/auth/keys", controller.CreateKey)
+	g.POST("/auth/keys/:id/revoke", controller.RevokeKey)
+	g.POST("/auth/keys/:id/rotate", controller.RotateKey)
+	g.GET("/auth/audit", controller.QueryAudit)
 }

--- a/api/rest/bind/bind_test.go
+++ b/api/rest/bind/bind_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestAllProtectsRESTButLeavesWebhooksPublic(t *testing.T) {
 	t.Setenv("CAESIUM_AUTH_MODE", "api-key")
+	t.Setenv("CAESIUM_DATABASE_PATH", t.TempDir())
 	require.NoError(t, env.Process())
 
 	db := testutil.OpenTestDB(t)

--- a/api/rest/bind/bind_test.go
+++ b/api/rest/bind/bind_test.go
@@ -1,0 +1,52 @@
+package bind
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllProtectsRESTButLeavesWebhooksPublic(t *testing.T) {
+	t.Setenv("CAESIUM_AUTH_MODE", "api-key")
+	require.NoError(t, env.Process())
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+
+	originalWebhookHandler := webhookHandler
+	t.Cleanup(func() {
+		webhookHandler = originalWebhookHandler
+	})
+
+	webhookCalls := 0
+	webhookHandler = func(c *echo.Context) error {
+		webhookCalls++
+		return c.String(http.StatusAccepted, "webhook")
+	}
+
+	e := echo.New()
+	All(e.Group("/v1"), nil, svc, auditor, limiter)
+
+	protectedReq := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	protectedRec := httptest.NewRecorder()
+	e.ServeHTTP(protectedRec, protectedReq)
+	require.Equal(t, http.StatusUnauthorized, protectedRec.Code)
+
+	webhookReq := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{}`))
+	webhookRec := httptest.NewRecorder()
+	e.ServeHTTP(webhookRec, webhookReq)
+	require.Equal(t, http.StatusAccepted, webhookRec.Code)
+	require.Equal(t, 1, webhookCalls)
+}

--- a/api/rest/controller/auth/audit_query.go
+++ b/api/rest/controller/auth/audit_query.go
@@ -1,0 +1,63 @@
+package auth
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/labstack/echo/v5"
+)
+
+func QueryAudit(c *echo.Context) error {
+	req := &auth.AuditQueryRequest{
+		Actor:  c.QueryParam("actor"),
+		Action: c.QueryParam("action"),
+	}
+
+	if since := c.QueryParam("since"); since != "" {
+		dur, err := parseDuration(since)
+		if err != nil {
+			// Try parsing as RFC3339.
+			t, err2 := time.Parse(time.RFC3339, since)
+			if err2 != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, "invalid since parameter").Wrap(err)
+			}
+			req.Since = &t
+		} else {
+			t := time.Now().UTC().Add(-dur)
+			req.Since = &t
+		}
+	}
+
+	if until := c.QueryParam("until"); until != "" {
+		t, err := time.Parse(time.RFC3339, until)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid until parameter").Wrap(err)
+		}
+		req.Until = &t
+	}
+
+	if limitStr := c.QueryParam("limit"); limitStr != "" {
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid limit").Wrap(err)
+		}
+		req.Limit = limit
+	}
+
+	if offsetStr := c.QueryParam("offset"); offsetStr != "" {
+		offset, err := strconv.Atoi(offsetStr)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid offset").Wrap(err)
+		}
+		req.Offset = offset
+	}
+
+	entries, err := Dependencies.Auditor.Query(req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to query audit log").Wrap(err)
+	}
+
+	return c.JSON(http.StatusOK, entries)
+}

--- a/api/rest/controller/auth/audit_query.go
+++ b/api/rest/controller/auth/audit_query.go
@@ -5,12 +5,12 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/caesium-cloud/caesium/internal/auth"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/labstack/echo/v5"
 )
 
-func QueryAudit(c *echo.Context) error {
-	req := &auth.AuditQueryRequest{
+func (ctrl *Controller) QueryAudit(c *echo.Context) error {
+	req := &iauth.AuditQueryRequest{
 		Actor:  c.QueryParam("actor"),
 		Action: c.QueryParam("action"),
 	}
@@ -54,7 +54,7 @@ func QueryAudit(c *echo.Context) error {
 		req.Offset = offset
 	}
 
-	entries, err := Dependencies.Auditor.Query(req)
+	entries, err := ctrl.auditor.Query(req)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to query audit log").Wrap(err)
 	}

--- a/api/rest/controller/auth/auth.go
+++ b/api/rest/controller/auth/auth.go
@@ -1,0 +1,19 @@
+package auth
+
+import (
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/pkg/log"
+)
+
+// Dependencies holds the shared dependencies for auth controllers.
+// Set during route binding.
+var Dependencies struct {
+	Service *auth.Service
+	Auditor *auth.AuditLogger
+}
+
+func logAuditFailure(err error) {
+	if err != nil {
+		log.Warn("failed to write audit log", "error", err)
+	}
+}

--- a/api/rest/controller/auth/auth.go
+++ b/api/rest/controller/auth/auth.go
@@ -1,15 +1,22 @@
 package auth
 
 import (
-	"github.com/caesium-cloud/caesium/internal/auth"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/caesium-cloud/caesium/pkg/log"
 )
 
-// Dependencies holds the shared dependencies for auth controllers.
-// Set during route binding.
-var Dependencies struct {
-	Service *auth.Service
-	Auditor *auth.AuditLogger
+// Controller owns the dependencies required by the auth REST handlers.
+type Controller struct {
+	service *iauth.Service
+	auditor *iauth.AuditLogger
+}
+
+// New constructs an auth controller with explicit dependencies.
+func New(service *iauth.Service, auditor *iauth.AuditLogger) *Controller {
+	return &Controller{
+		service: service,
+		auditor: auditor,
+	}
 }
 
 func logAuditFailure(err error) {

--- a/api/rest/controller/auth/auth_test.go
+++ b/api/rest/controller/auth/auth_test.go
@@ -1,0 +1,298 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func setupControllerDeps(t *testing.T) (*iauth.Service, *iauth.AuditLogger) {
+	t.Helper()
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	originalService := Dependencies.Service
+	originalAuditor := Dependencies.Auditor
+	t.Cleanup(func() {
+		Dependencies.Service = originalService
+		Dependencies.Auditor = originalAuditor
+	})
+
+	svc := iauth.NewService(db)
+	auditor := iauth.NewAuditLogger(db)
+	Dependencies.Service = svc
+	Dependencies.Auditor = auditor
+
+	return svc, auditor
+}
+
+func newAuthContext(t *testing.T, method, target string, body string) (*echo.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+
+	e := echo.New()
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	if body != "" {
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	}
+	req.RemoteAddr = "198.51.100.8:1234"
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	return c, rec
+}
+
+func readJSONBody[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
+	t.Helper()
+
+	var out T
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &out))
+	return out
+}
+
+func TestCreateKeyCreatesScopedKeyAndAuditEntry(t *testing.T) {
+	svc, auditor := setupControllerDeps(t)
+	c, rec := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{
+		"description":"CI key",
+		"role":"operator",
+		"scope":{"jobs":["etl-daily"]},
+		"expires_in":"2d"
+	}`)
+
+	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_admin"})
+
+	err := CreateKey(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	resp := readJSONBody[createKeyResponse](t, rec)
+	require.NotEmpty(t, resp.Key)
+	require.NotNil(t, resp.APIKey)
+	require.Equal(t, models.RoleOperator, resp.APIKey.Role)
+	require.Equal(t, "csk_live_admin", resp.APIKey.CreatedBy)
+	require.Equal(t, "CI key", resp.APIKey.Description)
+	require.NotNil(t, resp.APIKey.ExpiresAt)
+	require.WithinDuration(t, time.Now().UTC().Add(48*time.Hour), *resp.APIKey.ExpiresAt, 5*time.Second)
+
+	key, err := svc.ValidateKey(resp.Key)
+	require.NoError(t, err)
+	require.True(t, iauth.CheckScope(key.Scope, "etl-daily"))
+	require.False(t, iauth.CheckScope(key.Scope, "other-job"))
+
+	entries, err := auditor.Query(&iauth.AuditQueryRequest{Action: iauth.ActionKeyCreate})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "csk_live_admin", entries[0].Actor)
+	require.Equal(t, resp.APIKey.ID.String(), entries[0].ResourceID)
+}
+
+func TestCreateKeyRejectsInvalidRole(t *testing.T) {
+	setupControllerDeps(t)
+	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{"role":"bogus"}`)
+
+	err := CreateKey(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+func TestListKeysReturnsPersistedKeys(t *testing.T) {
+	svc, _ := setupControllerDeps(t)
+	_, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleViewer, CreatedBy: "test"})
+	require.NoError(t, err)
+
+	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/keys", "")
+	err = ListKeys(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var keys []models.APIKey
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &keys))
+	require.Len(t, keys, 1)
+	require.Equal(t, models.RoleViewer, keys[0].Role)
+}
+
+func TestRevokeKeyRevokesAndAudits(t *testing.T) {
+	svc, auditor := setupControllerDeps(t)
+	resp, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleRunner, CreatedBy: "seed"})
+	require.NoError(t, err)
+
+	c, rec := newAuthContext(t, http.MethodPost, "/v1/auth/keys/"+resp.Key.ID.String()+"/revoke", "")
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: resp.Key.ID.String()}})
+	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_admin"})
+
+	err = RevokeKey(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	_, err = svc.ValidateKey(resp.Plaintext)
+	require.ErrorIs(t, err, iauth.ErrKeyRevoked)
+
+	entries, err := auditor.Query(&iauth.AuditQueryRequest{Action: iauth.ActionKeyRevoke})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, resp.Key.ID.String(), entries[0].ResourceID)
+}
+
+func TestRotateKeyReturnsNewKeyAndAuditEntry(t *testing.T) {
+	svc, auditor := setupControllerDeps(t)
+	original, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleRunner, CreatedBy: "seed"})
+	require.NoError(t, err)
+
+	c, rec := newAuthContext(t, http.MethodPost, "/v1/auth/keys/"+original.Key.ID.String()+"/rotate", `{"grace_period":"2h"}`)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: original.Key.ID.String()}})
+	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_admin"})
+
+	err = RotateKey(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	resp := readJSONBody[createKeyResponse](t, rec)
+	require.NotEmpty(t, resp.Key)
+	require.NotEqual(t, original.Key.ID, resp.APIKey.ID)
+
+	newKey, err := svc.ValidateKey(resp.Key)
+	require.NoError(t, err)
+	require.Equal(t, resp.APIKey.ID, newKey.ID)
+
+	entries, err := auditor.Query(&iauth.AuditQueryRequest{Action: iauth.ActionKeyRotate})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, original.Key.ID.String(), entries[0].ResourceID)
+}
+
+func TestQueryAuditSupportsDurationAndActorFilters(t *testing.T) {
+	_, auditor := setupControllerDeps(t)
+
+	require.NoError(t, auditor.Log(iauth.AuditEntry{
+		Actor:    "alpha",
+		Action:   iauth.ActionKeyCreate,
+		Outcome:  iauth.OutcomeSuccess,
+		SourceIP: "198.51.100.1",
+	}))
+	require.NoError(t, auditor.Log(iauth.AuditEntry{
+		Actor:    "beta",
+		Action:   iauth.ActionKeyRevoke,
+		Outcome:  iauth.OutcomeSuccess,
+		SourceIP: "198.51.100.2",
+	}))
+
+	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/audit?since=24h&actor=beta&limit=10", "")
+	err := QueryAudit(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var entries []models.AuditLog
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+	require.Len(t, entries, 1)
+	require.Equal(t, "beta", entries[0].Actor)
+	require.Equal(t, iauth.ActionKeyRevoke, entries[0].Action)
+}
+
+func TestQueryAuditRejectsInvalidSince(t *testing.T) {
+	setupControllerDeps(t)
+	c, _ := newAuthContext(t, http.MethodGet, "/v1/auth/audit?since=not-a-duration-or-time", "")
+
+	err := QueryAudit(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+func TestParseDurationSupportsDays(t *testing.T) {
+	dur, err := parseDuration("3d")
+	require.NoError(t, err)
+	require.Equal(t, 72*time.Hour, dur)
+}
+
+func TestRevokeKeyRejectsInvalidUUID(t *testing.T) {
+	setupControllerDeps(t)
+	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys/not-a-uuid/revoke", "")
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: "not-a-uuid"}})
+
+	err := RevokeKey(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, he.Code)
+}
+
+func TestRotateKeyRejectsRevokedKey(t *testing.T) {
+	svc, _ := setupControllerDeps(t)
+	resp, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleRunner, CreatedBy: "seed"})
+	require.NoError(t, err)
+	require.NoError(t, svc.RevokeKey(resp.Key.ID))
+
+	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys/"+resp.Key.ID.String()+"/rotate", `{}`)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: resp.Key.ID.String()}})
+
+	err = RotateKey(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusConflict, he.Code)
+}
+
+func TestQueryAuditAcceptsRFC3339Since(t *testing.T) {
+	_, auditor := setupControllerDeps(t)
+	require.NoError(t, auditor.Log(iauth.AuditEntry{
+		Actor:    "alpha",
+		Action:   iauth.ActionKeyCreate,
+		Outcome:  iauth.OutcomeSuccess,
+		SourceIP: "198.51.100.1",
+	}))
+
+	since := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
+	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/audit?since="+since, "")
+	err := QueryAudit(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var entries []models.AuditLog
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &entries))
+	require.Len(t, entries, 1)
+}
+
+func TestCreateKeyUsesUnknownActorWhenMiddlewareIdentityMissing(t *testing.T) {
+	_, auditor := setupControllerDeps(t)
+	c, rec := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{"role":"viewer"}`)
+
+	err := CreateKey(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, rec.Code)
+
+	entries, err := auditor.Query(&iauth.AuditQueryRequest{Action: iauth.ActionKeyCreate})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "unknown", entries[0].Actor)
+}
+
+func TestRotateKeyRejectsInvalidGracePeriod(t *testing.T) {
+	setupControllerDeps(t)
+	id := uuid.New().String()
+	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys/"+id+"/rotate", `{"grace_period":"nope"}`)
+	c.SetPathValues(echo.PathValues{{Name: "id", Value: id}})
+
+	err := RotateKey(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusBadRequest, he.Code)
+}

--- a/api/rest/controller/auth/auth_test.go
+++ b/api/rest/controller/auth/auth_test.go
@@ -17,25 +17,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupControllerDeps(t *testing.T) (*iauth.Service, *iauth.AuditLogger) {
+func setupControllerDeps(t *testing.T) (*Controller, *iauth.Service, *iauth.AuditLogger) {
 	t.Helper()
 
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })
 
-	originalService := Dependencies.Service
-	originalAuditor := Dependencies.Auditor
-	t.Cleanup(func() {
-		Dependencies.Service = originalService
-		Dependencies.Auditor = originalAuditor
-	})
-
 	svc := iauth.NewService(db)
 	auditor := iauth.NewAuditLogger(db)
-	Dependencies.Service = svc
-	Dependencies.Auditor = auditor
-
-	return svc, auditor
+	return New(svc, auditor), svc, auditor
 }
 
 func newAuthContext(t *testing.T, method, target string, body string) (*echo.Context, *httptest.ResponseRecorder) {
@@ -61,7 +51,7 @@ func readJSONBody[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
 }
 
 func TestCreateKeyCreatesScopedKeyAndAuditEntry(t *testing.T) {
-	svc, auditor := setupControllerDeps(t)
+	ctrl, svc, auditor := setupControllerDeps(t)
 	c, rec := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{
 		"description":"CI key",
 		"role":"operator",
@@ -69,9 +59,9 @@ func TestCreateKeyCreatesScopedKeyAndAuditEntry(t *testing.T) {
 		"expires_in":"2d"
 	}`)
 
-	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_admin"})
+	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_admin", Role: models.RoleAdmin})
 
-	err := CreateKey(c)
+	err := ctrl.CreateKey(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
@@ -97,10 +87,10 @@ func TestCreateKeyCreatesScopedKeyAndAuditEntry(t *testing.T) {
 }
 
 func TestCreateKeyRejectsInvalidRole(t *testing.T) {
-	setupControllerDeps(t)
+	ctrl, _, _ := setupControllerDeps(t)
 	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{"role":"bogus"}`)
 
-	err := CreateKey(c)
+	err := ctrl.CreateKey(c)
 	require.Error(t, err)
 
 	he, ok := err.(*echo.HTTPError)
@@ -109,12 +99,12 @@ func TestCreateKeyRejectsInvalidRole(t *testing.T) {
 }
 
 func TestListKeysReturnsPersistedKeys(t *testing.T) {
-	svc, _ := setupControllerDeps(t)
+	ctrl, svc, _ := setupControllerDeps(t)
 	_, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleViewer, CreatedBy: "test"})
 	require.NoError(t, err)
 
 	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/keys", "")
-	err = ListKeys(c)
+	err = ctrl.ListKeys(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -125,7 +115,7 @@ func TestListKeysReturnsPersistedKeys(t *testing.T) {
 }
 
 func TestRevokeKeyRevokesAndAudits(t *testing.T) {
-	svc, auditor := setupControllerDeps(t)
+	ctrl, svc, auditor := setupControllerDeps(t)
 	resp, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleRunner, CreatedBy: "seed"})
 	require.NoError(t, err)
 
@@ -133,7 +123,7 @@ func TestRevokeKeyRevokesAndAudits(t *testing.T) {
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: resp.Key.ID.String()}})
 	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_admin"})
 
-	err = RevokeKey(c)
+	err = ctrl.RevokeKey(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -147,7 +137,7 @@ func TestRevokeKeyRevokesAndAudits(t *testing.T) {
 }
 
 func TestRotateKeyReturnsNewKeyAndAuditEntry(t *testing.T) {
-	svc, auditor := setupControllerDeps(t)
+	ctrl, svc, auditor := setupControllerDeps(t)
 	original, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleRunner, CreatedBy: "seed"})
 	require.NoError(t, err)
 
@@ -155,7 +145,7 @@ func TestRotateKeyReturnsNewKeyAndAuditEntry(t *testing.T) {
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: original.Key.ID.String()}})
 	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_admin"})
 
-	err = RotateKey(c)
+	err = ctrl.RotateKey(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusCreated, rec.Code)
 
@@ -174,7 +164,7 @@ func TestRotateKeyReturnsNewKeyAndAuditEntry(t *testing.T) {
 }
 
 func TestQueryAuditSupportsDurationAndActorFilters(t *testing.T) {
-	_, auditor := setupControllerDeps(t)
+	ctrl, _, auditor := setupControllerDeps(t)
 
 	require.NoError(t, auditor.Log(iauth.AuditEntry{
 		Actor:    "alpha",
@@ -190,7 +180,7 @@ func TestQueryAuditSupportsDurationAndActorFilters(t *testing.T) {
 	}))
 
 	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/audit?since=24h&actor=beta&limit=10", "")
-	err := QueryAudit(c)
+	err := ctrl.QueryAudit(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -202,10 +192,10 @@ func TestQueryAuditSupportsDurationAndActorFilters(t *testing.T) {
 }
 
 func TestQueryAuditRejectsInvalidSince(t *testing.T) {
-	setupControllerDeps(t)
+	ctrl, _, _ := setupControllerDeps(t)
 	c, _ := newAuthContext(t, http.MethodGet, "/v1/auth/audit?since=not-a-duration-or-time", "")
 
-	err := QueryAudit(c)
+	err := ctrl.QueryAudit(c)
 	require.Error(t, err)
 
 	he, ok := err.(*echo.HTTPError)
@@ -220,11 +210,11 @@ func TestParseDurationSupportsDays(t *testing.T) {
 }
 
 func TestRevokeKeyRejectsInvalidUUID(t *testing.T) {
-	setupControllerDeps(t)
+	ctrl, _, _ := setupControllerDeps(t)
 	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys/not-a-uuid/revoke", "")
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: "not-a-uuid"}})
 
-	err := RevokeKey(c)
+	err := ctrl.RevokeKey(c)
 	require.Error(t, err)
 
 	he, ok := err.(*echo.HTTPError)
@@ -233,7 +223,7 @@ func TestRevokeKeyRejectsInvalidUUID(t *testing.T) {
 }
 
 func TestRotateKeyRejectsRevokedKey(t *testing.T) {
-	svc, _ := setupControllerDeps(t)
+	ctrl, svc, _ := setupControllerDeps(t)
 	resp, err := svc.CreateKey(&iauth.CreateKeyRequest{Role: models.RoleRunner, CreatedBy: "seed"})
 	require.NoError(t, err)
 	require.NoError(t, svc.RevokeKey(resp.Key.ID))
@@ -241,7 +231,7 @@ func TestRotateKeyRejectsRevokedKey(t *testing.T) {
 	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys/"+resp.Key.ID.String()+"/rotate", `{}`)
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: resp.Key.ID.String()}})
 
-	err = RotateKey(c)
+	err = ctrl.RotateKey(c)
 	require.Error(t, err)
 
 	he, ok := err.(*echo.HTTPError)
@@ -250,7 +240,7 @@ func TestRotateKeyRejectsRevokedKey(t *testing.T) {
 }
 
 func TestQueryAuditAcceptsRFC3339Since(t *testing.T) {
-	_, auditor := setupControllerDeps(t)
+	ctrl, _, auditor := setupControllerDeps(t)
 	require.NoError(t, auditor.Log(iauth.AuditEntry{
 		Actor:    "alpha",
 		Action:   iauth.ActionKeyCreate,
@@ -260,7 +250,7 @@ func TestQueryAuditAcceptsRFC3339Since(t *testing.T) {
 
 	since := time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)
 	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/audit?since="+since, "")
-	err := QueryAudit(c)
+	err := ctrl.QueryAudit(c)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, rec.Code)
 
@@ -269,27 +259,46 @@ func TestQueryAuditAcceptsRFC3339Since(t *testing.T) {
 	require.Len(t, entries, 1)
 }
 
-func TestCreateKeyUsesUnknownActorWhenMiddlewareIdentityMissing(t *testing.T) {
-	_, auditor := setupControllerDeps(t)
-	c, rec := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{"role":"viewer"}`)
+func TestCreateKeyRequiresAuthenticatedCaller(t *testing.T) {
+	ctrl, _, auditor := setupControllerDeps(t)
+	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{"role":"viewer"}`)
 
-	err := CreateKey(c)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusCreated, rec.Code)
+	err := ctrl.CreateKey(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
 
 	entries, err := auditor.Query(&iauth.AuditQueryRequest{Action: iauth.ActionKeyCreate})
 	require.NoError(t, err)
-	require.Len(t, entries, 1)
-	require.Equal(t, "unknown", entries[0].Actor)
+	require.Len(t, entries, 0)
+}
+
+func TestCreateKeyRejectsHigherPrivilegeRoleThanCaller(t *testing.T) {
+	ctrl, _, auditor := setupControllerDeps(t)
+	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys", `{"role":"admin"}`)
+	c.Set(authmw.ContextKeyAuth, &models.APIKey{KeyPrefix: "csk_live_operator", Role: models.RoleOperator})
+
+	err := ctrl.CreateKey(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+
+	entries, err := auditor.Query(&iauth.AuditQueryRequest{Action: iauth.ActionKeyCreate})
+	require.NoError(t, err)
+	require.Len(t, entries, 0)
 }
 
 func TestRotateKeyRejectsInvalidGracePeriod(t *testing.T) {
-	setupControllerDeps(t)
+	ctrl, _, _ := setupControllerDeps(t)
 	id := uuid.New().String()
 	c, _ := newAuthContext(t, http.MethodPost, "/v1/auth/keys/"+id+"/rotate", `{"grace_period":"nope"}`)
 	c.SetPathValues(echo.PathValues{{Name: "id", Value: id}})
 
-	err := RotateKey(c)
+	err := ctrl.RotateKey(c)
 	require.Error(t, err)
 
 	he, ok := err.(*echo.HTTPError)

--- a/api/rest/controller/auth/key_create.go
+++ b/api/rest/controller/auth/key_create.go
@@ -1,0 +1,101 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/caesium-cloud/caesium/api/middleware"
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/labstack/echo/v5"
+)
+
+type createKeyRequest struct {
+	Description string           `json:"description"`
+	Role        string           `json:"role"`
+	Scope       *models.KeyScope `json:"scope,omitempty"`
+	ExpiresIn   string           `json:"expires_in,omitempty"` // e.g. "90d", "24h"
+}
+
+type createKeyResponse struct {
+	Key    string         `json:"key"`
+	APIKey *models.APIKey `json:"api_key"`
+}
+
+func CreateKey(c *echo.Context) error {
+	var req createKeyRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	if !models.ValidRole(req.Role) {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid role: %s (must be admin, operator, runner, or viewer)", req.Role))
+	}
+
+	var expiresAt *time.Time
+	if req.ExpiresIn != "" {
+		dur, err := parseDuration(req.ExpiresIn)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid expires_in").Wrap(err)
+		}
+		t := time.Now().UTC().Add(dur)
+		expiresAt = &t
+	}
+
+	caller := middleware.GetAuthKey(c)
+	createdBy := "unknown"
+	if caller != nil {
+		createdBy = caller.KeyPrefix
+	}
+
+	resp, err := Dependencies.Service.CreateKey(&auth.CreateKeyRequest{
+		Description: req.Description,
+		Role:        models.Role(req.Role),
+		Scope:       req.Scope,
+		CreatedBy:   createdBy,
+		ExpiresAt:   expiresAt,
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create api key").Wrap(err)
+	}
+
+	logAuditFailure(Dependencies.Auditor.Log(auth.AuditEntry{
+		Actor:        createdBy,
+		Action:       auth.ActionKeyCreate,
+		ResourceType: "api_key",
+		ResourceID:   resp.Key.ID.String(),
+		SourceIP:     c.RealIP(),
+		Outcome:      auth.OutcomeSuccess,
+		Metadata: map[string]interface{}{
+			"role":        req.Role,
+			"description": req.Description,
+		},
+	}))
+
+	return c.JSON(http.StatusCreated, createKeyResponse{
+		Key:    resp.Plaintext,
+		APIKey: resp.Key,
+	})
+}
+
+// parseDuration parses durations like "90d", "24h", "30m".
+func parseDuration(s string) (time.Duration, error) {
+	if len(s) < 2 {
+		return 0, fmt.Errorf("duration too short: %s", s)
+	}
+
+	suffix := s[len(s)-1]
+	value := s[:len(s)-1]
+
+	switch suffix {
+	case 'd':
+		var days int
+		if _, err := fmt.Sscanf(value, "%d", &days); err != nil {
+			return 0, err
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	default:
+		return time.ParseDuration(s)
+	}
+}

--- a/api/rest/controller/auth/key_create.go
+++ b/api/rest/controller/auth/key_create.go
@@ -23,7 +23,7 @@ type createKeyResponse struct {
 	APIKey *models.APIKey `json:"api_key"`
 }
 
-func CreateKey(c *echo.Context) error {
+func (ctrl *Controller) CreateKey(c *echo.Context) error {
 	var req createKeyRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
@@ -44,24 +44,28 @@ func CreateKey(c *echo.Context) error {
 	}
 
 	caller := middleware.GetAuthKey(c)
-	createdBy := "unknown"
-	if caller != nil {
-		createdBy = caller.KeyPrefix
+	if caller == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "authentication required")
 	}
 
-	resp, err := Dependencies.Service.CreateKey(&auth.CreateKeyRequest{
+	requestedRole := models.Role(req.Role)
+	if models.RoleLevel(requestedRole) > models.RoleLevel(caller.Role) {
+		return echo.NewHTTPError(http.StatusForbidden, "cannot create api key with higher privilege than caller")
+	}
+
+	resp, err := ctrl.service.CreateKey(&auth.CreateKeyRequest{
 		Description: req.Description,
-		Role:        models.Role(req.Role),
+		Role:        requestedRole,
 		Scope:       req.Scope,
-		CreatedBy:   createdBy,
+		CreatedBy:   caller.KeyPrefix,
 		ExpiresAt:   expiresAt,
 	})
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create api key").Wrap(err)
 	}
 
-	logAuditFailure(Dependencies.Auditor.Log(auth.AuditEntry{
-		Actor:        createdBy,
+	logAuditFailure(ctrl.auditor.Log(auth.AuditEntry{
+		Actor:        caller.KeyPrefix,
 		Action:       auth.ActionKeyCreate,
 		ResourceType: "api_key",
 		ResourceID:   resp.Key.ID.String(),

--- a/api/rest/controller/auth/key_list.go
+++ b/api/rest/controller/auth/key_list.go
@@ -6,8 +6,8 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
-func ListKeys(c *echo.Context) error {
-	keys, err := Dependencies.Service.ListKeys()
+func (ctrl *Controller) ListKeys(c *echo.Context) error {
+	keys, err := ctrl.service.ListKeys()
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to list api keys").Wrap(err)
 	}

--- a/api/rest/controller/auth/key_list.go
+++ b/api/rest/controller/auth/key_list.go
@@ -1,0 +1,15 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+)
+
+func ListKeys(c *echo.Context) error {
+	keys, err := Dependencies.Service.ListKeys()
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to list api keys").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, keys)
+}

--- a/api/rest/controller/auth/key_revoke.go
+++ b/api/rest/controller/auth/key_revoke.go
@@ -9,13 +9,13 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
-func RevokeKey(c *echo.Context) error {
+func (ctrl *Controller) RevokeKey(c *echo.Context) error {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid key id").Wrap(err)
 	}
 
-	if err := Dependencies.Service.RevokeKey(id); err != nil {
+	if err := ctrl.service.RevokeKey(id); err != nil {
 		if err == iauth.ErrKeyNotFound {
 			return echo.NewHTTPError(http.StatusNotFound, "api key not found")
 		}
@@ -28,7 +28,7 @@ func RevokeKey(c *echo.Context) error {
 		actor = caller.KeyPrefix
 	}
 
-	logAuditFailure(Dependencies.Auditor.Log(iauth.AuditEntry{
+	logAuditFailure(ctrl.auditor.Log(iauth.AuditEntry{
 		Actor:        actor,
 		Action:       iauth.ActionKeyRevoke,
 		ResourceType: "api_key",

--- a/api/rest/controller/auth/key_revoke.go
+++ b/api/rest/controller/auth/key_revoke.go
@@ -1,0 +1,41 @@
+package auth
+
+import (
+	"net/http"
+
+	"github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+func RevokeKey(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid key id").Wrap(err)
+	}
+
+	if err := Dependencies.Service.RevokeKey(id); err != nil {
+		if err == iauth.ErrKeyNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "api key not found")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to revoke api key").Wrap(err)
+	}
+
+	caller := middleware.GetAuthKey(c)
+	actor := "unknown"
+	if caller != nil {
+		actor = caller.KeyPrefix
+	}
+
+	logAuditFailure(Dependencies.Auditor.Log(iauth.AuditEntry{
+		Actor:        actor,
+		Action:       iauth.ActionKeyRevoke,
+		ResourceType: "api_key",
+		ResourceID:   id.String(),
+		SourceIP:     c.RealIP(),
+		Outcome:      iauth.OutcomeSuccess,
+	}))
+
+	return c.JSON(http.StatusOK, map[string]string{"status": "revoked"})
+}

--- a/api/rest/controller/auth/key_rotate.go
+++ b/api/rest/controller/auth/key_rotate.go
@@ -14,7 +14,7 @@ type rotateKeyRequest struct {
 	GracePeriod string `json:"grace_period"` // e.g. "24h"
 }
 
-func RotateKey(c *echo.Context) error {
+func (ctrl *Controller) RotateKey(c *echo.Context) error {
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid key id").Wrap(err)
@@ -40,7 +40,7 @@ func RotateKey(c *echo.Context) error {
 		actor = caller.KeyPrefix
 	}
 
-	resp, err := Dependencies.Service.RotateKey(id, gracePeriod, actor)
+	resp, err := ctrl.service.RotateKey(id, gracePeriod, actor)
 	if err != nil {
 		if err == iauth.ErrKeyNotFound {
 			return echo.NewHTTPError(http.StatusNotFound, "api key not found")
@@ -51,7 +51,7 @@ func RotateKey(c *echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to rotate api key").Wrap(err)
 	}
 
-	logAuditFailure(Dependencies.Auditor.Log(iauth.AuditEntry{
+	logAuditFailure(ctrl.auditor.Log(iauth.AuditEntry{
 		Actor:        actor,
 		Action:       iauth.ActionKeyRotate,
 		ResourceType: "api_key",

--- a/api/rest/controller/auth/key_rotate.go
+++ b/api/rest/controller/auth/key_rotate.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+type rotateKeyRequest struct {
+	GracePeriod string `json:"grace_period"` // e.g. "24h"
+}
+
+func RotateKey(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid key id").Wrap(err)
+	}
+
+	var req rotateKeyRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	gracePeriod := 24 * time.Hour
+	if req.GracePeriod != "" {
+		gp, err := parseDuration(req.GracePeriod)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid grace_period").Wrap(err)
+		}
+		gracePeriod = gp
+	}
+
+	caller := middleware.GetAuthKey(c)
+	actor := "unknown"
+	if caller != nil {
+		actor = caller.KeyPrefix
+	}
+
+	resp, err := Dependencies.Service.RotateKey(id, gracePeriod, actor)
+	if err != nil {
+		if err == iauth.ErrKeyNotFound {
+			return echo.NewHTTPError(http.StatusNotFound, "api key not found")
+		}
+		if err == iauth.ErrKeyRevoked {
+			return echo.NewHTTPError(http.StatusConflict, "cannot rotate a revoked key")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to rotate api key").Wrap(err)
+	}
+
+	logAuditFailure(Dependencies.Auditor.Log(iauth.AuditEntry{
+		Actor:        actor,
+		Action:       iauth.ActionKeyRotate,
+		ResourceType: "api_key",
+		ResourceID:   id.String(),
+		SourceIP:     c.RealIP(),
+		Outcome:      iauth.OutcomeSuccess,
+		Metadata: map[string]interface{}{
+			"new_key_id":   resp.Key.ID.String(),
+			"grace_period": gracePeriod.String(),
+		},
+	}))
+
+	return c.JSON(http.StatusCreated, createKeyResponse{
+		Key:    resp.Plaintext,
+		APIKey: resp.Key,
+	})
+}

--- a/api/rest/controller/job/list.go
+++ b/api/rest/controller/job/list.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/caesium-cloud/caesium/api/middleware"
 	"github.com/caesium-cloud/caesium/api/rest/service/job"
 	runsvc "github.com/caesium-cloud/caesium/api/rest/service/run"
 	"github.com/labstack/echo/v5"
@@ -16,6 +17,9 @@ func List(c *echo.Context) error {
 	req, err := parseListRequest(c)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+	if aliases := middleware.GetAllowedJobAliases(c); len(aliases) > 0 {
+		req.Aliases = aliases
 	}
 
 	jobs, err := job.Service(c.Request().Context()).List(req)

--- a/api/rest/service/job/job.go
+++ b/api/rest/service/job/job.go
@@ -85,6 +85,7 @@ type ListRequest struct {
 	Offset    uint64
 	OrderBy   []string
 	TriggerID string
+	Aliases   []string
 }
 
 func (j *jobService) List(req *ListRequest) (models.Jobs, error) {
@@ -99,6 +100,9 @@ func (j *jobService) List(req *ListRequest) (models.Jobs, error) {
 		}
 
 		q = q.Where("trigger_id = ?", req.TriggerID)
+	}
+	if len(req.Aliases) > 0 {
+		q = q.Where("alias IN ?", req.Aliases)
 	}
 
 	for _, orderBy := range req.OrderBy {

--- a/api/rest/service/job/job_test.go
+++ b/api/rest/service/job/job_test.go
@@ -89,3 +89,18 @@ func TestSetPausedNotFoundReturnsError(t *testing.T) {
 	_, err := svc.SetPaused(uuid.New(), true)
 	require.Error(t, err)
 }
+
+func TestListFiltersByAliases(t *testing.T) {
+	db := openTestDB(t)
+	svc := &jobService{ctx: context.Background(), db: db}
+
+	_, err := svc.Create(&CreateRequest{TriggerID: uuid.New(), Alias: "alpha"})
+	require.NoError(t, err)
+	_, err = svc.Create(&CreateRequest{TriggerID: uuid.New(), Alias: "beta"})
+	require.NoError(t, err)
+
+	jobs, err := svc.List(&ListRequest{Aliases: []string{"beta"}})
+	require.NoError(t, err)
+	require.Len(t, jobs, 1)
+	require.Equal(t, "beta", jobs[0].Alias)
+}

--- a/api/ui.go
+++ b/api/ui.go
@@ -24,7 +24,7 @@ func RegisterUI(e *echo.Echo) {
 		path := c.Request().URL.Path
 
 		// If it's a request for an API or health, don't handle it here
-		if strings.HasPrefix(path, "/v1") || strings.HasPrefix(path, "/gql") || path == "/health" || path == "/metrics" {
+		if strings.HasPrefix(path, "/v1") || strings.HasPrefix(path, "/gql") || path == "/health" || path == "/metrics" || path == "/auth/status" {
 			return echo.ErrNotFound
 		}
 

--- a/cmd/auth/audit.go
+++ b/cmd/auth/audit.go
@@ -26,6 +26,7 @@ var auditCmd = &cobra.Command{
 	Example: `  caesium auth audit --since 24h --actor csk_live_a1b2`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		server := strings.TrimSuffix(auditServer, "/")
+		apiKey := resolveAPIKey(cmd, auditAPIKey)
 
 		params := url.Values{}
 		if auditSince != "" {
@@ -47,8 +48,8 @@ var auditCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if auditAPIKey != "" {
-			req.Header.Set("Authorization", "Bearer "+auditAPIKey)
+		if apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 
 		resp, err := http.DefaultClient.Do(req)
@@ -79,7 +80,7 @@ func init() {
 	auditCmd.Flags().StringVar(&auditAction, "action", "", "Filter by action (e.g. job.create, api_key.revoke)")
 	auditCmd.Flags().IntVar(&auditLimit, "limit", 100, "Maximum number of entries to return")
 	auditCmd.Flags().StringVar(&auditServer, "server", "http://localhost:8080", "Caesium server base URL")
-	auditCmd.Flags().StringVar(&auditAPIKey, "api-key", "", "Admin API key for authentication")
+	auditCmd.Flags().StringVar(&auditAPIKey, "api-key", "", apiKeyFlagUsage("Admin"))
 
 	Cmd.AddCommand(auditCmd)
 }

--- a/cmd/auth/audit.go
+++ b/cmd/auth/audit.go
@@ -1,0 +1,85 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	auditSince  string
+	auditActor  string
+	auditAction string
+	auditLimit  int
+	auditServer string
+	auditAPIKey string
+)
+
+var auditCmd = &cobra.Command{
+	Use:     "audit",
+	Short:   "Query the audit log",
+	Example: `  caesium auth audit --since 24h --actor csk_live_a1b2`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		server := strings.TrimSuffix(auditServer, "/")
+
+		params := url.Values{}
+		if auditSince != "" {
+			params.Set("since", auditSince)
+		}
+		if auditActor != "" {
+			params.Set("actor", auditActor)
+		}
+		if auditAction != "" {
+			params.Set("action", auditAction)
+		}
+		if auditLimit > 0 {
+			params.Set("limit", fmt.Sprintf("%d", auditLimit))
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/auth/audit?%s", server, params.Encode())
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
+		if err != nil {
+			return err
+		}
+		if auditAPIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+auditAPIKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("audit query failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		var out interface{}
+		if err := json.Unmarshal(body, &out); err != nil {
+			cmd.Print(string(body))
+			return nil
+		}
+		pretty, _ := json.MarshalIndent(out, "", "  ")
+		cmd.Println(string(pretty))
+		return nil
+	},
+}
+
+func init() {
+	auditCmd.Flags().StringVar(&auditSince, "since", "", "Show entries since duration (e.g. 24h) or RFC3339 timestamp")
+	auditCmd.Flags().StringVar(&auditActor, "actor", "", "Filter by actor (key prefix or OIDC subject)")
+	auditCmd.Flags().StringVar(&auditAction, "action", "", "Filter by action (e.g. job.create, api_key.revoke)")
+	auditCmd.Flags().IntVar(&auditLimit, "limit", 100, "Maximum number of entries to return")
+	auditCmd.Flags().StringVar(&auditServer, "server", "http://localhost:8080", "Caesium server base URL")
+	auditCmd.Flags().StringVar(&auditAPIKey, "api-key", "", "Admin API key for authentication")
+
+	Cmd.AddCommand(auditCmd)
+}

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,6 +1,14 @@
 package auth
 
-import "github.com/spf13/cobra"
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const apiKeyEnvVar = "CAESIUM_API_KEY"
 
 // Cmd is the parent command for authentication operations.
 var Cmd = &cobra.Command{
@@ -16,4 +24,16 @@ var keyCmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(keyCmd)
+}
+
+func resolveAPIKey(cmd *cobra.Command, flagValue string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		cmd.PrintErrln(fmt.Sprintf("warning: --api-key is visible in process listings; prefer %s", apiKeyEnvVar))
+		return strings.TrimSpace(flagValue)
+	}
+	return strings.TrimSpace(os.Getenv(apiKeyEnvVar))
+}
+
+func apiKeyFlagUsage(role string) string {
+	return fmt.Sprintf("%s API key for authentication (prefer %s; --api-key is visible in process listings)", role, apiKeyEnvVar)
 }

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,0 +1,19 @@
+package auth
+
+import "github.com/spf13/cobra"
+
+// Cmd is the parent command for authentication operations.
+var Cmd = &cobra.Command{
+	Use:   "auth",
+	Short: "Manage API authentication and authorization",
+}
+
+// key is the parent command for API key operations.
+var keyCmd = &cobra.Command{
+	Use:   "key",
+	Short: "Manage API keys",
+}
+
+func init() {
+	Cmd.AddCommand(keyCmd)
+}

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -144,3 +144,49 @@ func TestAuditCommandBuildsQueryString(t *testing.T) {
 	require.Contains(t, query, "limit=10")
 	require.Contains(t, out.String(), "[]")
 }
+
+func TestKeyListCommandFallsBackToEnvironmentAPIKey(t *testing.T) {
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	t.Setenv(apiKeyEnvVar, "env-admin-token")
+	listServer = server.URL
+	listAPIKey = ""
+
+	var out bytes.Buffer
+	keyListCmd.SetOut(&out)
+	keyListCmd.SetErr(&out)
+	keyListCmd.SetContext(context.Background())
+
+	err := keyListCmd.RunE(keyListCmd, nil)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer env-admin-token", authHeader)
+	require.NotContains(t, out.String(), "warning:")
+}
+
+func TestKeyCreateCommandWarnsWhenAPIKeyFlagIsUsed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"key":"csk_live_secret","api_key":{"id":"abc","role":"operator"}}`))
+	}))
+	defer server.Close()
+
+	createRole = "operator"
+	createDescription = "warn"
+	createExpiresIn = ""
+	createServer = server.URL
+	createAPIKey = "flag-admin-token"
+	createScopeJobs = nil
+
+	var out bytes.Buffer
+	keyCreateCmd.SetOut(&out)
+	keyCreateCmd.SetErr(&out)
+	keyCreateCmd.SetContext(context.Background())
+
+	err := keyCreateCmd.RunE(keyCreateCmd, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), "warning: --api-key is visible in process listings")
+}

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -1,0 +1,146 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeyCreateCommandSendsScopeAndPrintsKey(t *testing.T) {
+	var authHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/v1/auth/keys", r.URL.Path)
+		authHeader = r.Header.Get("Authorization")
+
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "operator", body["role"])
+		require.Equal(t, "CI deploy key", body["description"])
+		require.Equal(t, "48h", body["expires_in"])
+		require.Equal(t, map[string]any{"jobs": []any{"etl-daily", "etl-hourly"}}, body["scope"])
+
+		_, _ = w.Write([]byte(`{"key":"csk_live_secret","api_key":{"id":"abc","role":"operator"}}`))
+	}))
+	defer server.Close()
+
+	createRole = "operator"
+	createDescription = "CI deploy key"
+	createExpiresIn = "48h"
+	createServer = server.URL
+	createAPIKey = "admin-token"
+	createScopeJobs = []string{"etl-daily", "etl-hourly"}
+
+	var out bytes.Buffer
+	keyCreateCmd.SetOut(&out)
+	keyCreateCmd.SetErr(&out)
+	keyCreateCmd.SetContext(context.Background())
+
+	err := keyCreateCmd.RunE(keyCreateCmd, nil)
+	require.NoError(t, err)
+	require.Equal(t, "Bearer admin-token", authHeader)
+	require.Contains(t, out.String(), "csk_live_secret")
+	require.Contains(t, out.String(), `"role": "operator"`)
+}
+
+func TestKeyListCommandPrintsFormattedJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
+		require.Equal(t, "/v1/auth/keys", r.URL.Path)
+		_, _ = w.Write([]byte(`[{"id":"abc","role":"viewer"}]`))
+	}))
+	defer server.Close()
+
+	listServer = server.URL
+	listAPIKey = "admin-token"
+
+	var out bytes.Buffer
+	keyListCmd.SetOut(&out)
+	keyListCmd.SetErr(&out)
+	keyListCmd.SetContext(context.Background())
+
+	err := keyListCmd.RunE(keyListCmd, nil)
+	require.NoError(t, err)
+	require.Contains(t, out.String(), `"role": "viewer"`)
+}
+
+func TestKeyRevokeCommandTargetsRevokeEndpoint(t *testing.T) {
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"status":"revoked"}`))
+	}))
+	defer server.Close()
+
+	revokeID = "1234"
+	revokeServer = server.URL
+	revokeAPIKey = "admin-token"
+
+	var out bytes.Buffer
+	keyRevokeCmd.SetOut(&out)
+	keyRevokeCmd.SetErr(&out)
+	keyRevokeCmd.SetContext(context.Background())
+
+	err := keyRevokeCmd.RunE(keyRevokeCmd, nil)
+	require.NoError(t, err)
+	require.Equal(t, "/v1/auth/keys/1234/revoke", gotPath)
+	require.Contains(t, out.String(), `"status": "revoked"`)
+}
+
+func TestKeyRotateCommandSendsGracePeriodAndPrintsNewKey(t *testing.T) {
+	var body map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		_, _ = w.Write([]byte(`{"key":"csk_live_rotated","api_key":{"id":"new","role":"runner"}}`))
+	}))
+	defer server.Close()
+
+	rotateID = "1234"
+	rotateGracePeriod = "6h"
+	rotateServer = server.URL
+	rotateAPIKey = "admin-token"
+
+	var out bytes.Buffer
+	keyRotateCmd.SetOut(&out)
+	keyRotateCmd.SetErr(&out)
+	keyRotateCmd.SetContext(context.Background())
+
+	err := keyRotateCmd.RunE(keyRotateCmd, nil)
+	require.NoError(t, err)
+	require.Equal(t, map[string]any{"grace_period": "6h"}, body)
+	require.Contains(t, out.String(), "csk_live_rotated")
+}
+
+func TestAuditCommandBuildsQueryString(t *testing.T) {
+	var query string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	auditSince = "24h"
+	auditActor = "alpha"
+	auditAction = "api_key.create"
+	auditLimit = 10
+	auditServer = server.URL
+	auditAPIKey = "admin-token"
+
+	var out bytes.Buffer
+	auditCmd.SetOut(&out)
+	auditCmd.SetErr(&out)
+	auditCmd.SetContext(context.Background())
+
+	err := auditCmd.RunE(auditCmd, nil)
+	require.NoError(t, err)
+	require.Contains(t, query, "since=24h")
+	require.Contains(t, query, "actor=alpha")
+	require.Contains(t, query, "action=api_key.create")
+	require.Contains(t, query, "limit=10")
+	require.Contains(t, out.String(), "[]")
+}

--- a/cmd/auth/key_create.go
+++ b/cmd/auth/key_create.go
@@ -26,6 +26,7 @@ var keyCreateCmd = &cobra.Command{
   caesium auth key create --role runner --description "ETL runner" --scope-jobs etl-daily,etl-hourly`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		server := strings.TrimSuffix(createServer, "/")
+		apiKey := resolveAPIKey(cmd, createAPIKey)
 
 		body := map[string]interface{}{
 			"role":        createRole,
@@ -50,8 +51,8 @@ var keyCreateCmd = &cobra.Command{
 			return err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		if createAPIKey != "" {
-			req.Header.Set("Authorization", "Bearer "+createAPIKey)
+		if apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 
 		resp, err := http.DefaultClient.Do(req)
@@ -92,7 +93,7 @@ func init() {
 	keyCreateCmd.Flags().StringVar(&createDescription, "description", "", "Human-readable description for the key")
 	keyCreateCmd.Flags().StringVar(&createExpiresIn, "expires", "", "Expiration duration (e.g. 90d, 24h)")
 	keyCreateCmd.Flags().StringVar(&createServer, "server", "http://localhost:8080", "Caesium server base URL")
-	keyCreateCmd.Flags().StringVar(&createAPIKey, "api-key", "", "Admin API key for authentication")
+	keyCreateCmd.Flags().StringVar(&createAPIKey, "api-key", "", apiKeyFlagUsage("Admin"))
 	keyCreateCmd.Flags().StringSliceVar(&createScopeJobs, "scope-jobs", nil, "Restrict key to specific job aliases (comma-separated)")
 	_ = keyCreateCmd.MarkFlagRequired("role")
 

--- a/cmd/auth/key_create.go
+++ b/cmd/auth/key_create.go
@@ -1,0 +1,100 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	createRole        string
+	createDescription string
+	createExpiresIn   string
+	createServer      string
+	createAPIKey      string
+	createScopeJobs   []string
+)
+
+var keyCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new API key",
+	Example: `  caesium auth key create --role operator --description "CI deploy key" --expires 90d
+  caesium auth key create --role runner --description "ETL runner" --scope-jobs etl-daily,etl-hourly`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		server := strings.TrimSuffix(createServer, "/")
+
+		body := map[string]interface{}{
+			"role":        createRole,
+			"description": createDescription,
+		}
+		if createExpiresIn != "" {
+			body["expires_in"] = createExpiresIn
+		}
+		if len(createScopeJobs) > 0 {
+			body["scope"] = map[string]interface{}{
+				"jobs": createScopeJobs,
+			}
+		}
+
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, server+"/v1/auth/keys", strings.NewReader(string(payload)))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if createAPIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+createAPIKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		respBody, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("key creation failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			cmd.Print(string(respBody))
+			return nil
+		}
+
+		if key, ok := result["key"].(string); ok {
+			cmd.Println("API Key (save this — it will not be shown again):")
+			cmd.Println(key)
+			cmd.Println()
+		}
+
+		if apiKey, ok := result["api_key"].(map[string]interface{}); ok {
+			pretty, _ := json.MarshalIndent(apiKey, "", "  ")
+			cmd.Println("Key metadata:")
+			cmd.Println(string(pretty))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	keyCreateCmd.Flags().StringVar(&createRole, "role", "", "Key role: admin, operator, runner, viewer (required)")
+	keyCreateCmd.Flags().StringVar(&createDescription, "description", "", "Human-readable description for the key")
+	keyCreateCmd.Flags().StringVar(&createExpiresIn, "expires", "", "Expiration duration (e.g. 90d, 24h)")
+	keyCreateCmd.Flags().StringVar(&createServer, "server", "http://localhost:8080", "Caesium server base URL")
+	keyCreateCmd.Flags().StringVar(&createAPIKey, "api-key", "", "Admin API key for authentication")
+	keyCreateCmd.Flags().StringSliceVar(&createScopeJobs, "scope-jobs", nil, "Restrict key to specific job aliases (comma-separated)")
+	_ = keyCreateCmd.MarkFlagRequired("role")
+
+	keyCmd.AddCommand(keyCreateCmd)
+}

--- a/cmd/auth/key_list.go
+++ b/cmd/auth/key_list.go
@@ -1,0 +1,59 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	listServer string
+	listAPIKey string
+)
+
+var keyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all API keys",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		server := strings.TrimSuffix(listServer, "/")
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, server+"/v1/auth/keys", nil)
+		if err != nil {
+			return err
+		}
+		if listAPIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+listAPIKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("key list failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		var out interface{}
+		if err := json.Unmarshal(body, &out); err != nil {
+			cmd.Print(string(body))
+			return nil
+		}
+		pretty, _ := json.MarshalIndent(out, "", "  ")
+		cmd.Println(string(pretty))
+		return nil
+	},
+}
+
+func init() {
+	keyListCmd.Flags().StringVar(&listServer, "server", "http://localhost:8080", "Caesium server base URL")
+	keyListCmd.Flags().StringVar(&listAPIKey, "api-key", "", "Admin API key for authentication")
+
+	keyCmd.AddCommand(keyListCmd)
+}

--- a/cmd/auth/key_list.go
+++ b/cmd/auth/key_list.go
@@ -20,13 +20,14 @@ var keyListCmd = &cobra.Command{
 	Short: "List all API keys",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		server := strings.TrimSuffix(listServer, "/")
+		apiKey := resolveAPIKey(cmd, listAPIKey)
 
 		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, server+"/v1/auth/keys", nil)
 		if err != nil {
 			return err
 		}
-		if listAPIKey != "" {
-			req.Header.Set("Authorization", "Bearer "+listAPIKey)
+		if apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 
 		resp, err := http.DefaultClient.Do(req)
@@ -53,7 +54,7 @@ var keyListCmd = &cobra.Command{
 
 func init() {
 	keyListCmd.Flags().StringVar(&listServer, "server", "http://localhost:8080", "Caesium server base URL")
-	keyListCmd.Flags().StringVar(&listAPIKey, "api-key", "", "Admin API key for authentication")
+	keyListCmd.Flags().StringVar(&listAPIKey, "api-key", "", apiKeyFlagUsage("Admin"))
 
 	keyCmd.AddCommand(keyListCmd)
 }

--- a/cmd/auth/key_revoke.go
+++ b/cmd/auth/key_revoke.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	revokeID     string
+	revokeServer string
+	revokeAPIKey string
+)
+
+var keyRevokeCmd = &cobra.Command{
+	Use:     "revoke",
+	Short:   "Revoke an API key",
+	Example: `  caesium auth key revoke --id <key-id>`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		server := strings.TrimSuffix(revokeServer, "/")
+		url := fmt.Sprintf("%s/v1/auth/keys/%s/revoke", server, revokeID)
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, nil)
+		if err != nil {
+			return err
+		}
+		if revokeAPIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+revokeAPIKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("key revocation failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		var out interface{}
+		if err := json.Unmarshal(body, &out); err != nil {
+			cmd.Print(string(body))
+			return nil
+		}
+		pretty, _ := json.MarshalIndent(out, "", "  ")
+		cmd.Println(string(pretty))
+		return nil
+	},
+}
+
+func init() {
+	keyRevokeCmd.Flags().StringVar(&revokeID, "id", "", "API key ID to revoke (required)")
+	keyRevokeCmd.Flags().StringVar(&revokeServer, "server", "http://localhost:8080", "Caesium server base URL")
+	keyRevokeCmd.Flags().StringVar(&revokeAPIKey, "api-key", "", "Admin API key for authentication")
+	_ = keyRevokeCmd.MarkFlagRequired("id")
+
+	keyCmd.AddCommand(keyRevokeCmd)
+}

--- a/cmd/auth/key_revoke.go
+++ b/cmd/auth/key_revoke.go
@@ -22,14 +22,15 @@ var keyRevokeCmd = &cobra.Command{
 	Example: `  caesium auth key revoke --id <key-id>`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		server := strings.TrimSuffix(revokeServer, "/")
+		apiKey := resolveAPIKey(cmd, revokeAPIKey)
 		url := fmt.Sprintf("%s/v1/auth/keys/%s/revoke", server, revokeID)
 
 		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, nil)
 		if err != nil {
 			return err
 		}
-		if revokeAPIKey != "" {
-			req.Header.Set("Authorization", "Bearer "+revokeAPIKey)
+		if apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 
 		resp, err := http.DefaultClient.Do(req)
@@ -57,7 +58,7 @@ var keyRevokeCmd = &cobra.Command{
 func init() {
 	keyRevokeCmd.Flags().StringVar(&revokeID, "id", "", "API key ID to revoke (required)")
 	keyRevokeCmd.Flags().StringVar(&revokeServer, "server", "http://localhost:8080", "Caesium server base URL")
-	keyRevokeCmd.Flags().StringVar(&revokeAPIKey, "api-key", "", "Admin API key for authentication")
+	keyRevokeCmd.Flags().StringVar(&revokeAPIKey, "api-key", "", apiKeyFlagUsage("Admin"))
 	_ = keyRevokeCmd.MarkFlagRequired("id")
 
 	keyCmd.AddCommand(keyRevokeCmd)

--- a/cmd/auth/key_rotate.go
+++ b/cmd/auth/key_rotate.go
@@ -23,6 +23,7 @@ var keyRotateCmd = &cobra.Command{
 	Example: `  caesium auth key rotate --id <key-id> --grace-period 24h`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		server := strings.TrimSuffix(rotateServer, "/")
+		apiKey := resolveAPIKey(cmd, rotateAPIKey)
 		url := fmt.Sprintf("%s/v1/auth/keys/%s/rotate", server, rotateID)
 
 		body := map[string]interface{}{}
@@ -39,8 +40,8 @@ var keyRotateCmd = &cobra.Command{
 			return err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		if rotateAPIKey != "" {
-			req.Header.Set("Authorization", "Bearer "+rotateAPIKey)
+		if apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 
 		resp, err := http.DefaultClient.Do(req)
@@ -80,7 +81,7 @@ func init() {
 	keyRotateCmd.Flags().StringVar(&rotateID, "id", "", "API key ID to rotate (required)")
 	keyRotateCmd.Flags().StringVar(&rotateGracePeriod, "grace-period", "24h", "Grace period before the old key expires")
 	keyRotateCmd.Flags().StringVar(&rotateServer, "server", "http://localhost:8080", "Caesium server base URL")
-	keyRotateCmd.Flags().StringVar(&rotateAPIKey, "api-key", "", "Admin API key for authentication")
+	keyRotateCmd.Flags().StringVar(&rotateAPIKey, "api-key", "", apiKeyFlagUsage("Admin"))
 	_ = keyRotateCmd.MarkFlagRequired("id")
 
 	keyCmd.AddCommand(keyRotateCmd)

--- a/cmd/auth/key_rotate.go
+++ b/cmd/auth/key_rotate.go
@@ -1,0 +1,87 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	rotateID          string
+	rotateGracePeriod string
+	rotateServer      string
+	rotateAPIKey      string
+)
+
+var keyRotateCmd = &cobra.Command{
+	Use:     "rotate",
+	Short:   "Rotate an API key with a grace period for the old key",
+	Example: `  caesium auth key rotate --id <key-id> --grace-period 24h`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		server := strings.TrimSuffix(rotateServer, "/")
+		url := fmt.Sprintf("%s/v1/auth/keys/%s/rotate", server, rotateID)
+
+		body := map[string]interface{}{}
+		if rotateGracePeriod != "" {
+			body["grace_period"] = rotateGracePeriod
+		}
+		payload, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, strings.NewReader(string(payload)))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if rotateAPIKey != "" {
+			req.Header.Set("Authorization", "Bearer "+rotateAPIKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		respBody, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("key rotation failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+		}
+
+		var result map[string]interface{}
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			cmd.Print(string(respBody))
+			return nil
+		}
+
+		if key, ok := result["key"].(string); ok {
+			cmd.Println("New API Key (save this — it will not be shown again):")
+			cmd.Println(key)
+			cmd.Println()
+		}
+
+		if apiKey, ok := result["api_key"].(map[string]interface{}); ok {
+			pretty, _ := json.MarshalIndent(apiKey, "", "  ")
+			cmd.Println("New key metadata:")
+			cmd.Println(string(pretty))
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	keyRotateCmd.Flags().StringVar(&rotateID, "id", "", "API key ID to rotate (required)")
+	keyRotateCmd.Flags().StringVar(&rotateGracePeriod, "grace-period", "24h", "Grace period before the old key expires")
+	keyRotateCmd.Flags().StringVar(&rotateServer, "server", "http://localhost:8080", "Caesium server base URL")
+	keyRotateCmd.Flags().StringVar(&rotateAPIKey, "api-key", "", "Admin API key for authentication")
+	_ = keyRotateCmd.MarkFlagRequired("id")
+
+	keyCmd.AddCommand(keyRotateCmd)
+}

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/caesium-cloud/caesium/cmd/auth"
 	"github.com/caesium-cloud/caesium/cmd/backfill"
 	"github.com/caesium-cloud/caesium/cmd/cache"
 	"github.com/caesium-cloud/caesium/cmd/dev"
@@ -12,6 +13,7 @@ import (
 )
 
 var cmds = []*cobra.Command{
+	auth.Cmd,
 	backfill.Cmd,
 	cache.Cmd,
 	dev.Cmd,

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -2,15 +2,18 @@ package start
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
 	"runtime/pprof"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/caesium-cloud/caesium/api"
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	runsvc "github.com/caesium-cloud/caesium/api/rest/service/run"
+	"github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/executor"
 	"github.com/caesium-cloud/caesium/internal/jobdef"
@@ -90,6 +93,10 @@ func start(cmd *cobra.Command, args []string) error {
 	runsvc.New(ctx).SetBus(bus)
 
 	vars := env.Variables()
+
+	// --- Authentication & Authorization ---
+	authSvc, auditor, limiter := initAuth(ctx, vars)
+
 	log.Info(
 		"execution configuration",
 		"max_parallel_tasks",
@@ -166,7 +173,7 @@ func start(cmd *cobra.Command, args []string) error {
 
 	go func() {
 		log.Info("spinning up api")
-		errs <- api.Start(ctx, bus)
+		errs <- api.Start(ctx, bus, authSvc, auditor, limiter)
 	}()
 
 	go func() {
@@ -215,6 +222,67 @@ func start(cmd *cobra.Command, args []string) error {
 	defer shutdown()
 
 	return <-errs
+}
+
+// initAuth sets up authentication services based on CAESIUM_AUTH_MODE.
+// Returns nil services when auth is disabled so callers can pass them through safely.
+func initAuth(ctx context.Context, vars env.Environment) (*auth.Service, *auth.AuditLogger, *auth.RateLimiter) {
+	conn := db.Connection()
+	authSvc := auth.NewService(conn)
+	auditor := auth.NewAuditLogger(conn)
+	limiter := auth.NewRateLimiter(vars.AuthRateLimitPerMinute, time.Minute)
+
+	switch vars.AuthMode {
+	case "none", "":
+		log.Warn("authentication is disabled — all endpoints are publicly accessible")
+		return authSvc, auditor, limiter
+
+	case "api-key":
+		log.Info("authentication enabled", "mode", vars.AuthMode)
+
+		// TLS requirement check.
+		if vars.AuthRequireTLS {
+			hasTLS := vars.TLSCert != "" && vars.TLSKey != ""
+			hasProxy := vars.TrustedProxies != ""
+			if !hasTLS && !hasProxy {
+				log.Fatal(
+					"TLS is required when authentication is enabled. " +
+						"Set CAESIUM_TLS_CERT/CAESIUM_TLS_KEY or CAESIUM_TRUSTED_PROXIES, " +
+						"or set CAESIUM_AUTH_REQUIRE_TLS=false to disable this check",
+				)
+			}
+		}
+
+		// Bootstrap: generate initial admin key if none exist.
+		plaintext, err := authSvc.Bootstrap()
+		if err != nil {
+			log.Fatal("auth bootstrap failure", "error", err)
+		}
+		if plaintext != "" {
+			// Print to stdout only — not to structured logs.
+			fmt.Println("==========================================================")
+			fmt.Println("  BOOTSTRAP ADMIN API KEY (shown once, save it now):")
+			fmt.Printf("  %s\n", plaintext)
+			fmt.Println("==========================================================")
+		} else {
+			// Verify at least one admin key exists.
+			exists, err := authSvc.AdminKeyExists()
+			if err != nil {
+				log.Fatal("failed to verify admin key existence", "error", err)
+			}
+			if !exists {
+				log.Fatal("no admin API key found — cannot start with authentication enabled")
+			}
+		}
+
+		authSvc.StartLastUsedFlusher(ctx)
+		limiter.StartCleanup(ctx.Done())
+		return authSvc, auditor, limiter
+
+	default:
+		log.Fatal("unknown CAESIUM_AUTH_MODE value", "mode", vars.AuthMode)
+		return nil, nil, nil // unreachable
+	}
 }
 
 func shutdown() {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -56,6 +56,28 @@ These features address the most common reasons a team would choose an alternativ
 
 **Design doc**: [`design-concurrency-priority.md`](design-concurrency-priority.md)
 
+### 1.5 API Key Auth Hardening Follow-up
+
+**Status**: Baseline API-key auth, RBAC, audit logging, UI login, scoped keys, and webhook/auth domain separation are shipped. The remaining work here is security hardening on top of that base.
+
+**Current state**: Caesium now protects the REST API and `/metrics` with API keys when `CAESIUM_AUTH_MODE=api-key`, disables GraphQL in that mode, and keeps webhook signature validation on its own auth path. There are still a few deferred hardening gaps in the implementation:
+
+1. `ValidateKey` has distinguishable failure paths (`not found`, `expired`, `revoked`) that should be normalized to reduce timing side channels.
+2. API keys are currently stored as a plain SHA-256 hash of the full bearer token; the follow-up should move to HMAC-SHA256 with a server-side secret or an equivalent keyed/salted design.
+3. Bootstrap admin-key creation is still a read-then-create flow and should become atomic to avoid duplicate bootstrap keys when multiple instances start concurrently.
+
+**Target state**: The API-key implementation is hardened for production multi-instance deployments:
+
+1. Authentication failures have a consistent timing envelope across missing, expired, revoked, and malformed keys.
+2. Stored key material is resistant to offline cracking after a database compromise without also compromising server-side secret material.
+3. Bootstrap admin-key creation is atomic and safe under concurrent startup.
+
+**Implementation plan**:
+1. Normalize validation-failure timing in `internal/auth/service.go` with a fixed minimum latency or equivalent dummy-work strategy.
+2. Replace bare `HashKey` with a keyed hash scheme and add the required server-side configuration plus migration notes.
+3. Make bootstrap admin-key creation transactional or conflict-driven so only one bootstrap key can be created under concurrent startup.
+4. Add focused tests for timing-path consistency, keyed-hash configuration behavior, and concurrent bootstrap semantics.
+
 ---
 
 ## Phase 2: Deepen Differentiators

--- a/internal/auth/audit.go
+++ b/internal/auth/audit.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// AuditOutcome enumerates the possible outcomes for an audit log entry.
+const (
+	OutcomeSuccess = "success"
+	OutcomeDenied  = "denied"
+	OutcomeError   = "error"
+)
+
+// AuditAction enumerates well-known auditable actions.
+const (
+	ActionAuthAttempt  = "auth.attempt"
+	ActionAuthDenied   = "auth.denied"
+	ActionKeyCreate    = "api_key.create"
+	ActionKeyRevoke    = "api_key.revoke"
+	ActionKeyRotate    = "api_key.rotate"
+	ActionJobCreate    = "job.create"
+	ActionJobDelete    = "job.delete"
+	ActionJobPause     = "job.pause"
+	ActionJobUnpause   = "job.unpause"
+	ActionRunTrigger   = "run.trigger"
+	ActionRunRetry     = "run.retry"
+	ActionBackfill     = "run.backfill"
+	ActionJobdefApply  = "jobdef.apply"
+	ActionCachePrune   = "cache.prune"
+	ActionCacheDelete  = "cache.delete"
+	ActionLogLevel     = "log.set_level"
+	ActionDBQuery      = "database.query"
+)
+
+// AuditLogger writes structured audit log entries to the database.
+type AuditLogger struct {
+	db *gorm.DB
+}
+
+// NewAuditLogger creates a new audit logger.
+func NewAuditLogger(db *gorm.DB) *AuditLogger {
+	return &AuditLogger{db: db}
+}
+
+// AuditEntry holds the fields for a single audit log write.
+type AuditEntry struct {
+	Actor        string
+	Action       string
+	ResourceType string
+	ResourceID   string
+	SourceIP     string
+	Outcome      string
+	Metadata     map[string]interface{}
+}
+
+// Log writes an audit entry to the database.
+func (a *AuditLogger) Log(entry AuditEntry) error {
+	var metaJSON []byte
+	if entry.Metadata != nil {
+		var err error
+		metaJSON, err = json.Marshal(entry.Metadata)
+		if err != nil {
+			return fmt.Errorf("marshal audit metadata: %w", err)
+		}
+	}
+
+	record := &models.AuditLog{
+		ID:           uuid.New(),
+		Timestamp:    time.Now().UTC(),
+		Actor:        entry.Actor,
+		Action:       entry.Action,
+		ResourceType: entry.ResourceType,
+		ResourceID:   entry.ResourceID,
+		SourceIP:     entry.SourceIP,
+		Outcome:      entry.Outcome,
+		Metadata:     metaJSON,
+	}
+
+	if err := a.db.Create(record).Error; err != nil {
+		return fmt.Errorf("write audit log: %w", err)
+	}
+	return nil
+}
+
+// AuditQueryRequest holds filters for querying the audit log.
+type AuditQueryRequest struct {
+	Since  *time.Time
+	Until  *time.Time
+	Actor  string
+	Action string
+	Limit  int
+	Offset int
+}
+
+// Query returns audit log entries matching the given filters.
+func (a *AuditLogger) Query(req *AuditQueryRequest) ([]models.AuditLog, error) {
+	q := a.db.Order("timestamp DESC")
+
+	if req.Since != nil {
+		q = q.Where("timestamp >= ?", *req.Since)
+	}
+	if req.Until != nil {
+		q = q.Where("timestamp <= ?", *req.Until)
+	}
+	if req.Actor != "" {
+		q = q.Where("actor = ?", req.Actor)
+	}
+	if req.Action != "" {
+		q = q.Where("action = ?", req.Action)
+	}
+
+	limit := req.Limit
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	q = q.Limit(limit)
+
+	if req.Offset > 0 {
+		q = q.Offset(req.Offset)
+	}
+
+	var entries []models.AuditLog
+	if err := q.Find(&entries).Error; err != nil {
+		return nil, fmt.Errorf("query audit log: %w", err)
+	}
+	return entries, nil
+}

--- a/internal/auth/audit_test.go
+++ b/internal/auth/audit_test.go
@@ -1,0 +1,177 @@
+package auth_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditLogWrite(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	err := auditor.Log(auth.AuditEntry{
+		Actor:        "csk_live_test",
+		Action:       auth.ActionKeyCreate,
+		ResourceType: "api_key",
+		ResourceID:   "abc-123",
+		SourceIP:     "1.2.3.4",
+		Outcome:      auth.OutcomeSuccess,
+		Metadata:     map[string]interface{}{"role": "admin"},
+	})
+	require.NoError(t, err)
+
+	// Verify it was persisted.
+	var count int64
+	db.Model(&models.AuditLog{}).Count(&count)
+	require.Equal(t, int64(1), count)
+}
+
+func TestAuditLogWriteWithoutMetadata(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	err := auditor.Log(auth.AuditEntry{
+		Actor:   "csk_live_test",
+		Action:  auth.ActionAuthDenied,
+		Outcome: auth.OutcomeDenied,
+	})
+	require.NoError(t, err)
+}
+
+func TestAuditQueryAll(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	for i := 0; i < 5; i++ {
+		err := auditor.Log(auth.AuditEntry{
+			Actor:   "csk_live_test",
+			Action:  auth.ActionKeyCreate,
+			Outcome: auth.OutcomeSuccess,
+		})
+		require.NoError(t, err)
+	}
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{})
+	require.NoError(t, err)
+	require.Len(t, entries, 5)
+}
+
+func TestAuditQueryByActor(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	_ = auditor.Log(auth.AuditEntry{Actor: "alice", Action: "a", Outcome: auth.OutcomeSuccess})
+	_ = auditor.Log(auth.AuditEntry{Actor: "bob", Action: "b", Outcome: auth.OutcomeSuccess})
+	_ = auditor.Log(auth.AuditEntry{Actor: "alice", Action: "c", Outcome: auth.OutcomeSuccess})
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Actor: "alice"})
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	for _, e := range entries {
+		require.Equal(t, "alice", e.Actor)
+	}
+}
+
+func TestAuditQueryByAction(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: auth.ActionKeyCreate, Outcome: auth.OutcomeSuccess})
+	_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: auth.ActionKeyRevoke, Outcome: auth.OutcomeSuccess})
+	_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: auth.ActionKeyCreate, Outcome: auth.OutcomeSuccess})
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Action: auth.ActionKeyRevoke})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, auth.ActionKeyRevoke, entries[0].Action)
+}
+
+func TestAuditQueryBySince(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: "old", Outcome: auth.OutcomeSuccess})
+
+	// Wait a bit so timestamps differ.
+	time.Sleep(50 * time.Millisecond)
+	cutoff := time.Now().UTC()
+	time.Sleep(50 * time.Millisecond)
+
+	_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: "new", Outcome: auth.OutcomeSuccess})
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Since: &cutoff})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "new", entries[0].Action)
+}
+
+func TestAuditQueryLimit(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	for i := 0; i < 10; i++ {
+		_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: "x", Outcome: auth.OutcomeSuccess})
+	}
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Limit: 3})
+	require.NoError(t, err)
+	require.Len(t, entries, 3)
+}
+
+func TestAuditQueryDefaultLimit(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	for i := 0; i < 150; i++ {
+		_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: "x", Outcome: auth.OutcomeSuccess})
+	}
+
+	// Default limit is 100.
+	entries, err := auditor.Query(&auth.AuditQueryRequest{})
+	require.NoError(t, err)
+	require.Len(t, entries, 100)
+}
+
+func TestAuditQueryOffset(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	for i := 0; i < 5; i++ {
+		_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: "x", Outcome: auth.OutcomeSuccess})
+	}
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Offset: 3, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 2) // 5 total, skip 3 = 2 remaining
+}
+
+func TestAuditQueryOrderDescending(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := auth.NewAuditLogger(db)
+
+	_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: "first", Outcome: auth.OutcomeSuccess})
+	time.Sleep(10 * time.Millisecond)
+	_ = auditor.Log(auth.AuditEntry{Actor: "a", Action: "second", Outcome: auth.OutcomeSuccess})
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{})
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	// Most recent first.
+	require.Equal(t, "second", entries[0].Action)
+	require.Equal(t, "first", entries[1].Action)
+}

--- a/internal/auth/keygen.go
+++ b/internal/auth/keygen.go
@@ -1,0 +1,71 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+)
+
+const (
+	// KeyPrefixLive is the scannable prefix for production API keys.
+	KeyPrefixLive = "csk_live_"
+
+	// randomBytes is the number of random bytes used in key generation (32 bytes = 256 bits).
+	randomBytes = 32
+
+	// displayPrefixLen is the length of the key_prefix column value (e.g. "csk_live_a1b2").
+	displayPrefixLen = 13
+)
+
+// base62 alphabet for URL-safe, scannable key encoding.
+const base62Chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// GenerateKey produces a new API key and its SHA-256 hash.
+// Returns (plaintext_key, key_prefix, key_hash, error).
+// The plaintext key must be shown exactly once at creation time.
+func GenerateKey() (plaintext, prefix, hash string, err error) {
+	random, err := base62Encode(randomBytes)
+	if err != nil {
+		return "", "", "", fmt.Errorf("generate key: %w", err)
+	}
+
+	plaintext = KeyPrefixLive + random
+	prefix = plaintext[:displayPrefixLen]
+	hash = HashKey(plaintext)
+	return plaintext, prefix, hash, nil
+}
+
+// HashKey returns the hex-encoded SHA-256 hash of a plaintext API key.
+func HashKey(plaintext string) string {
+	h := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(h[:])
+}
+
+// base62Encode generates n random bytes and encodes them in base62.
+func base62Encode(n int) (string, error) {
+	b := make([]byte, 0, n+8) // base62 output is slightly longer than input bytes
+	radix := big.NewInt(int64(len(base62Chars)))
+
+	raw := make([]byte, n)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("read random: %w", err)
+	}
+
+	num := new(big.Int).SetBytes(raw)
+	zero := big.NewInt(0)
+	mod := new(big.Int)
+
+	for num.Cmp(zero) > 0 {
+		num.DivMod(num, radix, mod)
+		b = append(b, base62Chars[mod.Int64()])
+	}
+
+	// Pad to ensure minimum length (very unlikely to be needed with 32 bytes).
+	for len(b) < n {
+		b = append(b, base62Chars[0])
+	}
+
+	return string(b), nil
+}

--- a/internal/auth/keygen_test.go
+++ b/internal/auth/keygen_test.go
@@ -1,0 +1,48 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateKey(t *testing.T) {
+	plaintext, prefix, hash, err := GenerateKey()
+	require.NoError(t, err)
+
+	// Key starts with the live prefix.
+	require.True(t, strings.HasPrefix(plaintext, KeyPrefixLive))
+
+	// Prefix is the first 13 characters of the full key.
+	require.Equal(t, plaintext[:displayPrefixLen], prefix)
+	require.Len(t, prefix, displayPrefixLen)
+
+	// Hash matches.
+	require.Equal(t, HashKey(plaintext), hash)
+
+	// Key has sufficient length (prefix + 32+ encoded chars).
+	require.Greater(t, len(plaintext), 30)
+}
+
+func TestGenerateKeyUniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		plaintext, _, _, err := GenerateKey()
+		require.NoError(t, err)
+		require.False(t, seen[plaintext], "duplicate key generated")
+		seen[plaintext] = true
+	}
+}
+
+func TestHashKeyDeterministic(t *testing.T) {
+	key := "csk_live_testkey123"
+	h1 := HashKey(key)
+	h2 := HashKey(key)
+	require.Equal(t, h1, h2)
+	require.Len(t, h1, 64) // SHA-256 hex = 64 chars
+}
+
+func TestHashKeyDifferentInputs(t *testing.T) {
+	require.NotEqual(t, HashKey("key1"), HashKey("key2"))
+}

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -1,0 +1,110 @@
+package auth
+
+import (
+	"sync"
+	"time"
+)
+
+// RateLimiter tracks failed authentication attempts per source IP
+// using a sliding window counter.
+type RateLimiter struct {
+	mu       sync.Mutex
+	windows  map[string]*window
+	limit    int
+	interval time.Duration
+}
+
+type window struct {
+	count   int
+	resetAt time.Time
+}
+
+// NewRateLimiter creates a rate limiter that allows `limit` failures per
+// `interval` per source IP.
+func NewRateLimiter(limit int, interval time.Duration) *RateLimiter {
+	return &RateLimiter{
+		windows:  make(map[string]*window),
+		limit:    limit,
+		interval: interval,
+	}
+}
+
+// RecordFailure increments the failure count for the given IP.
+// Returns true if the IP is now rate-limited.
+func (r *RateLimiter) RecordFailure(ip string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	w, ok := r.windows[ip]
+	if !ok || now.After(w.resetAt) {
+		r.windows[ip] = &window{count: 1, resetAt: now.Add(r.interval)}
+		return false
+	}
+
+	w.count++
+	return w.count > r.limit
+}
+
+// IsLimited returns true if the IP has exceeded the failure threshold.
+func (r *RateLimiter) IsLimited(ip string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	w, ok := r.windows[ip]
+	if !ok {
+		return false
+	}
+	if time.Now().After(w.resetAt) {
+		delete(r.windows, ip)
+		return false
+	}
+	return w.count > r.limit
+}
+
+// RetryAfter returns the number of seconds until the rate limit window resets
+// for the given IP. Returns 0 if not limited.
+func (r *RateLimiter) RetryAfter(ip string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	w, ok := r.windows[ip]
+	if !ok {
+		return 0
+	}
+	remaining := time.Until(w.resetAt)
+	if remaining <= 0 {
+		delete(r.windows, ip)
+		return 0
+	}
+	return int(remaining.Seconds()) + 1
+}
+
+// Cleanup removes expired windows. Call periodically to prevent memory growth.
+func (r *RateLimiter) Cleanup() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	now := time.Now()
+	for ip, w := range r.windows {
+		if now.After(w.resetAt) {
+			delete(r.windows, ip)
+		}
+	}
+}
+
+// StartCleanup runs a periodic cleanup goroutine.
+func (r *RateLimiter) StartCleanup(done <-chan struct{}) {
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				r.Cleanup()
+			}
+		}
+	}()
+}

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRateLimiterAllowsUnderThreshold(t *testing.T) {
+	rl := NewRateLimiter(3, time.Minute)
+
+	require.False(t, rl.RecordFailure("1.2.3.4"))
+	require.False(t, rl.RecordFailure("1.2.3.4"))
+	require.False(t, rl.RecordFailure("1.2.3.4"))
+	require.False(t, rl.IsLimited("1.2.3.4"))
+}
+
+func TestRateLimiterBlocksOverThreshold(t *testing.T) {
+	rl := NewRateLimiter(2, time.Minute)
+
+	rl.RecordFailure("1.2.3.4")
+	rl.RecordFailure("1.2.3.4")
+	limited := rl.RecordFailure("1.2.3.4") // 3rd failure, limit is 2
+	require.True(t, limited)
+	require.True(t, rl.IsLimited("1.2.3.4"))
+}
+
+func TestRateLimiterIsolatesIPs(t *testing.T) {
+	rl := NewRateLimiter(1, time.Minute)
+
+	rl.RecordFailure("1.2.3.4")
+	rl.RecordFailure("1.2.3.4") // over limit
+	require.True(t, rl.IsLimited("1.2.3.4"))
+	require.False(t, rl.IsLimited("5.6.7.8"))
+}
+
+func TestRateLimiterRetryAfter(t *testing.T) {
+	rl := NewRateLimiter(1, 30*time.Second)
+
+	rl.RecordFailure("1.2.3.4")
+	rl.RecordFailure("1.2.3.4")
+
+	retryAfter := rl.RetryAfter("1.2.3.4")
+	require.Greater(t, retryAfter, 0)
+	require.LessOrEqual(t, retryAfter, 31)
+}
+
+func TestRateLimiterCleanup(t *testing.T) {
+	rl := NewRateLimiter(1, time.Millisecond)
+
+	rl.RecordFailure("1.2.3.4")
+	rl.RecordFailure("1.2.3.4")
+
+	time.Sleep(5 * time.Millisecond)
+	rl.Cleanup()
+	require.False(t, rl.IsLimited("1.2.3.4"))
+}

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -32,6 +32,7 @@ var endpointPolicy = map[string]models.Role{
 	// Public — no auth required (handled by skip list, not here)
 
 	// Viewer
+	"GET /metrics":                   models.RoleViewer,
 	"GET /v1/jobs":                   models.RoleViewer,
 	"GET /v1/jobs/:id":               models.RoleViewer,
 	"GET /v1/jobs/:id/tasks":         models.RoleViewer,

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -1,0 +1,86 @@
+package auth
+
+import "github.com/caesium-cloud/caesium/internal/models"
+
+// RequiredRole returns the minimum role needed for a given HTTP method + path.
+func RequiredRole(method, path string) (models.Role, bool) {
+	role, ok := endpointPolicy[method+" "+path]
+	return role, ok
+}
+
+// HasRole returns true if the key's role is at or above the required level.
+func HasRole(keyRole, required models.Role) bool {
+	return models.RoleLevel(keyRole) >= models.RoleLevel(required)
+}
+
+// CheckScope validates whether the key is allowed to act on the given job alias.
+// A nil/empty scope means unrestricted access.
+func CheckScope(scopeJSON []byte, jobAlias string) bool {
+	scope, err := DecodeScope(scopeJSON)
+	if err != nil {
+		return false // malformed scope denies access
+	}
+	if scope == nil {
+		return true
+	}
+	return containsScopedJob(scope.Jobs, jobAlias)
+}
+
+// endpointPolicy maps "METHOD /path-pattern" to the minimum required role.
+// Parametric segments are replaced with `:id` by the middleware normaliser.
+var endpointPolicy = map[string]models.Role{
+	// Public — no auth required (handled by skip list, not here)
+
+	// Viewer
+	"GET /v1/jobs":                   models.RoleViewer,
+	"GET /v1/jobs/:id":               models.RoleViewer,
+	"GET /v1/jobs/:id/tasks":         models.RoleViewer,
+	"GET /v1/jobs/:id/dag":           models.RoleViewer,
+	"GET /v1/jobs/:id/runs":          models.RoleViewer,
+	"GET /v1/jobs/:id/runs/:id":      models.RoleViewer,
+	"GET /v1/jobs/:id/runs/:id/logs": models.RoleViewer,
+	"GET /v1/jobs/:id/cache":         models.RoleViewer,
+	"GET /v1/jobs/:id/backfills":     models.RoleViewer,
+	"GET /v1/jobs/:id/backfills/:id": models.RoleViewer,
+	"GET /v1/events":                 models.RoleViewer,
+	"GET /v1/stats":                  models.RoleViewer,
+	"GET /v1/triggers":               models.RoleViewer,
+	"GET /v1/triggers/:id":           models.RoleViewer,
+	"GET /v1/atoms":                  models.RoleViewer,
+	"GET /v1/atoms/:id":              models.RoleViewer,
+	"GET /v1/nodes/:id/workers":      models.RoleViewer,
+
+	// Runner
+	"POST /v1/jobs/:id/run":                      models.RoleRunner,
+	"POST /v1/jobs/:id/runs/:id/retry":           models.RoleRunner,
+	"POST /v1/jobs/:id/runs/:id/callbacks/retry": models.RoleRunner,
+	"POST /v1/jobs/:id/backfill":                 models.RoleRunner,
+	"POST /v1/triggers/:id/fire":                 models.RoleRunner,
+
+	// Operator
+	"POST /v1/jobs":                         models.RoleOperator,
+	"DELETE /v1/jobs/:id":                   models.RoleOperator,
+	"PUT /v1/jobs/:id/pause":                models.RoleOperator,
+	"PUT /v1/jobs/:id/unpause":              models.RoleOperator,
+	"POST /v1/jobdefs/apply":                models.RoleOperator,
+	"POST /v1/cache/prune":                  models.RoleOperator,
+	"DELETE /v1/jobs/:id/cache":             models.RoleOperator,
+	"DELETE /v1/jobs/:id/cache/:id":         models.RoleOperator,
+	"PUT /v1/jobs/:id/backfills/:id/cancel": models.RoleOperator,
+	"POST /v1/triggers":                     models.RoleOperator,
+	"PATCH /v1/triggers/:id":                models.RoleOperator,
+	"POST /v1/atoms":                        models.RoleOperator,
+	"DELETE /v1/atoms/:id":                  models.RoleOperator,
+
+	// Admin
+	"PUT /v1/logs/level":            models.RoleAdmin,
+	"GET /v1/logs/level":            models.RoleAdmin,
+	"GET /v1/logs/stream":           models.RoleAdmin,
+	"GET /v1/database/schema":       models.RoleAdmin,
+	"POST /v1/database/query":       models.RoleAdmin,
+	"GET /v1/auth/keys":             models.RoleAdmin,
+	"POST /v1/auth/keys":            models.RoleAdmin,
+	"POST /v1/auth/keys/:id/revoke": models.RoleAdmin,
+	"POST /v1/auth/keys/:id/rotate": models.RoleAdmin,
+	"GET /v1/auth/audit":            models.RoleAdmin,
+}

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasRole(t *testing.T) {
+	tests := []struct {
+		keyRole  models.Role
+		required models.Role
+		allowed  bool
+	}{
+		{models.RoleAdmin, models.RoleAdmin, true},
+		{models.RoleAdmin, models.RoleViewer, true},
+		{models.RoleOperator, models.RoleRunner, true},
+		{models.RoleViewer, models.RoleViewer, true},
+		{models.RoleViewer, models.RoleRunner, false},
+		{models.RoleRunner, models.RoleOperator, false},
+		{models.RoleRunner, models.RoleAdmin, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.keyRole)+"_vs_"+string(tt.required), func(t *testing.T) {
+			require.Equal(t, tt.allowed, HasRole(tt.keyRole, tt.required))
+		})
+	}
+}
+
+func TestCheckScopeNilAllowsAll(t *testing.T) {
+	require.True(t, CheckScope(nil, "any-job"))
+}
+
+func TestCheckScopeEmptyAllowsAll(t *testing.T) {
+	scope, _ := json.Marshal(models.KeyScope{})
+	require.True(t, CheckScope(scope, "any-job"))
+}
+
+func TestCheckScopeAllowsListedJob(t *testing.T) {
+	scope, _ := json.Marshal(models.KeyScope{Jobs: []string{"etl-daily", "etl-hourly"}})
+	require.True(t, CheckScope(scope, "etl-daily"))
+	require.True(t, CheckScope(scope, "etl-hourly"))
+	require.False(t, CheckScope(scope, "other-job"))
+}
+
+func TestCheckScopeMalformedDenies(t *testing.T) {
+	require.False(t, CheckScope([]byte("{invalid"), "any-job"))
+}
+
+func TestRequiredRoleKnownEndpoints(t *testing.T) {
+	role, ok := RequiredRole("GET", "/v1/jobs")
+	require.True(t, ok)
+	require.Equal(t, models.RoleViewer, role)
+
+	role, ok = RequiredRole("POST", "/v1/jobs/:id/run")
+	require.True(t, ok)
+	require.Equal(t, models.RoleRunner, role)
+
+	role, ok = RequiredRole("POST", "/v1/triggers")
+	require.True(t, ok)
+	require.Equal(t, models.RoleOperator, role)
+
+	role, ok = RequiredRole("PATCH", "/v1/triggers/:id")
+	require.True(t, ok)
+	require.Equal(t, models.RoleOperator, role)
+
+	role, ok = RequiredRole("POST", "/v1/triggers/:id/fire")
+	require.True(t, ok)
+	require.Equal(t, models.RoleRunner, role)
+
+	role, ok = RequiredRole("GET", "/v1/auth/keys")
+	require.True(t, ok)
+	require.Equal(t, models.RoleAdmin, role)
+}
+
+func TestRequiredRoleUnknownEndpoint(t *testing.T) {
+	_, ok := RequiredRole("GET", "/v1/unknown")
+	require.False(t, ok)
+}

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -51,7 +51,11 @@ func TestCheckScopeMalformedDenies(t *testing.T) {
 }
 
 func TestRequiredRoleKnownEndpoints(t *testing.T) {
-	role, ok := RequiredRole("GET", "/v1/jobs")
+	role, ok := RequiredRole("GET", "/metrics")
+	require.True(t, ok)
+	require.Equal(t, models.RoleViewer, role)
+
+	role, ok = RequiredRole("GET", "/v1/jobs")
 	require.True(t, ok)
 	require.Equal(t, models.RoleViewer, role)
 

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -1,0 +1,118 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// DecodeScope normalizes the persisted scope payload into a structured model.
+// Nil, empty, or empty-job scopes are treated as unrestricted.
+func DecodeScope(scopeJSON []byte) (*models.KeyScope, error) {
+	if len(scopeJSON) == 0 {
+		return nil, nil
+	}
+
+	var scope models.KeyScope
+	if err := json.Unmarshal(scopeJSON, &scope); err != nil {
+		return nil, err
+	}
+
+	seen := make(map[string]struct{}, len(scope.Jobs))
+	jobs := make([]string, 0, len(scope.Jobs))
+	for _, alias := range scope.Jobs {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		if _, ok := seen[alias]; ok {
+			continue
+		}
+		seen[alias] = struct{}{}
+		jobs = append(jobs, alias)
+	}
+
+	if len(jobs) == 0 {
+		return nil, nil
+	}
+
+	sort.Strings(jobs)
+	scope.Jobs = jobs
+	return &scope, nil
+}
+
+// ScopeJobs returns the normalized scoped job aliases or nil when unrestricted.
+func ScopeJobs(scopeJSON []byte) ([]string, error) {
+	scope, err := DecodeScope(scopeJSON)
+	if err != nil {
+		return nil, err
+	}
+	if scope == nil {
+		return nil, nil
+	}
+	return append([]string(nil), scope.Jobs...), nil
+}
+
+// IsScoped reports whether the scope payload restricts access to specific jobs.
+func IsScoped(scopeJSON []byte) (bool, error) {
+	jobs, err := ScopeJobs(scopeJSON)
+	if err != nil {
+		return false, err
+	}
+	return len(jobs) > 0, nil
+}
+
+func containsScopedJob(allowed []string, jobAlias string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+
+	jobAlias = strings.TrimSpace(jobAlias)
+	for _, alias := range allowed {
+		if alias == jobAlias {
+			return true
+		}
+	}
+	return false
+}
+
+// JobAliasByID resolves the job alias for a job identifier.
+func (s *Service) JobAliasByID(ctx context.Context, id uuid.UUID) (string, error) {
+	var job models.Job
+	if err := s.db.WithContext(ctx).Select("alias").First(&job, "id = ?", id).Error; err != nil {
+		return "", err
+	}
+	return job.Alias, nil
+}
+
+// JobAliasByRunID resolves the job alias for a job run identifier.
+func (s *Service) JobAliasByRunID(ctx context.Context, id uuid.UUID) (string, error) {
+	var run models.JobRun
+	if err := s.db.WithContext(ctx).Select("job_id").First(&run, "id = ?", id).Error; err != nil {
+		return "", err
+	}
+	return s.JobAliasByID(ctx, run.JobID)
+}
+
+// JobAliasByBackfillID resolves the job alias for a backfill identifier.
+func (s *Service) JobAliasByBackfillID(ctx context.Context, id uuid.UUID) (string, error) {
+	var backfill models.Backfill
+	if err := s.db.WithContext(ctx).Select("job_id").First(&backfill, "id = ?", id).Error; err != nil {
+		return "", err
+	}
+	return s.JobAliasByID(ctx, backfill.JobID)
+}
+
+func formatLookupError(kind string, err error) error {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	return fmt.Errorf("lookup %s scope target: %w", kind, err)
+}

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -3,14 +3,11 @@ package auth
 import (
 	"context"
 	"encoding/json"
-	"errors"
-	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
-	"gorm.io/gorm"
 )
 
 // DecodeScope normalizes the persisted scope payload into a structured model.
@@ -108,11 +105,4 @@ func (s *Service) JobAliasByBackfillID(ctx context.Context, id uuid.UUID) (strin
 		return "", err
 	}
 	return s.JobAliasByID(ctx, backfill.JobID)
-}
-
-func formatLookupError(kind string, err error) error {
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return err
-	}
-	return fmt.Errorf("lookup %s scope target: %w", kind, err)
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -1,0 +1,263 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrKeyNotFound = errors.New("api key not found")
+	ErrKeyRevoked  = errors.New("api key revoked")
+	ErrKeyExpired  = errors.New("api key expired")
+	ErrForbidden   = errors.New("insufficient permissions")
+)
+
+// Service provides API key management and validation.
+type Service struct {
+	db *gorm.DB
+
+	// lastUsedMu protects the async last_used_at update buffer.
+	lastUsedMu sync.Mutex
+	lastUsed   map[uuid.UUID]time.Time
+}
+
+// NewService creates a new auth service backed by the given database.
+func NewService(db *gorm.DB) *Service {
+	s := &Service{
+		db:       db,
+		lastUsed: make(map[uuid.UUID]time.Time),
+	}
+	return s
+}
+
+// StartLastUsedFlusher runs a background goroutine that periodically flushes
+// buffered last_used_at timestamps to the database. This keeps the hot auth
+// path free of writes.
+func (s *Service) StartLastUsedFlusher(ctx context.Context) {
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				s.flushLastUsed()
+				return
+			case <-ticker.C:
+				s.flushLastUsed()
+			}
+		}
+	}()
+}
+
+func (s *Service) flushLastUsed() {
+	s.lastUsedMu.Lock()
+	pending := s.lastUsed
+	s.lastUsed = make(map[uuid.UUID]time.Time, len(pending))
+	s.lastUsedMu.Unlock()
+
+	if len(pending) == 0 {
+		return
+	}
+
+	ids := make([]uuid.UUID, 0, len(pending))
+	for id := range pending {
+		ids = append(ids, id)
+	}
+
+	if err := s.db.Model(&models.APIKey{}).Where("id IN ?", ids).Update("last_used_at", time.Now().UTC()).Error; err != nil {
+		log.Warn("failed to batch update api key last_used_at", "error", err)
+	}
+}
+
+func (s *Service) recordLastUsed(id uuid.UUID) {
+	s.lastUsedMu.Lock()
+	s.lastUsed[id] = time.Now().UTC()
+	s.lastUsedMu.Unlock()
+}
+
+// ValidateKey looks up a plaintext API key, verifies it is active, and returns
+// the key record. On success it asynchronously updates last_used_at.
+func (s *Service) ValidateKey(plaintext string) (*models.APIKey, error) {
+	hash := HashKey(plaintext)
+
+	var key models.APIKey
+	if err := s.db.Where("key_hash = ?", hash).First(&key).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrKeyNotFound
+		}
+		return nil, fmt.Errorf("lookup api key: %w", err)
+	}
+
+	if key.IsRevoked() {
+		return nil, ErrKeyRevoked
+	}
+	if key.IsExpired() {
+		return nil, ErrKeyExpired
+	}
+
+	s.recordLastUsed(key.ID)
+	return &key, nil
+}
+
+// CreateKeyRequest holds the parameters for creating a new API key.
+type CreateKeyRequest struct {
+	Description string
+	Role        models.Role
+	Scope       *models.KeyScope
+	CreatedBy   string
+	ExpiresAt   *time.Time
+}
+
+// CreateKeyResponse is returned on key creation — the only time the plaintext is available.
+type CreateKeyResponse struct {
+	Plaintext string         `json:"key"`
+	Key       *models.APIKey `json:"api_key"`
+}
+
+// CreateKey generates a new API key and persists its hash.
+func (s *Service) CreateKey(req *CreateKeyRequest) (*CreateKeyResponse, error) {
+	plaintext, prefix, hash, err := GenerateKey()
+	if err != nil {
+		return nil, err
+	}
+
+	var scopeJSON []byte
+	if req.Scope != nil {
+		scopeJSON, err = json.Marshal(req.Scope)
+		if err != nil {
+			return nil, fmt.Errorf("marshal scope: %w", err)
+		}
+	}
+
+	key := &models.APIKey{
+		ID:          uuid.New(),
+		KeyPrefix:   prefix,
+		KeyHash:     hash,
+		Description: req.Description,
+		Role:        req.Role,
+		Scope:       scopeJSON,
+		CreatedBy:   req.CreatedBy,
+		CreatedAt:   time.Now().UTC(),
+		ExpiresAt:   req.ExpiresAt,
+	}
+
+	if err := s.db.Create(key).Error; err != nil {
+		return nil, fmt.Errorf("persist api key: %w", err)
+	}
+
+	return &CreateKeyResponse{Plaintext: plaintext, Key: key}, nil
+}
+
+// ListKeys returns all API keys (without hashes, which are excluded by the model JSON tag).
+func (s *Service) ListKeys() ([]models.APIKey, error) {
+	var keys []models.APIKey
+	if err := s.db.Order("created_at DESC").Find(&keys).Error; err != nil {
+		return nil, fmt.Errorf("list api keys: %w", err)
+	}
+	return keys, nil
+}
+
+// RevokeKey sets revoked_at on the specified key.
+func (s *Service) RevokeKey(id uuid.UUID) error {
+	now := time.Now().UTC()
+	result := s.db.Model(&models.APIKey{}).Where("id = ? AND revoked_at IS NULL", id).Update("revoked_at", now)
+	if result.Error != nil {
+		return fmt.Errorf("revoke api key: %w", result.Error)
+	}
+	if result.RowsAffected == 0 {
+		return ErrKeyNotFound
+	}
+	return nil
+}
+
+// RotateKey creates a new key and sets expires_at on the old key to allow a grace period.
+func (s *Service) RotateKey(id uuid.UUID, gracePeriod time.Duration, actor string) (*CreateKeyResponse, error) {
+	var oldKey models.APIKey
+	if err := s.db.First(&oldKey, id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrKeyNotFound
+		}
+		return nil, fmt.Errorf("lookup old key: %w", err)
+	}
+
+	if oldKey.IsRevoked() {
+		return nil, ErrKeyRevoked
+	}
+
+	// Create new key with same role and scope.
+	var scope *models.KeyScope
+	if len(oldKey.Scope) > 0 {
+		scope = &models.KeyScope{}
+		if err := json.Unmarshal(oldKey.Scope, scope); err != nil {
+			return nil, fmt.Errorf("unmarshal old scope: %w", err)
+		}
+	}
+
+	resp, err := s.CreateKey(&CreateKeyRequest{
+		Description: oldKey.Description + " (rotated)",
+		Role:        oldKey.Role,
+		Scope:       scope,
+		CreatedBy:   actor,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Set grace period on old key.
+	graceExpiry := time.Now().UTC().Add(gracePeriod)
+	if err := s.db.Model(&models.APIKey{}).Where("id = ?", id).Update("expires_at", graceExpiry).Error; err != nil {
+		return nil, fmt.Errorf("set grace period: %w", err)
+	}
+
+	return resp, nil
+}
+
+// AdminKeyExists returns true if at least one non-revoked, non-expired admin key exists.
+func (s *Service) AdminKeyExists() (bool, error) {
+	var count int64
+	now := time.Now().UTC()
+	err := s.db.Model(&models.APIKey{}).
+		Where(
+			"role = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?)",
+			models.RoleAdmin,
+			now,
+		).
+		Count(&count).Error
+	if err != nil {
+		return false, fmt.Errorf("check admin keys: %w", err)
+	}
+	return count > 0, nil
+}
+
+// Bootstrap generates the initial admin key on first startup with auth enabled.
+// Returns the plaintext key (to be printed to stdout once) or empty string if
+// an admin key already exists.
+func (s *Service) Bootstrap() (string, error) {
+	exists, err := s.AdminKeyExists()
+	if err != nil {
+		return "", err
+	}
+	if exists {
+		return "", nil
+	}
+
+	resp, err := s.CreateKey(&CreateKeyRequest{
+		Description: "Bootstrap admin key",
+		Role:        models.RoleAdmin,
+		CreatedBy:   "system",
+	})
+	if err != nil {
+		return "", fmt.Errorf("bootstrap admin key: %w", err)
+	}
+
+	return resp.Plaintext, nil
+}

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -1,0 +1,349 @@
+package auth_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateKeyAndValidate(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Description: "test key",
+		Role:        models.RoleOperator,
+		CreatedBy:   "test",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Plaintext)
+	require.True(t, strings.HasPrefix(resp.Plaintext, auth.KeyPrefixLive))
+	require.NotEmpty(t, resp.Key.ID)
+	require.Equal(t, models.RoleOperator, resp.Key.Role)
+	require.Equal(t, "test key", resp.Key.Description)
+	require.Equal(t, "test", resp.Key.CreatedBy)
+	require.Nil(t, resp.Key.RevokedAt)
+	require.Nil(t, resp.Key.ExpiresAt)
+
+	// Validate the key succeeds.
+	key, err := svc.ValidateKey(resp.Plaintext)
+	require.NoError(t, err)
+	require.Equal(t, resp.Key.ID, key.ID)
+	require.Equal(t, models.RoleOperator, key.Role)
+}
+
+func TestValidateKeyNotFound(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	_, err := svc.ValidateKey("csk_live_doesnotexist")
+	require.ErrorIs(t, err, auth.ErrKeyNotFound)
+}
+
+func TestValidateKeyRevoked(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleViewer,
+		CreatedBy: "test",
+	})
+	require.NoError(t, err)
+
+	err = svc.RevokeKey(resp.Key.ID)
+	require.NoError(t, err)
+
+	_, err = svc.ValidateKey(resp.Plaintext)
+	require.ErrorIs(t, err, auth.ErrKeyRevoked)
+}
+
+func TestValidateKeyExpired(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleViewer,
+		CreatedBy: "test",
+		ExpiresAt: &past,
+	})
+	require.NoError(t, err)
+
+	_, err = svc.ValidateKey(resp.Plaintext)
+	require.ErrorIs(t, err, auth.ErrKeyExpired)
+}
+
+func TestCreateKeyWithScope(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	scope := &models.KeyScope{Jobs: []string{"etl-daily", "etl-hourly"}}
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleRunner,
+		Scope:     scope,
+		CreatedBy: "test",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Key.Scope)
+
+	// Verify scope is persisted and retrievable.
+	key, err := svc.ValidateKey(resp.Plaintext)
+	require.NoError(t, err)
+	require.True(t, auth.CheckScope(key.Scope, "etl-daily"))
+	require.True(t, auth.CheckScope(key.Scope, "etl-hourly"))
+	require.False(t, auth.CheckScope(key.Scope, "other-job"))
+}
+
+func TestCreateKeyWithExpiry(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	future := time.Now().UTC().Add(24 * time.Hour)
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleViewer,
+		CreatedBy: "test",
+		ExpiresAt: &future,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.Key.ExpiresAt)
+
+	// Still valid — hasn't expired.
+	key, err := svc.ValidateKey(resp.Plaintext)
+	require.NoError(t, err)
+	require.Equal(t, resp.Key.ID, key.ID)
+}
+
+func TestListKeys(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	// Start empty.
+	keys, err := svc.ListKeys()
+	require.NoError(t, err)
+	require.Empty(t, keys)
+
+	// Create two keys.
+	_, err = svc.CreateKey(&auth.CreateKeyRequest{Role: models.RoleAdmin, CreatedBy: "test"})
+	require.NoError(t, err)
+	_, err = svc.CreateKey(&auth.CreateKeyRequest{Role: models.RoleViewer, CreatedBy: "test"})
+	require.NoError(t, err)
+
+	keys, err = svc.ListKeys()
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	// Most recent first.
+	require.Equal(t, models.RoleViewer, keys[0].Role)
+	require.Equal(t, models.RoleAdmin, keys[1].Role)
+}
+
+func TestRevokeKeyNotFound(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	err := svc.RevokeKey([16]byte{}) // zero UUID
+	require.ErrorIs(t, err, auth.ErrKeyNotFound)
+}
+
+func TestRevokeKeyIdempotent(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{Role: models.RoleViewer, CreatedBy: "test"})
+	require.NoError(t, err)
+
+	err = svc.RevokeKey(resp.Key.ID)
+	require.NoError(t, err)
+
+	// Second revoke should return not found (already revoked, WHERE clause excludes it).
+	err = svc.RevokeKey(resp.Key.ID)
+	require.ErrorIs(t, err, auth.ErrKeyNotFound)
+}
+
+func TestRotateKey(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	original, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Description: "original",
+		Role:        models.RoleOperator,
+		CreatedBy:   "test",
+	})
+	require.NoError(t, err)
+
+	// Rotate with 1-hour grace period.
+	rotated, err := svc.RotateKey(original.Key.ID, time.Hour, "admin")
+	require.NoError(t, err)
+	require.NotEmpty(t, rotated.Plaintext)
+	require.NotEqual(t, original.Plaintext, rotated.Plaintext)
+	require.Equal(t, models.RoleOperator, rotated.Key.Role)
+	require.Contains(t, rotated.Key.Description, "rotated")
+	require.Equal(t, "admin", rotated.Key.CreatedBy)
+
+	// New key works.
+	key, err := svc.ValidateKey(rotated.Plaintext)
+	require.NoError(t, err)
+	require.Equal(t, rotated.Key.ID, key.ID)
+
+	// Old key still works during grace period.
+	key, err = svc.ValidateKey(original.Plaintext)
+	require.NoError(t, err)
+	require.Equal(t, original.Key.ID, key.ID)
+}
+
+func TestRotateKeyRevokedFails(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{Role: models.RoleViewer, CreatedBy: "test"})
+	require.NoError(t, err)
+
+	err = svc.RevokeKey(resp.Key.ID)
+	require.NoError(t, err)
+
+	_, err = svc.RotateKey(resp.Key.ID, time.Hour, "admin")
+	require.ErrorIs(t, err, auth.ErrKeyRevoked)
+}
+
+func TestRotateKeyNotFound(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	_, err := svc.RotateKey([16]byte{}, time.Hour, "admin")
+	require.ErrorIs(t, err, auth.ErrKeyNotFound)
+}
+
+func TestBootstrapCreatesAdminKey(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	plaintext, err := svc.Bootstrap()
+	require.NoError(t, err)
+	require.NotEmpty(t, plaintext)
+	require.True(t, strings.HasPrefix(plaintext, auth.KeyPrefixLive))
+
+	// Validate the bootstrap key works.
+	key, err := svc.ValidateKey(plaintext)
+	require.NoError(t, err)
+	require.Equal(t, models.RoleAdmin, key.Role)
+	require.Equal(t, "system", key.CreatedBy)
+}
+
+func TestBootstrapNoopWhenAdminExists(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	// First bootstrap creates a key.
+	first, err := svc.Bootstrap()
+	require.NoError(t, err)
+	require.NotEmpty(t, first)
+
+	// Second bootstrap returns empty (admin already exists).
+	second, err := svc.Bootstrap()
+	require.NoError(t, err)
+	require.Empty(t, second)
+}
+
+func TestAdminKeyExists(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	exists, err := svc.AdminKeyExists()
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	_, err = svc.CreateKey(&auth.CreateKeyRequest{Role: models.RoleViewer, CreatedBy: "test"})
+	require.NoError(t, err)
+
+	// Viewer key doesn't count.
+	exists, err = svc.AdminKeyExists()
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	_, err = svc.CreateKey(&auth.CreateKeyRequest{Role: models.RoleAdmin, CreatedBy: "test"})
+	require.NoError(t, err)
+
+	exists, err = svc.AdminKeyExists()
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestAdminKeyExistsExcludesRevoked(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	resp, err := svc.CreateKey(&auth.CreateKeyRequest{Role: models.RoleAdmin, CreatedBy: "test"})
+	require.NoError(t, err)
+
+	exists, err := svc.AdminKeyExists()
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	err = svc.RevokeKey(resp.Key.ID)
+	require.NoError(t, err)
+
+	exists, err = svc.AdminKeyExists()
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestAdminKeyExistsExcludesExpired(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	past := time.Now().UTC().Add(-time.Hour)
+	_, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleAdmin,
+		CreatedBy: "test",
+		ExpiresAt: &past,
+	})
+	require.NoError(t, err)
+
+	exists, err := svc.AdminKeyExists()
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
+func TestBootstrapCreatesAdminKeyWhenOnlyExpiredAdminExists(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	svc := auth.NewService(db)
+
+	past := time.Now().UTC().Add(-time.Hour)
+	_, err := svc.CreateKey(&auth.CreateKeyRequest{
+		Role:      models.RoleAdmin,
+		CreatedBy: "test",
+		ExpiresAt: &past,
+	})
+	require.NoError(t, err)
+
+	plaintext, err := svc.Bootstrap()
+	require.NoError(t, err)
+	require.NotEmpty(t, plaintext)
+
+	key, err := svc.ValidateKey(plaintext)
+	require.NoError(t, err)
+	require.Equal(t, models.RoleAdmin, key.Role)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,8 +1,12 @@
 package metrics
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
+
+var registerOnce sync.Once
 
 var (
 	JobRunsTotal = prometheus.NewCounterVec(
@@ -171,26 +175,28 @@ var (
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
 func Register() {
-	prometheus.MustRegister(
-		JobRunsTotal,
-		JobRunDurationSeconds,
-		TaskRunsTotal,
-		TaskRunDurationSeconds,
-		JobsActive,
-		CallbackRunsTotal,
-		TriggerFiresTotal,
-		WorkerClaimsTotal,
-		WorkerClaimContentionTotal,
-		WorkerLeaseExpirationsTotal,
-		TaskRetriesTotal,
-		BackfillRunsTotal,
-		BackfillsActive,
-		TaskCacheHitsTotal,
-		TaskCacheMissesTotal,
-		TaskCacheEntries,
-		AuthRequestsTotal,
-		AuthFailuresTotal,
-		AuthKeyAgeSeconds,
-		AuditLogEntriesTotal,
-	)
+	registerOnce.Do(func() {
+		prometheus.MustRegister(
+			JobRunsTotal,
+			JobRunDurationSeconds,
+			TaskRunsTotal,
+			TaskRunDurationSeconds,
+			JobsActive,
+			CallbackRunsTotal,
+			TriggerFiresTotal,
+			WorkerClaimsTotal,
+			WorkerClaimContentionTotal,
+			WorkerLeaseExpirationsTotal,
+			TaskRetriesTotal,
+			BackfillRunsTotal,
+			BackfillsActive,
+			TaskCacheHitsTotal,
+			TaskCacheMissesTotal,
+			TaskCacheEntries,
+			AuthRequestsTotal,
+			AuthFailuresTotal,
+			AuthKeyAgeSeconds,
+			AuditLogEntriesTotal,
+		)
+	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -133,6 +133,40 @@ var (
 			Help: "Current number of task cache entries.",
 		},
 	)
+
+	// Auth metrics
+
+	AuthRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_auth_requests_total",
+			Help: "Total authenticated API requests by outcome, role, method, and path.",
+		},
+		[]string{"outcome", "role", "method", "path"},
+	)
+
+	AuthFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_auth_failures_total",
+			Help: "Total authentication failures by reason.",
+		},
+		[]string{"reason"},
+	)
+
+	AuthKeyAgeSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "caesium_auth_key_age_seconds",
+			Help:    "Age of API keys at request time in seconds.",
+			Buckets: []float64{3600, 86400, 604800, 2592000, 7776000, 15552000, 31536000},
+		},
+	)
+
+	AuditLogEntriesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_audit_log_entries_total",
+			Help: "Total audit log entries by action and outcome.",
+		},
+		[]string{"action", "outcome"},
+	)
 )
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
@@ -154,5 +188,9 @@ func Register() {
 		TaskCacheHitsTotal,
 		TaskCacheMissesTotal,
 		TaskCacheEntries,
+		AuthRequestsTotal,
+		AuthFailuresTotal,
+		AuthKeyAgeSeconds,
+		AuditLogEntriesTotal,
 	)
 }

--- a/internal/models/api_key.go
+++ b/internal/models/api_key.go
@@ -1,0 +1,76 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// Role defines the RBAC role hierarchy.
+// admin > operator > runner > viewer
+type Role string
+
+const (
+	RoleAdmin    Role = "admin"
+	RoleOperator Role = "operator"
+	RoleRunner   Role = "runner"
+	RoleViewer   Role = "viewer"
+)
+
+// RoleLevel returns the numeric privilege level for a role.
+// Higher values indicate more privileges.
+func RoleLevel(r Role) int {
+	switch r {
+	case RoleAdmin:
+		return 40
+	case RoleOperator:
+		return 30
+	case RoleRunner:
+		return 20
+	case RoleViewer:
+		return 10
+	default:
+		return 0
+	}
+}
+
+// ValidRole returns true if r is a recognised role string.
+func ValidRole(r string) bool {
+	switch Role(r) {
+	case RoleAdmin, RoleOperator, RoleRunner, RoleViewer:
+		return true
+	}
+	return false
+}
+
+// APIKey represents an API key stored in the database.
+// The plaintext key is never persisted — only the SHA-256 hash.
+type APIKey struct {
+	ID          uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	KeyPrefix   string         `gorm:"type:text;size:12;not null;index" json:"key_prefix"`
+	KeyHash     string         `gorm:"type:text;not null;uniqueIndex" json:"-"`
+	Description string         `gorm:"type:text" json:"description,omitempty"`
+	Role        Role           `gorm:"type:text;not null" json:"role"`
+	Scope       datatypes.JSON `gorm:"type:json" json:"scope,omitempty"`
+	CreatedBy   string         `gorm:"type:text" json:"created_by,omitempty"`
+	CreatedAt   time.Time      `gorm:"not null" json:"created_at"`
+	ExpiresAt   *time.Time     `json:"expires_at,omitempty"`
+	LastUsedAt  *time.Time     `json:"last_used_at,omitempty"`
+	RevokedAt   *time.Time     `json:"revoked_at,omitempty"`
+}
+
+// IsRevoked returns true when the key has been revoked.
+func (k *APIKey) IsRevoked() bool {
+	return k.RevokedAt != nil
+}
+
+// IsExpired returns true when the key has passed its expiration time.
+func (k *APIKey) IsExpired() bool {
+	return k.ExpiresAt != nil && time.Now().UTC().After(*k.ExpiresAt)
+}
+
+// KeyScope represents optional resource scoping for an API key.
+type KeyScope struct {
+	Jobs []string `json:"jobs,omitempty"`
+}

--- a/internal/models/api_key_test.go
+++ b/internal/models/api_key_test.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsRevokedFalseByDefault(t *testing.T) {
+	key := &APIKey{}
+	require.False(t, key.IsRevoked())
+}
+
+func TestIsRevokedTrueWhenSet(t *testing.T) {
+	now := time.Now()
+	key := &APIKey{RevokedAt: &now}
+	require.True(t, key.IsRevoked())
+}
+
+func TestIsExpiredFalseByDefault(t *testing.T) {
+	key := &APIKey{}
+	require.False(t, key.IsExpired())
+}
+
+func TestIsExpiredFalseWhenFuture(t *testing.T) {
+	future := time.Now().Add(time.Hour)
+	key := &APIKey{ExpiresAt: &future}
+	require.False(t, key.IsExpired())
+}
+
+func TestIsExpiredTrueWhenPast(t *testing.T) {
+	past := time.Now().Add(-time.Hour)
+	key := &APIKey{ExpiresAt: &past}
+	require.True(t, key.IsExpired())
+}
+
+func TestRoleLevelOrdering(t *testing.T) {
+	require.Greater(t, RoleLevel(RoleAdmin), RoleLevel(RoleOperator))
+	require.Greater(t, RoleLevel(RoleOperator), RoleLevel(RoleRunner))
+	require.Greater(t, RoleLevel(RoleRunner), RoleLevel(RoleViewer))
+	require.Equal(t, 0, RoleLevel(Role("unknown")))
+}
+
+func TestValidRole(t *testing.T) {
+	require.True(t, ValidRole("admin"))
+	require.True(t, ValidRole("operator"))
+	require.True(t, ValidRole("runner"))
+	require.True(t, ValidRole("viewer"))
+	require.False(t, ValidRole("superuser"))
+	require.False(t, ValidRole(""))
+}

--- a/internal/models/audit_log.go
+++ b/internal/models/audit_log.go
@@ -1,0 +1,21 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// AuditLog records every state-changing operation and auth rejection.
+type AuditLog struct {
+	ID           uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Timestamp    time.Time      `gorm:"not null;index" json:"timestamp"`
+	Actor        string         `gorm:"type:text;not null;index" json:"actor"`
+	Action       string         `gorm:"type:text;not null;index" json:"action"`
+	ResourceType string         `gorm:"type:text" json:"resource_type,omitempty"`
+	ResourceID   string         `gorm:"type:text" json:"resource_id,omitempty"`
+	SourceIP     string         `gorm:"type:text" json:"source_ip,omitempty"`
+	Outcome      string         `gorm:"type:text;not null" json:"outcome"`
+	Metadata     datatypes.JSON `gorm:"type:json" json:"metadata,omitempty"`
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -16,4 +16,6 @@ var All = []interface{}{
 	&TaskCache{},
 	&CallbackRun{},
 	&ExecutionEvent{},
+	&APIKey{},
+	&AuditLog{},
 }

--- a/justfile
+++ b/justfile
@@ -28,6 +28,7 @@ publish_image_ref := repo + "/" + image
 publish_builder_ref := repo + "/" + builder_image
 sock := env("CAESIUM_SOCK", default_sock)
 port := env("CAESIUM_PORT", "8080")
+auth_mode := env("CAESIUM_AUTH_MODE", "none")
 
 validate-platform:
     @if [ "{{ platform }}" != "linux/amd64" ] && [ "{{ platform }}" != "linux/arm64" ]; then \
@@ -129,6 +130,8 @@ run: build
         -p {{ port }}:8080 \
         -v {{ sock }}:/var/run/docker.sock \
         -e DOCKER_HOST=unix:///var/run/docker.sock \
+        -e CAESIUM_AUTH_MODE={{ auth_mode }} \
+        -e CAESIUM_AUTH_REQUIRE_TLS=false \
         --user 0:0 \
         {{ local_image_ref }}:{{ tag }} start
 

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -88,4 +88,13 @@ type Environment struct {
 	WebhookMaxBodySize            ByteSize      `envconfig:"WEBHOOK_MAX_BODY_SIZE" default:"1MB"`
 	WebhookRateLimitPerMinute     int           `envconfig:"WEBHOOK_RATE_LIMIT_PER_MINUTE" default:"120"`
 	WebhookRateLimitBurst         int           `envconfig:"WEBHOOK_RATE_LIMIT_BURST" default:"20"`
+
+	// Authentication & Authorization
+	AuthMode                string `envconfig:"AUTH_MODE" default:"none"` // none, api-key
+	AuthRequireTLS          bool   `envconfig:"AUTH_REQUIRE_TLS" default:"true"`
+	TLSCert                 string `envconfig:"TLS_CERT" default:""`
+	TLSKey                  string `envconfig:"TLS_KEY" default:""`
+	TrustedProxies          string `envconfig:"TRUSTED_PROXIES" default:""`
+	AuthRateLimitPerMinute  int    `envconfig:"AUTH_RATE_LIMIT_PER_MINUTE" default:"10"`
+	AuthRateLimitBurstAlert int    `envconfig:"AUTH_RATE_LIMIT_BURST_ALERT" default:"100"`
 }

--- a/ui/src/features/auth/AuthGate.tsx
+++ b/ui/src/features/auth/AuthGate.tsx
@@ -7,10 +7,9 @@ interface AuthGateProps {
 }
 
 /**
- * AuthGate checks whether authentication is required by probing a lightweight
- * viewer-level REST endpoint.
- * If the server returns 401, it shows the login page. If auth is not enabled
- * (server returns 2xx without credentials), it passes through directly.
+ * AuthGate checks whether authentication is required using the explicit
+ * `/auth/status` endpoint rather than inferring auth state from a protected
+ * resource side-channel.
  */
 export function AuthGate({ children }: AuthGateProps) {
   const [authRequired, setAuthRequired] = useState<boolean | null>(null);
@@ -25,9 +24,15 @@ export function AuthGate({ children }: AuthGateProps) {
 
     async function probe() {
       try {
-        const resp = await fetch("/v1/jobs?limit=1");
+        const resp = await fetch("/auth/status");
+        if (!resp.ok) {
+          if (!cancelled) setAuthRequired(false);
+          return;
+        }
+
+        const body = (await resp.json()) as { enabled?: boolean };
         if (!cancelled) {
-          setAuthRequired(resp.status === 401);
+          setAuthRequired(Boolean(body.enabled));
         }
       } catch {
         // Network error — assume auth not required, let real errors surface later.

--- a/ui/src/features/auth/AuthGate.tsx
+++ b/ui/src/features/auth/AuthGate.tsx
@@ -1,0 +1,57 @@
+import { useState, useEffect, useCallback } from "react";
+import { isAuthenticated, onAuthChange } from "@/lib/auth";
+import { LoginPage } from "./LoginPage";
+
+interface AuthGateProps {
+  children: React.ReactNode;
+}
+
+/**
+ * AuthGate checks whether authentication is required by probing a lightweight
+ * viewer-level REST endpoint.
+ * If the server returns 401, it shows the login page. If auth is not enabled
+ * (server returns 2xx without credentials), it passes through directly.
+ */
+export function AuthGate({ children }: AuthGateProps) {
+  const [authRequired, setAuthRequired] = useState<boolean | null>(null);
+  const [authed, setAuthed] = useState(isAuthenticated);
+
+  // Subscribe to auth state changes.
+  useEffect(() => onAuthChange(() => setAuthed(isAuthenticated())), []);
+
+  // Probe the server to determine if auth is enabled.
+  useEffect(() => {
+    let cancelled = false;
+
+    async function probe() {
+      try {
+        const resp = await fetch("/v1/jobs?limit=1");
+        if (!cancelled) {
+          setAuthRequired(resp.status === 401);
+        }
+      } catch {
+        // Network error — assume auth not required, let real errors surface later.
+        if (!cancelled) setAuthRequired(false);
+      }
+    }
+
+    probe();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleLogin = useCallback(() => {
+    setAuthed(true);
+  }, []);
+
+  // Still probing.
+  if (authRequired === null) return null;
+
+  // Auth is required but user hasn't authenticated yet.
+  if (authRequired && !authed) {
+    return <LoginPage onLogin={handleLogin} />;
+  }
+
+  return <>{children}</>;
+}

--- a/ui/src/features/auth/LoginPage.tsx
+++ b/ui/src/features/auth/LoginPage.tsx
@@ -1,0 +1,165 @@
+import { useState, useCallback } from "react";
+import { setApiKey } from "@/lib/auth";
+
+interface LoginPageProps {
+  onLogin: () => void;
+}
+
+export function LoginPage({ onLogin }: LoginPageProps) {
+  const [key, setKey] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setError(null);
+
+      const trimmed = key.trim();
+      if (!trimmed) {
+        setError("API key is required");
+        return;
+      }
+
+      if (!trimmed.startsWith("csk_")) {
+        setError("Invalid key format (expected csk_... prefix)");
+        return;
+      }
+
+      setLoading(true);
+
+      try {
+        // Verify the key against a viewer-level REST endpoint so scoped keys can log in.
+        const response = await fetch("/v1/jobs?limit=1", {
+          headers: { Authorization: `Bearer ${trimmed}` },
+        });
+
+        if (response.status === 401) {
+          setError("Invalid or expired API key");
+          return;
+        }
+
+        if (response.status === 403) {
+          setError("API key does not have sufficient permissions");
+          return;
+        }
+
+        // Key is valid — store in memory and proceed.
+        setApiKey(trimmed);
+        onLogin();
+      } catch {
+        setError("Unable to reach the server");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [key, onLogin],
+  );
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        minHeight: "100vh",
+        background: "var(--background, #09090b)",
+        color: "var(--foreground, #fafafa)",
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: "1rem",
+          width: "100%",
+          maxWidth: "400px",
+          padding: "2rem",
+          border: "1px solid var(--border, #27272a)",
+          borderRadius: "0.5rem",
+          background: "var(--card, #0a0a0a)",
+        }}
+      >
+        <h1
+          style={{
+            fontSize: "1.25rem",
+            fontWeight: 600,
+            textAlign: "center",
+            marginBottom: "0.5rem",
+          }}
+        >
+          Caesium
+        </h1>
+
+        <p
+          style={{
+            fontSize: "0.875rem",
+            textAlign: "center",
+            opacity: 0.7,
+          }}
+        >
+          Enter your API key to continue
+        </p>
+
+        <input
+          type="password"
+          value={key}
+          onChange={(e) => setKey(e.target.value)}
+          placeholder="csk_live_..."
+          autoFocus
+          autoComplete="off"
+          style={{
+            padding: "0.5rem 0.75rem",
+            borderRadius: "0.375rem",
+            border: "1px solid var(--border, #27272a)",
+            background: "var(--input, #09090b)",
+            color: "inherit",
+            fontSize: "0.875rem",
+            fontFamily: "monospace",
+          }}
+        />
+
+        {error && (
+          <p
+            style={{
+              fontSize: "0.8rem",
+              color: "var(--destructive, #ef4444)",
+              margin: 0,
+            }}
+          >
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            padding: "0.5rem 1rem",
+            borderRadius: "0.375rem",
+            border: "none",
+            background: "var(--primary, #fafafa)",
+            color: "var(--primary-foreground, #09090b)",
+            fontWeight: 500,
+            cursor: loading ? "not-allowed" : "pointer",
+            opacity: loading ? 0.6 : 1,
+          }}
+        >
+          {loading ? "Verifying..." : "Sign In"}
+        </button>
+
+        <p
+          style={{
+            fontSize: "0.75rem",
+            textAlign: "center",
+            opacity: 0.5,
+            margin: 0,
+          }}
+        >
+          Key is stored in memory only and cleared on tab close
+        </p>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/features/auth/__tests__/AuthGate.test.tsx
+++ b/ui/src/features/auth/__tests__/AuthGate.test.tsx
@@ -1,0 +1,65 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthGate } from "../AuthGate";
+import { clearApiKey, setApiKey } from "@/lib/auth";
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+describe("AuthGate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearApiKey();
+  });
+
+  it("renders the login page when the auth probe returns 401", async () => {
+    mockFetch.mockResolvedValue({ status: 401 });
+
+    render(
+      <AuthGate>
+        <div>protected</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Enter your API key to continue")).toBeInTheDocument();
+    });
+    expect(mockFetch).toHaveBeenCalledWith("/v1/jobs?limit=1");
+  });
+
+  it("renders children when auth is not required", async () => {
+    mockFetch.mockResolvedValue({ status: 200 });
+
+    render(
+      <AuthGate>
+        <div>protected</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("protected")).toBeInTheDocument();
+    });
+  });
+
+  it("reacts to auth state changes after a 401 probe", async () => {
+    mockFetch.mockResolvedValue({ status: 401 });
+
+    render(
+      <AuthGate>
+        <div>protected</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Enter your API key to continue")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      setApiKey("csk_live_secret");
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("protected")).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/src/features/auth/__tests__/AuthGate.test.tsx
+++ b/ui/src/features/auth/__tests__/AuthGate.test.tsx
@@ -12,8 +12,11 @@ describe("AuthGate", () => {
     clearApiKey();
   });
 
-  it("renders the login page when the auth probe returns 401", async () => {
-    mockFetch.mockResolvedValue({ status: 401 });
+  it("renders the login page when the auth status endpoint says auth is enabled", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ enabled: true }),
+    });
 
     render(
       <AuthGate>
@@ -24,11 +27,14 @@ describe("AuthGate", () => {
     await waitFor(() => {
       expect(screen.getByText("Enter your API key to continue")).toBeInTheDocument();
     });
-    expect(mockFetch).toHaveBeenCalledWith("/v1/jobs?limit=1");
+    expect(mockFetch).toHaveBeenCalledWith("/auth/status");
   });
 
   it("renders children when auth is not required", async () => {
-    mockFetch.mockResolvedValue({ status: 200 });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ enabled: false }),
+    });
 
     render(
       <AuthGate>
@@ -41,8 +47,11 @@ describe("AuthGate", () => {
     });
   });
 
-  it("reacts to auth state changes after a 401 probe", async () => {
-    mockFetch.mockResolvedValue({ status: 401 });
+  it("reacts to auth state changes after an enabled auth probe", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ enabled: true }),
+    });
 
     render(
       <AuthGate>

--- a/ui/src/features/auth/__tests__/LoginPage.test.tsx
+++ b/ui/src/features/auth/__tests__/LoginPage.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { LoginPage } from "../LoginPage";
+import { clearApiKey, getApiKey } from "@/lib/auth";
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearApiKey();
+  });
+
+  it("rejects keys without the expected prefix", async () => {
+    render(<LoginPage onLogin={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("csk_live_..."), {
+      target: { value: "invalid" },
+    });
+    fireEvent.click(screen.getByText("Sign In"));
+
+    expect(await screen.findByText("Invalid key format (expected csk_... prefix)")).toBeInTheDocument();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("shows an auth error when the server returns 401", async () => {
+    mockFetch.mockResolvedValue({ status: 401 });
+
+    render(<LoginPage onLogin={vi.fn()} />);
+
+    fireEvent.change(screen.getByPlaceholderText("csk_live_..."), {
+      target: { value: "csk_live_bad" },
+    });
+    fireEvent.click(screen.getByText("Sign In"));
+
+    expect(await screen.findByText("Invalid or expired API key")).toBeInTheDocument();
+    expect(getApiKey()).toBeNull();
+  });
+
+  it("stores the api key and calls onLogin on success", async () => {
+    const onLogin = vi.fn();
+    mockFetch.mockResolvedValue({ status: 200 });
+
+    render(<LoginPage onLogin={onLogin} />);
+
+    fireEvent.change(screen.getByPlaceholderText("csk_live_..."), {
+      target: { value: "csk_live_good" },
+    });
+    fireEvent.click(screen.getByText("Sign In"));
+
+    await waitFor(() => {
+      expect(onLogin).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/v1/jobs?limit=1", {
+      headers: { Authorization: "Bearer csk_live_good" },
+    });
+    expect(getApiKey()).toBe("csk_live_good");
+  });
+});

--- a/ui/src/features/auth/__tests__/LoginPage.test.tsx
+++ b/ui/src/features/auth/__tests__/LoginPage.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { LoginPage } from "../LoginPage";
-import { clearApiKey, getApiKey } from "@/lib/auth";
+import { clearApiKey, isAuthenticated } from "@/lib/auth";
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
@@ -35,7 +35,7 @@ describe("LoginPage", () => {
     fireEvent.click(screen.getByText("Sign In"));
 
     expect(await screen.findByText("Invalid or expired API key")).toBeInTheDocument();
-    expect(getApiKey()).toBeNull();
+    expect(isAuthenticated()).toBe(false);
   });
 
   it("stores the api key and calls onLogin on success", async () => {
@@ -56,6 +56,6 @@ describe("LoginPage", () => {
     expect(mockFetch).toHaveBeenCalledWith("/v1/jobs?limit=1", {
       headers: { Authorization: "Bearer csk_live_good" },
     });
-    expect(getApiKey()).toBe("csk_live_good");
+    expect(isAuthenticated()).toBe(true);
   });
 });

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { api, ApiError } from '@/lib/api';
-import { clearApiKey, getApiKey, setApiKey } from '@/lib/auth';
+import { clearApiKey, isAuthenticated, setApiKey } from '@/lib/auth';
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
@@ -121,6 +121,6 @@ describe('api', () => {
     });
 
     await expect(api.getJobs()).rejects.toMatchObject({ status: 401 });
-    expect(getApiKey()).toBeNull();
+    expect(isAuthenticated()).toBe(false);
   });
 });

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { api, ApiError } from '@/lib/api';
+import { clearApiKey, getApiKey, setApiKey } from '@/lib/auth';
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
@@ -16,6 +17,7 @@ function okResponse(body: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearApiKey();
 });
 
 describe('api', () => {
@@ -92,5 +94,33 @@ describe('api', () => {
       '/v1/cache/prune',
       expect.objectContaining({ method: 'POST' })
     );
+  });
+
+  it('adds the bearer token header when an api key is present', async () => {
+    setApiKey('csk_live_secret');
+    mockFetch.mockResolvedValue(okResponse([]));
+
+    await api.getJobs();
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/v1/jobs',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer csk_live_secret',
+        }),
+      })
+    );
+  });
+
+  it('clears the in-memory api key on 401 responses', async () => {
+    setApiKey('csk_live_secret');
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      text: () => Promise.resolve('Authentication required'),
+    });
+
+    await expect(api.getJobs()).rejects.toMatchObject({ status: 401 });
+    expect(getApiKey()).toBeNull();
   });
 });

--- a/ui/src/lib/__tests__/auth.test.ts
+++ b/ui/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { clearApiKey, getApiKey, isAuthenticated, onAuthChange, setApiKey } from "@/lib/auth";
+import { clearApiKey, isAuthenticated, onAuthChange, setApiKey, withAuthHeaders } from "@/lib/auth";
 
 describe("auth", () => {
   beforeEach(() => {
@@ -11,12 +11,14 @@ describe("auth", () => {
     expect(isAuthenticated()).toBe(false);
 
     setApiKey("csk_live_secret");
-    expect(getApiKey()).toBe("csk_live_secret");
     expect(isAuthenticated()).toBe(true);
+    expect(withAuthHeaders()).toMatchObject({
+      Authorization: "Bearer csk_live_secret",
+    });
 
     clearApiKey();
-    expect(getApiKey()).toBeNull();
     expect(isAuthenticated()).toBe(false);
+    expect(withAuthHeaders()).not.toHaveProperty("Authorization");
   });
 
   it("notifies listeners on auth changes", () => {

--- a/ui/src/lib/__tests__/auth.test.ts
+++ b/ui/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearApiKey, getApiKey, isAuthenticated, onAuthChange, setApiKey } from "@/lib/auth";
+
+describe("auth", () => {
+  beforeEach(() => {
+    clearApiKey();
+    vi.restoreAllMocks();
+  });
+
+  it("stores and clears the api key in memory", () => {
+    expect(isAuthenticated()).toBe(false);
+
+    setApiKey("csk_live_secret");
+    expect(getApiKey()).toBe("csk_live_secret");
+    expect(isAuthenticated()).toBe(true);
+
+    clearApiKey();
+    expect(getApiKey()).toBeNull();
+    expect(isAuthenticated()).toBe(false);
+  });
+
+  it("notifies listeners on auth changes", () => {
+    const listener = vi.fn();
+    const unsubscribe = onAuthChange(listener);
+
+    setApiKey("csk_live_secret");
+    clearApiKey();
+
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    setApiKey("csk_live_other");
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,4 +1,5 @@
 import { parseAllDocuments } from "yaml";
+import { getApiKey, clearApiKey } from "./auth";
 
 export interface Job {
   id: string;
@@ -308,13 +309,25 @@ async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
 }
 
 async function requestURL<T>(url: string, options?: RequestInit): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options?.headers as Record<string, string>),
+  };
+
+  const key = getApiKey();
+  if (key) {
+    headers["Authorization"] = `Bearer ${key}`;
+  }
+
   const response = await fetch(url, {
     ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
+    headers,
   });
+
+  if (response.status === 401) {
+    clearApiKey();
+    throw new ApiError(401, "Authentication required");
+  }
 
   if (!response.ok) {
     throw new ApiError(response.status, await response.text());

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1,5 +1,5 @@
 import { parseAllDocuments } from "yaml";
-import { getApiKey, clearApiKey } from "./auth";
+import { clearApiKey, withAuthHeaders } from "./auth";
 
 export interface Job {
   id: string;
@@ -309,15 +309,10 @@ async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
 }
 
 async function requestURL<T>(url: string, options?: RequestInit): Promise<T> {
-  const headers: Record<string, string> = {
+  const headers = withAuthHeaders({
     "Content-Type": "application/json",
     ...(options?.headers as Record<string, string>),
-  };
-
-  const key = getApiKey();
-  if (key) {
-    headers["Authorization"] = `Bearer ${key}`;
-  }
+  });
 
   const response = await fetch(url, {
     ...options,

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -1,0 +1,40 @@
+/**
+ * In-memory API key storage for UI authentication.
+ *
+ * The key is stored only in a module-scoped variable — not in localStorage
+ * or sessionStorage — to minimise XSS exposure. The session ends when the
+ * tab is closed or the user logs out.
+ */
+
+type AuthChangeListener = () => void;
+
+let apiKey: string | null = null;
+const listeners: Set<AuthChangeListener> = new Set();
+
+/** Store the API key in memory (never persisted to disk). */
+export function setApiKey(key: string): void {
+  apiKey = key;
+  listeners.forEach((fn) => fn());
+}
+
+/** Clear the API key (logout). */
+export function clearApiKey(): void {
+  apiKey = null;
+  listeners.forEach((fn) => fn());
+}
+
+/** Get the current API key, or null if not authenticated. */
+export function getApiKey(): string | null {
+  return apiKey;
+}
+
+/** Returns true if an API key is currently set. */
+export function isAuthenticated(): boolean {
+  return apiKey !== null;
+}
+
+/** Subscribe to auth state changes. Returns an unsubscribe function. */
+export function onAuthChange(fn: AuthChangeListener): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -11,6 +11,19 @@ type AuthChangeListener = () => void;
 let apiKey: string | null = null;
 const listeners: Set<AuthChangeListener> = new Set();
 
+function cloneHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) {
+    return {};
+  }
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+  return { ...headers };
+}
+
 /** Store the API key in memory (never persisted to disk). */
 export function setApiKey(key: string): void {
   apiKey = key;
@@ -23,14 +36,21 @@ export function clearApiKey(): void {
   listeners.forEach((fn) => fn());
 }
 
-/** Get the current API key, or null if not authenticated. */
-export function getApiKey(): string | null {
-  return apiKey;
-}
-
 /** Returns true if an API key is currently set. */
 export function isAuthenticated(): boolean {
   return apiKey !== null;
+}
+
+/**
+ * Injects the in-memory API key into a request headers object without exposing
+ * the raw key to other modules.
+ */
+export function withAuthHeaders(headers?: HeadersInit): Record<string, string> {
+  const nextHeaders = cloneHeaders(headers);
+  if (apiKey) {
+    nextHeaders.Authorization = `Bearer ${apiKey}`;
+  }
+  return nextHeaders;
 }
 
 /** Subscribe to auth state changes. Returns an unsubscribe function. */

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -6,6 +6,7 @@ import './index.css'
 import { router } from './router'
 import { Toaster } from '@/components/ui/sonner'
 import { ThemeProvider } from './components/theme-provider'
+import { AuthGate } from './features/auth/AuthGate'
 
 const queryClient = new QueryClient()
 
@@ -13,7 +14,9 @@ createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <QueryClientProvider client={queryClient}>
       <ThemeProvider defaultTheme="dark" storageKey="caesium-ui-theme">
-        <RouterProvider router={router} />
+        <AuthGate>
+          <RouterProvider router={router} />
+        </AuthGate>
         <Toaster />
       </ThemeProvider>
     </QueryClientProvider>


### PR DESCRIPTION
* Added API key authentication with role-based access control (admin > operator > runner > viewer), per-endpoint authorization policies, resource scoping, and a full audit log
* Add CLI key management (caesium auth key create/list/revoke/rotate, caesium auth audit) and UI login flow with in-memory key storage
* Default is `CAESIUM_AUTH_MODE=none` so there's no change for existing deployments workflows. 

```
CAESIUM_AUTH_MODE=api-key just run
docker logs caesium-server | grep csk_live
```
`<paste api-key into web UI>`

Next step will be to add authentication to webhooks. But I'll wait until you've finished working on those @rocketbitz. 
