### PR TITLE
UI refresh: brand redesign, status semantics, and sidebar enhancements

### DIFF
--- a/docs/ui-refresh-execution-plan.md
+++ b/docs/ui-refresh-execution-plan.md
@@ -1,6 +1,6 @@
 # UI Refresh — Execution Plan
 
-> Status: Active. Companion to [`design-ui-refresh.md`](design-ui-refresh.md). Each phase is its own PR train; each step lists files to touch, API gaps, and acceptance criteria so an agent can pick up a single bullet without rereading the design.
+> Status: Active — Phase 0 shipped (2026-04-28, branch `claude/eager-rubin-E3djS`). Phase 1 is next. Companion to [`design-ui-refresh.md`](design-ui-refresh.md). Each phase is its own PR train; each step lists files to touch, API gaps, and acceptance criteria so an agent can pick up a single bullet without rereading the design.
 
 ## How to use this plan
 
@@ -12,76 +12,54 @@
 
 ---
 
-## Phase 0 · Foundations
+## Phase 0 · Foundations ✅ Shipped 2026-04-28
+
+> Branch: `claude/eager-rubin-E3djS`. All acceptance criteria verified: 79/79 vitests pass, `npm run lint` clean, production build clean.
 
 Phase 0 changes propagate automatically into every page. Land them first; the rest becomes additive.
 
-### 0.1 — Extend design tokens in `ui/src/index.css`
+### 0.1 — Extend design tokens in `ui/src/index.css` ✅
 
-Add the brand surface, brand accent, and text level tokens called out in [`design-ui-refresh.md`](design-ui-refresh.md) §"Palette" to both `:root` (light) and `.dark`.
+**Shipped:**
+- `ui/src/index.css` — added `--cyan-glow`, `--cyan-dim`, `--gold-dim`, `--void`, `--midnight`, `--obsidian`, `--graphite`, `--silt`, `--text-1..4`, `--success`, `--warning`, `--danger`, `--running`, `--cached`, `--chart-1..5`. Light theme overrides for the same keys. Brand keyframes (`orbit-spin`, `nucleus-pulse`, `cyan-pulse`, `gold-pulse`) + reduced-motion CSS guard.
+- `ui/tailwind.config.js` — extended `theme.extend.colors` with all new tokens (utility classes `bg-midnight`, `text-text-2`, `bg-danger`, etc.). Merged `keyframes` + `animation` extensions alongside existing accordion ones.
 
-**Files to touch:**
-- `ui/src/index.css` — add `--cyan-glow`, `--cyan-dim`, `--gold-dim`, `--midnight`, `--obsidian`, `--graphite`, `--silt`, `--text-1..4`, `--success`, `--warning`, `--danger`, `--running`, `--cached`. Light theme overrides for the same keys.
-- `ui/tailwind.config.js` — extend `theme.extend.colors` so utility classes (`bg-midnight`, `text-text-2`, etc.) compose with the new tokens. Map shadcn names (`accent`, `chart-1..5`) onto the brand palette so existing components inherit without per-component overrides.
+### 0.2 — Status semantics helper ✅
 
-**Acceptance:**
-- Existing pages render in the new color scheme with no per-component changes.
-- `just unit-test` and `npm run lint` pass.
-- Storybook (if present) reflects the palette globally.
+**Shipped:**
+- `ui/src/lib/status.ts` — `statusMeta(status)` returns `{ label, fg, bg, border, dotClass }` for seven statuses + alias normalization + unknown fallback.
+- `ui/src/lib/__tests__/status.test.ts` — 5 vitests covering all seven statuses, animation classes, alias normalization, and null/undefined inputs.
+- `rg "succeeded.*hsl|failed.*hsl|running.*hsl" ui/src` returns no matches.
 
-### 0.2 — Status semantics helper
+### 0.3 — Brand primitive: animated `AtomLogo` ✅
 
-**Files to touch:**
-- New: `ui/src/lib/status.ts` exporting `statusMeta(status: RunStatus): { label, fg, bg, border, dotClass }`.
-- Audit `ui/src/features/jobs/`, `ui/src/features/stats/`, `ui/src/features/triggers/` — anywhere a status string maps to a color literal, replace with `statusMeta(status)`.
+**Shipped:**
+- `ui/src/components/brand/atom-logo.tsx` — three orbital ellipses + nucleus + three gold satellites. `animated?: boolean` (default `true`). `useReducedMotion()` disables spin. Exposes `forceReducedMotion` test hook. Stable per-instance gradient id via `useId()`.
+- `ui/src/hooks/useReducedMotion.ts` — subscribes to `prefers-reduced-motion: reduce` media query.
+- `ui/src/components/brand/__tests__/atom-logo.test.tsx` — 4 vitests (default/animated-off/reduced-motion/reduced-motion-forced).
+- `ui/src/components/caesium-logo.tsx` — converted to a static re-export shim (`<AtomLogo animated={false} />`); remove in Phase 1 cleanup.
 
-**Acceptance:**
-- `rg "succeeded.*hsl|failed.*hsl|running.*hsl" ui/src` returns no per-component matches outside `lib/status.ts`.
-- A vitest covers the seven statuses + the `unknown` fallback.
-- All seven statuses (`running`, `succeeded`, `failed`, `queued`, `paused`, `cached`, `skipped`) have a stable visual treatment in the running app.
+### 0.4 — UI primitives ✅
 
-### 0.3 — Brand primitive: animated `AtomLogo`
+**Shipped:**
 
-**Files to touch:**
-- New: `ui/src/components/brand/atom-logo.tsx`. Three orbital ellipses + nucleus + three gold satellites, matching [`prototype/ui-kit.jsx`](design/ui-refresh/prototype/ui-kit.jsx) but as TSX. Prop: `animated?: boolean` (default `true`). `useReducedMotion()` (custom or from a tiny library) disables the spin when the user prefers reduced motion.
-- Migration: keep `ui/src/components/caesium-logo.tsx` as a re-export of the static `<AtomLogo animated={false} />` so existing imports compile; remove it at the end of Phase 1 once all callers have switched.
+| Primitive | File | Tests |
+| --------- | ---- | ----- |
+| `<StatusBadge>` | `ui/src/components/ui/status-badge.tsx` | `__tests__/status-badge.test.tsx` (4 tests) |
+| `<Sparkline>` | `ui/src/components/ui/sparkline.tsx` | `__tests__/sparkline.test.tsx` (3 tests) |
+| `<EmptyState>` | `ui/src/components/ui/empty-state.tsx` | `__tests__/empty-state.test.tsx` (4 tests) |
+| `<UTCClock>` + `UTCClockProvider` | `ui/src/components/ui/utc-clock.tsx` | `__tests__/utc-clock.test.tsx` (4 tests) |
+| `<UsageBar>` | `ui/src/components/ui/usage-bar.tsx` | `__tests__/usage-bar.test.tsx` (5 tests) |
+| `USAGE_THRESHOLDS` / `usageLevel` | `ui/src/lib/thresholds.ts` | covered by usage-bar tests |
 
-**Acceptance:**
-- `<AtomLogo />` renders identically to the prototype motif (same orbits, same colors).
-- A test covers the reduced-motion fallback.
-- Sidebar header uses the animated variant.
+### 0.5 — App shell visual upgrade ✅
 
-### 0.4 — UI primitives
-
-Land each as its own commit. Each ships with a vitest in `__tests__/`.
-
-| New primitive                              | What it replaces in pages                                |
-| ------------------------------------------ | -------------------------------------------------------- |
-| `ui/src/components/ui/status-badge.tsx`    | Hand-rolled `<span>` pills on Jobs, JobDetail, Triggers, RunDetail. Variants: `filled` (default), `soft`, `dot`. |
-| `ui/src/components/ui/sparkline.tsx`       | Used on Jobs list. SVG; accepts `runs: RunSummary[]`. Lazy-renders after first paint. |
-| `ui/src/components/ui/empty-state.tsx`     | Replaces ad-hoc empty messages on Jobs, Triggers, etc.   |
-| `ui/src/components/ui/utc-clock.tsx`       | Header. Single `setInterval` shared via context.         |
-| `ui/src/components/ui/usage-bar.tsx`       | New — used on System nodes table. Threshold constants live in `ui/src/lib/thresholds.ts`. |
-
-**Acceptance:**
-- Each primitive has a test covering: every variant or status, the empty case, and `prefers-reduced-motion` behavior where applicable.
-- `<Button>` keeps its existing API; nothing in Phase 0 modifies it.
-
-### 0.5 — App shell visual upgrade
-
-**Files to touch:**
-- `ui/src/components/layout/AppShell.tsx`, `ui/src/components/layout/Sidebar.tsx`, `ui/src/components/layout/Header.tsx`.
-- New hook: `ui/src/features/jobs/useNavCounts.ts` — one batched query (e.g. `GET /v1/jobs?count_only=true` per route, debounced) that returns sidebar badge counts. 30s refetch interval. If `count_only` doesn't exist server-side, ship the hook with full-list counting and file the API gap (§API gaps below).
-- New hook: `ui/src/features/system/useClusterHealth.ts` — polls `/v1/system/health` every 15s. If the endpoint doesn't exist yet, return a stub `{ status: 'unknown' }` and gate the cluster footer on `status !== 'unknown'`.
-
-**Visual changes:**
-- Sidebar: gold accent rail on the left edge, animated `AtomLogo` in the brand mark, count badges per nav item, cluster health footer (3-row mini-table).
-- Header: breadcrumb, command-palette trigger (reuse `ui/src/components/command-menu.tsx`), `<UTCClock />`, theme toggle, notifications icon. Backdrop-blur over `--void`.
-
-**Acceptance:**
-- Every existing route in `router.tsx` still resolves.
-- Nav badges update without page refresh.
-- The header is sticky and renders correctly in both themes.
+**Shipped:**
+- `ui/src/components/layout/Sidebar.tsx` — gold accent rail, animated `AtomLogo`, count badges (from `useNavCounts`), cluster health footer (gated on `state !== 'unknown'`). Active route shows 2px gold inset shadow.
+- `ui/src/components/layout/Header.tsx` — sticky + backdrop-blur, route-aware breadcrumb, command-menu, `<UTCClock />`, notifications icon, theme toggle.
+- `ui/src/components/layout/AppShell.tsx` — wraps children in `UTCClockProvider` for a single shared tick.
+- `ui/src/features/jobs/useNavCounts.ts` — client-side count fallback (30s refetch). API gap filed: `GET /v1/jobs?count_only=true`.
+- `ui/src/features/system/useClusterHealth.ts` — polls `/v1/system/health` every 15s; classifies to `operational | degraded | incident | unknown`.
 
 ---
 

--- a/ui/src/components/brand/__tests__/atom-logo.test.tsx
+++ b/ui/src/components/brand/__tests__/atom-logo.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { AtomLogo } from "../atom-logo";
+
+describe("<AtomLogo />", () => {
+  it("renders a labelled SVG with three orbits, a nucleus, and three satellites", () => {
+    const { container } = render(<AtomLogo size={64} />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-label")).toBe("Caesium");
+    expect(svg?.getAttribute("width")).toBe("64");
+
+    expect(container.querySelectorAll("ellipse").length).toBe(3);
+    // 1 glow halo + 1 nucleus + 3 gold satellites = 5 circles
+    expect(container.querySelectorAll("circle").length).toBe(5);
+  });
+
+  it("animates by default", () => {
+    const { container } = render(<AtomLogo />);
+    expect(container.querySelectorAll(".atom-orbit").length).toBe(3);
+    expect(container.querySelector(".atom-nucleus")).not.toBeNull();
+    expect(container.querySelector("svg")?.getAttribute("data-reduced-motion")).toBe(
+      "false",
+    );
+  });
+
+  it("renders static when animation is disabled via prop", () => {
+    const { container } = render(<AtomLogo animated={false} />);
+    expect(container.querySelectorAll(".atom-orbit").length).toBe(0);
+    expect(container.querySelector(".atom-nucleus")).toBeNull();
+    expect(container.querySelector("svg")?.getAttribute("data-reduced-motion")).toBe(
+      "true",
+    );
+  });
+
+  it("renders static when reduced motion is preferred", () => {
+    const { container } = render(<AtomLogo forceReducedMotion />);
+    expect(container.querySelectorAll(".atom-orbit").length).toBe(0);
+    expect(container.querySelector(".atom-nucleus")).toBeNull();
+    expect(container.querySelector("svg")?.getAttribute("data-reduced-motion")).toBe(
+      "true",
+    );
+  });
+});

--- a/ui/src/components/brand/atom-logo.tsx
+++ b/ui/src/components/brand/atom-logo.tsx
@@ -1,0 +1,143 @@
+import { useId } from "react";
+import { cn } from "@/lib/utils";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+interface AtomLogoProps {
+  /** Pixel size of the SVG square. Defaults to `40`. */
+  size?: number;
+  /**
+   * Whether to animate the orbits + nucleus. Defaults to `true`.
+   * Always renders static when the user prefers reduced motion.
+   */
+  animated?: boolean;
+  className?: string;
+  /** Test hook only. Forces the reduced-motion branch. */
+  forceReducedMotion?: boolean;
+}
+
+/**
+ * The Caesium atom: a stable nucleus with three deterministic orbits and
+ * three gold satellites at fixed positions. The animated variant spins each
+ * orbit at a different period (one reversed) and pulses the nucleus.
+ */
+export function AtomLogo({
+  size = 40,
+  animated = true,
+  className,
+  forceReducedMotion = false,
+}: AtomLogoProps) {
+  const reducedMotion = useReducedMotion();
+  const motionOff = forceReducedMotion || reducedMotion || !animated;
+
+  // Stable per-instance gradient id — keeps multiple <AtomLogo>s from sharing.
+  const gradId = `atom-nuc-glow-${useId().replace(/[^a-zA-Z0-9_-]/g, "")}`;
+
+  const orbitClass = motionOff ? "" : "atom-orbit";
+  const nucleusClass = motionOff ? "" : "atom-nucleus";
+
+  return (
+    <svg
+      viewBox="0 0 512 512"
+      width={size}
+      height={size}
+      className={cn("block", className)}
+      role="img"
+      aria-label="Caesium"
+      data-reduced-motion={motionOff ? "true" : "false"}
+    >
+      <defs>
+        <radialGradient id={gradId} cx="50%" cy="50%" r="50%">
+          <stop offset="0%" stopColor="hsl(var(--cyan-glow))" stopOpacity="0.55" />
+          <stop offset="100%" stopColor="hsl(var(--cyan-glow))" stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <circle cx="256" cy="256" r="76" fill={`url(#${gradId})`} />
+      <g
+        className={orbitClass}
+        style={
+          motionOff
+            ? undefined
+            : {
+                transformOrigin: "256px 256px",
+                animation: "orbit-spin 22s linear infinite",
+              }
+        }
+      >
+        <ellipse
+          cx="256"
+          cy="256"
+          rx="210"
+          ry="70"
+          stroke="hsl(var(--cyan))"
+          strokeWidth="3.5"
+          opacity="0.9"
+          fill="none"
+          transform="rotate(-60 256 256)"
+        />
+      </g>
+      <g
+        className={orbitClass}
+        style={
+          motionOff
+            ? undefined
+            : {
+                transformOrigin: "256px 256px",
+                animation: "orbit-spin 30s linear infinite reverse",
+              }
+        }
+      >
+        <ellipse
+          cx="256"
+          cy="256"
+          rx="210"
+          ry="70"
+          stroke="hsl(var(--cyan))"
+          strokeWidth="3.5"
+          opacity="0.85"
+          fill="none"
+        />
+      </g>
+      <g
+        className={orbitClass}
+        style={
+          motionOff
+            ? undefined
+            : {
+                transformOrigin: "256px 256px",
+                animation: "orbit-spin 38s linear infinite",
+              }
+        }
+      >
+        <ellipse
+          cx="256"
+          cy="256"
+          rx="210"
+          ry="70"
+          stroke="hsl(var(--cyan))"
+          strokeWidth="3.5"
+          opacity="0.9"
+          fill="none"
+          transform="rotate(60 256 256)"
+        />
+      </g>
+      <circle
+        cx="256"
+        cy="256"
+        r="20"
+        fill="hsl(var(--cyan))"
+        className={nucleusClass}
+        style={
+          motionOff
+            ? undefined
+            : {
+                transformOrigin: "256px 256px",
+                animation: "nucleus-pulse 2.4s ease-in-out infinite",
+              }
+        }
+      />
+      <circle cx="361" cy="74" r="10" fill="hsl(var(--gold))" />
+      <circle cx="46" cy="256" r="10" fill="hsl(var(--gold))" />
+      <circle cx="361" cy="438" r="10" fill="hsl(var(--gold))" />
+    </svg>
+  );
+}

--- a/ui/src/components/caesium-logo.tsx
+++ b/ui/src/components/caesium-logo.tsx
@@ -1,36 +1,15 @@
-import { cn } from "@/lib/utils";
+import { AtomLogo } from "@/components/brand/atom-logo";
 
 interface CaesiumLogoProps {
   className?: string;
 }
 
+/**
+ * @deprecated Use `AtomLogo` from `@/components/brand/atom-logo`.
+ *
+ * Kept as a static re-export so existing imports compile during the UI
+ * refresh. Phase 1 cleanup removes this shim once every caller has migrated.
+ */
 export function CaesiumLogo({ className }: CaesiumLogoProps) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 512 512"
-      fill="none"
-      className={cn("text-caesium-cyan", className)}
-    >
-      <circle cx="256" cy="256" r="60" fill="currentColor" opacity="0.15" />
-      <ellipse
-        cx="256" cy="256" rx="210" ry="70"
-        stroke="currentColor" strokeWidth="3.5" opacity="0.85"
-        transform="rotate(-60 256 256)"
-      />
-      <ellipse
-        cx="256" cy="256" rx="210" ry="70"
-        stroke="currentColor" strokeWidth="3.5" opacity="0.85"
-      />
-      <ellipse
-        cx="256" cy="256" rx="210" ry="70"
-        stroke="currentColor" strokeWidth="3.5" opacity="0.85"
-        transform="rotate(60 256 256)"
-      />
-      <circle cx="256" cy="256" r="18" fill="currentColor" />
-      <circle cx="361" cy="74" r="9" className="fill-caesium-gold" />
-      <circle cx="46" cy="256" r="9" className="fill-caesium-gold" />
-      <circle cx="361" cy="438" r="9" className="fill-caesium-gold" />
-    </svg>
-  );
+  return <AtomLogo animated={false} className={className} />;
 }

--- a/ui/src/components/layout/AppShell.tsx
+++ b/ui/src/components/layout/AppShell.tsx
@@ -3,6 +3,7 @@ import { Sidebar } from "./Sidebar";
 import { Header } from "./Header";
 import { useEffect } from "react";
 import { events } from "@/lib/events";
+import { UTCClockProvider } from "@/components/ui/utc-clock";
 
 export function AppShell() {
   const navigate = useNavigate();
@@ -46,14 +47,16 @@ export function AppShell() {
   }, [navigate]);
 
   return (
-    <div className="flex h-screen w-full bg-transparent text-foreground">
-      <Sidebar />
-      <div className="flex flex-col flex-1 overflow-hidden">
-        <Header />
-        <main className="flex-1 overflow-auto p-6 animate-in fade-in duration-500 md:p-8">
-          <Outlet />
-        </main>
+    <UTCClockProvider>
+      <div className="flex h-screen w-full bg-transparent text-foreground">
+        <Sidebar />
+        <div className="flex flex-col flex-1 overflow-hidden">
+          <Header />
+          <main className="flex-1 overflow-auto p-6 animate-in fade-in duration-500 md:p-8">
+            <Outlet />
+          </main>
+        </div>
       </div>
-    </div>
+    </UTCClockProvider>
   );
 }

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,17 +1,101 @@
+import { Link, useRouterState } from "@tanstack/react-router";
+import { Bell, ChevronRight } from "lucide-react";
 import { ModeToggle } from "../mode-toggle";
 import { CommandMenu } from "../command-menu";
+import { Button } from "@/components/ui/button";
+import { UTCClock } from "@/components/ui/utc-clock";
+
+interface Crumb {
+  label: string;
+  to?: string;
+}
+
+const ROOT_CRUMB: Crumb = { label: "Caesium", to: "/jobs" };
+
+const ROUTE_LABELS: Record<string, string> = {
+  jobs: "Jobs",
+  triggers: "Triggers",
+  atoms: "Atoms",
+  stats: "Stats",
+  system: "System",
+  jobdefs: "JobDefs",
+  database: "Database",
+  logs: "Logs",
+  runs: "Runs",
+};
+
+function buildCrumbs(pathname: string): Crumb[] {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0) return [ROOT_CRUMB];
+  const crumbs: Crumb[] = [ROOT_CRUMB];
+  let acc = "";
+  segments.forEach((segment, idx) => {
+    acc += `/${segment}`;
+    const isLast = idx === segments.length - 1;
+    const known = ROUTE_LABELS[segment.toLowerCase()];
+    const label = known ?? (segment.length > 12 ? `${segment.slice(0, 8)}…` : segment);
+    crumbs.push({ label, to: isLast ? undefined : acc });
+  });
+  return crumbs;
+}
+
+function Breadcrumb() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const crumbs = buildCrumbs(pathname);
+  return (
+    <nav aria-label="Breadcrumb" className="hidden items-center gap-1.5 text-xs lg:flex">
+      {crumbs.map((crumb, idx) => {
+        const isLast = idx === crumbs.length - 1;
+        return (
+          <span key={`${crumb.label}-${idx}`} className="flex items-center gap-1.5">
+            {idx > 0 ? (
+              <ChevronRight aria-hidden="true" className="h-3 w-3 text-text-4" />
+            ) : null}
+            {crumb.to && !isLast ? (
+              <Link
+                to={crumb.to}
+                className="font-medium uppercase tracking-[0.18em] text-text-3 hover:text-text-1"
+              >
+                {crumb.label}
+              </Link>
+            ) : (
+              <span
+                aria-current={isLast ? "page" : undefined}
+                className="font-medium uppercase tracking-[0.18em] text-text-1"
+              >
+                {crumb.label}
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
 
 export function Header() {
   return (
-    <header className="flex h-14 items-center justify-between border-b border-border/70 bg-background/80 px-6 backdrop-blur">
+    <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border/70 bg-background/70 px-6 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="flex items-center gap-4">
         <div className="hidden items-center gap-2 lg:flex">
-          <span className="h-2 w-2 rounded-full bg-caesium-gold shadow-[0_0_18px_rgba(245,158,11,0.45)]" />
-          <span className="text-[0.62rem] font-medium uppercase tracking-[0.34em] text-muted-foreground">Operator Console</span>
+          <span className="h-2 w-2 rounded-full bg-gold animate-gold-pulse shadow-[0_0_18px_hsl(var(--gold)/0.45)]" />
+          <span className="text-[0.62rem] font-medium uppercase tracking-[0.34em] text-text-3">
+            Operator Console
+          </span>
         </div>
-        <CommandMenu />
+        <Breadcrumb />
       </div>
       <div className="flex items-center gap-2">
+        <CommandMenu />
+        <UTCClock className="hidden md:flex" />
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Notifications"
+          className="text-text-2 hover:text-text-1"
+        >
+          <Bell className="h-4 w-4" />
+        </Button>
         <ModeToggle />
       </div>
     </header>

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -1,42 +1,166 @@
 import { Link } from "@tanstack/react-router";
-import { BarChart, Database, FileCode2, LayoutDashboard, Radio, Server } from "lucide-react";
-import { CaesiumLogo } from "@/components/caesium-logo";
+import {
+  BarChart,
+  Database,
+  FileCode2,
+  LayoutDashboard,
+  Radio,
+  Server,
+  type LucideIcon,
+} from "lucide-react";
+import { AtomLogo } from "@/components/brand/atom-logo";
+import { useNavCounts } from "@/features/jobs/useNavCounts";
+import { useClusterHealth, type ClusterHealthState } from "@/features/system/useClusterHealth";
+import { cn } from "@/lib/utils";
+
+interface NavItem {
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  count: number | null;
+}
+
+const STATE_META: Record<
+  ClusterHealthState,
+  { label: string; dot: string; copy: string }
+> = {
+  operational: {
+    label: "Operational",
+    dot: "bg-success",
+    copy: "All systems nominal",
+  },
+  degraded: {
+    label: "Degraded",
+    dot: "bg-warning animate-gold-pulse",
+    copy: "Investigating one or more checks",
+  },
+  incident: {
+    label: "Incident",
+    dot: "bg-danger",
+    copy: "One or more checks failing",
+  },
+  unknown: {
+    label: "Unknown",
+    dot: "bg-text-4",
+    copy: "Health unavailable",
+  },
+};
+
+function formatUptime(seconds: number | null): string {
+  if (seconds == null) return "—";
+  if (seconds < 60) return `${Math.floor(seconds)}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86_400)}d`;
+}
+
+function CountBadge({ value }: { value: number | null }) {
+  if (value == null) return null;
+  return (
+    <span className="ml-auto inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full border border-graphite bg-obsidian/70 px-1.5 font-mono text-[10px] tabular-nums text-text-2">
+      {value}
+    </span>
+  );
+}
 
 export function Sidebar() {
-  const navItems = [
-    { to: "/jobs", label: "Jobs", icon: LayoutDashboard },
-    { to: "/triggers", label: "Triggers", icon: Radio },
-    { to: "/atoms", label: "Atoms", icon: Database },
-    { to: "/stats", label: "Stats", icon: BarChart },
-    { to: "/system", label: "System", icon: Server },
-    { to: "/jobdefs", label: "JobDefs", icon: FileCode2 },
+  const counts = useNavCounts();
+  const health = useClusterHealth();
+  const stateMeta = STATE_META[health.state];
+
+  const navItems: NavItem[] = [
+    { to: "/jobs", label: "Jobs", icon: LayoutDashboard, count: counts.jobs },
+    { to: "/triggers", label: "Triggers", icon: Radio, count: counts.triggers },
+    { to: "/atoms", label: "Atoms", icon: Database, count: counts.atoms },
+    { to: "/stats", label: "Stats", icon: BarChart, count: null },
+    { to: "/system", label: "System", icon: Server, count: null },
+    { to: "/jobdefs", label: "JobDefs", icon: FileCode2, count: null },
   ];
 
   return (
-    <aside className="flex w-72 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground shadow-2xl shadow-sidebar/30">
-      <div className="border-b border-sidebar-border px-6 py-5">
+    <aside className="relative flex w-64 flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground shadow-2xl shadow-sidebar/30">
+      {/* Gold accent rail on the left edge */}
+      <span
+        aria-hidden="true"
+        className="absolute inset-y-0 left-0 w-[2px] bg-gradient-to-b from-gold/0 via-gold/60 to-gold/0"
+      />
+
+      <div className="border-b border-sidebar-border px-5 py-5">
         <div className="flex items-center gap-3">
-          <CaesiumLogo className="h-10 w-10 shrink-0 drop-shadow-[0_0_24px_rgba(0,180,216,0.35)]" />
+          <AtomLogo size={40} className="shrink-0 drop-shadow-[0_0_24px_hsl(var(--cyan)/0.35)]" />
           <div className="min-w-0">
-            <div className="text-[0.62rem] font-medium uppercase tracking-[0.38em] text-caesium-gold/80">Control Plane</div>
-            <div className="truncate text-lg font-semibold uppercase tracking-[0.34em] text-sidebar-foreground">Caesium</div>
+            <div className="text-[0.62rem] font-medium uppercase tracking-[0.38em] text-gold/80">
+              Control Plane
+            </div>
+            <div className="truncate text-lg font-semibold uppercase tracking-[0.34em] text-sidebar-foreground">
+              Caesium
+            </div>
           </div>
         </div>
       </div>
-      <nav className="flex-1 space-y-2 p-4">
+
+      <nav className="flex-1 space-y-1.5 p-3">
         {navItems.map((item) => (
           <Link
             key={item.to}
             to={item.to}
-            activeProps={{ className: "bg-sidebar-accent text-sidebar-foreground shadow-[inset_0_0_0_1px_rgba(0,180,216,0.25)]" }}
-            inactiveProps={{ className: "text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground" }}
-            className="flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-all"
+            activeProps={{
+              className:
+                "bg-sidebar-accent text-sidebar-foreground shadow-[inset_2px_0_0_hsl(var(--gold))]",
+            }}
+            inactiveProps={{
+              className: "text-sidebar-muted hover:bg-sidebar-accent/50 hover:text-sidebar-foreground",
+            }}
+            className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors"
           >
-            <item.icon className="h-4 w-4 text-caesium-gold" />
-            {item.label}
+            <item.icon className="h-4 w-4 text-gold" />
+            <span>{item.label}</span>
+            <CountBadge value={item.count} />
           </Link>
         ))}
       </nav>
+
+      <ClusterFooter
+        state={health.state}
+        uptimeSeconds={health.uptimeSeconds}
+        stateMeta={stateMeta}
+      />
     </aside>
+  );
+}
+
+interface ClusterFooterProps {
+  state: ClusterHealthState;
+  uptimeSeconds: number | null;
+  stateMeta: (typeof STATE_META)[ClusterHealthState];
+}
+
+function ClusterFooter({ state, uptimeSeconds, stateMeta }: ClusterFooterProps) {
+  if (state === "unknown") {
+    return null;
+  }
+  return (
+    <div className="border-t border-sidebar-border px-4 py-3">
+      <div className="text-[10px] font-medium uppercase tracking-[0.32em] text-text-3">
+        Cluster
+      </div>
+      <dl className="mt-2 space-y-1.5 text-xs">
+        <div className="flex items-center justify-between">
+          <dt className="text-text-3">Status</dt>
+          <dd className="flex items-center gap-1.5 text-text-1">
+            <span className={cn("inline-block h-2 w-2 rounded-full", stateMeta.dot)} />
+            {stateMeta.label}
+          </dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt className="text-text-3">Uptime</dt>
+          <dd className="font-mono tabular-nums text-text-2">{formatUptime(uptimeSeconds)}</dd>
+        </div>
+        <div className="flex items-start justify-between gap-3">
+          <dt className="text-text-3">Health</dt>
+          <dd className="text-right text-[11px] text-text-3">{stateMeta.copy}</dd>
+        </div>
+      </dl>
+    </div>
   );
 }

--- a/ui/src/components/ui/__tests__/empty-state.test.tsx
+++ b/ui/src/components/ui/__tests__/empty-state.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { EmptyState } from "../empty-state";
+
+describe("<EmptyState />", () => {
+  it("renders title + atom motif with no subtitle/action by default", () => {
+    const { container } = render(<EmptyState title="Nothing here" />);
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+    expect(container.querySelector("svg[aria-label='Caesium']")).not.toBeNull();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("renders subtitle and action when provided", () => {
+    render(
+      <EmptyState
+        title="No jobs"
+        subtitle="Apply a job definition to get started."
+        action={<button>Apply</button>}
+      />,
+    );
+    expect(screen.getByText("Apply a job definition to get started.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Apply" })).toBeInTheDocument();
+  });
+
+  it("uses a static atom motif (no animation) so empty states stay calm", () => {
+    const { container } = render(<EmptyState title="Empty" />);
+    const svg = container.querySelector("svg[aria-label='Caesium']");
+    expect(svg?.getAttribute("data-reduced-motion")).toBe("true");
+  });
+
+  it("accepts a custom icon override", () => {
+    render(<EmptyState title="No data" icon={<span data-testid="custom" />} />);
+    expect(screen.getByTestId("custom")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/__tests__/sparkline.test.tsx
+++ b/ui/src/components/ui/__tests__/sparkline.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { act, render } from "@testing-library/react";
+import { Sparkline } from "../sparkline";
+
+function flushAnimationFrame() {
+  return act(async () => {
+    await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+  });
+}
+
+describe("<Sparkline />", () => {
+  it("renders a placeholder dash for an empty run list", () => {
+    const { container } = render(<Sparkline runs={[]} />);
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.textContent).toContain("—");
+  });
+
+  it("lazy-renders after the first animation frame", async () => {
+    const runs = [
+      { status: "succeeded", duration: 30 },
+      { status: "failed", duration: 12 },
+      { status: "running" },
+    ];
+    const { container } = render(<Sparkline runs={runs} />);
+    expect(container.querySelector("svg")).toBeNull();
+    await flushAnimationFrame();
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.querySelectorAll("rect").length).toBe(3);
+  });
+
+  it("animates running bars only", async () => {
+    const runs = [
+      { status: "succeeded", duration: 10 },
+      { status: "running" },
+    ];
+    const { container } = render(<Sparkline runs={runs} />);
+    await flushAnimationFrame();
+    const animates = container.querySelectorAll("animate");
+    expect(animates.length).toBe(1);
+  });
+});

--- a/ui/src/components/ui/__tests__/status-badge.test.tsx
+++ b/ui/src/components/ui/__tests__/status-badge.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { StatusBadge } from "../status-badge";
+import { ALL_RUN_STATUSES } from "@/lib/status";
+
+describe("<StatusBadge />", () => {
+  it("renders every canonical status with the expected label", () => {
+    for (const status of ALL_RUN_STATUSES) {
+      const { container, unmount } = render(<StatusBadge status={status} />);
+      const badge = container.querySelector(`[data-status="${status}"]`);
+      expect(badge).not.toBeNull();
+      expect(badge?.textContent).toContain(status);
+      unmount();
+    }
+  });
+
+  it("supports filled, soft, and dot variants", () => {
+    const { container, rerender } = render(<StatusBadge status="running" variant="filled" />);
+    expect(container.querySelector('[data-variant="filled"]')).not.toBeNull();
+
+    rerender(<StatusBadge status="running" variant="soft" />);
+    expect(container.querySelector('[data-variant="soft"]')).not.toBeNull();
+
+    rerender(<StatusBadge status="running" variant="dot" />);
+    // dot variant has no [data-variant] attribute on the wrapper
+    expect(container.querySelector('[data-variant]')).toBeNull();
+    expect(container.querySelector('[data-status="running"]')).not.toBeNull();
+  });
+
+  it("falls back to 'unknown' for unrecognized statuses", () => {
+    render(<StatusBadge status="nonsense" />);
+    expect(screen.getByText("unknown")).toBeInTheDocument();
+  });
+
+  it("respects an explicit label override", () => {
+    render(<StatusBadge status="succeeded" label="Done" />);
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/__tests__/usage-bar.test.tsx
+++ b/ui/src/components/ui/__tests__/usage-bar.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { UsageBar } from "../usage-bar";
+import { USAGE_THRESHOLDS } from "@/lib/thresholds";
+
+describe("<UsageBar />", () => {
+  it("tints below the warn threshold as 'ok'", () => {
+    const { container } = render(<UsageBar value={USAGE_THRESHOLDS.warn - 1} label="CPU" />);
+    expect(container.querySelector("[data-level='ok']")).not.toBeNull();
+  });
+
+  it("tints between warn and danger as 'warn'", () => {
+    const { container } = render(<UsageBar value={USAGE_THRESHOLDS.warn} />);
+    expect(container.querySelector("[data-level='warn']")).not.toBeNull();
+    const { container: c2 } = render(<UsageBar value={USAGE_THRESHOLDS.danger - 1} />);
+    expect(c2.querySelector("[data-level='warn']")).not.toBeNull();
+  });
+
+  it("tints at or above danger as 'danger'", () => {
+    const { container } = render(<UsageBar value={USAGE_THRESHOLDS.danger} />);
+    expect(container.querySelector("[data-level='danger']")).not.toBeNull();
+    const { container: c2 } = render(<UsageBar value={120} />);
+    expect(c2.querySelector("[data-level='danger']")).not.toBeNull();
+  });
+
+  it("clamps out-of-range values into [0, 100]", () => {
+    render(<UsageBar value={-50} label="CPU" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.getAttribute("aria-valuenow")).toBe("0");
+
+    render(<UsageBar value={500} label="MEM" />);
+    const bars = screen.getAllByRole("progressbar");
+    expect(bars[bars.length - 1].getAttribute("aria-valuenow")).toBe("100");
+  });
+
+  it("exposes label + value to assistive tech", () => {
+    render(<UsageBar value={42.7} label="CPU" />);
+    const bar = screen.getByRole("progressbar", { name: "CPU" });
+    expect(bar.getAttribute("aria-valuenow")).toBe("42.7");
+    expect(bar.getAttribute("aria-valuetext")).toBe("43 percent");
+  });
+});

--- a/ui/src/components/ui/__tests__/utc-clock.test.tsx
+++ b/ui/src/components/ui/__tests__/utc-clock.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render } from "@testing-library/react";
+import { UTCClock, UTCClockProvider } from "../utc-clock";
+
+describe("<UTCClock />", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(Date.UTC(2025, 0, 1, 12, 34, 56)));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the current UTC time padded to HH:MM:SS", () => {
+    const { container } = render(<UTCClock />);
+    expect(container.textContent).toContain("12:34:56 UTC");
+  });
+
+  it("ticks once per second when running standalone", () => {
+    const { container } = render(<UTCClock />);
+    expect(container.textContent).toContain("12:34:56");
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(container.textContent).toContain("12:34:57");
+  });
+
+  it("multiple clocks under one provider read from the same tick", () => {
+    const { container } = render(
+      <UTCClockProvider>
+        <UTCClock />
+        <UTCClock />
+        <UTCClock />
+      </UTCClockProvider>,
+    );
+    const texts = Array.from(container.querySelectorAll("span.font-mono")).map(
+      (n) => n.textContent,
+    );
+    expect(new Set(texts).size).toBe(1);
+  });
+
+  it("hides the gold pulse dot when hideDot is set", () => {
+    const { container } = render(<UTCClock hideDot />);
+    expect(container.querySelector(".animate-gold-pulse")).toBeNull();
+  });
+});

--- a/ui/src/components/ui/empty-state.tsx
+++ b/ui/src/components/ui/empty-state.tsx
@@ -1,0 +1,43 @@
+import { type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { AtomLogo } from "@/components/brand/atom-logo";
+
+interface EmptyStateProps {
+  title: string;
+  subtitle?: string;
+  action?: ReactNode;
+  /** Override the default atom-motif graphic. */
+  icon?: ReactNode;
+  className?: string;
+}
+
+/**
+ * Stock empty-state surface. Uses a static AtomLogo as the motif so the page
+ * stays calm; no spinning logos for "nothing here yet."
+ */
+export function EmptyState({
+  title,
+  subtitle,
+  action,
+  icon,
+  className,
+}: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        "flex flex-col items-center justify-center gap-3.5 px-5 py-16 text-center",
+        className,
+      )}
+    >
+      <div className="opacity-70">
+        {icon ?? <AtomLogo size={80} animated={false} />}
+      </div>
+      <div className="text-base font-medium text-text-1">{title}</div>
+      {subtitle ? (
+        <div className="max-w-sm text-[13px] text-text-3">{subtitle}</div>
+      ) : null}
+      {action ? <div className="pt-1">{action}</div> : null}
+    </div>
+  );
+}

--- a/ui/src/components/ui/sparkline.tsx
+++ b/ui/src/components/ui/sparkline.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
+import { statusMeta } from "@/lib/status";
+
+export interface RunSummary {
+  status: string;
+  /** Run duration in seconds. May be missing for in-flight runs. */
+  duration?: number | null;
+}
+
+interface SparklineProps {
+  /** Run history, oldest → newest. The component renders newest on the right. */
+  runs: RunSummary[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+/**
+ * Compact run-history sparkline. Each bar's height encodes duration
+ * relative to the max in the window; bar color = `statusMeta(status).fg`.
+ *
+ * Lazy-renders a single frame after mount so it never blocks initial paint.
+ * Pass an empty array to render the placeholder dash.
+ */
+export function Sparkline({
+  runs,
+  width = 90,
+  height = 22,
+  className,
+}: SparklineProps) {
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setReady(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  if (!runs || runs.length === 0) {
+    return (
+      <span
+        aria-label="no runs"
+        className={cn("inline-flex items-center text-[11px] text-text-4", className)}
+      >
+        —
+      </span>
+    );
+  }
+
+  if (!ready) {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn("inline-block", className)}
+        style={{ width, height }}
+      />
+    );
+  }
+
+  const max = Math.max(...runs.map((r) => r.duration ?? 0), 60);
+  const count = runs.length;
+  const gap = 2;
+  const barWidth = Math.max(1, (width - (count - 1) * gap) / count);
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      role="img"
+      aria-label={`${count} recent runs`}
+      className={cn("block", className)}
+    >
+      {runs.map((run, idx) => {
+        const meta = statusMeta(run.status);
+        const isRunning = meta.label === "running";
+        const value = isRunning ? height * 0.6 : Math.max(3, ((run.duration ?? 0) / max) * height);
+        return (
+          <rect
+            key={idx}
+            x={idx * (barWidth + gap)}
+            y={height - value}
+            width={barWidth}
+            height={value}
+            rx={1.5}
+            fill={meta.fg}
+            opacity={isRunning ? 0.95 : 0.85}
+          >
+            {isRunning ? (
+              <animate
+                attributeName="opacity"
+                values="0.6;1;0.6"
+                dur="1.4s"
+                repeatCount="indefinite"
+              />
+            ) : null}
+          </rect>
+        );
+      })}
+    </svg>
+  );
+}

--- a/ui/src/components/ui/sparkline.tsx
+++ b/ui/src/components/ui/sparkline.tsx
@@ -56,7 +56,7 @@ export function Sparkline({
     );
   }
 
-  const max = Math.max(...runs.map((r) => r.duration ?? 0), 60);
+  const max = runs.reduce((acc, r) => Math.max(acc, r.duration ?? 0), 60);
   const count = runs.length;
   const gap = 2;
   const barWidth = Math.max(1, (width - (count - 1) * gap) / count);

--- a/ui/src/components/ui/status-badge.tsx
+++ b/ui/src/components/ui/status-badge.tsx
@@ -1,0 +1,84 @@
+import { type CSSProperties } from "react";
+import { cn } from "@/lib/utils";
+import { statusMeta } from "@/lib/status";
+
+export type StatusBadgeVariant = "filled" | "soft" | "dot";
+export type StatusBadgeSize = "sm" | "md";
+
+interface StatusBadgeProps {
+  status: string;
+  variant?: StatusBadgeVariant;
+  size?: StatusBadgeSize;
+  /** Override the rendered label; defaults to the canonical status label. */
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Status pill backed by `statusMeta`. Three visual variants:
+ * - `filled` (default): tinted background + matching border
+ * - `soft`: transparent background, colored text only
+ * - `dot`: dot + label, no chrome
+ */
+export function StatusBadge({
+  status,
+  variant = "filled",
+  size = "md",
+  label,
+  className,
+}: StatusBadgeProps) {
+  const meta = statusMeta(status);
+  const text = label ?? meta.label;
+
+  const sizing =
+    size === "sm"
+      ? "px-1.5 py-[2px] text-[10px]"
+      : "px-2 py-[3px] text-[11px]";
+  const dotSize = size === "sm" ? "h-1.5 w-1.5" : "h-2 w-2";
+
+  if (variant === "dot") {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center gap-1.5 font-medium uppercase tracking-[0.04em]",
+          size === "sm" ? "text-[10px]" : "text-[11px]",
+          className,
+        )}
+        style={{ color: meta.fg }}
+        data-status={meta.label}
+      >
+        <span
+          aria-hidden="true"
+          className={cn("inline-block rounded-full", dotSize, meta.dotClass)}
+          style={{ backgroundColor: meta.fg }}
+        />
+        {text}
+      </span>
+    );
+  }
+
+  const fill: CSSProperties =
+    variant === "soft"
+      ? { color: meta.fg, backgroundColor: "transparent", borderColor: "transparent" }
+      : { color: meta.fg, backgroundColor: meta.bg, borderColor: meta.border };
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border font-semibold uppercase tracking-[0.04em] whitespace-nowrap",
+        sizing,
+        className,
+      )}
+      style={fill}
+      data-status={meta.label}
+      data-variant={variant}
+    >
+      <span
+        aria-hidden="true"
+        className={cn("inline-block rounded-full", dotSize, meta.dotClass)}
+        style={{ backgroundColor: meta.fg }}
+      />
+      {text}
+    </span>
+  );
+}

--- a/ui/src/components/ui/usage-bar.tsx
+++ b/ui/src/components/ui/usage-bar.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@/lib/utils";
+import { USAGE_THRESHOLDS, usageLevel, type UsageLevel } from "@/lib/thresholds";
+
+interface UsageBarProps {
+  /** Value in `[0, 100]`. Out-of-range values are clamped. */
+  value: number;
+  /** Optional inline label rendered above the bar (e.g. `"CPU"`). */
+  label?: string;
+  /** Render the numeric percent next to the bar. Defaults to `true`. */
+  showValue?: boolean;
+  className?: string;
+  /** Pixel height of the bar track. Defaults to `6`. */
+  height?: number;
+}
+
+const LEVEL_FILL: Record<UsageLevel, string> = {
+  ok: "hsl(var(--success))",
+  warn: "hsl(var(--warning))",
+  danger: "hsl(var(--danger))",
+};
+
+/**
+ * Horizontal usage bar (CPU, memory, disk). Tints by `USAGE_THRESHOLDS`
+ * (warn / danger) so the same color story applies everywhere.
+ */
+export function UsageBar({
+  value,
+  label,
+  showValue = true,
+  className,
+  height = 6,
+}: UsageBarProps) {
+  const clamped = Math.max(0, Math.min(100, value));
+  const level = usageLevel(clamped);
+  const fill = LEVEL_FILL[level];
+
+  return (
+    <div className={cn("flex flex-col gap-1", className)} data-level={level}>
+      {label || showValue ? (
+        <div className="flex items-baseline justify-between gap-3 text-[11px]">
+          {label ? <span className="text-text-3">{label}</span> : <span />}
+          {showValue ? (
+            <span className="font-mono tabular-nums text-text-2">
+              {clamped.toFixed(0)}%
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={clamped}
+        aria-valuetext={`${clamped.toFixed(0)} percent`}
+        aria-label={label}
+        className="w-full overflow-hidden rounded-full bg-graphite/60"
+        style={{ height }}
+      >
+        <div
+          className="h-full rounded-full transition-[width] duration-500"
+          style={{ width: `${clamped}%`, backgroundColor: fill }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export { USAGE_THRESHOLDS };

--- a/ui/src/components/ui/utc-clock.tsx
+++ b/ui/src/components/ui/utc-clock.tsx
@@ -1,0 +1,78 @@
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+const TickContext = createContext<Date | null>(null);
+
+/**
+ * Provides a shared "ticking now()" to every `<UTCClock />` and any future
+ * clock-driven primitive — so we never fan out a `setInterval` per consumer.
+ *
+ * Mount once near the app root. Consumers that don't have the provider above
+ * them will fall back to a local timer.
+ */
+export function UTCClockProvider({
+  children,
+  intervalMs = 1000,
+}: {
+  children: ReactNode;
+  intervalMs?: number;
+}) {
+  const [now, setNow] = useState<Date>(() => new Date());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(new Date()), intervalMs);
+    return () => window.clearInterval(id);
+  }, [intervalMs]);
+  return <TickContext.Provider value={now}>{children}</TickContext.Provider>;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function formatUTC(date: Date): string {
+  return `${pad(date.getUTCHours())}:${pad(date.getUTCMinutes())}:${pad(date.getUTCSeconds())}`;
+}
+
+interface UTCClockProps {
+  className?: string;
+  /** Suppress the gold pulse dot. Useful in dense layouts. */
+  hideDot?: boolean;
+}
+
+export function UTCClock({ className, hideDot = false }: UTCClockProps) {
+  const ctxNow = useContext(TickContext);
+  const hasProvider = ctxNow !== null;
+  const [localNow, setLocalNow] = useState<Date>(() => new Date());
+
+  // When a provider is mounted above us we let it drive the tick; otherwise
+  // we run our own interval.
+  useEffect(() => {
+    if (hasProvider) return;
+    const id = window.setInterval(() => setLocalNow(new Date()), 1000);
+    return () => window.clearInterval(id);
+  }, [hasProvider]);
+
+  const now = ctxNow ?? localNow;
+  const text = useMemo(() => formatUTC(now), [now]);
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      {hideDot ? null : (
+        <span
+          aria-hidden="true"
+          className="inline-block h-[7px] w-[7px] rounded-full bg-gold animate-gold-pulse shadow-[0_0_12px_hsl(var(--gold)/0.7)]"
+        />
+      )}
+      <span className="font-mono tabular-nums text-[11px] tracking-[0.12em] text-text-2">
+        {text} UTC
+      </span>
+    </div>
+  );
+}

--- a/ui/src/features/jobs/useNavCounts.ts
+++ b/ui/src/features/jobs/useNavCounts.ts
@@ -1,0 +1,54 @@
+import { useQueries } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+const REFETCH_MS = 30_000;
+
+export interface NavCounts {
+  jobs: number | null;
+  triggers: number | null;
+  atoms: number | null;
+}
+
+/**
+ * Aggregates the counts shown in the sidebar nav badges.
+ *
+ * The execution plan (§0.5) calls for a single batched query against
+ * `GET /v1/jobs?count_only=true` per route. That endpoint does not exist
+ * yet — until it does, we fall back to the existing list endpoints and
+ * count their length client-side.
+ *
+ * API gap (tracked in `docs/ui-refresh-execution-plan.md` §"API gap summary"):
+ *   - `GET /v1/jobs?count_only=true`
+ *   - `GET /v1/jobs/summary` (status counts, used by 1.1)
+ */
+export function useNavCounts(): NavCounts {
+  const results = useQueries({
+    queries: [
+      {
+        queryKey: ["nav-counts", "jobs"],
+        queryFn: api.getJobs,
+        refetchInterval: REFETCH_MS,
+        staleTime: REFETCH_MS / 2,
+      },
+      {
+        queryKey: ["nav-counts", "triggers"],
+        queryFn: api.getTriggers,
+        refetchInterval: REFETCH_MS,
+        staleTime: REFETCH_MS / 2,
+      },
+      {
+        queryKey: ["nav-counts", "atoms"],
+        queryFn: api.getAtoms,
+        refetchInterval: REFETCH_MS,
+        staleTime: REFETCH_MS / 2,
+      },
+    ],
+  });
+
+  const [jobs, triggers, atoms] = results;
+  return {
+    jobs: jobs.data ? jobs.data.length : null,
+    triggers: triggers.data ? triggers.data.length : null,
+    atoms: atoms.data ? atoms.data.length : null,
+  };
+}

--- a/ui/src/features/system/useClusterHealth.ts
+++ b/ui/src/features/system/useClusterHealth.ts
@@ -1,0 +1,56 @@
+import { useQuery } from "@tanstack/react-query";
+import { api, type HealthResponse } from "@/lib/api";
+
+const REFETCH_MS = 15_000;
+
+export type ClusterHealthState = "operational" | "degraded" | "incident" | "unknown";
+
+export interface ClusterHealth {
+  state: ClusterHealthState;
+  uptimeSeconds: number | null;
+  raw: HealthResponse | null;
+}
+
+const KNOWN_HEALTHY = new Set(["ok", "healthy", "operational", "ready", "up"]);
+const KNOWN_DEGRADED = new Set(["degraded", "warning", "warn"]);
+
+function classify(status: string | undefined): ClusterHealthState {
+  if (!status) return "unknown";
+  const key = status.toLowerCase();
+  if (KNOWN_HEALTHY.has(key)) return "operational";
+  if (KNOWN_DEGRADED.has(key)) return "degraded";
+  if (key === "down" || key === "incident" || key === "error" || key === "failed") {
+    return "incident";
+  }
+  return "unknown";
+}
+
+/**
+ * Polls `/v1/system/health` (via `api.getHealth`) every 15s.
+ *
+ * Returns `{ state: 'unknown' }` until a response lands or if the endpoint
+ * fails — callers gate the cluster footer on `state !== 'unknown'`.
+ *
+ * The plan's stub fallback is here intentionally: when the new
+ * `/v1/system/health` shape lands (Phase 3.1), we'll widen the typing without
+ * breaking the consumer surface.
+ */
+export function useClusterHealth(): ClusterHealth {
+  const { data, isError } = useQuery({
+    queryKey: ["cluster-health"],
+    queryFn: api.getHealth,
+    refetchInterval: REFETCH_MS,
+    staleTime: REFETCH_MS / 2,
+    retry: 1,
+  });
+
+  if (isError || !data) {
+    return { state: "unknown", uptimeSeconds: null, raw: null };
+  }
+
+  return {
+    state: classify(data.status),
+    uptimeSeconds: typeof data.uptime === "number" ? data.uptime : null,
+    raw: data,
+  };
+}

--- a/ui/src/features/system/useClusterHealth.ts
+++ b/ui/src/features/system/useClusterHealth.ts
@@ -26,19 +26,24 @@ function classify(status: string | undefined): ClusterHealthState {
 }
 
 /**
- * Polls `/v1/system/health` (via `api.getHealth`) every 15s.
+ * Polls `/health` every 15s and classifies the cluster state.
  *
- * Returns `{ state: 'unknown' }` until a response lands or if the endpoint
- * fails — callers gate the cluster footer on `state !== 'unknown'`.
+ * Uses `api.getHealthStatus` (non-throwing variant) so HTTP 503 responses
+ * from the server — which signal degraded or incident health — still deliver
+ * a parseable JSON body. `api.getHealth` throws on any non-2xx, making those
+ * states invisible and silently falling back to `unknown`.
  *
- * The plan's stub fallback is here intentionally: when the new
- * `/v1/system/health` shape lands (Phase 3.1), we'll widen the typing without
- * breaking the consumer surface.
+ * `data.uptime` is a Go `time.Duration` (nanoseconds); divide by 1e9 to get
+ * seconds, matching the conversion in `SystemPage.tsx`.
+ *
+ * Returns `{ state: 'unknown' }` only on genuine network failure or when no
+ * response has arrived yet. Callers gate the cluster footer on
+ * `state !== 'unknown'`.
  */
 export function useClusterHealth(): ClusterHealth {
   const { data, isError } = useQuery({
     queryKey: ["cluster-health"],
-    queryFn: api.getHealth,
+    queryFn: api.getHealthStatus,
     refetchInterval: REFETCH_MS,
     staleTime: REFETCH_MS / 2,
     retry: 1,
@@ -50,7 +55,7 @@ export function useClusterHealth(): ClusterHealth {
 
   return {
     state: classify(data.status),
-    uptimeSeconds: typeof data.uptime === "number" ? data.uptime : null,
+    uptimeSeconds: typeof data.uptime === "number" ? data.uptime / 1e9 : null,
     raw: data,
   };
 }

--- a/ui/src/hooks/useReducedMotion.ts
+++ b/ui/src/hooks/useReducedMotion.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+/**
+ * Subscribes to the `prefers-reduced-motion: reduce` media query.
+ * Returns `true` when the user has asked the OS to minimize motion.
+ *
+ * Components that use this should fall back to a static rendering — never
+ * a "lite" animation; reduced motion means *no* motion.
+ */
+export function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia(QUERY).matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(QUERY);
+    const handler = (event: MediaQueryListEvent) => setReduced(event.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return reduced;
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -21,34 +21,68 @@
 
     --card: 0 0% 100%;
     --card-foreground: 235 24% 12%;
- 
+
     --popover: 0 0% 100%;
     --popover-foreground: 235 24% 12%;
- 
+
     --primary: 191 100% 42%;
     --primary-foreground: 240 33% 4%;
- 
+
     --secondary: 205 50% 94%;
     --secondary-foreground: 235 24% 12%;
- 
+
     --muted: 205 38% 93%;
     --muted-foreground: 228 14% 41%;
- 
+
     --accent: 38 92% 50%;
     --accent-foreground: 240 33% 4%;
- 
+
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 205 30% 87%;
     --input: 205 30% 87%;
     --ring: 191 100% 42%;
- 
+
     --radius: 0.5rem;
 
     --caesium-cyan: 191 100% 42%;
     --caesium-gold: 38 92% 50%;
     --caesium-void: 240 33% 4%;
+
+    /* Brand surfaces (light values; dark values override below) */
+    --void: 210 30% 98%;
+    --midnight: 0 0% 100%;
+    --obsidian: 210 25% 96%;
+    --graphite: 210 20% 91%;
+    --silt: 210 18% 84%;
+
+    /* Brand accent extensions */
+    --cyan: 191 100% 35%;
+    --cyan-glow: 191 100% 42%;
+    --cyan-dim: 191 80% 35%;
+    --gold: 38 92% 50%;
+    --gold-dim: 38 80% 42%;
+
+    /* Text levels */
+    --text-1: 235 30% 12%;
+    --text-2: 228 14% 38%;
+    --text-3: 220 10% 50%;
+    --text-4: 220 12% 70%;
+
+    /* Status semantic tokens */
+    --success: 152 65% 38%;
+    --warning: 38 92% 50%;
+    --danger: 0 78% 52%;
+    --running: 191 100% 42%;
+    --cached: 178 60% 42%;
+
+    /* Chart palette — maps shadcn chart-* names onto brand tones */
+    --chart-1: 191 100% 42%;
+    --chart-2: 38 92% 50%;
+    --chart-3: 152 65% 38%;
+    --chart-4: 0 78% 52%;
+    --chart-5: 178 60% 42%;
 
     /* Sidebar */
     --sidebar: 215 30% 97%;
@@ -79,7 +113,7 @@
     --popover: 240 24% 7%;
     --popover-foreground: 210 40% 96%;
 
-    --primary: 191 100% 42%;
+    --primary: 191 100% 47%;
     --primary-foreground: 240 33% 4%;
 
     --secondary: 236 19% 15%;
@@ -88,15 +122,49 @@
     --muted: 236 18% 18%;
     --muted-foreground: 220 12% 68%;
 
-    --accent: 38 92% 50%;
+    --accent: 38 92% 56%;
     --accent-foreground: 240 33% 4%;
 
-    --destructive: 0 62.8% 30.6%;
+    --destructive: 0 78% 62%;
     --destructive-foreground: 210 40% 98%;
 
     --border: 236 18% 16%;
     --input: 236 18% 16%;
-    --ring: 191 100% 42%;
+    --ring: 191 100% 47%;
+
+    /* Brand surfaces */
+    --void: 240 33% 4%;
+    --midnight: 240 25% 7%;
+    --obsidian: 240 18% 11%;
+    --graphite: 240 14% 17%;
+    --silt: 240 10% 22%;
+
+    /* Brand accent extensions */
+    --cyan: 191 100% 47%;
+    --cyan-glow: 191 100% 60%;
+    --cyan-dim: 191 80% 35%;
+    --gold: 38 92% 56%;
+    --gold-dim: 38 80% 42%;
+
+    /* Text levels */
+    --text-1: 210 40% 96%;
+    --text-2: 220 14% 72%;
+    --text-3: 220 12% 50%;
+    --text-4: 220 14% 32%;
+
+    /* Status semantic tokens */
+    --success: 152 65% 45%;
+    --warning: 38 92% 56%;
+    --danger: 0 78% 62%;
+    --running: 191 100% 50%;
+    --cached: 178 60% 50%;
+
+    /* Chart palette */
+    --chart-1: 191 100% 60%;
+    --chart-2: 38 92% 56%;
+    --chart-3: 152 65% 45%;
+    --chart-4: 0 78% 62%;
+    --chart-5: 178 60% 50%;
 
     /* Sidebar */
     --sidebar: 240 33% 4%;
@@ -147,6 +215,31 @@
 @layer utilities {
   .fill-caesium-gold {
     fill: hsl(var(--caesium-gold));
+  }
+}
+
+/* ── Brand motion ── */
+@keyframes orbit-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+@keyframes nucleus-pulse {
+  0%, 100% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.18); opacity: 0.85; }
+}
+@keyframes cyan-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 hsl(var(--cyan) / 0.55), 0 0 14px 0 hsl(var(--cyan) / 0.5); }
+  70% { box-shadow: 0 0 0 9px hsl(var(--cyan) / 0), 0 0 14px 0 hsl(var(--cyan) / 0.5); }
+}
+@keyframes gold-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 hsl(var(--gold) / 0.55), 0 0 12px 0 hsl(var(--gold) / 0.4); }
+  70% { box-shadow: 0 0 0 8px hsl(var(--gold) / 0), 0 0 12px 0 hsl(var(--gold) / 0.4); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .atom-orbit, .atom-nucleus,
+  .pulse-cyan, .pulse-gold {
+    animation: none !important;
   }
 }
 

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -237,8 +237,14 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .atom-orbit, .atom-nucleus,
-  .pulse-cyan, .pulse-gold {
+  /* AtomLogo JS-driven animation classes */
+  .atom-orbit,
+  .atom-nucleus,
+  /* Tailwind utility classes generated from tailwind.config.js keyframes */
+  .animate-orbit-spin,
+  .animate-nucleus-pulse,
+  .animate-cyan-pulse,
+  .animate-gold-pulse {
     animation: none !important;
   }
 }

--- a/ui/src/lib/__tests__/status.test.ts
+++ b/ui/src/lib/__tests__/status.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { ALL_RUN_STATUSES, statusMeta } from "../status";
+
+describe("statusMeta", () => {
+  it("returns a stable shape for every canonical status", () => {
+    for (const status of ALL_RUN_STATUSES) {
+      const meta = statusMeta(status);
+      expect(meta.label).toBe(status);
+      expect(meta.fg).toMatch(/^hsl\(/);
+      expect(meta.bg).toMatch(/^hsl\(/);
+      expect(meta.border).toMatch(/^hsl\(/);
+      expect(typeof meta.dotClass).toBe("string");
+    }
+  });
+
+  it("animates only running and paused dots", () => {
+    expect(statusMeta("running").dotClass).toContain("cyan-pulse");
+    expect(statusMeta("paused").dotClass).toContain("gold-pulse");
+    expect(statusMeta("succeeded").dotClass).toBe("");
+    expect(statusMeta("failed").dotClass).toBe("");
+    expect(statusMeta("queued").dotClass).toBe("");
+    expect(statusMeta("cached").dotClass).toBe("");
+    expect(statusMeta("skipped").dotClass).toBe("");
+  });
+
+  it("normalizes common aliases to canonical statuses", () => {
+    expect(statusMeta("success").label).toBe("succeeded");
+    expect(statusMeta("ERROR").label).toBe("failed");
+    expect(statusMeta("Cancelled").label).toBe("failed");
+    expect(statusMeta("pending").label).toBe("queued");
+    expect(statusMeta("active").label).toBe("running");
+  });
+
+  it("falls back to a neutral 'unknown' meta", () => {
+    const fallback = statusMeta("definitely-not-a-status");
+    expect(fallback.label).toBe("unknown");
+    expect(fallback.fg).toMatch(/^hsl\(/);
+  });
+
+  it("handles null / undefined / empty input", () => {
+    expect(statusMeta(null).label).toBe("unknown");
+    expect(statusMeta(undefined).label).toBe("unknown");
+    expect(statusMeta("").label).toBe("unknown");
+  });
+});

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -393,6 +393,25 @@ export const api = {
   deleteAtom: (id: string) => request<void>(`/atoms/${id}`, { method: "DELETE" }),
   getStats: () => request<StatsResponse>("/stats"),
   getHealth: () => requestURL<HealthResponse>("/health"),
+  /**
+   * Like `getHealth` but reads the response body on any non-401 status code.
+   * The server returns HTTP 503 for degraded/incident states, which causes
+   * `requestURL` (and therefore `getHealth`) to throw — making those states
+   * unobservable. This variant is used by `useClusterHealth` so the sidebar
+   * can display degraded and incident states rather than falling back to
+   * `unknown` on every non-2xx response.
+   */
+  getHealthStatus: async (): Promise<HealthResponse> => {
+    const headers = withAuthHeaders({ "Content-Type": "application/json" });
+    const response = await fetch("/health", { headers });
+    if (response.status === 401) {
+      clearApiKey();
+      throw new ApiError(401, "Authentication required");
+    }
+    const text = await response.text();
+    if (!text) throw new ApiError(response.status, "Empty health response");
+    return JSON.parse(text) as HealthResponse;
+  },
   getDatabaseSchema: () => request<DatabaseSchemaResponse>("/database/schema"),
   queryDatabase: (body: DatabaseQueryRequest) =>
     request<DatabaseQueryResponse>("/database/query", {

--- a/ui/src/lib/status.ts
+++ b/ui/src/lib/status.ts
@@ -1,0 +1,140 @@
+/**
+ * Canonical status semantics for the operator console.
+ *
+ * Every status-tinted surface (badges, dots, sparkline tints, log-level chips,
+ * DAG edge colors, table row borders) reads from `statusMeta(status)`.
+ * Per-component color literals are a refactoring target; new code must call
+ * this helper rather than hard-coding a color.
+ */
+
+export type RunStatus =
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "queued"
+  | "paused"
+  | "cached"
+  | "skipped";
+
+export interface StatusMeta {
+  /** Lowercase display label, e.g. "running". */
+  label: string;
+  /** Foreground (text) color as a CSS `hsl(...)` expression. */
+  fg: string;
+  /** Background tint as a CSS `hsl(...)` expression (low alpha). */
+  bg: string;
+  /** Border / outline color as a CSS `hsl(...)` expression. */
+  border: string;
+  /**
+   * Animation class name (or empty string).
+   * Pulse animations are scoped to active states (`running`, `paused`).
+   */
+  dotClass: string;
+}
+
+const META: Record<RunStatus, StatusMeta> = {
+  running: {
+    label: "running",
+    fg: "hsl(var(--cyan-glow))",
+    bg: "hsl(var(--running) / 0.14)",
+    border: "hsl(var(--running) / 0.4)",
+    dotClass: "animate-cyan-pulse",
+  },
+  succeeded: {
+    label: "succeeded",
+    fg: "hsl(var(--success))",
+    bg: "hsl(var(--success) / 0.12)",
+    border: "hsl(var(--success) / 0.3)",
+    dotClass: "",
+  },
+  failed: {
+    label: "failed",
+    fg: "hsl(var(--danger))",
+    bg: "hsl(var(--danger) / 0.12)",
+    border: "hsl(var(--danger) / 0.35)",
+    dotClass: "",
+  },
+  queued: {
+    label: "queued",
+    fg: "hsl(var(--text-2))",
+    bg: "hsl(var(--text-3) / 0.12)",
+    border: "hsl(var(--text-3) / 0.25)",
+    dotClass: "",
+  },
+  paused: {
+    label: "paused",
+    fg: "hsl(var(--gold))",
+    bg: "hsl(var(--gold) / 0.12)",
+    border: "hsl(var(--gold) / 0.35)",
+    dotClass: "animate-gold-pulse",
+  },
+  cached: {
+    label: "cached",
+    fg: "hsl(var(--cached))",
+    bg: "hsl(var(--cached) / 0.12)",
+    border: "hsl(var(--cached) / 0.3)",
+    dotClass: "",
+  },
+  skipped: {
+    label: "skipped",
+    fg: "hsl(var(--text-3))",
+    bg: "hsl(var(--text-4) / 0.18)",
+    border: "hsl(var(--text-4) / 0.3)",
+    dotClass: "",
+  },
+};
+
+const UNKNOWN: StatusMeta = {
+  label: "unknown",
+  fg: "hsl(var(--text-3))",
+  bg: "hsl(var(--text-4) / 0.18)",
+  border: "hsl(var(--text-4) / 0.3)",
+  dotClass: "",
+};
+
+const ALIASES: Record<string, RunStatus> = {
+  success: "succeeded",
+  succeeded: "succeeded",
+  ok: "succeeded",
+  fail: "failed",
+  failed: "failed",
+  error: "failed",
+  errored: "failed",
+  cancelled: "failed",
+  canceled: "failed",
+  pending: "queued",
+  waiting: "queued",
+  scheduled: "queued",
+  active: "running",
+  in_progress: "running",
+  running: "running",
+  paused: "paused",
+  cached: "cached",
+  hit: "cached",
+  skipped: "skipped",
+  skip: "skipped",
+  queued: "queued",
+};
+
+/**
+ * Resolve a status string (or unknown enum) to its visual treatment.
+ * Falls back to a neutral grey for anything we don't recognize.
+ */
+export function statusMeta(status: string | null | undefined): StatusMeta {
+  if (!status) return UNKNOWN;
+  const key = String(status).trim().toLowerCase();
+  if (key in META) return META[key as RunStatus];
+  const aliased = ALIASES[key];
+  if (aliased) return META[aliased];
+  return UNKNOWN;
+}
+
+export const ALL_RUN_STATUSES: RunStatus[] = [
+  "running",
+  "succeeded",
+  "failed",
+  "queued",
+  "paused",
+  "cached",
+  "skipped",
+];

--- a/ui/src/lib/thresholds.ts
+++ b/ui/src/lib/thresholds.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared threshold constants for usage-style indicators.
+ *
+ * `<UsageBar />` and any other component that tints a value by intensity
+ * pulls from this file so we have one place to tune the boundaries.
+ */
+export const USAGE_THRESHOLDS = {
+  /** Below this, the bar reads as healthy. */
+  warn: 65,
+  /** At or above this, the bar reads as critical. */
+  danger: 85,
+} as const;
+
+export type UsageLevel = "ok" | "warn" | "danger";
+
+export function usageLevel(percent: number): UsageLevel {
+  if (percent >= USAGE_THRESHOLDS.danger) return "danger";
+  if (percent >= USAGE_THRESHOLDS.warn) return "warn";
+  return "ok";
+}

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -59,6 +59,38 @@ export default {
           gold: "hsl(var(--caesium-gold))",
           void: "hsl(var(--caesium-void))",
         },
+        // Brand surfaces / accents (extended palette).
+        cyan: {
+          DEFAULT: "hsl(var(--cyan))",
+          glow: "hsl(var(--cyan-glow))",
+          dim: "hsl(var(--cyan-dim))",
+        },
+        gold: {
+          DEFAULT: "hsl(var(--gold))",
+          dim: "hsl(var(--gold-dim))",
+        },
+        void: "hsl(var(--void))",
+        midnight: "hsl(var(--midnight))",
+        obsidian: "hsl(var(--obsidian))",
+        graphite: "hsl(var(--graphite))",
+        silt: "hsl(var(--silt))",
+        // Text levels.
+        "text-1": "hsl(var(--text-1))",
+        "text-2": "hsl(var(--text-2))",
+        "text-3": "hsl(var(--text-3))",
+        "text-4": "hsl(var(--text-4))",
+        // Status semantics.
+        success: "hsl(var(--success))",
+        warning: "hsl(var(--warning))",
+        danger: "hsl(var(--danger))",
+        running: "hsl(var(--running))",
+        cached: "hsl(var(--cached))",
+        // Chart palette (shadcn-compatible).
+        "chart-1": "hsl(var(--chart-1))",
+        "chart-2": "hsl(var(--chart-2))",
+        "chart-3": "hsl(var(--chart-3))",
+        "chart-4": "hsl(var(--chart-4))",
+        "chart-5": "hsl(var(--chart-5))",
         sidebar: {
           DEFAULT: "hsl(var(--sidebar))",
           foreground: "hsl(var(--sidebar-foreground))",
@@ -89,10 +121,42 @@ export default {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "orbit-spin": {
+          from: { transform: "rotate(0deg)" },
+          to: { transform: "rotate(360deg)" },
+        },
+        "nucleus-pulse": {
+          "0%, 100%": { transform: "scale(1)", opacity: "1" },
+          "50%": { transform: "scale(1.18)", opacity: "0.85" },
+        },
+        "cyan-pulse": {
+          "0%, 100%": {
+            boxShadow:
+              "0 0 0 0 hsl(var(--cyan) / 0.55), 0 0 14px 0 hsl(var(--cyan) / 0.5)",
+          },
+          "70%": {
+            boxShadow:
+              "0 0 0 9px hsl(var(--cyan) / 0), 0 0 14px 0 hsl(var(--cyan) / 0.5)",
+          },
+        },
+        "gold-pulse": {
+          "0%, 100%": {
+            boxShadow:
+              "0 0 0 0 hsl(var(--gold) / 0.55), 0 0 12px 0 hsl(var(--gold) / 0.4)",
+          },
+          "70%": {
+            boxShadow:
+              "0 0 0 8px hsl(var(--gold) / 0), 0 0 12px 0 hsl(var(--gold) / 0.4)",
+          },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "orbit-spin": "orbit-spin 22s linear infinite",
+        "nucleus-pulse": "nucleus-pulse 2.4s ease-in-out infinite",
+        "cyan-pulse": "cyan-pulse 1.6s ease-out infinite",
+        "gold-pulse": "gold-pulse 2s ease-out infinite",
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR implements Phase 1 of the UI refresh, introducing a cohesive design system with a new atom-based brand identity, canonical status semantics, and enhanced sidebar navigation with live counts and cluster health indicators.

## Key Changes

### Brand & Visual Identity
- **New AtomLogo component** (`ui/src/components/brand/atom-logo.tsx`): Replaces CaesiumLogo with an animated SVG featuring three deterministic orbits, a pulsing nucleus, and three gold satellites. Respects `prefers-reduced-motion` and supports static rendering.
- **Expanded color palette** in `index.css` and `tailwind.config.js`: Introduces semantic tokens (cyan, gold, text levels 1–4, status colors: success/warning/danger/running/cached) and chart palette (chart-1 through chart-5) for consistent theming across light and dark modes.
- **Brand motion keyframes**: Added `orbit-spin` and `nucleus-pulse` animations, plus `cyan-pulse` and `gold-pulse` for status indicators.

### Status Semantics System
- **New `lib/status.ts`**: Canonical `statusMeta()` function that maps run statuses (running, succeeded, failed, queued, paused, cached, skipped) to visual metadata (foreground, background, border colors, and animation classes). Includes alias normalization (e.g., "success" → "succeeded", "error" → "failed").
- **StatusBadge component** (`ui/src/components/ui/status-badge.tsx`): Three variants (filled, soft, dot) backed by `statusMeta()` for consistent status rendering across the app.
- **Sparkline component** (`ui/src/components/ui/sparkline.tsx`): Compact run-history visualization with bars colored by status and height-encoded duration. Lazy-renders after first animation frame to avoid blocking paint.

### Sidebar Enhancements
- **Live nav counts**: Sidebar nav items now display badge counts for Jobs, Triggers, and Atoms via `useNavCounts()` hook.
- **Cluster health indicator**: New `useClusterHealth()` hook polls `/v1/system/health` every 15s and displays operational state (operational/degraded/incident/unknown) with semantic coloring and uptime display.
- **Gold accent rail**: Added a left-edge gradient accent to the sidebar for visual emphasis.
- **Refined spacing & typography**: Adjusted padding, font sizes, and tracking for improved readability.

### Header & Navigation
- **Breadcrumb navigation**: Dynamic breadcrumb trail built from route pathname with known route labels and truncation for long segments.
- **UTCClock component** (`ui/src/components/ui/utc-clock.tsx`): Displays current UTC time with optional gold pulse dot. Includes `UTCClockProvider` for efficient shared ticking across multiple clock instances.
- **Sticky header**: Header now uses `sticky top-0 z-30` with backdrop blur for better UX.

### Utility Components & Helpers
- **UsageBar** (`ui/src/components/ui/usage-bar.tsx`): Horizontal progress bar for CPU/memory/disk with threshold-based tinting (ok/warn/danger).
- **EmptyState** (`ui/src/components/ui/empty-state.tsx`): Stock empty-state surface with static atom motif, title, subtitle, and optional action.
- **useReducedMotion hook** (`ui/src/hooks/useReducedMotion.ts`): Subscribes to `prefers-reduced-motion: reduce` media query for accessibility.
- **Thresholds module** (`ui/src/lib/thresholds.ts`): Centralized usage threshold constants (warn: 65%, danger: 85%).

### Deprecation & Migration
- **CaesiumLogo shim**: Marked as deprecated; now re-exports `AtomLogo` to maintain backward compatibility during Phase 1. Scheduled for removal in Phase 1 cleanup.

### Testing
- Comprehensive test suites added for all new components and utilities:
  - `utc-clock.test.tsx`: Time formatting, ticking, provider sharing
  - `status.

https://claude.ai/code/session_01RBrSPR3PjrnrWbaaXJQFFy