### PR TITLE
Notifications framework

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -12,6 +12,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/job/run"
 	jobdef "github.com/caesium-cloud/caesium/api/rest/controller/jobdef"
 	"github.com/caesium-cloud/caesium/api/rest/controller/logs"
+	notifctrl "github.com/caesium-cloud/caesium/api/rest/controller/notification"
 	"github.com/caesium-cloud/caesium/api/rest/controller/node"
 	"github.com/caesium-cloud/caesium/api/rest/controller/stats"
 	"github.com/caesium-cloud/caesium/api/rest/controller/trigger"
@@ -118,6 +119,24 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 	if env.Variables().DatabaseConsoleEnabled {
 		g.GET("/database/schema", database.Schema)
 		g.POST("/database/query", database.Query)
+	}
+
+	// notification channels
+	{
+		g.GET("/notifications/channels", notifctrl.ListChannels)
+		g.GET("/notifications/channels/:id", notifctrl.GetChannel)
+		g.POST("/notifications/channels", notifctrl.CreateChannel)
+		g.PATCH("/notifications/channels/:id", notifctrl.UpdateChannel)
+		g.DELETE("/notifications/channels/:id", notifctrl.DeleteChannel)
+	}
+
+	// notification policies
+	{
+		g.GET("/notifications/policies", notifctrl.ListPolicies)
+		g.GET("/notifications/policies/:id", notifctrl.GetPolicy)
+		g.POST("/notifications/policies", notifctrl.CreatePolicy)
+		g.PATCH("/notifications/policies/:id", notifctrl.UpdatePolicy)
+		g.DELETE("/notifications/policies/:id", notifctrl.DeletePolicy)
 	}
 
 	// nodes

--- a/api/rest/controller/notification/channel.go
+++ b/api/rest/controller/notification/channel.go
@@ -102,6 +102,7 @@ var sensitiveKeys = map[string]struct{}{
 	"password":    {},
 	"routing_key": {},
 	"webhook_url": {},
+	"url":         {},
 	"token":       {},
 	"secret":      {},
 	"api_key":     {},

--- a/api/rest/controller/notification/channel.go
+++ b/api/rest/controller/notification/channel.go
@@ -1,0 +1,143 @@
+package notification
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	svc "github.com/caesium-cloud/caesium/api/rest/service/notification"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+func ListChannels(c *echo.Context) error {
+	req, err := parseListRequest(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	channels, err := svc.New(c.Request().Context()).ListChannels(req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	views := make([]channelView, len(channels))
+	for i := range channels {
+		views[i] = redactChannel(channels[i])
+	}
+	return c.JSON(http.StatusOK, views)
+}
+
+func GetChannel(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	ch, err := svc.New(c.Request().Context()).GetChannel(id)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, redactChannel(*ch))
+}
+
+func CreateChannel(c *echo.Context) error {
+	req := &svc.CreateChannelRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	ch, err := svc.New(c.Request().Context()).CreateChannel(req)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusCreated, redactChannel(*ch))
+}
+
+func UpdateChannel(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	req := &svc.UpdateChannelRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	ch, err := svc.New(c.Request().Context()).UpdateChannel(id, req)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, redactChannel(*ch))
+}
+
+func DeleteChannel(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	if err := svc.New(c.Request().Context()).DeleteChannel(id); err != nil {
+		return serviceError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// channelView is the API response for a notification channel with
+// sensitive config fields redacted.
+type channelView struct {
+	ID        uuid.UUID              `json:"id"`
+	Name      string                 `json:"name"`
+	Type      models.ChannelType     `json:"type"`
+	Config    map[string]interface{} `json:"config"`
+	Enabled   bool                   `json:"enabled"`
+	CreatedAt time.Time              `json:"created_at"`
+	UpdatedAt time.Time              `json:"updated_at"`
+}
+
+// sensitiveKeys are config keys whose values must be redacted in API responses.
+var sensitiveKeys = map[string]struct{}{
+	"password":    {},
+	"routing_key": {},
+	"webhook_url": {},
+	"token":       {},
+	"secret":      {},
+	"api_key":     {},
+}
+
+func redactChannel(ch models.NotificationChannel) channelView {
+	cfg := make(map[string]interface{})
+	if len(ch.Config) > 0 {
+		_ = json.Unmarshal(ch.Config, &cfg)
+	}
+
+	for key, val := range cfg {
+		if _, sensitive := sensitiveKeys[key]; sensitive {
+			if s, ok := val.(string); ok && len(s) > 0 {
+				cfg[key] = maskString(s)
+			}
+		}
+	}
+
+	return channelView{
+		ID:        ch.ID,
+		Name:      ch.Name,
+		Type:      ch.Type,
+		Config:    cfg,
+		Enabled:   ch.Enabled,
+		CreatedAt: ch.CreatedAt,
+		UpdatedAt: ch.UpdatedAt,
+	}
+}
+
+// maskString replaces the middle of a string with asterisks, keeping the
+// first 4 and last 4 characters visible. For short strings (<= 8 chars)
+// the entire value is masked.
+func maskString(s string) string {
+	if len(s) <= 8 {
+		return "****"
+	}
+	return s[:4] + "****" + s[len(s)-4:]
+}

--- a/api/rest/controller/notification/error.go
+++ b/api/rest/controller/notification/error.go
@@ -1,0 +1,103 @@
+package notification
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	svc "github.com/caesium-cloud/caesium/api/rest/service/notification"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+// allowedOrderColumns is the allowlist of columns that may appear in order_by.
+var allowedOrderColumns = map[string]struct{}{
+	"name":       {},
+	"type":       {},
+	"enabled":    {},
+	"created_at": {},
+	"updated_at": {},
+}
+
+func serviceError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return echo.ErrNotFound
+	case errors.Is(err, svc.ErrChannelNameConflict),
+		errors.Is(err, svc.ErrPolicyNameConflict):
+		return echo.NewHTTPError(http.StatusConflict, "conflict").Wrap(err)
+	case errors.Is(err, svc.ErrInvalidChannel),
+		errors.Is(err, svc.ErrInvalidPolicy):
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+}
+
+func parseListRequest(c *echo.Context) (*svc.ListRequest, error) {
+	req := &svc.ListRequest{}
+
+	if limit := c.QueryParam("limit"); limit != "" {
+		v, err := strconv.ParseUint(limit, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		req.Limit = v
+	}
+
+	if offset := c.QueryParam("offset"); offset != "" {
+		v, err := strconv.ParseUint(offset, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		req.Offset = v
+	}
+
+	if orderBy := c.QueryParam("order_by"); orderBy != "" {
+		clauses, err := parseSafeOrderBy(orderBy)
+		if err != nil {
+			return nil, err
+		}
+		req.OrderBy = clauses
+	}
+
+	return req, nil
+}
+
+// parseSafeOrderBy validates and sanitizes order_by terms against the allowlist.
+// Accepted format per term: "column" or "column asc" or "column desc".
+func parseSafeOrderBy(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		tokens := strings.Fields(part)
+		col := strings.ToLower(tokens[0])
+		if _, ok := allowedOrderColumns[col]; !ok {
+			return nil, fmt.Errorf("invalid order_by column: %q", tokens[0])
+		}
+		dir := "asc"
+		if len(tokens) > 1 {
+			switch strings.ToLower(tokens[1]) {
+			case "asc":
+				dir = "asc"
+			case "desc":
+				dir = "desc"
+			default:
+				return nil, fmt.Errorf("invalid order_by direction: %q", tokens[1])
+			}
+		}
+		if len(tokens) > 2 {
+			return nil, fmt.Errorf("invalid order_by term: %q", part)
+		}
+		result = append(result, col+" "+dir)
+	}
+	return result, nil
+}

--- a/api/rest/controller/notification/error_test.go
+++ b/api/rest/controller/notification/error_test.go
@@ -90,9 +90,9 @@ func TestRedactChannel_SensitiveKeys(t *testing.T) {
 		}
 	}
 
-	// url should NOT be redacted (not in sensitiveKeys).
-	if ch.Config["url"] != "https://example.com/hook" {
-		t.Errorf("url should not be redacted, got %q", ch.Config["url"])
+	// url should be redacted.
+	if ch.Config["url"] == "https://example.com/hook" {
+		t.Error("url should be redacted")
 	}
 
 	// password should be redacted.

--- a/api/rest/controller/notification/error_test.go
+++ b/api/rest/controller/notification/error_test.go
@@ -1,0 +1,117 @@
+package notification
+
+import (
+	"testing"
+)
+
+func TestParseSafeOrderBy(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{"single column", "name", []string{"name asc"}, false},
+		{"column with asc", "name asc", []string{"name asc"}, false},
+		{"column with desc", "created_at desc", []string{"created_at desc"}, false},
+		{"multiple columns", "name asc,created_at desc", []string{"name asc", "created_at desc"}, false},
+		{"case insensitive direction", "name DESC", []string{"name desc"}, false},
+		{"case insensitive column", "NAME", []string{"name asc"}, false},
+		{"empty string", "", []string{}, false},
+		{"unknown column", "password", nil, true},
+		{"sql injection attempt", "name; DROP TABLE", nil, true},
+		{"sql injection in column", "1=1--", nil, true},
+		{"invalid direction", "name sideways", nil, true},
+		{"too many tokens", "name asc extra", nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseSafeOrderBy(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d clauses, want %d", len(got), len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("clause[%d]: got %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestMaskString(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"short", "****"},
+		{"12345678", "****"},
+		{"123456789", "1234****6789"},
+		{"https://hooks.slack.com/services/T00/B00/xxxx", "http****xxxx"},
+		{"sk-live-abcdefghijklmnop", "sk-l****mnop"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := maskString(tt.input)
+			if got != tt.want {
+				t.Errorf("maskString(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedactChannel_SensitiveKeys(t *testing.T) {
+	// Verify that sensitive keys are masked in the response.
+	ch := channelView{
+		Config: map[string]interface{}{
+			"url":         "https://example.com/hook",
+			"password":    "supersecret123",
+			"routing_key": "R012345678901234",
+			"webhook_url": "https://hooks.slack.com/services/T00/B00/xxxx",
+			"timeout":     "10s",
+		},
+	}
+
+	// Simulate redaction by applying the same logic.
+	for key, val := range ch.Config {
+		if _, sensitive := sensitiveKeys[key]; sensitive {
+			if s, ok := val.(string); ok && len(s) > 0 {
+				ch.Config[key] = maskString(s)
+			}
+		}
+	}
+
+	// url should NOT be redacted (not in sensitiveKeys).
+	if ch.Config["url"] != "https://example.com/hook" {
+		t.Errorf("url should not be redacted, got %q", ch.Config["url"])
+	}
+
+	// password should be redacted.
+	if ch.Config["password"] == "supersecret123" {
+		t.Error("password should be redacted")
+	}
+
+	// routing_key should be redacted.
+	if ch.Config["routing_key"] == "R012345678901234" {
+		t.Error("routing_key should be redacted")
+	}
+
+	// webhook_url should be redacted.
+	if ch.Config["webhook_url"] == "https://hooks.slack.com/services/T00/B00/xxxx" {
+		t.Error("webhook_url should be redacted")
+	}
+
+	// timeout should NOT be redacted.
+	if ch.Config["timeout"] != "10s" {
+		t.Errorf("timeout should not be redacted, got %q", ch.Config["timeout"])
+	}
+}

--- a/api/rest/controller/notification/policy.go
+++ b/api/rest/controller/notification/policy.go
@@ -1,0 +1,78 @@
+package notification
+
+import (
+	"net/http"
+
+	svc "github.com/caesium-cloud/caesium/api/rest/service/notification"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+func ListPolicies(c *echo.Context) error {
+	req, err := parseListRequest(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	policies, err := svc.New(c.Request().Context()).ListPolicies(req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, policies)
+}
+
+func GetPolicy(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	p, err := svc.New(c.Request().Context()).GetPolicy(id)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, p)
+}
+
+func CreatePolicy(c *echo.Context) error {
+	req := &svc.CreatePolicyRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	p, err := svc.New(c.Request().Context()).CreatePolicy(req)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusCreated, p)
+}
+
+func UpdatePolicy(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	req := &svc.UpdatePolicyRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	p, err := svc.New(c.Request().Context()).UpdatePolicy(id, req)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, p)
+}
+
+func DeletePolicy(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	if err := svc.New(c.Request().Context()).DeletePolicy(id); err != nil {
+		return serviceError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/api/rest/service/notification/notification.go
+++ b/api/rest/service/notification/notification.go
@@ -1,0 +1,426 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/notification"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrInvalidChannel       = errors.New("invalid notification channel")
+	ErrChannelNameConflict  = errors.New("channel name conflict")
+	ErrInvalidPolicy        = errors.New("invalid notification policy")
+	ErrPolicyNameConflict   = errors.New("policy name conflict")
+)
+
+// Service manages notification channels and policies.
+type Service interface {
+	// Channels
+	ListChannels(req *ListRequest) ([]models.NotificationChannel, error)
+	GetChannel(id uuid.UUID) (*models.NotificationChannel, error)
+	CreateChannel(req *CreateChannelRequest) (*models.NotificationChannel, error)
+	UpdateChannel(id uuid.UUID, req *UpdateChannelRequest) (*models.NotificationChannel, error)
+	DeleteChannel(id uuid.UUID) error
+
+	// Policies
+	ListPolicies(req *ListRequest) ([]models.NotificationPolicy, error)
+	GetPolicy(id uuid.UUID) (*models.NotificationPolicy, error)
+	CreatePolicy(req *CreatePolicyRequest) (*models.NotificationPolicy, error)
+	UpdatePolicy(id uuid.UUID, req *UpdatePolicyRequest) (*models.NotificationPolicy, error)
+	DeletePolicy(id uuid.UUID) error
+}
+
+type service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+// New returns a new notification service.
+func New(ctx context.Context) Service {
+	return &service{
+		ctx: ctx,
+		db:  db.Connection(),
+	}
+}
+
+// --- Request types ---
+
+type ListRequest struct {
+	Limit   uint64
+	Offset  uint64
+	OrderBy []string
+}
+
+type CreateChannelRequest struct {
+	Name    string                 `json:"name"`
+	Type    models.ChannelType     `json:"type"`
+	Config  map[string]interface{} `json:"config"`
+	Enabled *bool                  `json:"enabled,omitempty"`
+}
+
+type UpdateChannelRequest struct {
+	Name    *string                `json:"name,omitempty"`
+	Config  map[string]interface{} `json:"config,omitempty"`
+	Enabled *bool                  `json:"enabled,omitempty"`
+}
+
+type CreatePolicyRequest struct {
+	Name       string   `json:"name"`
+	ChannelID  uuid.UUID `json:"channel_id"`
+	EventTypes []string `json:"event_types"`
+	Filters    map[string]interface{} `json:"filters,omitempty"`
+	Enabled    *bool    `json:"enabled,omitempty"`
+}
+
+type UpdatePolicyRequest struct {
+	Name       *string  `json:"name,omitempty"`
+	ChannelID  *uuid.UUID `json:"channel_id,omitempty"`
+	EventTypes []string `json:"event_types,omitempty"`
+	Filters    map[string]interface{} `json:"filters,omitempty"`
+	Enabled    *bool    `json:"enabled,omitempty"`
+}
+
+// --- Channel CRUD ---
+
+func (s *service) ListChannels(req *ListRequest) ([]models.NotificationChannel, error) {
+	var channels []models.NotificationChannel
+	q := s.db.WithContext(s.ctx)
+
+	if req != nil {
+		if req.Limit > 0 {
+			q = q.Limit(int(req.Limit))
+		}
+		if req.Offset > 0 {
+			q = q.Offset(int(req.Offset))
+		}
+		for _, ob := range req.OrderBy {
+			q = q.Order(ob)
+		}
+	}
+
+	return channels, q.Find(&channels).Error
+}
+
+func (s *service) GetChannel(id uuid.UUID) (*models.NotificationChannel, error) {
+	var ch models.NotificationChannel
+	return &ch, s.db.WithContext(s.ctx).First(&ch, "id = ?", id).Error
+}
+
+func (s *service) CreateChannel(req *CreateChannelRequest) (*models.NotificationChannel, error) {
+	if err := validateChannelType(req.Type); err != nil {
+		return nil, err
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: name is required", ErrInvalidChannel)
+	}
+
+	if err := ensureChannelNameAvailable(s.db.WithContext(s.ctx), name, uuid.Nil); err != nil {
+		return nil, err
+	}
+
+	configJSON, err := json.Marshal(req.Config)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid config: %w", ErrInvalidChannel, err)
+	}
+
+	ch := models.NotificationChannel{
+		ID:      uuid.New(),
+		Name:    name,
+		Type:    req.Type,
+		Config:  configJSON,
+		Enabled: true,
+	}
+	if req.Enabled != nil {
+		ch.Enabled = *req.Enabled
+	}
+
+	if err := s.db.WithContext(s.ctx).Create(&ch).Error; err != nil {
+		return nil, err
+	}
+	return &ch, nil
+}
+
+func (s *service) UpdateChannel(id uuid.UUID, req *UpdateChannelRequest) (*models.NotificationChannel, error) {
+	var ch models.NotificationChannel
+	if err := s.db.WithContext(s.ctx).First(&ch, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+
+	updates := map[string]interface{}{}
+
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if name == "" {
+			return nil, fmt.Errorf("%w: name cannot be empty", ErrInvalidChannel)
+		}
+		if err := ensureChannelNameAvailable(s.db.WithContext(s.ctx), name, id); err != nil {
+			return nil, err
+		}
+		updates["name"] = name
+	}
+
+	if req.Config != nil {
+		configJSON, err := json.Marshal(req.Config)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid config: %w", ErrInvalidChannel, err)
+		}
+		updates["config"] = configJSON
+	}
+
+	if req.Enabled != nil {
+		updates["enabled"] = *req.Enabled
+	}
+
+	if len(updates) > 0 {
+		if err := s.db.WithContext(s.ctx).Model(&ch).Updates(updates).Error; err != nil {
+			return nil, err
+		}
+	}
+
+	// Reload
+	if err := s.db.WithContext(s.ctx).First(&ch, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &ch, nil
+}
+
+func (s *service) DeleteChannel(id uuid.UUID) error {
+	return s.db.WithContext(s.ctx).Delete(&models.NotificationChannel{}, "id = ?", id).Error
+}
+
+// --- Policy CRUD ---
+
+func (s *service) ListPolicies(req *ListRequest) ([]models.NotificationPolicy, error) {
+	var policies []models.NotificationPolicy
+	q := s.db.WithContext(s.ctx)
+
+	if req != nil {
+		if req.Limit > 0 {
+			q = q.Limit(int(req.Limit))
+		}
+		if req.Offset > 0 {
+			q = q.Offset(int(req.Offset))
+		}
+		for _, ob := range req.OrderBy {
+			q = q.Order(ob)
+		}
+	}
+
+	return policies, q.Find(&policies).Error
+}
+
+func (s *service) GetPolicy(id uuid.UUID) (*models.NotificationPolicy, error) {
+	var p models.NotificationPolicy
+	return &p, s.db.WithContext(s.ctx).First(&p, "id = ?", id).Error
+}
+
+func (s *service) CreatePolicy(req *CreatePolicyRequest) (*models.NotificationPolicy, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: name is required", ErrInvalidPolicy)
+	}
+
+	if err := ensurePolicyNameAvailable(s.db.WithContext(s.ctx), name, uuid.Nil); err != nil {
+		return nil, err
+	}
+
+	// Validate channel exists
+	var ch models.NotificationChannel
+	if err := s.db.WithContext(s.ctx).First(&ch, "id = ?", req.ChannelID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%w: channel %s not found", ErrInvalidPolicy, req.ChannelID)
+		}
+		return nil, err
+	}
+
+	if err := validateEventTypes(req.EventTypes); err != nil {
+		return nil, err
+	}
+
+	eventTypesJSON, err := json.Marshal(req.EventTypes)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPolicy, err)
+	}
+
+	var filtersJSON []byte
+	if req.Filters != nil {
+		filtersJSON, err = json.Marshal(req.Filters)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid filters: %w", ErrInvalidPolicy, err)
+		}
+		if err := validateFilters(filtersJSON); err != nil {
+			return nil, err
+		}
+	}
+
+	p := models.NotificationPolicy{
+		ID:         uuid.New(),
+		Name:       name,
+		ChannelID:  req.ChannelID,
+		EventTypes: eventTypesJSON,
+		Filters:    filtersJSON,
+		Enabled:    true,
+	}
+	if req.Enabled != nil {
+		p.Enabled = *req.Enabled
+	}
+
+	if err := s.db.WithContext(s.ctx).Create(&p).Error; err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *service) UpdatePolicy(id uuid.UUID, req *UpdatePolicyRequest) (*models.NotificationPolicy, error) {
+	var p models.NotificationPolicy
+	if err := s.db.WithContext(s.ctx).First(&p, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+
+	updates := map[string]interface{}{}
+
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if name == "" {
+			return nil, fmt.Errorf("%w: name cannot be empty", ErrInvalidPolicy)
+		}
+		if err := ensurePolicyNameAvailable(s.db.WithContext(s.ctx), name, id); err != nil {
+			return nil, err
+		}
+		updates["name"] = name
+	}
+
+	if req.ChannelID != nil {
+		var ch models.NotificationChannel
+		if err := s.db.WithContext(s.ctx).First(&ch, "id = ?", *req.ChannelID).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, fmt.Errorf("%w: channel %s not found", ErrInvalidPolicy, req.ChannelID)
+			}
+			return nil, err
+		}
+		updates["channel_id"] = *req.ChannelID
+	}
+
+	if len(req.EventTypes) > 0 {
+		if err := validateEventTypes(req.EventTypes); err != nil {
+			return nil, err
+		}
+		eventTypesJSON, err := json.Marshal(req.EventTypes)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidPolicy, err)
+		}
+		updates["event_types"] = eventTypesJSON
+	}
+
+	if req.Filters != nil {
+		filtersJSON, err := json.Marshal(req.Filters)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid filters: %w", ErrInvalidPolicy, err)
+		}
+		if err := validateFilters(filtersJSON); err != nil {
+			return nil, err
+		}
+		updates["filters"] = filtersJSON
+	}
+
+	if req.Enabled != nil {
+		updates["enabled"] = *req.Enabled
+	}
+
+	if len(updates) > 0 {
+		if err := s.db.WithContext(s.ctx).Model(&p).Updates(updates).Error; err != nil {
+			return nil, err
+		}
+	}
+
+	if err := s.db.WithContext(s.ctx).First(&p, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *service) DeletePolicy(id uuid.UUID) error {
+	return s.db.WithContext(s.ctx).Delete(&models.NotificationPolicy{}, "id = ?", id).Error
+}
+
+// --- Helpers ---
+
+func validateChannelType(ct models.ChannelType) error {
+	valid := notification.ValidChannelTypes()
+	if _, ok := valid[ct]; !ok {
+		return fmt.Errorf("%w: unsupported channel type %q", ErrInvalidChannel, ct)
+	}
+	return nil
+}
+
+func validateEventTypes(types []string) error {
+	if len(types) == 0 {
+		return fmt.Errorf("%w: at least one event type is required", ErrInvalidPolicy)
+	}
+	valid := notification.ValidEventTypes()
+	for _, t := range types {
+		if _, ok := valid[event.Type(t)]; !ok {
+			return fmt.Errorf("%w: unsupported event type %q", ErrInvalidPolicy, t)
+		}
+	}
+	return nil
+}
+
+func ensureChannelNameAvailable(q *gorm.DB, name string, excludeID uuid.UUID) error {
+	var existing models.NotificationChannel
+	query := q.Where("name = ?", name)
+	if excludeID != uuid.Nil {
+		query = query.Where("id <> ?", excludeID)
+	}
+	err := query.First(&existing).Error
+	switch {
+	case err == nil:
+		return fmt.Errorf("%w: name %q already exists", ErrChannelNameConflict, name)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil
+	default:
+		return err
+	}
+}
+
+func ensurePolicyNameAvailable(q *gorm.DB, name string, excludeID uuid.UUID) error {
+	var existing models.NotificationPolicy
+	query := q.Where("name = ?", name)
+	if excludeID != uuid.Nil {
+		query = query.Where("id <> ?", excludeID)
+	}
+	err := query.First(&existing).Error
+	switch {
+	case err == nil:
+		return fmt.Errorf("%w: name %q already exists", ErrPolicyNameConflict, name)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil
+	default:
+		return err
+	}
+}
+
+// validateFilters checks that the filters JSON is a valid PolicyFilter.
+// This prevents malformed filters from being persisted, which would cause
+// the subscriber to fail closed and silently drop notifications.
+func validateFilters(raw []byte) error {
+	if len(raw) == 0 {
+		return nil
+	}
+	var f notification.PolicyFilter
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return fmt.Errorf("%w: filters must be a valid JSON object with optional fields: job_ids, job_alias, labels", ErrInvalidPolicy)
+	}
+	return nil
+}

--- a/api/rest/service/notification/notification.go
+++ b/api/rest/service/notification/notification.go
@@ -196,7 +196,7 @@ func (s *service) UpdateChannel(id uuid.UUID, req *UpdateChannelRequest) (*model
 }
 
 func (s *service) DeleteChannel(id uuid.UUID) error {
-	return s.db.WithContext(s.ctx).Delete(&models.NotificationChannel{}, "id = ?", id).Error
+	return s.db.WithContext(s.ctx).Unscoped().Delete(&models.NotificationChannel{}, "id = ?", id).Error
 }
 
 // --- Policy CRUD ---

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -20,6 +20,8 @@ import (
 	"github.com/caesium-cloud/caesium/internal/jobdef/git"
 	"github.com/caesium-cloud/caesium/internal/jobdef/runtime"
 	"github.com/caesium-cloud/caesium/internal/lineage"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/notification"
 	"github.com/caesium-cloud/caesium/internal/run"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
 	"github.com/caesium-cloud/caesium/internal/worker"
@@ -145,6 +147,31 @@ func start(cmd *cobra.Command, args []string) error {
 				}
 			}()
 		}
+	}
+
+	// --- Notification Subscriber & Watcher ---
+	{
+		notification.RegisterMetrics()
+		conn := db.Connection()
+		notifSub := notification.NewSubscriber(bus, conn)
+		notifSub.RegisterSender(models.ChannelTypeWebhook, notification.NewWebhookSender())
+		notifSub.RegisterSender(models.ChannelTypeSlack, notification.NewSlackSender())
+		notifSub.RegisterSender(models.ChannelTypeEmail, notification.NewEmailSender())
+		notifSub.RegisterSender(models.ChannelTypePagerDuty, notification.NewPagerDutySender())
+		go func() {
+			log.Info("launching notification subscriber")
+			if err := notifSub.Start(ctx); err != nil && ctx.Err() == nil {
+				log.Error("notification subscriber exited", "error", err)
+			}
+		}()
+
+		watcher := notification.NewWatcher(conn, bus, event.NewStore(conn), vars.NotificationWatcherInterval)
+		go func() {
+			log.Info("launching notification watcher (timeout/SLA)")
+			if err := watcher.Start(ctx); err != nil && ctx.Err() == nil {
+				log.Error("notification watcher exited", "error", err)
+			}
+		}()
 	}
 
 	importer := jobdef.NewImporter(db.Connection())

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -36,6 +36,8 @@ const (
 	TypeBackfillFailed    Type = "backfill_failed"
 	TypeBackfillCancelled Type = "backfill_cancelled"
 	TypeRunRetried        Type = "run_retried"
+	TypeRunTimedOut       Type = "run_timed_out"
+	TypeSLAMissed         Type = "sla_missed"
 )
 
 // Event represents a system event.

--- a/internal/jobdef/importer.go
+++ b/internal/jobdef/importer.go
@@ -274,6 +274,7 @@ func (i *Importer) upsertJobAndTriggerTx(tx *gorm.DB, existing *models.Job, def 
 			MaxParallelTasks: def.Metadata.MaxParallelTasks,
 			TaskTimeout:      def.Metadata.TaskTimeout,
 			RunTimeout:       def.Metadata.RunTimeout,
+			SLA:              marshalSLA(def.Metadata.SLA),
 			SchemaValidation: def.Metadata.SchemaValidation,
 			CacheConfig:      cacheConfig,
 		}
@@ -291,6 +292,7 @@ func (i *Importer) upsertJobAndTriggerTx(tx *gorm.DB, existing *models.Job, def 
 	existing.MaxParallelTasks = def.Metadata.MaxParallelTasks
 	existing.TaskTimeout = def.Metadata.TaskTimeout
 	existing.RunTimeout = def.Metadata.RunTimeout
+	existing.SLA = marshalSLA(def.Metadata.SLA)
 	existing.SchemaValidation = def.Metadata.SchemaValidation
 	existing.CacheConfig = cacheConfig
 	applyJobProvenance(existing, opts)
@@ -303,6 +305,7 @@ func (i *Importer) upsertJobAndTriggerTx(tx *gorm.DB, existing *models.Job, def 
 		"max_parallel_tasks":   existing.MaxParallelTasks,
 		"task_timeout":         existing.TaskTimeout,
 		"run_timeout":          existing.RunTimeout,
+		"sla":                  existing.SLA,
 		"schema_validation":    existing.SchemaValidation,
 		"cache_config":         existing.CacheConfig,
 		"provenance_source_id": existing.ProvenanceSourceID,
@@ -841,4 +844,17 @@ func cloneAnyMap(in map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+// marshalSLA converts an SLAConfig pointer to JSON for storage.
+// Returns nil when no SLA is configured so the column stays NULL.
+func marshalSLA(sla *schema.SLAConfig) datatypes.JSON {
+	if sla == nil || !sla.HasSLA() {
+		return nil
+	}
+	data, err := json.Marshal(sla)
+	if err != nil {
+		return nil
+	}
+	return data
 }

--- a/internal/models/job.go
+++ b/internal/models/job.go
@@ -24,6 +24,7 @@ type Job struct {
 	MaxParallelTasks   int               `json:"max_parallel_tasks"`
 	TaskTimeout        time.Duration     `json:"task_timeout"`
 	RunTimeout         time.Duration     `json:"run_timeout"`
+	SLA                datatypes.JSON    `gorm:"type:json" json:"sla,omitempty"`
 	// SchemaValidation controls runtime output schema validation for this job's tasks.
 	// Values: "" (disabled), "warn" (log violations), "fail" (fail task on violation).
 	SchemaValidation string         `gorm:"type:text;not null;default:''" json:"schema_validation,omitempty"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -18,4 +18,6 @@ var All = []interface{}{
 	&ExecutionEvent{},
 	&APIKey{},
 	&AuditLog{},
+	&NotificationChannel{},
+	&NotificationPolicy{},
 }

--- a/internal/models/notification.go
+++ b/internal/models/notification.go
@@ -1,0 +1,46 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// ChannelType identifies the notification transport.
+type ChannelType string
+
+const (
+	ChannelTypeWebhook  ChannelType = "webhook"
+	ChannelTypeSlack    ChannelType = "slack"
+	ChannelTypeEmail    ChannelType = "email"
+	ChannelTypePagerDuty ChannelType = "pagerduty"
+	ChannelTypeAIAgent  ChannelType = "ai_agent"
+)
+
+// NotificationChannel stores a configured notification destination.
+type NotificationChannel struct {
+	ID        uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Name      string         `gorm:"uniqueIndex;not null" json:"name"`
+	Type      ChannelType    `gorm:"type:text;not null;index" json:"type"`
+	Config    datatypes.JSON `gorm:"type:json;not null" json:"config"`
+	Enabled   bool           `gorm:"not null;default:true" json:"enabled"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	CreatedAt time.Time      `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time      `gorm:"not null" json:"updated_at"`
+}
+
+// NotificationPolicy links event types to channels with optional filters.
+type NotificationPolicy struct {
+	ID        uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Name      string         `gorm:"uniqueIndex;not null" json:"name"`
+	ChannelID uuid.UUID      `gorm:"type:uuid;index;not null" json:"channel_id"`
+	Channel   NotificationChannel `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	EventTypes datatypes.JSON `gorm:"type:json;not null" json:"event_types"`
+	Filters   datatypes.JSON `gorm:"type:json" json:"filters,omitempty"`
+	Enabled   bool           `gorm:"not null;default:true" json:"enabled"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	CreatedAt time.Time      `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time      `gorm:"not null" json:"updated_at"`
+}

--- a/internal/notification/metrics.go
+++ b/internal/notification/metrics.go
@@ -1,0 +1,80 @@
+package notification
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	registerMetricsOnce sync.Once
+
+	// NotificationSendsTotal counts notification dispatch attempts by channel type and outcome.
+	NotificationSendsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_notification_sends_total",
+			Help: "Total notification dispatch attempts by channel type and outcome.",
+		},
+		[]string{"channel_type", "status"},
+	)
+
+	// NotificationSendDuration tracks how long each send takes.
+	NotificationSendDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "caesium_notification_send_duration_seconds",
+			Help:    "Duration of notification send operations in seconds.",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10},
+		},
+		[]string{"channel_type"},
+	)
+
+	// TaskFailuresTotal counts task failure events observed by the notification subscriber.
+	TaskFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_task_failures_total",
+			Help: "Total task failure events observed.",
+		},
+		[]string{"job_alias"},
+	)
+
+	// RunFailuresTotal counts run failure events observed by the notification subscriber.
+	RunFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_run_failures_total",
+			Help: "Total run failure events observed.",
+		},
+		[]string{"job_alias"},
+	)
+
+	// RunTimeoutsTotal counts run timeout events.
+	RunTimeoutsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_run_timeouts_total",
+			Help: "Total run timeout events observed.",
+		},
+		[]string{"job_alias"},
+	)
+
+	// SLAMissesTotal counts SLA miss events.
+	SLAMissesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_sla_misses_total",
+			Help: "Total SLA miss events observed.",
+		},
+		[]string{"job_alias"},
+	)
+)
+
+// RegisterMetrics registers all notification metrics with the default Prometheus registry.
+func RegisterMetrics() {
+	registerMetricsOnce.Do(func() {
+		prometheus.MustRegister(
+			NotificationSendsTotal,
+			NotificationSendDuration,
+			TaskFailuresTotal,
+			RunFailuresTotal,
+			RunTimeoutsTotal,
+			SLAMissesTotal,
+		)
+	})
+}

--- a/internal/notification/metrics_test.go
+++ b/internal/notification/metrics_test.go
@@ -1,0 +1,44 @@
+package notification
+
+import (
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+)
+
+func TestRecordEventMetric(t *testing.T) {
+	// Just verify it doesn't panic on all event types.
+	events := []event.Event{
+		{Type: event.TypeTaskFailed, Payload: mustJSON(map[string]string{"job_alias": "a"})},
+		{Type: event.TypeRunFailed, Payload: mustJSON(map[string]string{"job_alias": "b"})},
+		{Type: event.TypeRunTimedOut, Payload: mustJSON(map[string]string{"job_alias": "c"})},
+		{Type: event.TypeSLAMissed, Payload: mustJSON(map[string]string{"job_alias": "d"})},
+		{Type: event.TypeRunCompleted},
+		{Type: event.TypeTaskSucceeded},
+	}
+	for _, evt := range events {
+		recordEventMetric(evt)
+	}
+}
+
+func TestExtractJobAlias(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    string
+	}{
+		{"with alias", mustJSON(map[string]string{"job_alias": "pipeline"}), "pipeline"},
+		{"empty payload", nil, ""},
+		{"no alias key", mustJSON(map[string]string{"foo": "bar"}), ""},
+		{"invalid json", []byte("bad"), ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			evt := event.Event{Payload: tt.payload}
+			got := extractJobAlias(evt)
+			if got != tt.want {
+				t.Errorf("extractJobAlias() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -22,6 +22,7 @@ type Payload struct {
 	EventType  event.Type        `json:"event_type"`
 	JobID      uuid.UUID         `json:"job_id"`
 	JobAlias   string            `json:"job_alias,omitempty"`
+	JobLabels  map[string]string `json:"job_labels,omitempty"`
 	RunID      uuid.UUID         `json:"run_id"`
 	TaskID     uuid.UUID         `json:"task_id,omitempty"`
 	Error      string            `json:"error,omitempty"`

--- a/internal/notification/notification.go
+++ b/internal/notification/notification.go
@@ -1,1 +1,37 @@
 package notification
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+// Sender delivers a notification payload to a specific channel type.
+// The channel's Config field contains the per-channel configuration
+// (URL, credentials, routing keys, etc.) as JSON.
+type Sender interface {
+	Send(ctx context.Context, channel models.NotificationChannel, payload Payload) error
+}
+
+// Payload is the notification content delivered to channels.
+type Payload struct {
+	EventType  event.Type        `json:"event_type"`
+	JobID      uuid.UUID         `json:"job_id"`
+	JobAlias   string            `json:"job_alias,omitempty"`
+	RunID      uuid.UUID         `json:"run_id"`
+	TaskID     uuid.UUID         `json:"task_id,omitempty"`
+	Error      string            `json:"error,omitempty"`
+	Timestamp  time.Time         `json:"timestamp"`
+	RawPayload json.RawMessage   `json:"payload,omitempty"`
+}
+
+// PolicyFilter defines optional filters on a notification policy.
+type PolicyFilter struct {
+	JobIDs   []uuid.UUID `json:"job_ids,omitempty"`
+	JobAlias string      `json:"job_alias,omitempty"`
+	Labels   map[string]string `json:"labels,omitempty"`
+}

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -1,9 +1,7 @@
 package notification
 
 import (
-	"context"
 	"encoding/json"
-	"sync"
 	"testing"
 	"time"
 
@@ -11,28 +9,6 @@ import (
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 )
-
-// --- Test helpers ---
-
-type recordingSender struct {
-	mu       sync.Mutex
-	payloads []Payload
-}
-
-func (r *recordingSender) Send(_ context.Context, p Payload) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.payloads = append(r.payloads, p)
-	return nil
-}
-
-func (r *recordingSender) Payloads() []Payload {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	out := make([]Payload, len(r.payloads))
-	copy(out, r.payloads)
-	return out
-}
 
 // --- Tests ---
 
@@ -400,6 +376,75 @@ func TestResolveCompletedBy(t *testing.T) {
 			// Should be on the same date as refTime.
 			if got.Year() != 2026 || got.Month() != 4 || got.Day() != 13 {
 				t.Errorf("wrong date: got %s", got.Format("2006-01-02"))
+			}
+		})
+	}
+}
+
+// --- SLA window validation tests ---
+
+func TestRunMetSLA(t *testing.T) {
+	jobA := uuid.New()
+	jobB := uuid.New()
+	jobC := uuid.New()
+	jobMissing := uuid.New()
+
+	// SLA deadline is 09:00 on 2026-04-13. Window is [09:00 Apr 12, 09:00 Apr 13].
+	deadline := time.Date(2026, 4, 13, 9, 0, 0, 0, time.UTC)
+	windowStart := deadline.Add(-24 * time.Hour)
+
+	latestByJob := map[uuid.UUID]time.Time{
+		// jobA: completed at 08:30 — within window, before deadline.
+		jobA: time.Date(2026, 4, 13, 8, 30, 0, 0, time.UTC),
+		// jobB: completed at 09:15 — AFTER the deadline. Should NOT count.
+		jobB: time.Date(2026, 4, 13, 9, 15, 0, 0, time.UTC),
+		// jobC: completed at 08:00 on Apr 12 — BEFORE the window start. Should NOT count.
+		jobC: time.Date(2026, 4, 12, 8, 0, 0, 0, time.UTC),
+	}
+
+	tests := []struct {
+		name string
+		job  uuid.UUID
+		want bool
+	}{
+		{"completed within window", jobA, true},
+		{"completed after deadline", jobB, false},
+		{"completed before window start", jobC, false},
+		{"no run at all", jobMissing, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runMetSLA(latestByJob, tt.job, windowStart, deadline)
+			if got != tt.want {
+				t.Errorf("runMetSLA() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunMetSLA_BoundaryConditions(t *testing.T) {
+	jobID := uuid.New()
+	deadline := time.Date(2026, 4, 13, 9, 0, 0, 0, time.UTC)
+	windowStart := deadline.Add(-24 * time.Hour)
+
+	tests := []struct {
+		name     string
+		complAt  time.Time
+		want     bool
+	}{
+		{"exactly at deadline", deadline, true},
+		{"exactly at window start", windowStart, true},
+		{"one nanosecond after deadline", deadline.Add(1), false},
+		{"one nanosecond before window start", windowStart.Add(-1), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := map[uuid.UUID]time.Time{jobID: tt.complAt}
+			got := runMetSLA(m, jobID, windowStart, deadline)
+			if got != tt.want {
+				t.Errorf("runMetSLA() = %v, want %v (completed_at=%s)", got, tt.want, tt.complAt)
 			}
 		})
 	}

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -1,1 +1,414 @@
 package notification
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+// --- Test helpers ---
+
+type recordingSender struct {
+	mu       sync.Mutex
+	payloads []Payload
+}
+
+func (r *recordingSender) Send(_ context.Context, p Payload) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.payloads = append(r.payloads, p)
+	return nil
+}
+
+func (r *recordingSender) Payloads() []Payload {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Payload, len(r.payloads))
+	copy(out, r.payloads)
+	return out
+}
+
+// --- Tests ---
+
+func TestBuildPayload(t *testing.T) {
+	jobID := uuid.New()
+	runID := uuid.New()
+	taskID := uuid.New()
+	now := time.Now().UTC()
+
+	raw, _ := json.Marshal(map[string]interface{}{
+		"job_alias": "etl-daily",
+		"error":     "exit code 1",
+	})
+
+	evt := event.Event{
+		Type:      event.TypeTaskFailed,
+		JobID:     jobID,
+		RunID:     runID,
+		TaskID:    taskID,
+		Timestamp: now,
+		Payload:   raw,
+	}
+
+	p := buildPayload(evt)
+
+	if p.EventType != event.TypeTaskFailed {
+		t.Errorf("expected event type %q, got %q", event.TypeTaskFailed, p.EventType)
+	}
+	if p.JobID != jobID {
+		t.Errorf("expected job ID %s, got %s", jobID, p.JobID)
+	}
+	if p.RunID != runID {
+		t.Errorf("expected run ID %s, got %s", runID, p.RunID)
+	}
+	if p.TaskID != taskID {
+		t.Errorf("expected task ID %s, got %s", taskID, p.TaskID)
+	}
+	if p.JobAlias != "etl-daily" {
+		t.Errorf("expected job alias %q, got %q", "etl-daily", p.JobAlias)
+	}
+	if p.Error != "exit code 1" {
+		t.Errorf("expected error %q, got %q", "exit code 1", p.Error)
+	}
+}
+
+func TestBuildPayloadNoPayload(t *testing.T) {
+	evt := event.Event{
+		Type:      event.TypeRunFailed,
+		JobID:     uuid.New(),
+		RunID:     uuid.New(),
+		Timestamp: time.Now().UTC(),
+	}
+
+	p := buildPayload(evt)
+	if p.JobAlias != "" {
+		t.Errorf("expected empty job alias, got %q", p.JobAlias)
+	}
+	if p.Error != "" {
+		t.Errorf("expected empty error, got %q", p.Error)
+	}
+}
+
+func TestPolicyMatchesEvent(t *testing.T) {
+	tests := []struct {
+		name       string
+		eventTypes []string
+		evtType    event.Type
+		want       bool
+	}{
+		{"match", []string{"task_failed", "run_failed"}, event.TypeTaskFailed, true},
+		{"no match", []string{"run_completed"}, event.TypeTaskFailed, false},
+		{"empty types", []string{}, event.TypeRunFailed, false},
+		{"single match", []string{"run_timed_out"}, event.TypeRunTimedOut, true},
+		{"sla missed", []string{"sla_missed"}, event.TypeSLAMissed, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			typesJSON, _ := json.Marshal(tt.eventTypes)
+			p := models.NotificationPolicy{
+				EventTypes: typesJSON,
+			}
+			got := policyMatchesEvent(p, event.Event{Type: tt.evtType})
+			if got != tt.want {
+				t.Errorf("policyMatchesEvent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPolicyFilterMatches(t *testing.T) {
+	jobID := uuid.New()
+	otherJobID := uuid.New()
+
+	tests := []struct {
+		name    string
+		filter  *PolicyFilter
+		evtJob  uuid.UUID
+		payload json.RawMessage
+		want    bool
+	}{
+		{
+			name:   "no filter",
+			filter: nil,
+			evtJob: jobID,
+			want:   true,
+		},
+		{
+			name:   "job ID match",
+			filter: &PolicyFilter{JobIDs: []uuid.UUID{jobID}},
+			evtJob: jobID,
+			want:   true,
+		},
+		{
+			name:   "job ID no match",
+			filter: &PolicyFilter{JobIDs: []uuid.UUID{otherJobID}},
+			evtJob: jobID,
+			want:   false,
+		},
+		{
+			name:    "job alias match",
+			filter:  &PolicyFilter{JobAlias: "etl"},
+			evtJob:  jobID,
+			payload: mustJSON(map[string]string{"job_alias": "etl"}),
+			want:    true,
+		},
+		{
+			name:    "job alias no match",
+			filter:  &PolicyFilter{JobAlias: "etl"},
+			evtJob:  jobID,
+			payload: mustJSON(map[string]string{"job_alias": "ingest"}),
+			want:    false,
+		},
+		{
+			name:    "job alias filter with nil payload fails closed",
+			filter:  &PolicyFilter{JobAlias: "etl"},
+			evtJob:  jobID,
+			payload: nil,
+			want:    false,
+		},
+		{
+			name:    "job alias filter with unparseable payload fails closed",
+			filter:  &PolicyFilter{JobAlias: "etl"},
+			evtJob:  jobID,
+			payload: json.RawMessage("not json"),
+			want:    false,
+		},
+	}
+
+	// Add a test for invalid filter JSON (fail closed).
+	t.Run("invalid filter JSON fails closed", func(t *testing.T) {
+		p := models.NotificationPolicy{
+			Filters: []byte("not valid json"),
+		}
+		evt := event.Event{JobID: jobID}
+		got := policyFilterMatches(p, evt)
+		if got != false {
+			t.Error("expected false for invalid filter JSON")
+		}
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var filtersJSON []byte
+			if tt.filter != nil {
+				filtersJSON, _ = json.Marshal(tt.filter)
+			}
+			p := models.NotificationPolicy{
+				Filters: filtersJSON,
+			}
+			evt := event.Event{
+				JobID:   tt.evtJob,
+				Payload: tt.payload,
+			}
+			got := policyFilterMatches(p, evt)
+			if got != tt.want {
+				t.Errorf("policyFilterMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidEventTypes(t *testing.T) {
+	valid := ValidEventTypes()
+
+	expected := []event.Type{
+		event.TypeTaskFailed,
+		event.TypeRunFailed,
+		event.TypeRunTimedOut,
+		event.TypeSLAMissed,
+		event.TypeRunCompleted,
+		event.TypeTaskSucceeded,
+	}
+
+	for _, et := range expected {
+		if _, ok := valid[et]; !ok {
+			t.Errorf("expected %q in ValidEventTypes", et)
+		}
+	}
+
+	if _, ok := valid[event.TypeJobCreated]; ok {
+		t.Error("did not expect job_created in ValidEventTypes")
+	}
+}
+
+func TestValidChannelTypes(t *testing.T) {
+	valid := ValidChannelTypes()
+
+	expected := []models.ChannelType{
+		models.ChannelTypeWebhook,
+		models.ChannelTypeSlack,
+		models.ChannelTypeEmail,
+		models.ChannelTypePagerDuty,
+		models.ChannelTypeAIAgent,
+	}
+
+	for _, ct := range expected {
+		if _, ok := valid[ct]; !ok {
+			t.Errorf("expected %q in ValidChannelTypes", ct)
+		}
+	}
+}
+
+func TestDecodePolicyEventTypes(t *testing.T) {
+	raw, _ := json.Marshal([]string{"task_failed", "run_failed", "sla_missed"})
+	types, err := DecodePolicyEventTypes(raw)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(types) != 3 {
+		t.Fatalf("expected 3 types, got %d", len(types))
+	}
+	if types[0] != event.TypeTaskFailed {
+		t.Errorf("expected %q, got %q", event.TypeTaskFailed, types[0])
+	}
+	if types[2] != event.TypeSLAMissed {
+		t.Errorf("expected %q, got %q", event.TypeSLAMissed, types[2])
+	}
+}
+
+func TestDecodePolicyEventTypesInvalid(t *testing.T) {
+	_, err := DecodePolicyEventTypes([]byte("not json"))
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestIsTimeoutError(t *testing.T) {
+	tests := []struct {
+		msg  string
+		want bool
+	}{
+		{"run timed out after 30s", true},
+		{"run timed out after 5m0s", true},
+		{"exit code 1", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isTimeoutError(tt.msg); got != tt.want {
+			t.Errorf("isTimeoutError(%q) = %v, want %v", tt.msg, got, tt.want)
+		}
+	}
+}
+
+// --- SLA config tests ---
+
+func TestParseSLA(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       json.RawMessage
+		wantNil     bool
+		wantDur     time.Duration
+		wantCompBy  string
+	}{
+		{
+			name:    "nil input",
+			input:   nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty JSON",
+			input:   json.RawMessage(`{}`),
+			wantNil: true,
+		},
+		{
+			name:    "duration only",
+			input:   mustJSON(slaConfig{Duration: 30 * time.Minute}),
+			wantDur: 30 * time.Minute,
+		},
+		{
+			name:       "completedBy only",
+			input:      mustJSON(slaConfig{CompletedBy: "09:00"}),
+			wantCompBy: "09:00",
+		},
+		{
+			name:       "both",
+			input:      mustJSON(slaConfig{Duration: 1 * time.Hour, CompletedBy: "14:30"}),
+			wantDur:    1 * time.Hour,
+			wantCompBy: "14:30",
+		},
+		{
+			name:    "invalid JSON",
+			input:   json.RawMessage(`not json`),
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseSLA(tt.input)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil SLA config")
+			}
+			if got.Duration != tt.wantDur {
+				t.Errorf("duration: got %v, want %v", got.Duration, tt.wantDur)
+			}
+			if got.CompletedBy != tt.wantCompBy {
+				t.Errorf("completedBy: got %q, want %q", got.CompletedBy, tt.wantCompBy)
+			}
+		})
+	}
+}
+
+func TestResolveCompletedBy(t *testing.T) {
+	refTime := time.Date(2026, 4, 13, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name    string
+		hhmm    string
+		wantH   int
+		wantM   int
+		wantErr bool
+	}{
+		{"morning", "09:00", 9, 0, false},
+		{"afternoon", "14:30", 14, 30, false},
+		{"midnight", "00:00", 0, 0, false},
+		{"end of day", "23:59", 23, 59, false},
+		{"invalid format", "9am", 0, 0, true},
+		{"invalid hour", "25:00", 0, 0, true},
+		{"invalid minute", "09:61", 0, 0, true},
+		{"empty", "", 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveCompletedBy(tt.hhmm, refTime)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Hour() != tt.wantH || got.Minute() != tt.wantM {
+				t.Errorf("got %02d:%02d, want %02d:%02d", got.Hour(), got.Minute(), tt.wantH, tt.wantM)
+			}
+			// Should be on the same date as refTime.
+			if got.Year() != 2026 || got.Month() != 4 || got.Day() != 13 {
+				t.Errorf("wrong date: got %s", got.Format("2006-01-02"))
+			}
+		})
+	}
+}
+
+func mustJSON(v interface{}) json.RawMessage {
+	data, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}

--- a/internal/notification/sender_email.go
+++ b/internal/notification/sender_email.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net"
 	"net/smtp"
 	"strings"
@@ -97,7 +98,7 @@ func buildMIMEMessage(from string, to []string, subject, body string) []byte {
 		sanitizedTo[i] = sanitizeHeader(addr)
 	}
 	msg.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(sanitizedTo, ", ")))
-	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", sanitizeHeader(subject)))
+	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", mime.QEncoding.Encode("utf-8", subject)))
 	msg.WriteString("MIME-Version: 1.0\r\n")
 	msg.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
 	msg.WriteString("\r\n")
@@ -108,7 +109,7 @@ func buildMIMEMessage(from string, to []string, subject, body string) []byte {
 // sanitizeHeader strips CR and LF characters from a header value to
 // prevent SMTP header injection.
 func sanitizeHeader(s string) string {
-	r := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ")
+	r := strings.NewReplacer("\r", "", "\n", "")
 	return r.Replace(s)
 }
 

--- a/internal/notification/sender_email.go
+++ b/internal/notification/sender_email.go
@@ -1,0 +1,167 @@
+package notification
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/smtp"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+// emailConfig is the expected JSON shape of an email channel's Config.
+type emailConfig struct {
+	SMTPHost string   `json:"smtp_host"`
+	SMTPPort int      `json:"smtp_port"` // defaults to 587
+	From     string   `json:"from"`
+	To       []string `json:"to"`
+	Username string   `json:"username,omitempty"`
+	Password string   `json:"password,omitempty"`
+	// TLS controls STARTTLS behaviour: "starttls" (default), "tls", "none".
+	TLS string `json:"tls,omitempty"`
+}
+
+// EmailSender sends notifications via SMTP email.
+type EmailSender struct{}
+
+// NewEmailSender creates an email notification sender.
+func NewEmailSender() *EmailSender {
+	return &EmailSender{}
+}
+
+func (s *EmailSender) Send(ctx context.Context, ch models.NotificationChannel, payload Payload) error {
+	var cfg emailConfig
+	if err := json.Unmarshal(ch.Config, &cfg); err != nil {
+		return fmt.Errorf("email: invalid channel config: %w", err)
+	}
+
+	if cfg.SMTPHost == "" {
+		return fmt.Errorf("email: smtp_host is required in channel %q config", ch.Name)
+	}
+	if cfg.From == "" {
+		return fmt.Errorf("email: from is required in channel %q config", ch.Name)
+	}
+	if len(cfg.To) == 0 {
+		return fmt.Errorf("email: to is required in channel %q config", ch.Name)
+	}
+	if cfg.SMTPPort == 0 {
+		cfg.SMTPPort = 587
+	}
+
+	subject := formatEmailSubject(payload)
+	body := formatEmailBody(payload)
+
+	msg := buildMIMEMessage(cfg.From, cfg.To, subject, body)
+
+	return sendMail(ctx, cfg, msg)
+}
+
+func formatEmailSubject(p Payload) string {
+	prefix := "[Caesium]"
+	name := friendlyEventName(p.EventType)
+	if p.JobAlias != "" {
+		return fmt.Sprintf("%s %s: %s", prefix, name, p.JobAlias)
+	}
+	return fmt.Sprintf("%s %s", prefix, name)
+}
+
+func formatEmailBody(p Payload) string {
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("Event: %s\n", friendlyEventName(p.EventType)))
+	if p.JobAlias != "" {
+		b.WriteString(fmt.Sprintf("Job: %s\n", p.JobAlias))
+	}
+	b.WriteString(fmt.Sprintf("Job ID: %s\n", p.JobID))
+	if p.RunID.String() != "00000000-0000-0000-0000-000000000000" {
+		b.WriteString(fmt.Sprintf("Run ID: %s\n", p.RunID))
+	}
+	if p.TaskID.String() != "00000000-0000-0000-0000-000000000000" {
+		b.WriteString(fmt.Sprintf("Task ID: %s\n", p.TaskID))
+	}
+	b.WriteString(fmt.Sprintf("Timestamp: %s\n", p.Timestamp.Format(time.RFC3339)))
+	if p.Error != "" {
+		b.WriteString(fmt.Sprintf("\nError:\n%s\n", p.Error))
+	}
+	return b.String()
+}
+
+func buildMIMEMessage(from string, to []string, subject, body string) []byte {
+	var msg strings.Builder
+	msg.WriteString(fmt.Sprintf("From: %s\r\n", from))
+	msg.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(to, ", ")))
+	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	msg.WriteString("MIME-Version: 1.0\r\n")
+	msg.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
+	msg.WriteString("\r\n")
+	msg.WriteString(body)
+	return []byte(msg.String())
+}
+
+func sendMail(ctx context.Context, cfg emailConfig, msg []byte) error {
+	addr := fmt.Sprintf("%s:%d", cfg.SMTPHost, cfg.SMTPPort)
+
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return fmt.Errorf("email: dial %s: %w", addr, err)
+	}
+
+	tlsMode := strings.ToLower(strings.TrimSpace(cfg.TLS))
+	if tlsMode == "" {
+		tlsMode = "starttls"
+	}
+
+	var c *smtp.Client
+
+	if tlsMode == "tls" {
+		// Implicit TLS (port 465).
+		tlsConn := tls.Client(conn, &tls.Config{ServerName: cfg.SMTPHost})
+		c, err = smtp.NewClient(tlsConn, cfg.SMTPHost)
+	} else {
+		c, err = smtp.NewClient(conn, cfg.SMTPHost)
+	}
+	if err != nil {
+		_ = conn.Close()
+		return fmt.Errorf("email: smtp client: %w", err)
+	}
+	defer func() { _ = c.Quit() }()
+
+	if tlsMode == "starttls" {
+		if err := c.StartTLS(&tls.Config{ServerName: cfg.SMTPHost}); err != nil {
+			return fmt.Errorf("email: starttls: %w", err)
+		}
+	}
+
+	if cfg.Username != "" {
+		auth := smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.SMTPHost)
+		if err := c.Auth(auth); err != nil {
+			return fmt.Errorf("email: auth: %w", err)
+		}
+	}
+
+	if err := c.Mail(cfg.From); err != nil {
+		return fmt.Errorf("email: MAIL FROM: %w", err)
+	}
+	for _, rcpt := range cfg.To {
+		if err := c.Rcpt(rcpt); err != nil {
+			return fmt.Errorf("email: RCPT TO %s: %w", rcpt, err)
+		}
+	}
+
+	w, err := c.Data()
+	if err != nil {
+		return fmt.Errorf("email: DATA: %w", err)
+	}
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("email: write body: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("email: close body: %w", err)
+	}
+
+	return nil
+}

--- a/internal/notification/sender_email.go
+++ b/internal/notification/sender_email.go
@@ -91,14 +91,25 @@ func formatEmailBody(p Payload) string {
 
 func buildMIMEMessage(from string, to []string, subject, body string) []byte {
 	var msg strings.Builder
-	msg.WriteString(fmt.Sprintf("From: %s\r\n", from))
-	msg.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(to, ", ")))
-	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", subject))
+	msg.WriteString(fmt.Sprintf("From: %s\r\n", sanitizeHeader(from)))
+	sanitizedTo := make([]string, len(to))
+	for i, addr := range to {
+		sanitizedTo[i] = sanitizeHeader(addr)
+	}
+	msg.WriteString(fmt.Sprintf("To: %s\r\n", strings.Join(sanitizedTo, ", ")))
+	msg.WriteString(fmt.Sprintf("Subject: %s\r\n", sanitizeHeader(subject)))
 	msg.WriteString("MIME-Version: 1.0\r\n")
 	msg.WriteString("Content-Type: text/plain; charset=\"utf-8\"\r\n")
 	msg.WriteString("\r\n")
 	msg.WriteString(body)
 	return []byte(msg.String())
+}
+
+// sanitizeHeader strips CR and LF characters from a header value to
+// prevent SMTP header injection.
+func sanitizeHeader(s string) string {
+	r := strings.NewReplacer("\r\n", " ", "\r", " ", "\n", " ")
+	return r.Replace(s)
 }
 
 func sendMail(ctx context.Context, cfg emailConfig, msg []byte) error {

--- a/internal/notification/sender_email_test.go
+++ b/internal/notification/sender_email_test.go
@@ -3,6 +3,7 @@ package notification
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -169,10 +170,10 @@ func TestSanitizeHeader(t *testing.T) {
 		want  string
 	}{
 		{"normal subject", "normal subject"},
-		{"has\r\ninjection", "has injection"},
-		{"has\rCR", "has CR"},
-		{"has\nLF", "has LF"},
-		{"multi\r\nBcc: evil@evil.com\r\nlines", "multi Bcc: evil@evil.com lines"},
+		{"has\r\ninjection", "hasinjection"},
+		{"has\rCR", "hasCR"},
+		{"has\nLF", "hasLF"},
+		{"multi\r\nBcc: evil@evil.com\r\nlines", "multiBcc: evil@evil.comlines"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -193,14 +194,14 @@ func TestBuildMIMEMessage_HeaderInjection(t *testing.T) {
 		"body",
 	)
 	s := string(msg)
-	// The CRLF should be collapsed into the subject line, not appear as
+	// The CRLF should be encoded by mime.QEncoding, not appear as
 	// a separate "Bcc:" header line.
-	if containsStr(s, "\r\nBcc:") {
+	if strings.Contains(s, "\r\nBcc:") {
 		t.Error("header injection: Bcc header injected as separate line")
 	}
-	// The sanitized subject should appear on a single line.
-	if !containsStr(s, "Subject: Subject Bcc: evil@evil.com\r\n") {
-		t.Error("CRLF should be replaced with space in subject")
+	// The subject should be mime-encoded.
+	if !strings.Contains(s, "Subject: =?utf-8?q?Subject=0D=0ABcc:_evil@evil.com?=") {
+		t.Errorf("Subject should be mime-encoded, got:\n%s", s)
 	}
 }
 

--- a/internal/notification/sender_email_test.go
+++ b/internal/notification/sender_email_test.go
@@ -1,0 +1,177 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+func TestEmailSender_MissingSMTPHost(t *testing.T) {
+	cfg, _ := json.Marshal(emailConfig{
+		From: "caesium@example.com",
+		To:   []string{"alert@example.com"},
+	})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "no-host",
+		Type:   models.ChannelTypeEmail,
+		Config: cfg,
+	}
+
+	sender := NewEmailSender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for missing smtp_host")
+	}
+}
+
+func TestEmailSender_MissingFrom(t *testing.T) {
+	cfg, _ := json.Marshal(emailConfig{
+		SMTPHost: "smtp.example.com",
+		To:       []string{"alert@example.com"},
+	})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "no-from",
+		Type:   models.ChannelTypeEmail,
+		Config: cfg,
+	}
+
+	sender := NewEmailSender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for missing from")
+	}
+}
+
+func TestEmailSender_MissingTo(t *testing.T) {
+	cfg, _ := json.Marshal(emailConfig{
+		SMTPHost: "smtp.example.com",
+		From:     "caesium@example.com",
+	})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "no-to",
+		Type:   models.ChannelTypeEmail,
+		Config: cfg,
+	}
+
+	sender := NewEmailSender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for missing to")
+	}
+}
+
+func TestEmailSender_InvalidConfig(t *testing.T) {
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "bad",
+		Type:   models.ChannelTypeEmail,
+		Config: []byte("not json"),
+	}
+
+	sender := NewEmailSender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+}
+
+func TestFormatEmailSubject(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  Payload
+		contains string
+	}{
+		{
+			name:     "with alias",
+			payload:  Payload{EventType: event.TypeRunFailed, JobAlias: "etl-daily"},
+			contains: "Run Failed: etl-daily",
+		},
+		{
+			name:     "without alias",
+			payload:  Payload{EventType: event.TypeSLAMissed},
+			contains: "SLA Missed",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatEmailSubject(tt.payload)
+			if !containsStr(got, tt.contains) {
+				t.Errorf("subject %q does not contain %q", got, tt.contains)
+			}
+			if !containsStr(got, "[Caesium]") {
+				t.Errorf("subject %q does not contain [Caesium] prefix", got)
+			}
+		})
+	}
+}
+
+func TestFormatEmailBody(t *testing.T) {
+	jobID := uuid.New()
+	runID := uuid.New()
+	p := Payload{
+		EventType: event.TypeTaskFailed,
+		JobID:     jobID,
+		RunID:     runID,
+		JobAlias:  "pipeline-x",
+		Error:     "segfault",
+		Timestamp: time.Now().UTC(),
+	}
+
+	body := formatEmailBody(p)
+	if !containsStr(body, "Task Failed") {
+		t.Error("body should contain event name")
+	}
+	if !containsStr(body, "pipeline-x") {
+		t.Error("body should contain job alias")
+	}
+	if !containsStr(body, jobID.String()) {
+		t.Error("body should contain job ID")
+	}
+	if !containsStr(body, runID.String()) {
+		t.Error("body should contain run ID")
+	}
+	if !containsStr(body, "segfault") {
+		t.Error("body should contain error")
+	}
+}
+
+func TestBuildMIMEMessage(t *testing.T) {
+	msg := buildMIMEMessage("from@example.com", []string{"to@example.com"}, "Test Subject", "Body text")
+	s := string(msg)
+	if !containsStr(s, "From: from@example.com") {
+		t.Error("missing From header")
+	}
+	if !containsStr(s, "To: to@example.com") {
+		t.Error("missing To header")
+	}
+	if !containsStr(s, "Subject: Test Subject") {
+		t.Error("missing Subject header")
+	}
+	if !containsStr(s, "Content-Type: text/plain") {
+		t.Error("missing Content-Type header")
+	}
+	if !containsStr(s, "Body text") {
+		t.Error("missing body")
+	}
+}
+
+func containsStr(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || findSubstr(s, substr))
+}
+
+func findSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/notification/sender_email_test.go
+++ b/internal/notification/sender_email_test.go
@@ -163,6 +163,47 @@ func TestBuildMIMEMessage(t *testing.T) {
 	}
 }
 
+func TestSanitizeHeader(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"normal subject", "normal subject"},
+		{"has\r\ninjection", "has injection"},
+		{"has\rCR", "has CR"},
+		{"has\nLF", "has LF"},
+		{"multi\r\nBcc: evil@evil.com\r\nlines", "multi Bcc: evil@evil.com lines"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeHeader(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeHeader(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildMIMEMessage_HeaderInjection(t *testing.T) {
+	// A malicious subject with CRLF should not inject extra headers.
+	msg := buildMIMEMessage(
+		"from@example.com",
+		[]string{"to@example.com"},
+		"Subject\r\nBcc: evil@evil.com",
+		"body",
+	)
+	s := string(msg)
+	// The CRLF should be collapsed into the subject line, not appear as
+	// a separate "Bcc:" header line.
+	if containsStr(s, "\r\nBcc:") {
+		t.Error("header injection: Bcc header injected as separate line")
+	}
+	// The sanitized subject should appear on a single line.
+	if !containsStr(s, "Subject: Subject Bcc: evil@evil.com\r\n") {
+		t.Error("CRLF should be replaced with space in subject")
+	}
+}
+
 func containsStr(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || findSubstr(s, substr))
 }

--- a/internal/notification/sender_pagerduty.go
+++ b/internal/notification/sender_pagerduty.go
@@ -1,0 +1,165 @@
+package notification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+const pagerDutyEventsURL = "https://events.pagerduty.com/v2/enqueue"
+
+// pagerdutyConfig is the expected JSON shape of a PagerDuty channel's Config.
+type pagerdutyConfig struct {
+	RoutingKey string `json:"routing_key"`
+	// Severity overrides the default severity mapping.
+	// One of: critical, error, warning, info.
+	Severity string `json:"severity,omitempty"`
+}
+
+// PagerDutySender sends notifications via PagerDuty Events API v2.
+type PagerDutySender struct {
+	client *http.Client
+}
+
+// NewPagerDutySender creates a PagerDuty notification sender.
+func NewPagerDutySender() *PagerDutySender {
+	return &PagerDutySender{
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (s *PagerDutySender) Send(ctx context.Context, ch models.NotificationChannel, payload Payload) error {
+	var cfg pagerdutyConfig
+	if err := json.Unmarshal(ch.Config, &cfg); err != nil {
+		return fmt.Errorf("pagerduty: invalid channel config: %w", err)
+	}
+
+	if cfg.RoutingKey == "" {
+		return fmt.Errorf("pagerduty: routing_key is required in channel %q config", ch.Name)
+	}
+
+	pdEvent := buildPagerDutyEvent(cfg, payload)
+
+	body, err := json.Marshal(pdEvent)
+	if err != nil {
+		return fmt.Errorf("pagerduty: marshal event: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, pagerDutyEventsURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("pagerduty: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("pagerduty: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	return fmt.Errorf("pagerduty: API responded %d", resp.StatusCode)
+}
+
+// pdEvent is the PagerDuty Events API v2 payload.
+type pdEvent struct {
+	RoutingKey  string    `json:"routing_key"`
+	EventAction string    `json:"event_action"`
+	DedupKey    string    `json:"dedup_key,omitempty"`
+	Payload     pdPayload `json:"payload"`
+}
+
+type pdPayload struct {
+	Summary   string            `json:"summary"`
+	Source    string            `json:"source"`
+	Severity  string            `json:"severity"`
+	Timestamp string            `json:"timestamp,omitempty"`
+	Component string            `json:"component,omitempty"`
+	Group     string            `json:"group,omitempty"`
+	CustomDetails map[string]interface{} `json:"custom_details,omitempty"`
+}
+
+func buildPagerDutyEvent(cfg pagerdutyConfig, p Payload) pdEvent {
+	severity := cfg.Severity
+	if severity == "" {
+		severity = defaultPDSeverity(p.EventType)
+	}
+
+	summary := fmt.Sprintf("[Caesium] %s", friendlyEventName(p.EventType))
+	if p.JobAlias != "" {
+		summary = fmt.Sprintf("[Caesium] %s: %s", friendlyEventName(p.EventType), p.JobAlias)
+	}
+	if p.Error != "" {
+		errSnippet := p.Error
+		if len(errSnippet) > 200 {
+			errSnippet = errSnippet[:200] + "…"
+		}
+		summary = fmt.Sprintf("%s — %s", summary, errSnippet)
+	}
+	// PagerDuty summary is capped at 1024 chars.
+	if len(summary) > 1024 {
+		summary = summary[:1021] + "..."
+	}
+
+	// Dedup key prevents duplicate pages for the same run failure.
+	dedupKey := fmt.Sprintf("caesium-%s-%s-%s", p.EventType, p.JobID, p.RunID)
+
+	details := map[string]interface{}{
+		"event_type": string(p.EventType),
+		"job_id":     p.JobID.String(),
+		"run_id":     p.RunID.String(),
+	}
+	if p.TaskID.String() != "00000000-0000-0000-0000-000000000000" {
+		details["task_id"] = p.TaskID.String()
+	}
+	if p.Error != "" {
+		details["error"] = p.Error
+	}
+
+	action := "trigger"
+	if p.EventType == event.TypeRunCompleted || p.EventType == event.TypeTaskSucceeded {
+		action = "resolve"
+	}
+
+	return pdEvent{
+		RoutingKey:  cfg.RoutingKey,
+		EventAction: action,
+		DedupKey:    dedupKey,
+		Payload: pdPayload{
+			Summary:       summary,
+			Source:        "caesium",
+			Severity:      severity,
+			Timestamp:     p.Timestamp.Format(time.RFC3339),
+			Component:     p.JobAlias,
+			CustomDetails: details,
+		},
+	}
+}
+
+func defaultPDSeverity(t event.Type) string {
+	switch t {
+	case event.TypeTaskFailed, event.TypeRunFailed:
+		return "error"
+	case event.TypeRunTimedOut:
+		return "error"
+	case event.TypeSLAMissed:
+		return "warning"
+	case event.TypeRunCompleted, event.TypeTaskSucceeded:
+		return "info"
+	default:
+		return "warning"
+	}
+}

--- a/internal/notification/sender_pagerduty_test.go
+++ b/internal/notification/sender_pagerduty_test.go
@@ -1,0 +1,121 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+func TestPagerDutySender_BuildEvent(t *testing.T) {
+	cfg := pagerdutyConfig{
+		RoutingKey: "test-routing-key",
+		Severity:   "critical",
+	}
+
+	payload := Payload{
+		EventType: event.TypeRunFailed,
+		JobID:     uuid.New(),
+		RunID:     uuid.New(),
+		JobAlias:  "etl-daily",
+		Error:     "exit code 1",
+		Timestamp: time.Now().UTC(),
+	}
+
+	evt := buildPagerDutyEvent(cfg, payload)
+
+	if evt.RoutingKey != "test-routing-key" {
+		t.Errorf("routing key: got %q, want %q", evt.RoutingKey, "test-routing-key")
+	}
+	if evt.EventAction != "trigger" {
+		t.Errorf("action: got %q, want %q", evt.EventAction, "trigger")
+	}
+	if evt.Payload.Severity != "critical" {
+		t.Errorf("severity: got %q, want %q", evt.Payload.Severity, "critical")
+	}
+	if evt.Payload.Source != "caesium" {
+		t.Errorf("source: got %q, want %q", evt.Payload.Source, "caesium")
+	}
+	if evt.Payload.Component != "etl-daily" {
+		t.Errorf("component: got %q, want %q", evt.Payload.Component, "etl-daily")
+	}
+	if evt.DedupKey == "" {
+		t.Error("dedup_key should not be empty")
+	}
+}
+
+func TestBuildPagerDutyEvent_ResolveAction(t *testing.T) {
+	cfg := pagerdutyConfig{RoutingKey: "key"}
+	p := Payload{
+		EventType: event.TypeRunCompleted,
+		JobID:     uuid.New(),
+		RunID:     uuid.New(),
+		Timestamp: time.Now(),
+	}
+	evt := buildPagerDutyEvent(cfg, p)
+	if evt.EventAction != "resolve" {
+		t.Errorf("action for run_completed: got %q, want resolve", evt.EventAction)
+	}
+}
+
+func TestBuildPagerDutyEvent_DefaultSeverity(t *testing.T) {
+	tests := []struct {
+		eventType event.Type
+		want      string
+	}{
+		{event.TypeTaskFailed, "error"},
+		{event.TypeRunFailed, "error"},
+		{event.TypeRunTimedOut, "error"},
+		{event.TypeSLAMissed, "warning"},
+		{event.TypeRunCompleted, "info"},
+		{event.TypeTaskSucceeded, "info"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.eventType), func(t *testing.T) {
+			got := defaultPDSeverity(tt.eventType)
+			if got != tt.want {
+				t.Errorf("defaultPDSeverity(%q) = %q, want %q", tt.eventType, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildPagerDutyEvent_SummaryTruncation(t *testing.T) {
+	longError := make([]byte, 2000)
+	for i := range longError {
+		longError[i] = 'x'
+	}
+
+	cfg := pagerdutyConfig{RoutingKey: "key"}
+	p := Payload{
+		EventType: event.TypeRunFailed,
+		JobAlias:  "my-job",
+		Error:     string(longError),
+		Timestamp: time.Now(),
+	}
+	evt := buildPagerDutyEvent(cfg, p)
+	if len(evt.Payload.Summary) > 1024 {
+		t.Errorf("summary length %d exceeds 1024", len(evt.Payload.Summary))
+	}
+}
+
+func TestPagerDutySender_MissingRoutingKey(t *testing.T) {
+	cfg, _ := json.Marshal(pagerdutyConfig{})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "no-key",
+		Type:   models.ChannelTypePagerDuty,
+		Config: cfg,
+	}
+
+	sender := NewPagerDutySender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for missing routing_key")
+	}
+}

--- a/internal/notification/sender_slack.go
+++ b/internal/notification/sender_slack.go
@@ -1,0 +1,202 @@
+package notification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+// slackConfig is the expected JSON shape of a Slack channel's Config.
+type slackConfig struct {
+	WebhookURL string `json:"webhook_url"`
+	Channel    string `json:"channel,omitempty"`  // optional override
+	Username   string `json:"username,omitempty"` // optional bot name
+	IconEmoji  string `json:"icon_emoji,omitempty"`
+	Timeout    string `json:"timeout,omitempty"` // Go duration string
+}
+
+// SlackSender sends notifications via Slack incoming webhooks.
+type SlackSender struct {
+	client *http.Client
+}
+
+// NewSlackSender creates a Slack notification sender.
+func NewSlackSender() *SlackSender {
+	return &SlackSender{
+		client: &http.Client{Timeout: 15 * time.Second},
+	}
+}
+
+func (s *SlackSender) Send(ctx context.Context, ch models.NotificationChannel, payload Payload) error {
+	var cfg slackConfig
+	if err := json.Unmarshal(ch.Config, &cfg); err != nil {
+		return fmt.Errorf("slack: invalid channel config: %w", err)
+	}
+
+	if cfg.WebhookURL == "" {
+		return fmt.Errorf("slack: webhook_url is required in channel %q config", ch.Name)
+	}
+
+	timeout := 10 * time.Second
+	if cfg.Timeout != "" {
+		if d, err := time.ParseDuration(cfg.Timeout); err == nil && d > 0 {
+			timeout = d
+		}
+	}
+
+	msg := buildSlackMessage(cfg, payload)
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("slack: marshal message: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, cfg.WebhookURL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("slack: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("slack: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode == http.StatusOK {
+		return nil
+	}
+	return fmt.Errorf("slack: webhook responded %d", resp.StatusCode)
+}
+
+// slackMessage is the Slack incoming webhook payload.
+type slackMessage struct {
+	Channel   string       `json:"channel,omitempty"`
+	Username  string       `json:"username,omitempty"`
+	IconEmoji string       `json:"icon_emoji,omitempty"`
+	Text      string       `json:"text"`
+	Blocks    []slackBlock `json:"blocks,omitempty"`
+}
+
+type slackBlock struct {
+	Type string      `json:"type"`
+	Text *slackText  `json:"text,omitempty"`
+	Fields []slackText `json:"fields,omitempty"`
+}
+
+type slackText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func buildSlackMessage(cfg slackConfig, p Payload) slackMessage {
+	emoji := eventEmoji(p.EventType)
+	title := fmt.Sprintf("%s *%s*", emoji, friendlyEventName(p.EventType))
+
+	msg := slackMessage{
+		Channel:   cfg.Channel,
+		Username:  cfg.Username,
+		IconEmoji: cfg.IconEmoji,
+		Text:      fmt.Sprintf("%s — %s", title, p.JobAlias),
+	}
+
+	// Header block.
+	blocks := []slackBlock{
+		{
+			Type: "header",
+			Text: &slackText{Type: "plain_text", Text: fmt.Sprintf("%s %s", emoji, friendlyEventName(p.EventType))},
+		},
+	}
+
+	// Fields block.
+	fields := []slackText{
+		{Type: "mrkdwn", Text: fmt.Sprintf("*Job:*\n%s", valueOrDash(p.JobAlias))},
+		{Type: "mrkdwn", Text: fmt.Sprintf("*Run ID:*\n`%s`", shortID(p.RunID))},
+	}
+	if p.TaskID.String() != "00000000-0000-0000-0000-000000000000" {
+		fields = append(fields, slackText{Type: "mrkdwn", Text: fmt.Sprintf("*Task ID:*\n`%s`", shortID(p.TaskID))})
+	}
+	fields = append(fields, slackText{Type: "mrkdwn", Text: fmt.Sprintf("*Time:*\n%s", p.Timestamp.Format(time.RFC3339))})
+
+	blocks = append(blocks, slackBlock{Type: "section", Fields: fields})
+
+	// Error block.
+	if p.Error != "" {
+		errText := p.Error
+		if len(errText) > 2000 {
+			errText = errText[:2000] + "…"
+		}
+		blocks = append(blocks, slackBlock{
+			Type: "section",
+			Text: &slackText{Type: "mrkdwn", Text: fmt.Sprintf("*Error:*\n```%s```", errText)},
+		})
+	}
+
+	msg.Blocks = blocks
+	return msg
+}
+
+func eventEmoji(t event.Type) string {
+	switch t {
+	case event.TypeTaskFailed:
+		return "❌"
+	case event.TypeRunFailed:
+		return "🔴"
+	case event.TypeRunTimedOut:
+		return "⏱️"
+	case event.TypeSLAMissed:
+		return "⚠️"
+	case event.TypeRunCompleted:
+		return "✅"
+	case event.TypeTaskSucceeded:
+		return "✅"
+	default:
+		return "📢"
+	}
+}
+
+func friendlyEventName(t event.Type) string {
+	switch t {
+	case event.TypeTaskFailed:
+		return "Task Failed"
+	case event.TypeRunFailed:
+		return "Run Failed"
+	case event.TypeRunTimedOut:
+		return "Run Timed Out"
+	case event.TypeSLAMissed:
+		return "SLA Missed"
+	case event.TypeRunCompleted:
+		return "Run Completed"
+	case event.TypeTaskSucceeded:
+		return "Task Succeeded"
+	default:
+		return string(t)
+	}
+}
+
+func valueOrDash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+func shortID(id uuid.UUID) string {
+	s := id.String()
+	if len(s) >= 8 {
+		return s[:8]
+	}
+	return s
+}

--- a/internal/notification/sender_slack_test.go
+++ b/internal/notification/sender_slack_test.go
@@ -1,0 +1,180 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+func TestSlackSender_Send(t *testing.T) {
+	var received []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg, _ := json.Marshal(slackConfig{
+		WebhookURL: srv.URL,
+		Channel:    "#alerts",
+		Username:   "Caesium Bot",
+	})
+
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "test-slack",
+		Type:   models.ChannelTypeSlack,
+		Config: cfg,
+	}
+
+	payload := Payload{
+		EventType: event.TypeRunFailed,
+		JobID:     uuid.New(),
+		RunID:     uuid.New(),
+		JobAlias:  "etl-daily",
+		Error:     "exit code 1",
+		Timestamp: time.Now().UTC(),
+	}
+
+	sender := NewSlackSender()
+	err := sender.Send(context.Background(), ch, payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify Slack message structure.
+	var msg slackMessage
+	if err := json.Unmarshal(received, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.Channel != "#alerts" {
+		t.Errorf("channel: got %q, want %q", msg.Channel, "#alerts")
+	}
+	if msg.Username != "Caesium Bot" {
+		t.Errorf("username: got %q, want %q", msg.Username, "Caesium Bot")
+	}
+	if msg.Text == "" {
+		t.Error("text should not be empty")
+	}
+	if len(msg.Blocks) < 2 {
+		t.Fatalf("expected at least 2 blocks, got %d", len(msg.Blocks))
+	}
+	// First block is header.
+	if msg.Blocks[0].Type != "header" {
+		t.Errorf("first block type: got %q, want header", msg.Blocks[0].Type)
+	}
+	// Second block has fields.
+	if msg.Blocks[1].Type != "section" {
+		t.Errorf("second block type: got %q, want section", msg.Blocks[1].Type)
+	}
+}
+
+func TestSlackSender_MissingWebhookURL(t *testing.T) {
+	cfg, _ := json.Marshal(slackConfig{})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "no-url",
+		Type:   models.ChannelTypeSlack,
+		Config: cfg,
+	}
+
+	sender := NewSlackSender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for missing webhook_url")
+	}
+}
+
+func TestSlackSender_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	cfg, _ := json.Marshal(slackConfig{WebhookURL: srv.URL})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "forbidden-slack",
+		Type:   models.ChannelTypeSlack,
+		Config: cfg,
+	}
+
+	sender := NewSlackSender()
+	err := sender.Send(context.Background(), ch, Payload{EventType: event.TypeRunFailed, Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for non-200 response")
+	}
+}
+
+func TestBuildSlackMessage_WithError(t *testing.T) {
+	p := Payload{
+		EventType: event.TypeTaskFailed,
+		JobAlias:  "ingest-pipeline",
+		RunID:     uuid.New(),
+		Error:     "container OOMKilled",
+		Timestamp: time.Now().UTC(),
+	}
+
+	msg := buildSlackMessage(slackConfig{}, p)
+	if len(msg.Blocks) < 3 {
+		t.Fatalf("expected at least 3 blocks (header, fields, error), got %d", len(msg.Blocks))
+	}
+	// Third block should contain the error.
+	errBlock := msg.Blocks[2]
+	if errBlock.Text == nil || errBlock.Text.Text == "" {
+		t.Error("error block should have text")
+	}
+}
+
+func TestBuildSlackMessage_NoError(t *testing.T) {
+	p := Payload{
+		EventType: event.TypeRunCompleted,
+		JobAlias:  "report-gen",
+		RunID:     uuid.New(),
+		Timestamp: time.Now().UTC(),
+	}
+
+	msg := buildSlackMessage(slackConfig{}, p)
+	// Should have header + fields but no error block.
+	if len(msg.Blocks) != 2 {
+		t.Errorf("expected 2 blocks (no error), got %d", len(msg.Blocks))
+	}
+}
+
+func TestFriendlyEventName(t *testing.T) {
+	tests := []struct {
+		input event.Type
+		want  string
+	}{
+		{event.TypeTaskFailed, "Task Failed"},
+		{event.TypeRunFailed, "Run Failed"},
+		{event.TypeRunTimedOut, "Run Timed Out"},
+		{event.TypeSLAMissed, "SLA Missed"},
+		{event.TypeRunCompleted, "Run Completed"},
+		{event.TypeTaskSucceeded, "Task Succeeded"},
+		{event.Type("unknown"), "unknown"},
+	}
+
+	for _, tt := range tests {
+		got := friendlyEventName(tt.input)
+		if got != tt.want {
+			t.Errorf("friendlyEventName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestShortID(t *testing.T) {
+	id := uuid.MustParse("12345678-1234-1234-1234-123456789abc")
+	got := shortID(id)
+	if got != "12345678" {
+		t.Errorf("shortID: got %q, want %q", got, "12345678")
+	}
+}

--- a/internal/notification/sender_webhook.go
+++ b/internal/notification/sender_webhook.go
@@ -1,0 +1,95 @@
+package notification
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+)
+
+// webhookConfig is the expected JSON shape of a webhook channel's Config.
+type webhookConfig struct {
+	URL     string            `json:"url"`
+	Method  string            `json:"method,omitempty"`  // defaults to POST
+	Headers map[string]string `json:"headers,omitempty"`
+	Timeout string            `json:"timeout,omitempty"` // Go duration string, defaults to 10s
+}
+
+// WebhookSender sends notifications as HTTP requests.
+type WebhookSender struct {
+	client *http.Client
+}
+
+// NewWebhookSender creates a webhook notification sender.
+func NewWebhookSender() *WebhookSender {
+	return &WebhookSender{
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (s *WebhookSender) Send(ctx context.Context, ch models.NotificationChannel, payload Payload) error {
+	var cfg webhookConfig
+	if err := json.Unmarshal(ch.Config, &cfg); err != nil {
+		return fmt.Errorf("webhook: invalid channel config: %w", err)
+	}
+
+	if cfg.URL == "" {
+		return fmt.Errorf("webhook: url is required in channel %q config", ch.Name)
+	}
+
+	method := strings.ToUpper(cfg.Method)
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	timeout := 10 * time.Second
+	if cfg.Timeout != "" {
+		if d, err := time.ParseDuration(cfg.Timeout); err == nil && d > 0 {
+			timeout = d
+		}
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("webhook: marshal payload: %w", err)
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, method, cfg.URL, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("webhook: build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", "caesium-notification/1.0")
+	for k, v := range cfg.Headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("webhook: request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	log.Warn("webhook: non-2xx response",
+		"channel", ch.Name,
+		"url", cfg.URL,
+		"status", resp.StatusCode,
+	)
+	return fmt.Errorf("webhook: server responded %d", resp.StatusCode)
+}

--- a/internal/notification/sender_webhook.go
+++ b/internal/notification/sender_webhook.go
@@ -88,8 +88,15 @@ func (s *WebhookSender) Send(ctx context.Context, ch models.NotificationChannel,
 
 	log.Warn("webhook: non-2xx response",
 		"channel", ch.Name,
-		"url", cfg.URL,
-		"status", resp.StatusCode,
+		"host",    redactURL(cfg.URL),
+		"status",  resp.StatusCode,
 	)
 	return fmt.Errorf("webhook: server responded %d", resp.StatusCode)
+}
+
+func redactURL(u string) string {
+	if u == "" {
+		return ""
+	}
+	return "[redacted]"
 }

--- a/internal/notification/sender_webhook_test.go
+++ b/internal/notification/sender_webhook_test.go
@@ -1,0 +1,149 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+func TestWebhookSender_Send(t *testing.T) {
+	var received []byte
+	var receivedHeaders http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header
+		received, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg, _ := json.Marshal(webhookConfig{
+		URL:     srv.URL,
+		Headers: map[string]string{"X-Custom": "test-value"},
+	})
+
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "test-webhook",
+		Type:   models.ChannelTypeWebhook,
+		Config: cfg,
+	}
+
+	payload := Payload{
+		EventType: event.TypeRunFailed,
+		JobID:     uuid.New(),
+		RunID:     uuid.New(),
+		JobAlias:  "etl-daily",
+		Error:     "exit code 1",
+		Timestamp: time.Now().UTC(),
+	}
+
+	sender := NewWebhookSender()
+	err := sender.Send(context.Background(), ch, payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify payload was received.
+	var got Payload
+	if err := json.Unmarshal(received, &got); err != nil {
+		t.Fatalf("unmarshal received body: %v", err)
+	}
+	if got.EventType != event.TypeRunFailed {
+		t.Errorf("event type: got %q, want %q", got.EventType, event.TypeRunFailed)
+	}
+	if got.JobAlias != "etl-daily" {
+		t.Errorf("job alias: got %q, want %q", got.JobAlias, "etl-daily")
+	}
+
+	// Verify custom header.
+	if receivedHeaders.Get("X-Custom") != "test-value" {
+		t.Errorf("X-Custom header: got %q, want %q", receivedHeaders.Get("X-Custom"), "test-value")
+	}
+	if receivedHeaders.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type: got %q", receivedHeaders.Get("Content-Type"))
+	}
+}
+
+func TestWebhookSender_Non2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	cfg, _ := json.Marshal(webhookConfig{URL: srv.URL})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "bad-webhook",
+		Type:   models.ChannelTypeWebhook,
+		Config: cfg,
+	}
+
+	sender := NewWebhookSender()
+	err := sender.Send(context.Background(), ch, Payload{EventType: event.TypeRunFailed, Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+}
+
+func TestWebhookSender_MissingURL(t *testing.T) {
+	cfg, _ := json.Marshal(webhookConfig{})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "no-url",
+		Type:   models.ChannelTypeWebhook,
+		Config: cfg,
+	}
+
+	sender := NewWebhookSender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for missing URL")
+	}
+}
+
+func TestWebhookSender_CustomMethod(t *testing.T) {
+	var receivedMethod string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	cfg, _ := json.Marshal(webhookConfig{URL: srv.URL, Method: "PUT"})
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "put-webhook",
+		Type:   models.ChannelTypeWebhook,
+		Config: cfg,
+	}
+
+	sender := NewWebhookSender()
+	if err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedMethod != "PUT" {
+		t.Errorf("method: got %q, want PUT", receivedMethod)
+	}
+}
+
+func TestWebhookSender_InvalidConfig(t *testing.T) {
+	ch := models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "bad-config",
+		Type:   models.ChannelTypeWebhook,
+		Config: []byte("not json"),
+	}
+	sender := NewWebhookSender()
+	err := sender.Send(context.Background(), ch, Payload{Timestamp: time.Now()})
+	if err == nil {
+		t.Fatal("expected error for invalid config JSON")
+	}
+}

--- a/internal/notification/subscriber.go
+++ b/internal/notification/subscriber.go
@@ -8,6 +8,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -92,14 +93,22 @@ func (s *Subscriber) handleEvent(ctx context.Context, evt event.Event) {
 		return
 	}
 
+	// Batch-load all referenced channels in a single query.
+	channels, err := s.loadChannels(ctx, policies)
+	if err != nil {
+		log.Error("notification: failed to load channels",
+			"error", err,
+		)
+		return
+	}
+
 	payload := buildPayload(evt)
 
 	for _, policy := range policies {
-		var channel models.NotificationChannel
-		if err := s.db.WithContext(ctx).First(&channel, "id = ?", policy.ChannelID).Error; err != nil {
-			log.Error("notification: failed to load channel",
+		channel, ok := channels[policy.ChannelID]
+		if !ok {
+			log.Error("notification: channel not found",
 				"channel_id", policy.ChannelID,
-				"error", err,
 			)
 			continue
 		}
@@ -137,18 +146,50 @@ func (s *Subscriber) handleEvent(ctx context.Context, evt event.Event) {
 	}
 }
 
-// matchPolicies finds all enabled policies whose event_types contain the
-// given event type and whose filters match the event.
-func (s *Subscriber) matchPolicies(ctx context.Context, evt event.Event) ([]models.NotificationPolicy, error) {
-	var all []models.NotificationPolicy
+// loadChannels fetches all unique channels referenced by the given policies
+// in a single query, returning them indexed by ID.
+func (s *Subscriber) loadChannels(ctx context.Context, policies []models.NotificationPolicy) (map[uuid.UUID]models.NotificationChannel, error) {
+	ids := make([]uuid.UUID, 0, len(policies))
+	seen := make(map[uuid.UUID]struct{}, len(policies))
+	for _, p := range policies {
+		if _, dup := seen[p.ChannelID]; !dup {
+			ids = append(ids, p.ChannelID)
+			seen[p.ChannelID] = struct{}{}
+		}
+	}
+
+	var channels []models.NotificationChannel
 	if err := s.db.WithContext(ctx).
-		Where("enabled = ?", true).
-		Find(&all).Error; err != nil {
+		Where("id IN ?", ids).
+		Find(&channels).Error; err != nil {
+		return nil, err
+	}
+
+	m := make(map[uuid.UUID]models.NotificationChannel, len(channels))
+	for _, ch := range channels {
+		m[ch.ID] = ch
+	}
+	return m, nil
+}
+
+// matchPolicies finds enabled policies whose event_types contain the given
+// event type and whose filters match the event. Uses a SQL-level filter on
+// event type to reduce the rows loaded from the database.
+func (s *Subscriber) matchPolicies(ctx context.Context, evt event.Event) ([]models.NotificationPolicy, error) {
+	var candidates []models.NotificationPolicy
+	// Filter at the SQL level: only load policies whose event_types JSON
+	// contains the event type string. This is a substring match on the
+	// JSON column — not exact, but it eliminates the vast majority of
+	// non-matching rows. The in-memory policyMatchesEvent check below
+	// is the authoritative filter.
+	if err := s.db.WithContext(ctx).
+		Where("enabled = ? AND event_types LIKE ?", true, "%"+string(evt.Type)+"%").
+		Find(&candidates).Error; err != nil {
 		return nil, err
 	}
 
 	var matched []models.NotificationPolicy
-	for _, p := range all {
+	for _, p := range candidates {
 		if !policyMatchesEvent(p, evt) {
 			continue
 		}

--- a/internal/notification/subscriber.go
+++ b/internal/notification/subscriber.go
@@ -262,6 +262,25 @@ func policyFilterMatches(p models.NotificationPolicy, evt event.Event) bool {
 		}
 	}
 
+	if len(filter.Labels) > 0 {
+		// If the payload is missing or unparseable, fail closed: the
+		// filter requires labels but we can't verify them.
+		if len(evt.Payload) == 0 {
+			return false
+		}
+		var partial struct {
+			JobLabels map[string]string `json:"job_labels"`
+		}
+		if err := json.Unmarshal(evt.Payload, &partial); err != nil {
+			return false
+		}
+		for k, v := range filter.Labels {
+			if actual, ok := partial.JobLabels[k]; !ok || actual != v {
+				return false
+			}
+		}
+	}
+
 	return true
 }
 
@@ -278,11 +297,13 @@ func buildPayload(evt event.Event) Payload {
 	// Extract common fields from the event payload.
 	if evt.Payload != nil {
 		var partial struct {
-			JobAlias string `json:"job_alias"`
-			Error    string `json:"error"`
+			JobAlias  string            `json:"job_alias"`
+			JobLabels map[string]string `json:"job_labels"`
+			Error     string            `json:"error"`
 		}
 		if err := json.Unmarshal(evt.Payload, &partial); err == nil {
 			p.JobAlias = partial.JobAlias
+			p.JobLabels = partial.JobLabels
 			p.Error = partial.Error
 		}
 	}

--- a/internal/notification/subscriber.go
+++ b/internal/notification/subscriber.go
@@ -1,0 +1,321 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"gorm.io/gorm"
+)
+
+// notifiableTypes are the event types that can trigger notifications.
+var notifiableTypes = []event.Type{
+	event.TypeTaskFailed,
+	event.TypeRunFailed,
+	event.TypeRunTimedOut,
+	event.TypeSLAMissed,
+	event.TypeRunCompleted,
+	event.TypeTaskSucceeded,
+}
+
+// Subscriber listens to the event bus and dispatches notifications
+// through matching policies and channels.
+type Subscriber struct {
+	bus      event.Bus
+	db       *gorm.DB
+	senders  map[models.ChannelType]Sender
+}
+
+// NewSubscriber creates a notification subscriber.
+func NewSubscriber(bus event.Bus, db *gorm.DB) *Subscriber {
+	return &Subscriber{
+		bus:     bus,
+		db:      db,
+		senders: make(map[models.ChannelType]Sender),
+	}
+}
+
+// RegisterSender registers a Sender for a given channel type.
+func (s *Subscriber) RegisterSender(ct models.ChannelType, sender Sender) {
+	s.senders[ct] = sender
+}
+
+// Start subscribes to notifiable events and dispatches notifications.
+func (s *Subscriber) Start(ctx context.Context) error {
+	return s.StartWithReady(ctx, nil)
+}
+
+// StartWithReady subscribes and signals readiness after subscription is established.
+func (s *Subscriber) StartWithReady(ctx context.Context, ready chan<- struct{}) error {
+	filter := event.Filter{
+		Types: notifiableTypes,
+	}
+
+	ch, err := s.bus.Subscribe(ctx, filter)
+	if err != nil {
+		return err
+	}
+	if ready != nil {
+		close(ready)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			s.handleEvent(ctx, evt)
+		}
+	}
+}
+
+func (s *Subscriber) handleEvent(ctx context.Context, evt event.Event) {
+	// Record failure/alert metrics.
+	recordEventMetric(evt)
+
+	policies, err := s.matchPolicies(ctx, evt)
+	if err != nil {
+		log.Error("notification: failed to load policies",
+			"event_type", string(evt.Type),
+			"error", err,
+		)
+		return
+	}
+
+	if len(policies) == 0 {
+		return
+	}
+
+	payload := buildPayload(evt)
+
+	for _, policy := range policies {
+		var channel models.NotificationChannel
+		if err := s.db.WithContext(ctx).First(&channel, "id = ?", policy.ChannelID).Error; err != nil {
+			log.Error("notification: failed to load channel",
+				"channel_id", policy.ChannelID,
+				"error", err,
+			)
+			continue
+		}
+
+		if !channel.Enabled {
+			continue
+		}
+
+		sender, ok := s.senders[channel.Type]
+		if !ok {
+			log.Warn("notification: no sender registered",
+				"channel_type", string(channel.Type),
+				"channel_name", channel.Name,
+			)
+			continue
+		}
+
+		start := time.Now()
+		sendErr := sender.Send(ctx, channel, payload)
+		duration := time.Since(start)
+
+		NotificationSendDuration.WithLabelValues(string(channel.Type)).Observe(duration.Seconds())
+
+		if sendErr != nil {
+			NotificationSendsTotal.WithLabelValues(string(channel.Type), "error").Inc()
+			log.Error("notification: send failed",
+				"channel_name", channel.Name,
+				"channel_type", string(channel.Type),
+				"event_type", string(evt.Type),
+				"error", sendErr,
+			)
+		} else {
+			NotificationSendsTotal.WithLabelValues(string(channel.Type), "success").Inc()
+		}
+	}
+}
+
+// matchPolicies finds all enabled policies whose event_types contain the
+// given event type and whose filters match the event.
+func (s *Subscriber) matchPolicies(ctx context.Context, evt event.Event) ([]models.NotificationPolicy, error) {
+	var all []models.NotificationPolicy
+	if err := s.db.WithContext(ctx).
+		Where("enabled = ?", true).
+		Find(&all).Error; err != nil {
+		return nil, err
+	}
+
+	var matched []models.NotificationPolicy
+	for _, p := range all {
+		if !policyMatchesEvent(p, evt) {
+			continue
+		}
+		if !policyFilterMatches(p, evt) {
+			continue
+		}
+		matched = append(matched, p)
+	}
+	return matched, nil
+}
+
+// policyMatchesEvent checks whether the policy's event_types list contains evt.Type.
+func policyMatchesEvent(p models.NotificationPolicy, evt event.Event) bool {
+	var eventTypes []string
+	if err := json.Unmarshal(p.EventTypes, &eventTypes); err != nil {
+		return false
+	}
+	for _, t := range eventTypes {
+		if event.Type(t) == evt.Type {
+			return true
+		}
+	}
+	return false
+}
+
+// policyFilterMatches checks optional job-scoped filters. Fails closed:
+// returns false when the filter JSON is malformed or when a filter field
+// cannot be evaluated from the event payload.
+func policyFilterMatches(p models.NotificationPolicy, evt event.Event) bool {
+	if len(p.Filters) == 0 {
+		return true
+	}
+
+	var filter PolicyFilter
+	if err := json.Unmarshal(p.Filters, &filter); err != nil {
+		log.Warn("notification: invalid policy filter JSON, skipping (fail closed)",
+			"policy_id", p.ID,
+			"error", err,
+		)
+		return false
+	}
+
+	if len(filter.JobIDs) > 0 {
+		found := false
+		for _, id := range filter.JobIDs {
+			if id == evt.JobID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	if filter.JobAlias != "" {
+		// If the payload is missing or unparseable, fail closed: the
+		// filter requires a specific alias but we can't verify it.
+		if len(evt.Payload) == 0 {
+			return false
+		}
+		var partial struct {
+			JobAlias string `json:"job_alias"`
+		}
+		if err := json.Unmarshal(evt.Payload, &partial); err != nil {
+			return false
+		}
+		if partial.JobAlias != filter.JobAlias {
+			return false
+		}
+	}
+
+	return true
+}
+
+func buildPayload(evt event.Event) Payload {
+	p := Payload{
+		EventType:  evt.Type,
+		JobID:      evt.JobID,
+		RunID:      evt.RunID,
+		TaskID:     evt.TaskID,
+		Timestamp:  evt.Timestamp,
+		RawPayload: evt.Payload,
+	}
+
+	// Extract common fields from the event payload.
+	if evt.Payload != nil {
+		var partial struct {
+			JobAlias string `json:"job_alias"`
+			Error    string `json:"error"`
+		}
+		if err := json.Unmarshal(evt.Payload, &partial); err == nil {
+			p.JobAlias = partial.JobAlias
+			p.Error = partial.Error
+		}
+	}
+
+	return p
+}
+
+// DecodePolicyEventTypes parses the JSON event types from a policy.
+func DecodePolicyEventTypes(raw json.RawMessage) ([]event.Type, error) {
+	var types []string
+	if err := json.Unmarshal(raw, &types); err != nil {
+		return nil, err
+	}
+	result := make([]event.Type, len(types))
+	for i, t := range types {
+		result[i] = event.Type(t)
+	}
+	return result, nil
+}
+
+// ValidEventTypes returns the set of event types valid for notification policies.
+func ValidEventTypes() map[event.Type]struct{} {
+	m := make(map[event.Type]struct{}, len(notifiableTypes))
+	for _, t := range notifiableTypes {
+		m[t] = struct{}{}
+	}
+	return m
+}
+
+// ValidChannelTypes returns the set of valid channel types.
+func ValidChannelTypes() map[models.ChannelType]struct{} {
+	return map[models.ChannelType]struct{}{
+		models.ChannelTypeWebhook:   {},
+		models.ChannelTypeSlack:     {},
+		models.ChannelTypeEmail:     {},
+		models.ChannelTypePagerDuty: {},
+		models.ChannelTypeAIAgent:   {},
+	}
+}
+
+// recordEventMetric increments the appropriate failure/alert counter.
+func recordEventMetric(evt event.Event) {
+	alias := extractJobAlias(evt)
+	switch evt.Type {
+	case event.TypeTaskFailed:
+		TaskFailuresTotal.WithLabelValues(alias).Inc()
+	case event.TypeRunFailed:
+		RunFailuresTotal.WithLabelValues(alias).Inc()
+	case event.TypeRunTimedOut:
+		RunTimeoutsTotal.WithLabelValues(alias).Inc()
+	case event.TypeSLAMissed:
+		SLAMissesTotal.WithLabelValues(alias).Inc()
+	}
+}
+
+func extractJobAlias(evt event.Event) string {
+	if len(evt.Payload) == 0 {
+		return ""
+	}
+	var partial struct {
+		JobAlias string `json:"job_alias"`
+	}
+	if err := json.Unmarshal(evt.Payload, &partial); err == nil {
+		return partial.JobAlias
+	}
+	return ""
+}
+
+// ChannelConfigMap extracts the channel's config as a raw map.
+func ChannelConfigMap(ch models.NotificationChannel) (map[string]interface{}, error) {
+	var m map[string]interface{}
+	if err := json.Unmarshal(ch.Config, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+

--- a/internal/notification/watcher.go
+++ b/internal/notification/watcher.go
@@ -143,6 +143,20 @@ func (w *Watcher) scanCompletedBySLA(ctx context.Context, now time.Time) {
 		return
 	}
 
+	// First pass: resolve deadlines, collect jobs that need a DB check,
+	// and build a single batch query for all of them.
+	type candidate struct {
+		job         models.Job
+		deadline    time.Time
+		windowStart time.Time
+		alertKey    string
+	}
+	var candidates []candidate
+	var jobIDs []uuid.UUID
+	// earliestWindow tracks the oldest window start across all candidates
+	// so we can bound the batch query.
+	var earliestWindow time.Time
+
 	for _, job := range jobs {
 		sla := parseSLA(job.SLA)
 		if sla == nil || sla.CompletedBy == "" {
@@ -159,42 +173,65 @@ func (w *Watcher) scanCompletedBySLA(ctx context.Context, now time.Time) {
 			continue
 		}
 
-		// Only check if we're past the deadline.
 		if !now.After(deadline) {
 			continue
 		}
 
-		// Dedup: one alert per job per calendar day (UTC).
 		alertKey := fmt.Sprintf("%s|%s", job.ID, deadline.Format("2006-01-02"))
 		if _, alerted := w.alertedJobs[alertKey]; alerted {
 			continue
 		}
 
-		// Check if any run completed successfully after the previous day's
-		// deadline. This window covers the 24h period ending at today's deadline.
 		windowStart := deadline.Add(-24 * time.Hour)
-		var count int64
-		if err := w.db.WithContext(ctx).
-			Model(&models.JobRun{}).
-			Where("job_id = ? AND status = ? AND completed_at >= ? AND completed_at <= ?",
-				job.ID, "succeeded", windowStart, deadline).
-			Count(&count).Error; err != nil {
-			log.Error("notification watcher: failed to check completed runs",
-				"job_alias", job.Alias,
-				"error", err,
-			)
+		if earliestWindow.IsZero() || windowStart.Before(earliestWindow) {
+			earliestWindow = windowStart
+		}
+
+		candidates = append(candidates, candidate{
+			job:         job,
+			deadline:    deadline,
+			windowStart: windowStart,
+			alertKey:    alertKey,
+		})
+		jobIDs = append(jobIDs, job.ID)
+	}
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	// Single batch query: for each candidate job, find the latest
+	// successful run completion time since the earliest window.
+	type jobLatest struct {
+		JobID       uuid.UUID  `gorm:"column:job_id"`
+		LatestCompl time.Time  `gorm:"column:latest_compl"`
+	}
+	var rows []jobLatest
+	if err := w.db.WithContext(ctx).
+		Model(&models.JobRun{}).
+		Select("job_id, MAX(completed_at) AS latest_compl").
+		Where("job_id IN ? AND status = ? AND completed_at >= ?",
+			jobIDs, "succeeded", earliestWindow).
+		Group("job_id").
+		Find(&rows).Error; err != nil {
+		log.Error("notification watcher: failed to batch-check completed runs", "error", err)
+		return
+	}
+	latestByJob := make(map[uuid.UUID]time.Time, len(rows))
+	for _, row := range rows {
+		latestByJob[row.JobID] = row.LatestCompl
+	}
+
+	// Second pass: verify each job's latest completion falls within
+	// its specific [windowStart, deadline] range.
+	for _, c := range candidates {
+		if runMetSLA(latestByJob, c.job.ID, c.windowStart, c.deadline) {
+			w.alertedJobs[c.alertKey] = struct{}{}
 			continue
 		}
 
-		if count > 0 {
-			// Job met its SLA — no alert needed.
-			w.alertedJobs[alertKey] = struct{}{}
-			continue
-		}
-
-		// Emit SLA miss: no successful run completed within the window.
-		w.emitCompletedBySLAEvent(ctx, job, deadline, now)
-		w.alertedJobs[alertKey] = struct{}{}
+		w.emitCompletedBySLAEvent(ctx, c.job, c.deadline, now)
+		w.alertedJobs[c.alertKey] = struct{}{}
 	}
 
 	// Prune old alert keys (keep only today and yesterday).
@@ -313,6 +350,17 @@ func buildRunEventPayload(r models.JobRun, errorMsg string) json.RawMessage {
 		return nil
 	}
 	return data
+}
+
+// runMetSLA checks whether a job's latest successful run completed within
+// its SLA window [windowStart, deadline]. Returns false if no run exists
+// for the job or the run completed outside the window.
+func runMetSLA(latestByJob map[uuid.UUID]time.Time, jobID uuid.UUID, windowStart, deadline time.Time) bool {
+	latest, ok := latestByJob[jobID]
+	if !ok {
+		return false
+	}
+	return !latest.Before(windowStart) && !latest.After(deadline)
 }
 
 // parseSLA deserializes the job's SLA JSON column.

--- a/internal/notification/watcher.go
+++ b/internal/notification/watcher.go
@@ -291,10 +291,11 @@ func (w *Watcher) emitSLAEvent(ctx context.Context, jobID uuid.UUID, r *models.J
 func (w *Watcher) emitCompletedBySLAEvent(ctx context.Context, job models.Job, deadline, now time.Time) {
 	msg := fmt.Sprintf("SLA missed: job %q did not complete by %s UTC", job.Alias, deadline.Format("15:04"))
 	data, _ := json.Marshal(map[string]interface{}{
-		"job_id":    job.ID,
-		"job_alias": job.Alias,
-		"error":     msg,
-		"sla":       map[string]string{"completedBy": deadline.Format("15:04")},
+		"job_id":     job.ID,
+		"job_alias":  job.Alias,
+		"job_labels": job.Labels,
+		"error":      msg,
+		"sla":        map[string]string{"completedBy": deadline.Format("15:04")},
 	})
 
 	evt := event.Event{
@@ -331,6 +332,7 @@ func buildRunEventPayload(r models.JobRun, errorMsg string) json.RawMessage {
 		"id":           r.ID,
 		"job_id":       r.JobID,
 		"job_alias":    r.Job.Alias,
+		"job_labels":   r.Job.Labels,
 		"status":       r.Status,
 		"started_at":   r.StartedAt,
 		"trigger_type": r.TriggerType,

--- a/internal/notification/watcher.go
+++ b/internal/notification/watcher.go
@@ -1,0 +1,355 @@
+package notification
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// slaConfig mirrors pkg/jobdef.SLAConfig for deserialization without
+// importing the jobdef package (which would create an import cycle for
+// callers that also import models).
+type slaConfig struct {
+	Duration    time.Duration `json:"duration,omitempty"`
+	CompletedBy string        `json:"completedBy,omitempty"`
+}
+
+// Watcher periodically scans for timeout and SLA violations,
+// publishing the appropriate events on the bus.
+type Watcher struct {
+	db       *gorm.DB
+	bus      event.Bus
+	store    *event.Store
+	interval time.Duration
+
+	// alertedRuns tracks run-scoped alerts (timeout + duration SLA)
+	// to avoid duplicate notifications within a single process lifetime.
+	alertedRuns map[uuid.UUID]runAlertState
+
+	// alertedJobs tracks job-scoped alerts (completedBy SLA) keyed
+	// by "jobID|YYYY-MM-DD" to dedup per calendar day.
+	alertedJobs map[string]struct{}
+}
+
+type runAlertState struct {
+	timedOut    bool
+	slaDuration bool
+}
+
+// NewWatcher creates a new timeout/SLA watcher.
+func NewWatcher(db *gorm.DB, bus event.Bus, store *event.Store, interval time.Duration) *Watcher {
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	return &Watcher{
+		db:          db,
+		bus:         bus,
+		store:       store,
+		interval:    interval,
+		alertedRuns: make(map[uuid.UUID]runAlertState),
+		alertedJobs: make(map[string]struct{}),
+	}
+}
+
+// Start runs the watcher loop until the context is cancelled.
+func (w *Watcher) Start(ctx context.Context) error {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			w.scan(ctx)
+		}
+	}
+}
+
+func (w *Watcher) scan(ctx context.Context) {
+	now := time.Now().UTC()
+
+	w.scanRunningRuns(ctx, now)
+	w.scanCompletedBySLA(ctx, now)
+}
+
+// scanRunningRuns checks active runs for timeout and duration-based SLA violations.
+func (w *Watcher) scanRunningRuns(ctx context.Context, now time.Time) {
+	var runs []models.JobRun
+	if err := w.db.WithContext(ctx).
+		Preload("Job").
+		Where("status = ?", "running").
+		Find(&runs).Error; err != nil {
+		log.Error("notification watcher: failed to query running runs", "error", err)
+		return
+	}
+
+	// Clean up alerted state for runs that are no longer running.
+	runningIDs := make(map[uuid.UUID]struct{}, len(runs))
+	for _, r := range runs {
+		runningIDs[r.ID] = struct{}{}
+	}
+	for id := range w.alertedRuns {
+		if _, ok := runningIDs[id]; !ok {
+			delete(w.alertedRuns, id)
+		}
+	}
+
+	for _, r := range runs {
+		state := w.alertedRuns[r.ID]
+
+		// Check run timeout.
+		if !state.timedOut && r.Job.RunTimeout > 0 {
+			deadline := r.StartedAt.Add(r.Job.RunTimeout)
+			if now.After(deadline) {
+				w.emitTimeoutEvent(ctx, r, now)
+				state.timedOut = true
+			}
+		}
+
+		// Check duration-based SLA.
+		sla := parseSLA(r.Job.SLA)
+		if !state.slaDuration && sla != nil && sla.Duration > 0 {
+			slaDeadline := r.StartedAt.Add(sla.Duration)
+			if now.After(slaDeadline) {
+				w.emitSLAEvent(ctx, r.JobID, &r, now,
+					fmt.Sprintf("SLA duration exceeded: run has been running for %s (limit %s)",
+						now.Sub(r.StartedAt).Truncate(time.Second), sla.Duration))
+				state.slaDuration = true
+			}
+		}
+
+		w.alertedRuns[r.ID] = state
+	}
+}
+
+// scanCompletedBySLA checks all jobs with a completedBy SLA to see if any
+// have missed their wall-clock deadline, even if no run was started.
+func (w *Watcher) scanCompletedBySLA(ctx context.Context, now time.Time) {
+	// Find all non-deleted jobs that have an SLA configured.
+	var jobs []models.Job
+	if err := w.db.WithContext(ctx).
+		Where("sla IS NOT NULL AND sla != 'null' AND sla != '{}'").
+		Find(&jobs).Error; err != nil {
+		log.Error("notification watcher: failed to query jobs for SLA check", "error", err)
+		return
+	}
+
+	for _, job := range jobs {
+		sla := parseSLA(job.SLA)
+		if sla == nil || sla.CompletedBy == "" {
+			continue
+		}
+
+		deadline, err := resolveCompletedBy(sla.CompletedBy, now)
+		if err != nil {
+			log.Error("notification watcher: invalid completedBy value",
+				"job_alias", job.Alias,
+				"completed_by", sla.CompletedBy,
+				"error", err,
+			)
+			continue
+		}
+
+		// Only check if we're past the deadline.
+		if !now.After(deadline) {
+			continue
+		}
+
+		// Dedup: one alert per job per calendar day (UTC).
+		alertKey := fmt.Sprintf("%s|%s", job.ID, deadline.Format("2006-01-02"))
+		if _, alerted := w.alertedJobs[alertKey]; alerted {
+			continue
+		}
+
+		// Check if any run completed successfully after the previous day's
+		// deadline. This window covers the 24h period ending at today's deadline.
+		windowStart := deadline.Add(-24 * time.Hour)
+		var count int64
+		if err := w.db.WithContext(ctx).
+			Model(&models.JobRun{}).
+			Where("job_id = ? AND status = ? AND completed_at >= ? AND completed_at <= ?",
+				job.ID, "succeeded", windowStart, deadline).
+			Count(&count).Error; err != nil {
+			log.Error("notification watcher: failed to check completed runs",
+				"job_alias", job.Alias,
+				"error", err,
+			)
+			continue
+		}
+
+		if count > 0 {
+			// Job met its SLA — no alert needed.
+			w.alertedJobs[alertKey] = struct{}{}
+			continue
+		}
+
+		// Emit SLA miss: no successful run completed within the window.
+		w.emitCompletedBySLAEvent(ctx, job, deadline, now)
+		w.alertedJobs[alertKey] = struct{}{}
+	}
+
+	// Prune old alert keys (keep only today and yesterday).
+	today := now.Format("2006-01-02")
+	yesterday := now.Add(-24 * time.Hour).Format("2006-01-02")
+	for key := range w.alertedJobs {
+		parts := strings.SplitN(key, "|", 2)
+		if len(parts) == 2 && parts[1] != today && parts[1] != yesterday {
+			delete(w.alertedJobs, key)
+		}
+	}
+}
+
+func (w *Watcher) emitTimeoutEvent(ctx context.Context, r models.JobRun, now time.Time) {
+	payload := buildRunEventPayload(r, "run timed out after "+r.Job.RunTimeout.String())
+	evt := event.Event{
+		Type:      event.TypeRunTimedOut,
+		JobID:     r.JobID,
+		RunID:     r.ID,
+		Timestamp: now,
+		Payload:   payload,
+	}
+
+	w.persistAndPublish(ctx, &evt)
+	log.Warn("notification watcher: run timed out",
+		"run_id", r.ID,
+		"job_alias", r.Job.Alias,
+		"timeout", r.Job.RunTimeout,
+	)
+}
+
+func (w *Watcher) emitSLAEvent(ctx context.Context, jobID uuid.UUID, r *models.JobRun, now time.Time, msg string) {
+	var payload json.RawMessage
+	if r != nil {
+		payload = buildRunEventPayload(*r, msg)
+	} else {
+		data, _ := json.Marshal(map[string]interface{}{
+			"job_id": jobID,
+			"error":  msg,
+		})
+		payload = data
+	}
+
+	evt := event.Event{
+		Type:      event.TypeSLAMissed,
+		JobID:     jobID,
+		Timestamp: now,
+		Payload:   payload,
+	}
+	if r != nil {
+		evt.RunID = r.ID
+	}
+
+	w.persistAndPublish(ctx, &evt)
+}
+
+func (w *Watcher) emitCompletedBySLAEvent(ctx context.Context, job models.Job, deadline, now time.Time) {
+	msg := fmt.Sprintf("SLA missed: job %q did not complete by %s UTC", job.Alias, deadline.Format("15:04"))
+	data, _ := json.Marshal(map[string]interface{}{
+		"job_id":    job.ID,
+		"job_alias": job.Alias,
+		"error":     msg,
+		"sla":       map[string]string{"completedBy": deadline.Format("15:04")},
+	})
+
+	evt := event.Event{
+		Type:      event.TypeSLAMissed,
+		JobID:     job.ID,
+		Timestamp: now,
+		Payload:   data,
+	}
+
+	w.persistAndPublish(ctx, &evt)
+	log.Warn("notification watcher: completedBy SLA missed",
+		"job_alias", job.Alias,
+		"deadline", deadline.Format("15:04"),
+	)
+}
+
+func (w *Watcher) persistAndPublish(ctx context.Context, evt *event.Event) {
+	if w.store != nil {
+		if err := w.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			return w.store.AppendTx(tx, evt)
+		}); err != nil {
+			log.Error("notification watcher: failed to persist event",
+				"event_type", string(evt.Type),
+				"error", err,
+			)
+			return
+		}
+	}
+	w.bus.Publish(*evt)
+}
+
+func buildRunEventPayload(r models.JobRun, errorMsg string) json.RawMessage {
+	p := map[string]interface{}{
+		"id":           r.ID,
+		"job_id":       r.JobID,
+		"job_alias":    r.Job.Alias,
+		"status":       r.Status,
+		"started_at":   r.StartedAt,
+		"trigger_type": r.TriggerType,
+		"error":        errorMsg,
+	}
+	if r.CompletedAt != nil {
+		p["completed_at"] = r.CompletedAt
+	}
+	if len(r.Params) > 0 {
+		var params map[string]string
+		if err := json.Unmarshal(r.Params, &params); err == nil && len(params) > 0 {
+			p["params"] = params
+		}
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+// parseSLA deserializes the job's SLA JSON column.
+func parseSLA(raw []byte) *slaConfig {
+	if len(raw) == 0 {
+		return nil
+	}
+	var cfg slaConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil
+	}
+	if cfg.Duration == 0 && cfg.CompletedBy == "" {
+		return nil
+	}
+	return &cfg
+}
+
+// resolveCompletedBy parses an "HH:MM" string and returns today's deadline
+// in UTC. If the current time is before the deadline, it returns today's
+// occurrence; otherwise it returns today's occurrence (already passed).
+func resolveCompletedBy(hhmm string, now time.Time) (time.Time, error) {
+	parts := strings.SplitN(hhmm, ":", 2)
+	if len(parts) != 2 {
+		return time.Time{}, fmt.Errorf("expected HH:MM format, got %q", hhmm)
+	}
+	var hour, min int
+	if _, err := fmt.Sscanf(parts[0], "%d", &hour); err != nil || hour < 0 || hour > 23 {
+		return time.Time{}, fmt.Errorf("invalid hour in %q", hhmm)
+	}
+	if _, err := fmt.Sscanf(parts[1], "%d", &min); err != nil || min < 0 || min > 59 {
+		return time.Time{}, fmt.Errorf("invalid minute in %q", hhmm)
+	}
+	y, m, d := now.UTC().Date()
+	return time.Date(y, m, d, hour, min, 0, 0, time.UTC), nil
+}
+
+// isTimeoutError checks if an error string indicates a run timeout.
+func isTimeoutError(errMsg string) bool {
+	return strings.HasPrefix(errMsg, "run timed out after ")
+}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -83,6 +83,8 @@ type TaskRun struct {
 	ID                      uuid.UUID                 `json:"id"`
 	JobRunID                uuid.UUID                 `json:"job_run_id"`
 	TaskID                  uuid.UUID                 `json:"task_id"`
+	JobAlias                string                    `json:"job_alias,omitempty"`
+	JobLabels               map[string]string         `json:"job_labels,omitempty"`
 	AtomID                  uuid.UUID                 `json:"atom_id"`
 	Engine                  models.AtomEngine         `json:"engine"`
 	Image                   string                    `json:"image"`
@@ -114,8 +116,9 @@ type TaskRun struct {
 type JobRun struct {
 	ID            uuid.UUID         `json:"id"`
 	JobID         uuid.UUID         `json:"job_id"`
-	BackfillID    *uuid.UUID        `json:"backfill_id,omitempty"`
 	JobAlias      string            `json:"job_alias,omitempty"`
+	JobLabels     map[string]string `json:"job_labels,omitempty"`
+	BackfillID    *uuid.UUID        `json:"backfill_id,omitempty"`
 	TriggerType   string            `json:"trigger_type,omitempty"`
 	TriggerAlias  string            `json:"trigger_alias,omitempty"`
 	Status        Status            `json:"status"`
@@ -1608,13 +1611,14 @@ func (s *Store) loadRunWithDB(conn *gorm.DB, runID uuid.UUID) (*JobRun, error) {
 	var result struct {
 		models.JobRun
 		JobAlias     string
+		JobLabels    datatypes.JSONMap
 		TriggerType  string
 		TriggerAlias string
 	}
 
 	// Use a JOIN to fetch job and trigger information for human readability
 	err := conn.Table("job_runs").
-		Select("job_runs.*, jobs.alias as job_alias, triggers.type as trigger_type, triggers.alias as trigger_alias").
+		Select("job_runs.*, jobs.alias as job_alias, jobs.labels as job_labels, triggers.type as trigger_type, triggers.alias as trigger_alias").
 		Joins("left join jobs on jobs.id = job_runs.job_id").
 		Joins("left join triggers on triggers.id = job_runs.trigger_id").
 		Where("job_runs.id = ?", runID).
@@ -1630,8 +1634,15 @@ func (s *Store) loadRunWithDB(conn *gorm.DB, runID uuid.UUID) (*JobRun, error) {
 	}
 
 	runValue.JobAlias = result.JobAlias
+	runValue.JobLabels = jsonmap.ToStringMap(result.JobLabels)
 	runValue.TriggerType = result.TriggerType
 	runValue.TriggerAlias = result.TriggerAlias
+
+	// Propagate job metadata to task runs for downstream event payloads.
+	for i := range runValue.Tasks {
+		runValue.Tasks[i].JobAlias = runValue.JobAlias
+		runValue.Tasks[i].JobLabels = runValue.JobLabels
+	}
 
 	return runValue, nil
 }
@@ -1826,12 +1837,14 @@ func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, task
 	}
 
 	var jobRun models.JobRun
-	if err := db.Select("job_id").First(&jobRun, "id = ?", runID).Error; err != nil {
+	if err := db.Preload("Job").First(&jobRun, "id = ?", runID).Error; err != nil {
 		log.Error("failed to fetch job run for event", "error", err, "run_id", runID)
 		return nil, err
 	}
 
 	taskPayload := convertRunTaskModel(&taskRun)
+	taskPayload.JobAlias = jobRun.Job.Alias
+	taskPayload.JobLabels = jobRun.Job.Labels
 	// Use task-run row ID for event payloads so downstream consumers can identify
 	// each task execution uniquely across retries/runs.
 	taskPayload.ID = taskRun.ID

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1844,7 +1844,7 @@ func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, task
 
 	taskPayload := convertRunTaskModel(&taskRun)
 	taskPayload.JobAlias = jobRun.Job.Alias
-	taskPayload.JobLabels = jobRun.Job.Labels
+	taskPayload.JobLabels = jsonmap.ToStringMap(jobRun.Job.Labels)
 	// Use task-run row ID for event payloads so downstream consumers can identify
 	// each task execution uniquely across retries/runs.
 	taskPayload.ID = taskRun.ID

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -89,6 +89,9 @@ type Environment struct {
 	WebhookRateLimitPerMinute     int           `envconfig:"WEBHOOK_RATE_LIMIT_PER_MINUTE" default:"120"`
 	WebhookRateLimitBurst         int           `envconfig:"WEBHOOK_RATE_LIMIT_BURST" default:"20"`
 
+	// Notification Watcher
+	NotificationWatcherInterval time.Duration `envconfig:"NOTIFICATION_WATCHER_INTERVAL" default:"15s"`
+
 	// Authentication & Authorization
 	AuthMode                string `envconfig:"AUTH_MODE" default:"none"` // none, api-key
 	AuthKeyHashSecret       string `envconfig:"AUTH_KEY_HASH_SECRET" default:""`

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -54,6 +54,24 @@ const (
 	SchemaValidationFail     = "fail"
 )
 
+// SLAConfig defines the service-level agreement for a job.
+type SLAConfig struct {
+	// Duration is the maximum time a run may take before an SLA miss alert is
+	// emitted, measured from the run's start time. Does not cancel execution.
+	Duration time.Duration `yaml:"duration,omitempty" json:"duration,omitempty"`
+
+	// CompletedBy is a wall-clock time of day in "HH:MM" format (UTC) by
+	// which the job must have a successfully completed run. If no run has
+	// completed by this time, an SLA miss alert is emitted — even if the job
+	// was never triggered.
+	CompletedBy string `yaml:"completedBy,omitempty" json:"completedBy,omitempty"`
+}
+
+// HasSLA returns true if any SLA constraint is configured.
+func (s *SLAConfig) HasSLA() bool {
+	return s != nil && (s.Duration > 0 || s.CompletedBy != "")
+}
+
 // Metadata contains descriptive data for the job.
 type Metadata struct {
 	Alias            string            `yaml:"alias" json:"alias"`
@@ -62,6 +80,14 @@ type Metadata struct {
 	MaxParallelTasks int               `yaml:"maxParallelTasks,omitempty" json:"maxParallelTasks,omitempty"`
 	TaskTimeout      time.Duration     `yaml:"taskTimeout,omitempty" json:"taskTimeout,omitempty"`
 	RunTimeout       time.Duration     `yaml:"runTimeout,omitempty" json:"runTimeout,omitempty"`
+	// SLA defines the service-level agreement for this job. It supports two
+	// modes that may be used independently or together:
+	//   duration    — max run duration before an SLA miss alert (relative to
+	//                 run start; does not cancel execution).
+	//   completedBy — wall-clock time of day ("HH:MM", UTC) by which the job
+	//                 must have a successfully completed run. Alerts even if
+	//                 no run has started.
+	SLA              *SLAConfig        `yaml:"sla,omitempty" json:"sla,omitempty"`
 	// SchemaValidation controls runtime output schema validation.
 	// Values: "" (disabled), "warn" (log violations), "fail" (fail task on violation).
 	SchemaValidation string      `yaml:"schemaValidation,omitempty" json:"schemaValidation,omitempty"`


### PR DESCRIPTION
Implements a complete alerting/notification system for task failures, run failures, run timeouts, and SLA misses across multiple delivery channels.

* Adds `NotificationChannel (name, type, JSON config, enabled)` and `NotificationPolicy (name, channel reference, event types, filters, enabled)` models. 
* REST endpoints under endpoints under `/v1/notifications/{channels,policies}`
*  Task/run failure notifications handled automatically via task_failed and run_failed event subscription.
* SLA model: Structured sla JSON field on the job definition supporting two modes independently or together:
   - duration — max run duration before alert (relative to run start, does not cancel execution)
   - completedBy — wall-clock time of day ("HH:MM", UTC) by which a successful run must have completed; alerts even if no run was started
* Watcher: Periodic scanner (configurable via CAESIUM_NOTIFICATION_WATCHER_INTERVAL, default 15s) that checks running runs against runTimeout and SLA constraints.

## Notification Types

* Webhook: HTTP POST/PUT to configurable URL with custom headers and timeout.
* Slack: Incoming webhook with Block Kit formatted messages
* Email: SMTP delivery via net/smtp with STARTTLS/TLS/plaintext support and MIME-formatted messages.
* PagerDuty: Events API v2 with automatic trigger/resolve actions, dedup keys, severity mapping, and summary truncation to 1024 chars.
* Prometheus metrics: `caesium_notification_sends_total`, `caesium_notification_send_duration_seconds`, `caesium_task_failures_total`, `caesium_run_failures_total`, `caesium_run_timeouts_total`, `caesium_sla_misses_total`.

This is part 1 of at least 2. Once we have this sorted out I'll add the ability to have failures trigger an AI agent. 