### PR TITLE
[codex] Implement phase 0 database locking fixes

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -115,6 +115,8 @@ func start(cmd *cobra.Command, args []string) error {
 		vars.WorkerPoolSize,
 		"worker_poll_interval",
 		vars.WorkerPollInterval,
+		"worker_reclaim_interval",
+		vars.WorkerReclaimInterval,
 		"worker_lease_ttl",
 		vars.WorkerLeaseTTL,
 		"node_labels",
@@ -225,6 +227,8 @@ func start(cmd *cobra.Command, args []string) error {
 				poolSize,
 				"poll_interval",
 				vars.WorkerPollInterval,
+				"reclaim_interval",
+				vars.WorkerReclaimInterval,
 				"lease_ttl",
 				vars.WorkerLeaseTTL,
 			)
@@ -233,7 +237,9 @@ func start(cmd *cobra.Command, args []string) error {
 			claimer := worker.NewClaimer(vars.NodeAddress, store, vars.WorkerLeaseTTL, worker.ParseNodeLabels(vars.NodeLabels))
 			executorFn := worker.NewRuntimeExecutor(store, vars.TaskTimeout, vars.WorkerLeaseTTL, vars.TaskFailurePolicy)
 			wakeups := worker.SubscribeWakeups(ctx, bus)
-			w := worker.NewWorker(claimer, worker.NewPool(poolSize), vars.WorkerPollInterval, executorFn).WithWakeups(wakeups)
+			w := worker.NewWorker(claimer, worker.NewPool(poolSize), vars.WorkerPollInterval, executorFn).
+				WithReclaimInterval(vars.WorkerReclaimInterval).
+				WithWakeups(wakeups)
 			errs <- w.Run(ctx)
 		}()
 	} else {

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@ These files are useful context, but each should be treated according to its stat
 - [design-arm64-support.md](design-arm64-support.md)
 - [design-event-triggers.md](design-event-triggers.md)
 - [design-concurrency-priority.md](design-concurrency-priority.md)
+- [design-database-locking-fix.md](design-database-locking-fix.md)
 - [design-sla-management.md](design-sla-management.md)
 - [design-task-templates.md](design-task-templates.md)
 - [design-helm-kubernetes-deployment.md](design-helm-kubernetes-deployment.md)

--- a/docs/design-database-locking-fix.md
+++ b/docs/design-database-locking-fix.md
@@ -76,16 +76,16 @@ Goal: eliminate the bulk of `database is locked` errors with low-risk changes th
 
 - [ ] **Wrap `ClaimNext` and `ReclaimExpired` with bounded `SQLITE_BUSY`/`LOCKED` retry.**
   - File: `internal/worker/claimer.go`.
-  - Helper `withBusyRetry(ctx, fn)` performing up to 5 attempts with exponential backoff (10ms, 20ms, 40ms, 80ms, 160ms) plus per-attempt jitter, total ~310ms cap. Reuse `isClaimContentionErr` (line 231).
+  - Helper `withBusyRetry(ctx, backoffs, fn)` performing up to 5 attempts with per-claimer exponential backoff (10ms, 20ms, 40ms, 80ms, 160ms) plus per-attempt jitter, total ~310ms cap. Reuse `isClaimContentionErr` (line 231).
   - Wrap the transaction calls at `claimer.go:67` and `:170`. Increment `caesium_worker_claim_contention_total` on each retry, not just on the first.
   - Acceptance: under simulated contention (see [Test plan](#test-plan)), `ClaimNext` returns success when `busy_timeout` plus retry can resolve it. Errors only bubble up after exhausting retries.
   - Risk: low. Retries are bounded; backoff is short.
 
 - [ ] **Throttle `ReclaimExpired` so it does not run every iteration.**
   - File: `internal/worker/worker.go:66-69`.
-  - Run reclaim only when `ClaimNext` returned no task in the previous iteration **and** at least `reclaimInterval` has passed since the last reclaim (default 30s, env-configurable as `CAESIUM_WORKER_RECLAIM_INTERVAL`).
+  - Run reclaim only when at least `reclaimInterval` has passed since the last reclaim (default 30s, env-configurable as `CAESIUM_WORKER_RECLAIM_INTERVAL`).
   - Stagger by adding a per-worker random offset at `Worker` init so the cluster-wide reclaim cadence is naturally desynchronized.
-  - Acceptance: in a 3-node cluster idle test, the rate of reclaim transactions falls by ~15× while no expired lease lingers more than `leaseTTL + reclaimInterval`.
+  - Acceptance: in a 3-node cluster test, the rate of reclaim transactions falls by ~15× while no expired lease lingers more than `leaseTTL + reclaimInterval`.
   - Risk: low. Lease TTL is 5min by default; even a 30s reclaim cadence has ample headroom.
 
 - [ ] **Surface a `caesium_db_busy_retries_total` counter and `caesium_reclaim_duration_seconds` histogram.**

--- a/docs/design-database-locking-fix.md
+++ b/docs/design-database-locking-fix.md
@@ -68,27 +68,29 @@ Phases are ordered by risk and impact. Each phase should land, get measured, and
 
 Goal: eliminate the bulk of `database is locked` errors with low-risk changes that need no schema or API changes.
 
-- [ ] **Add `busy_timeout` and `synchronous` PRAGMAs to dqlite open.**
-  - File: `pkg/dqlite/dqlite.go` (after `app.Open` at line 78, before the `sqlite_version()` query).
-  - Run `PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;`. Do **not** set `journal_mode` — dqlite owns it.
-  - Acceptance: PRAGMAs are set on the single dqlite conn at startup; `SELECT * FROM pragma_busy_timeout` returns 5000 after `Connection()`.
+Status: implemented in PR #153. The production dqlite path uses the native `app.WithBusyTimeout` option because go-dqlite rejects SQL PRAGMA statements; injected connection paths still apply the SQL `busy_timeout` and `synchronous=NORMAL` PRAGMAs and are covered by tests.
+
+- [x] **Add `busy_timeout` and `synchronous` PRAGMAs to dqlite open.**
+  - File: `pkg/dqlite/dqlite.go`.
+  - Use `app.WithBusyTimeout(5s)` for go-dqlite connections. For injected SQL connection pools, run `PRAGMA busy_timeout=5000; PRAGMA synchronous=NORMAL;`. Do **not** set `journal_mode` — dqlite owns it.
+  - Acceptance: production dqlite connections are opened with a 5s busy timeout; injected SQL connection pools report `pragma_busy_timeout=5000` and `synchronous=NORMAL`.
   - Risk: low. `synchronous=NORMAL` weakens single-node durability slightly, but dqlite's Raft replication provides durability at the cluster level.
 
-- [ ] **Wrap `ClaimNext` and `ReclaimExpired` with bounded `SQLITE_BUSY`/`LOCKED` retry.**
+- [x] **Wrap `ClaimNext` and `ReclaimExpired` with bounded `SQLITE_BUSY`/`LOCKED` retry.**
   - File: `internal/worker/claimer.go`.
   - Helper `withBusyRetry(ctx, backoffs, fn)` performing up to 5 attempts with per-claimer exponential backoff (10ms, 20ms, 40ms, 80ms, 160ms) plus per-attempt jitter, total ~310ms cap. Reuse `isClaimContentionErr` (line 231).
   - Wrap the transaction calls at `claimer.go:67` and `:170`. Increment `caesium_worker_claim_contention_total` on each retry, not just on the first.
   - Acceptance: under simulated contention (see [Test plan](#test-plan)), `ClaimNext` returns success when `busy_timeout` plus retry can resolve it. Errors only bubble up after exhausting retries.
   - Risk: low. Retries are bounded; backoff is short.
 
-- [ ] **Throttle `ReclaimExpired` so it does not run every iteration.**
+- [x] **Throttle `ReclaimExpired` so it does not run every iteration.**
   - File: `internal/worker/worker.go:66-69`.
   - Run reclaim only when at least `reclaimInterval` has passed since the last reclaim (default 30s, env-configurable as `CAESIUM_WORKER_RECLAIM_INTERVAL`).
   - Stagger by adding a per-worker random offset at `Worker` init so the cluster-wide reclaim cadence is naturally desynchronized.
   - Acceptance: in a 3-node cluster test, the rate of reclaim transactions falls by ~15× while no expired lease lingers more than `leaseTTL + reclaimInterval`.
   - Risk: low. Lease TTL is 5min by default; even a 30s reclaim cadence has ample headroom.
 
-- [ ] **Surface a `caesium_db_busy_retries_total` counter and `caesium_reclaim_duration_seconds` histogram.**
+- [x] **Surface a `caesium_db_busy_retries_total` counter and `caesium_reclaim_duration_seconds` histogram.**
   - File: `internal/metrics/metrics.go`.
   - Increment on every retry attempt; observe at the end of each `ReclaimExpired`.
   - Acceptance: metrics exposed at `/metrics`; visible in default Grafana dashboard config (`docs/observability.md` if present).

--- a/docs/parallel-execution-operations.md
+++ b/docs/parallel-execution-operations.md
@@ -20,7 +20,7 @@ This guide covers runtime configuration, rollout, and troubleshooting for parall
 | `CAESIUM_WORKER_ENABLED` | `true` | Enables distributed worker loop on this node. |
 | `CAESIUM_WORKER_POOL_SIZE` | `4` | Max concurrent claimed tasks per node. |
 | `CAESIUM_WORKER_POLL_INTERVAL` | `2s` | Poll cadence for new claimable tasks. |
-| `CAESIUM_WORKER_RECLAIM_INTERVAL` | `30s` | Minimum interval between expired-lease reclaim attempts after an idle claim pass. |
+| `CAESIUM_WORKER_RECLAIM_INTERVAL` | `30s` | Minimum interval between expired-lease reclaim attempts. |
 | `CAESIUM_WORKER_LEASE_TTL` | `5m` | Lease duration for claimed tasks before reclaim. |
 | `CAESIUM_NODE_ADDRESS` | `127.0.0.1:9001` | Logical node identity written to `task_runs.claimed_by`. |
 | `CAESIUM_NODE_LABELS` | `""` | Optional node labels (`k=v,k2=v2`) for task `nodeSelector` affinity. |
@@ -64,7 +64,7 @@ Use metrics:
 - Increase `CAESIUM_WORKER_POOL_SIZE` to raise per-node throughput.
 - Increase `CAESIUM_MAX_PARALLEL_TASKS` for better local mode utilization.
 - Increase `CAESIUM_WORKER_LEASE_TTL` for long-running tasks to reduce reclaim churn.
-- Increase `CAESIUM_WORKER_RECLAIM_INTERVAL` to reduce idle-cluster reclaim write pressure.
+- Increase `CAESIUM_WORKER_RECLAIM_INTERVAL` to reduce reclaim write pressure.
 - Decrease `CAESIUM_WORKER_POLL_INTERVAL` for lower claim latency (at higher DB pressure).
 - Use `CAESIUM_NODE_LABELS` + task `nodeSelector` to place specialized workloads.
 

--- a/docs/parallel-execution-operations.md
+++ b/docs/parallel-execution-operations.md
@@ -20,6 +20,7 @@ This guide covers runtime configuration, rollout, and troubleshooting for parall
 | `CAESIUM_WORKER_ENABLED` | `true` | Enables distributed worker loop on this node. |
 | `CAESIUM_WORKER_POOL_SIZE` | `4` | Max concurrent claimed tasks per node. |
 | `CAESIUM_WORKER_POLL_INTERVAL` | `2s` | Poll cadence for new claimable tasks. |
+| `CAESIUM_WORKER_RECLAIM_INTERVAL` | `30s` | Minimum interval between expired-lease reclaim attempts after an idle claim pass. |
 | `CAESIUM_WORKER_LEASE_TTL` | `5m` | Lease duration for claimed tasks before reclaim. |
 | `CAESIUM_NODE_ADDRESS` | `127.0.0.1:9001` | Logical node identity written to `task_runs.claimed_by`. |
 | `CAESIUM_NODE_LABELS` | `""` | Optional node labels (`k=v,k2=v2`) for task `nodeSelector` affinity. |
@@ -55,12 +56,15 @@ Use metrics:
 - `caesium_worker_claims_total{node_id}`
 - `caesium_worker_claim_contention_total{node_id}`
 - `caesium_worker_lease_expirations_total{node_id}`
+- `caesium_db_busy_retries_total`
+- `caesium_reclaim_duration_seconds`
 
 ## Tuning Guidance
 
 - Increase `CAESIUM_WORKER_POOL_SIZE` to raise per-node throughput.
 - Increase `CAESIUM_MAX_PARALLEL_TASKS` for better local mode utilization.
 - Increase `CAESIUM_WORKER_LEASE_TTL` for long-running tasks to reduce reclaim churn.
+- Increase `CAESIUM_WORKER_RECLAIM_INTERVAL` to reduce idle-cluster reclaim write pressure.
 - Decrease `CAESIUM_WORKER_POLL_INTERVAL` for lower claim latency (at higher DB pressure).
 - Use `CAESIUM_NODE_LABELS` + task `nodeSelector` to place specialized workloads.
 
@@ -76,6 +80,7 @@ Use metrics:
 ### High claim contention
 
 - Watch `caesium_worker_claim_contention_total`.
+- Watch `caesium_db_busy_retries_total` for lock retries that are being absorbed before surfacing to workers.
 - Increase `CAESIUM_WORKER_POOL_SIZE` judiciously and consider a higher poll interval.
 - Ensure task affinity rules are not over-constraining claims.
 

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -475,6 +475,10 @@ var harnessMetricSpecs = map[string]metricSpec{
 		labelNames: []string{"job_id", "status"},
 		read:       readCounterVec(metrics.CallbackRunsTotal),
 	},
+	"caesium_db_busy_retries_total": {
+		labelNames: nil,
+		read:       readCounter(metrics.DBBusyRetriesTotal),
+	},
 	"caesium_job_runs_total": {
 		labelNames: []string{"job_id", "status"},
 		read:       readCounterVec(metrics.JobRunsTotal),
@@ -523,6 +527,20 @@ var harnessMetricSpecs = map[string]metricSpec{
 		labelNames: []string{"node_id"},
 		read:       readCounterVec(metrics.WorkerLeaseExpirationsTotal),
 	},
+}
+
+func readCounter(counter prometheus.Counter) func([]string) (float64, error) {
+	return func(labelValues []string) (float64, error) {
+		if len(labelValues) != 0 {
+			return 0, fmt.Errorf("metric does not accept labels")
+		}
+
+		var metric dto.Metric
+		if err := counter.(prometheus.Metric).Write(&metric); err != nil {
+			return 0, err
+		}
+		return metric.GetCounter().GetValue(), nil
+	}
 }
 
 func readCounterVec(vec *prometheus.CounterVec) func([]string) (float64, error) {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -83,6 +83,21 @@ var (
 		[]string{"node_id"},
 	)
 
+	DBBusyRetriesTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "caesium_db_busy_retries_total",
+			Help: "Total number of database busy/locked retry attempts.",
+		},
+	)
+
+	ReclaimDurationSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "caesium_reclaim_duration_seconds",
+			Help:    "Duration of expired task lease reclaim attempts in seconds.",
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		},
+	)
+
 	WorkerLeaseExpirationsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "caesium_worker_lease_expirations_total",
@@ -194,6 +209,8 @@ func Register() {
 			TriggerFiresTotal,
 			WorkerClaimsTotal,
 			WorkerClaimContentionTotal,
+			DBBusyRetriesTotal,
+			ReclaimDurationSeconds,
 			WorkerLeaseExpirationsTotal,
 			TaskRetriesTotal,
 			BackfillRunsTotal,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -30,6 +30,8 @@ func (s *MetricsSuite) SetupTest() {
 		TriggerFiresTotal,
 		WorkerClaimsTotal,
 		WorkerClaimContentionTotal,
+		DBBusyRetriesTotal,
+		ReclaimDurationSeconds,
 		WorkerLeaseExpirationsTotal,
 		TaskRetriesTotal,
 		WebhookAuthFailuresTotal,
@@ -133,6 +135,35 @@ func (s *MetricsSuite) TestWorkerClaimContentionTotalIncrements() {
 
 	val := metrictestutil.CounterValue(s.T(), WorkerClaimContentionTotal, "node-a")
 	s.GreaterOrEqual(val, float64(2))
+}
+
+func (s *MetricsSuite) TestDBBusyRetriesTotalIncrements() {
+	DBBusyRetriesTotal.Inc()
+	DBBusyRetriesTotal.Inc()
+
+	var m dto.Metric
+	s.Require().NoError(DBBusyRetriesTotal.Write(&m))
+	s.GreaterOrEqual(m.GetCounter().GetValue(), float64(2))
+}
+
+func (s *MetricsSuite) TestReclaimDurationSecondsObserves() {
+	ReclaimDurationSeconds.Observe(0.125)
+
+	families, err := s.registry.Gather()
+	s.Require().NoError(err)
+
+	found := false
+	for _, fam := range families {
+		if fam.GetName() == "caesium_reclaim_duration_seconds" {
+			for _, m := range fam.GetMetric() {
+				h := m.GetHistogram()
+				if h != nil && h.GetSampleCount() > 0 {
+					found = true
+				}
+			}
+		}
+	}
+	s.True(found, "expected reclaim duration histogram sample")
 }
 
 func (s *MetricsSuite) TestWorkerLeaseExpirationsTotalAdds() {

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"maps"
+	"math/rand/v2"
 	"strings"
 	"time"
 
@@ -18,6 +19,14 @@ import (
 )
 
 const defaultLeaseTTL = 5 * time.Minute
+
+var busyRetryBackoffs = []time.Duration{
+	10 * time.Millisecond,
+	20 * time.Millisecond,
+	40 * time.Millisecond,
+	80 * time.Millisecond,
+	160 * time.Millisecond,
+}
 
 type Claimer struct {
 	nodeID     string
@@ -59,95 +68,105 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 		return nil, err
 	}
 
-	now := time.Now().UTC()
-	leaseExpiry := now.Add(c.leaseTTL)
 	var claimed *models.TaskRun
-
 	pendingEvents := make([]event.Event, 0, 1)
-	err := c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var candidates []models.TaskRun
-		runningRunIDs := tx.Model(&models.JobRun{}).
-			Select("id").
-			Where("status = ?", string(run.StatusRunning))
-		err := tx.
-			Table("task_runs AS tr").
-			Select("tr.*").
-			Joins("JOIN job_runs AS jr ON jr.id = tr.job_run_id").
-			Where(
-				"jr.status = ? AND tr.status = ? AND tr.outstanding_predecessors = ? AND (tr.claimed_by = '' OR tr.claim_expires_at IS NULL OR tr.claim_expires_at < ?)",
-				string(run.StatusRunning),
-				string(run.TaskStatusPending),
-				0,
-				now,
-			).
-			Order("tr.created_at ASC").
-			Limit(64).
-			Find(&candidates).Error
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil
-		}
-		if err != nil {
+
+	err := withBusyRetry(ctx, func() error {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if len(candidates) == 0 {
-			return nil
-		}
 
-		for _, candidate := range candidates {
-			if !matchesNodeSelector(candidate.NodeSelector, c.nodeLabels) {
-				continue
-			}
+		now := time.Now().UTC()
+		leaseExpiry := now.Add(c.leaseTTL)
+		claimed = nil
+		attemptEvents := make([]event.Event, 0, 1)
 
-			result := tx.Model(&models.TaskRun{}).
+		err := c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			var candidates []models.TaskRun
+			runningRunIDs := tx.Model(&models.JobRun{}).
+				Select("id").
+				Where("status = ?", string(run.StatusRunning))
+			err := tx.
+				Table("task_runs AS tr").
+				Select("tr.*").
+				Joins("JOIN job_runs AS jr ON jr.id = tr.job_run_id").
 				Where(
-					"id = ? AND job_run_id IN (?) AND status = ? AND outstanding_predecessors = ? AND (claimed_by = '' OR claim_expires_at IS NULL OR claim_expires_at < ?)",
-					candidate.ID,
-					runningRunIDs,
+					"jr.status = ? AND tr.status = ? AND tr.outstanding_predecessors = ? AND (tr.claimed_by = '' OR tr.claim_expires_at IS NULL OR tr.claim_expires_at < ?)",
+					string(run.StatusRunning),
 					string(run.TaskStatusPending),
 					0,
 					now,
 				).
-				Updates(map[string]interface{}{
-					"claimed_by":       c.nodeID,
-					"claim_expires_at": leaseExpiry,
-					"claim_attempt":    candidate.ClaimAttempt + 1,
-					"status":           string(run.TaskStatusRunning),
-				})
-			if result.Error != nil {
-				if isClaimContentionErr(result.Error) {
-					metrics.WorkerClaimContentionTotal.WithLabelValues(c.nodeID).Inc()
-				}
-				return result.Error
+				Order("tr.created_at ASC").
+				Limit(64).
+				Find(&candidates).Error
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil
 			}
-			if result.RowsAffected == 0 {
-				// Another node won the race.
-				metrics.WorkerClaimContentionTotal.WithLabelValues(c.nodeID).Inc()
-				continue
+			if err != nil {
+				return err
+			}
+			if len(candidates) == 0 {
+				return nil
 			}
 
-			claimedTask := &models.TaskRun{}
-			if err := tx.First(claimedTask, "id = ?", candidate.ID).Error; err != nil {
-				return err
+			for _, candidate := range candidates {
+				if !matchesNodeSelector(candidate.NodeSelector, c.nodeLabels) {
+					continue
+				}
+
+				result := tx.Model(&models.TaskRun{}).
+					Where(
+						"id = ? AND job_run_id IN (?) AND status = ? AND outstanding_predecessors = ? AND (claimed_by = '' OR claim_expires_at IS NULL OR claim_expires_at < ?)",
+						candidate.ID,
+						runningRunIDs,
+						string(run.TaskStatusPending),
+						0,
+						now,
+					).
+					Updates(map[string]interface{}{
+						"claimed_by":       c.nodeID,
+						"claim_expires_at": leaseExpiry,
+						"claim_attempt":    candidate.ClaimAttempt + 1,
+						"status":           string(run.TaskStatusRunning),
+					})
+				if result.Error != nil {
+					return result.Error
+				}
+				if result.RowsAffected == 0 {
+					// Another node won the race.
+					metrics.WorkerClaimContentionTotal.WithLabelValues(c.nodeID).Inc()
+					continue
+				}
+
+				claimedTask := &models.TaskRun{}
+				if err := tx.First(claimedTask, "id = ?", candidate.ID).Error; err != nil {
+					return err
+				}
+				claimed = claimedTask
+				evt := event.Event{
+					Type:      event.TypeTaskClaimed,
+					Timestamp: time.Now().UTC(),
+				}
+				var jobRun models.JobRun
+				if err := tx.Select("job_id").First(&jobRun, "id = ?", claimedTask.JobRunID).Error; err == nil {
+					evt.JobID = jobRun.JobID
+				}
+				evt.RunID = claimedTask.JobRunID
+				evt.TaskID = claimedTask.TaskID
+				if err := c.store.RecordEventTx(tx, &evt); err != nil {
+					return err
+				}
+				attemptEvents = append(attemptEvents, evt)
+				break
 			}
-			claimed = claimedTask
-			evt := event.Event{
-				Type:      event.TypeTaskClaimed,
-				Timestamp: time.Now().UTC(),
-			}
-			var jobRun models.JobRun
-			if err := tx.Select("job_id").First(&jobRun, "id = ?", claimedTask.JobRunID).Error; err == nil {
-				evt.JobID = jobRun.JobID
-			}
-			evt.RunID = claimedTask.JobRunID
-			evt.TaskID = claimedTask.TaskID
-			if err := c.store.RecordEventTx(tx, &evt); err != nil {
-				return err
-			}
-			pendingEvents = append(pendingEvents, evt)
-			break
+			return nil
+		})
+		if err == nil {
+			pendingEvents = attemptEvents
 		}
-		return nil
-	})
+		return err
+	}, c.observeBusyRetry)
 	if err != nil {
 		return nil, err
 	}
@@ -160,72 +179,137 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 }
 
 func (c *Claimer) ReclaimExpired(ctx context.Context) error {
-	now := time.Now().UTC()
-	runningRunIDs := c.store.DB().
-		Model(&models.JobRun{}).
-		Select("id").
-		Where("status = ?", string(run.StatusRunning))
+	start := time.Now()
+	defer func() {
+		metrics.ReclaimDurationSeconds.Observe(time.Since(start).Seconds())
+	}()
 
 	pendingEvents := make([]event.Event, 0, 8)
-	err := c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-		var expired []models.TaskRun
-		if err := tx.
-			Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ?", runningRunIDs, string(run.TaskStatusRunning), now).
-			Find(&expired).Error; err != nil {
+	err := withBusyRetry(ctx, func() error {
+		if err := ctx.Err(); err != nil {
 			return err
 		}
 
-		result := tx.Model(&models.TaskRun{}).
-			Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ?", runningRunIDs, string(run.TaskStatusRunning), now).
-			Updates(map[string]interface{}{
-				"status":           string(run.TaskStatusPending),
-				"claimed_by":       "",
-				"claim_expires_at": nil,
-				"runtime_id":       "",
-				"started_at":       nil,
-			})
-		if result.Error != nil {
-			return result.Error
-		}
+		now := time.Now().UTC()
+		attemptEvents := make([]event.Event, 0, 8)
 
-		for _, taskRun := range expired {
-			var jobRun models.JobRun
-			if err := tx.Select("job_id").First(&jobRun, "id = ?", taskRun.JobRunID).Error; err != nil {
-				return err
-			}
-			leaseEvt := event.Event{
-				Type:      event.TypeTaskLeaseExpired,
-				JobID:     jobRun.JobID,
-				RunID:     taskRun.JobRunID,
-				TaskID:    taskRun.TaskID,
-				Timestamp: time.Now().UTC(),
-			}
-			if err := c.store.RecordEventTx(tx, &leaseEvt); err != nil {
-				return err
-			}
-			pendingEvents = append(pendingEvents, leaseEvt)
+		err := c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			runningRunIDs := tx.Model(&models.JobRun{}).
+				Select("id").
+				Where("status = ?", string(run.StatusRunning))
 
-			readyEvt := event.Event{
-				Type:      event.TypeTaskReady,
-				JobID:     jobRun.JobID,
-				RunID:     taskRun.JobRunID,
-				TaskID:    taskRun.TaskID,
-				Timestamp: time.Now().UTC(),
-			}
-			if err := c.store.RecordEventTx(tx, &readyEvt); err != nil {
+			var expired []models.TaskRun
+			if err := tx.
+				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ?", runningRunIDs, string(run.TaskStatusRunning), now).
+				Find(&expired).Error; err != nil {
 				return err
 			}
-			pendingEvents = append(pendingEvents, readyEvt)
+
+			result := tx.Model(&models.TaskRun{}).
+				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ?", runningRunIDs, string(run.TaskStatusRunning), now).
+				Updates(map[string]interface{}{
+					"status":           string(run.TaskStatusPending),
+					"claimed_by":       "",
+					"claim_expires_at": nil,
+					"runtime_id":       "",
+					"started_at":       nil,
+				})
+			if result.Error != nil {
+				return result.Error
+			}
+
+			for _, taskRun := range expired {
+				var jobRun models.JobRun
+				if err := tx.Select("job_id").First(&jobRun, "id = ?", taskRun.JobRunID).Error; err != nil {
+					return err
+				}
+				leaseEvt := event.Event{
+					Type:      event.TypeTaskLeaseExpired,
+					JobID:     jobRun.JobID,
+					RunID:     taskRun.JobRunID,
+					TaskID:    taskRun.TaskID,
+					Timestamp: time.Now().UTC(),
+				}
+				if err := c.store.RecordEventTx(tx, &leaseEvt); err != nil {
+					return err
+				}
+				attemptEvents = append(attemptEvents, leaseEvt)
+
+				readyEvt := event.Event{
+					Type:      event.TypeTaskReady,
+					JobID:     jobRun.JobID,
+					RunID:     taskRun.JobRunID,
+					TaskID:    taskRun.TaskID,
+					Timestamp: time.Now().UTC(),
+				}
+				if err := c.store.RecordEventTx(tx, &readyEvt); err != nil {
+					return err
+				}
+				attemptEvents = append(attemptEvents, readyEvt)
+			}
+			if result.RowsAffected > 0 {
+				metrics.WorkerLeaseExpirationsTotal.WithLabelValues(c.nodeID).Add(float64(result.RowsAffected))
+			}
+			return nil
+		})
+		if err == nil {
+			pendingEvents = attemptEvents
 		}
-		if result.RowsAffected > 0 {
-			metrics.WorkerLeaseExpirationsTotal.WithLabelValues(c.nodeID).Add(float64(result.RowsAffected))
-		}
-		return nil
-	})
+		return err
+	}, c.observeBusyRetry)
 	if err == nil {
 		c.store.PublishEvents(pendingEvents...)
 	}
 	return err
+}
+
+func (c *Claimer) observeBusyRetry(error) {
+	metrics.WorkerClaimContentionTotal.WithLabelValues(c.nodeID).Inc()
+}
+
+func withBusyRetry(ctx context.Context, fn func() error, onRetry func(error)) error {
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = fn()
+		if err == nil || !isClaimContentionErr(err) {
+			return err
+		}
+		if attempt >= len(busyRetryBackoffs) {
+			return err
+		}
+
+		metrics.DBBusyRetriesTotal.Inc()
+		if onRetry != nil {
+			onRetry(err)
+		}
+		if sleepErr := sleepBusyRetry(ctx, busyRetryBackoffs[attempt]); sleepErr != nil {
+			return sleepErr
+		}
+	}
+}
+
+func sleepBusyRetry(ctx context.Context, base time.Duration) error {
+	timer := time.NewTimer(jitterBusyRetryBackoff(base))
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func jitterBusyRetryBackoff(base time.Duration) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+
+	maxJitter := int64(base / 5)
+	if maxJitter <= 0 {
+		return base
+	}
+	return base - time.Duration(rand.Int64N(maxJitter+1))
 }
 
 func isClaimContentionErr(err error) bool {
@@ -237,7 +321,13 @@ func isClaimContentionErr(err error) bool {
 	if errors.As(err, &sqliteErr) {
 		return sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked
 	}
-	return false
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database table is locked") ||
+		strings.Contains(msg, "database schema is locked") ||
+		strings.Contains(msg, "sqlite_busy") ||
+		strings.Contains(msg, "sqlite_locked")
 }
 
 func ParseNodeLabels(raw string) map[string]string {

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -20,19 +20,12 @@ import (
 
 const defaultLeaseTTL = 5 * time.Minute
 
-var busyRetryBackoffs = []time.Duration{
-	10 * time.Millisecond,
-	20 * time.Millisecond,
-	40 * time.Millisecond,
-	80 * time.Millisecond,
-	160 * time.Millisecond,
-}
-
 type Claimer struct {
-	nodeID     string
-	nodeLabels map[string]string
-	store      *run.Store
-	leaseTTL   time.Duration
+	nodeID            string
+	nodeLabels        map[string]string
+	store             *run.Store
+	leaseTTL          time.Duration
+	busyRetryBackoffs []time.Duration
 }
 
 func NewClaimer(nodeID string, store *run.Store, leaseTTL time.Duration, nodeLabels ...map[string]string) *Claimer {
@@ -55,10 +48,21 @@ func NewClaimer(nodeID string, store *run.Store, leaseTTL time.Duration, nodeLab
 	}
 
 	return &Claimer{
-		nodeID:     nodeID,
-		nodeLabels: labels,
-		store:      store,
-		leaseTTL:   leaseTTL,
+		nodeID:            nodeID,
+		nodeLabels:        labels,
+		store:             store,
+		leaseTTL:          leaseTTL,
+		busyRetryBackoffs: defaultBusyRetryBackoffSchedule(),
+	}
+}
+
+func defaultBusyRetryBackoffSchedule() []time.Duration {
+	return []time.Duration{
+		10 * time.Millisecond,
+		20 * time.Millisecond,
+		40 * time.Millisecond,
+		80 * time.Millisecond,
+		160 * time.Millisecond,
 	}
 }
 
@@ -71,7 +75,7 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 	var claimed *models.TaskRun
 	pendingEvents := make([]event.Event, 0, 1)
 
-	err := withBusyRetry(ctx, func() error {
+	err := withBusyRetry(ctx, c.busyRetryBackoffs, func() error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
@@ -90,6 +94,8 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 				Table("task_runs AS tr").
 				Select("tr.*").
 				Joins("JOIN job_runs AS jr ON jr.id = tr.job_run_id").
+				// Pending rows can still carry claim metadata after an interrupted or
+				// partially rolled-back handoff, so claim only unclaimed or expired rows.
 				Where(
 					"jr.status = ? AND tr.status = ? AND tr.outstanding_predecessors = ? AND (tr.claimed_by = '' OR tr.claim_expires_at IS NULL OR tr.claim_expires_at < ?)",
 					string(run.StatusRunning),
@@ -185,13 +191,15 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 	}()
 
 	pendingEvents := make([]event.Event, 0, 8)
-	err := withBusyRetry(ctx, func() error {
+	var reclaimedCount int64
+	err := withBusyRetry(ctx, c.busyRetryBackoffs, func() error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
 		now := time.Now().UTC()
 		attemptEvents := make([]event.Event, 0, 8)
+		var attemptReclaimedCount int64
 
 		err := c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			runningRunIDs := tx.Model(&models.JobRun{}).
@@ -247,17 +255,19 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				}
 				attemptEvents = append(attemptEvents, readyEvt)
 			}
-			if result.RowsAffected > 0 {
-				metrics.WorkerLeaseExpirationsTotal.WithLabelValues(c.nodeID).Add(float64(result.RowsAffected))
-			}
+			attemptReclaimedCount = result.RowsAffected
 			return nil
 		})
 		if err == nil {
 			pendingEvents = attemptEvents
+			reclaimedCount = attemptReclaimedCount
 		}
 		return err
 	}, c.observeBusyRetry)
 	if err == nil {
+		if reclaimedCount > 0 {
+			metrics.WorkerLeaseExpirationsTotal.WithLabelValues(c.nodeID).Add(float64(reclaimedCount))
+		}
 		c.store.PublishEvents(pendingEvents...)
 	}
 	return err
@@ -267,14 +277,14 @@ func (c *Claimer) observeBusyRetry(error) {
 	metrics.WorkerClaimContentionTotal.WithLabelValues(c.nodeID).Inc()
 }
 
-func withBusyRetry(ctx context.Context, fn func() error, onRetry func(error)) error {
+func withBusyRetry(ctx context.Context, backoffs []time.Duration, fn func() error, onRetry func(error)) error {
 	var err error
 	for attempt := 0; ; attempt++ {
 		err = fn()
 		if err == nil || !isClaimContentionErr(err) {
 			return err
 		}
-		if attempt >= len(busyRetryBackoffs) {
+		if attempt >= len(backoffs) {
 			return err
 		}
 
@@ -282,7 +292,7 @@ func withBusyRetry(ctx context.Context, fn func() error, onRetry func(error)) er
 		if onRetry != nil {
 			onRetry(err)
 		}
-		if sleepErr := sleepBusyRetry(ctx, busyRetryBackoffs[attempt]); sleepErr != nil {
+		if sleepErr := sleepBusyRetry(ctx, backoffs[attempt]); sleepErr != nil {
 			return sleepErr
 		}
 	}

--- a/internal/worker/claimer_test.go
+++ b/internal/worker/claimer_test.go
@@ -180,12 +180,9 @@ END;
 }
 
 func TestWithBusyRetryRetriesBusyErrors(t *testing.T) {
-	restoreBackoffs := setBusyRetryBackoffsForTest([]time.Duration{0, 0})
-	defer restoreBackoffs()
-
 	attempts := 0
 	retries := 0
-	err := withBusyRetry(context.Background(), func() error {
+	err := withBusyRetry(context.Background(), []time.Duration{0, 0}, func() error {
 		attempts++
 		if attempts < 3 {
 			return sqlite3.Error{Code: sqlite3.ErrBusy}
@@ -201,12 +198,9 @@ func TestWithBusyRetryRetriesBusyErrors(t *testing.T) {
 }
 
 func TestWithBusyRetryExhaustsBusyErrors(t *testing.T) {
-	restoreBackoffs := setBusyRetryBackoffsForTest([]time.Duration{0, 0})
-	defer restoreBackoffs()
-
 	attempts := 0
 	retries := 0
-	err := withBusyRetry(context.Background(), func() error {
+	err := withBusyRetry(context.Background(), []time.Duration{0, 0}, func() error {
 		attempts++
 		return sqlite3.Error{Code: sqlite3.ErrLocked}
 	}, func(error) {
@@ -371,12 +365,4 @@ func seedTaskRun(t *testing.T, db *gorm.DB, in seedTaskRunInput) *models.TaskRun
 
 func ptrTime(v time.Time) *time.Time {
 	return &v
-}
-
-func setBusyRetryBackoffsForTest(backoffs []time.Duration) func() {
-	previous := busyRetryBackoffs
-	busyRetryBackoffs = backoffs
-	return func() {
-		busyRetryBackoffs = previous
-	}
 }

--- a/internal/worker/claimer_test.go
+++ b/internal/worker/claimer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/jsonmap"
 	"github.com/google/uuid"
+	"github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
@@ -178,6 +179,45 @@ END;
 	require.GreaterOrEqual(t, metrictestutil.CounterValue(t, metrics.WorkerClaimContentionTotal, "node-racer"), float64(1))
 }
 
+func TestWithBusyRetryRetriesBusyErrors(t *testing.T) {
+	restoreBackoffs := setBusyRetryBackoffsForTest([]time.Duration{0, 0})
+	defer restoreBackoffs()
+
+	attempts := 0
+	retries := 0
+	err := withBusyRetry(context.Background(), func() error {
+		attempts++
+		if attempts < 3 {
+			return sqlite3.Error{Code: sqlite3.ErrBusy}
+		}
+		return nil
+	}, func(error) {
+		retries++
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts)
+	require.Equal(t, 2, retries)
+}
+
+func TestWithBusyRetryExhaustsBusyErrors(t *testing.T) {
+	restoreBackoffs := setBusyRetryBackoffsForTest([]time.Duration{0, 0})
+	defer restoreBackoffs()
+
+	attempts := 0
+	retries := 0
+	err := withBusyRetry(context.Background(), func() error {
+		attempts++
+		return sqlite3.Error{Code: sqlite3.ErrLocked}
+	}, func(error) {
+		retries++
+	})
+
+	require.Error(t, err)
+	require.Equal(t, 3, attempts)
+	require.Equal(t, 2, retries)
+}
+
 func TestClaimerClaimNextRespectsNodeSelector(t *testing.T) {
 	db := jobdeftestutil.OpenTestDB(t)
 	t.Cleanup(func() {
@@ -331,4 +371,12 @@ func seedTaskRun(t *testing.T, db *gorm.DB, in seedTaskRunInput) *models.TaskRun
 
 func ptrTime(v time.Time) *time.Time {
 	return &v
+}
+
+func setBusyRetryBackoffsForTest(backoffs []time.Duration) func() {
+	previous := busyRetryBackoffs
+	busyRetryBackoffs = backoffs
+	return func() {
+		busyRetryBackoffs = previous
+	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -70,8 +70,6 @@ func (w *Worker) WithReclaimInterval(interval time.Duration) *Worker {
 }
 
 func (w *Worker) Run(ctx context.Context) error {
-	previousClaimIdle := false
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -80,7 +78,7 @@ func (w *Worker) Run(ctx context.Context) error {
 		default:
 		}
 
-		w.reclaimIfDue(ctx, previousClaimIdle)
+		w.reclaimIfDue(ctx)
 
 		task, err := w.claimer.ClaimNext(ctx)
 		if err != nil {
@@ -90,7 +88,6 @@ func (w *Worker) Run(ctx context.Context) error {
 			}
 			log.Error("failed to claim next task", "error", err)
 		}
-		previousClaimIdle = err == nil && task == nil
 
 		if err != nil || task == nil {
 			if sleepErr := waitForWork(ctx, w.wakeups, w.pollInterval); sleepErr != nil {
@@ -112,10 +109,7 @@ func (w *Worker) Run(ctx context.Context) error {
 	}
 }
 
-func (w *Worker) reclaimIfDue(ctx context.Context, previousClaimIdle bool) {
-	if !previousClaimIdle {
-		return
-	}
+func (w *Worker) reclaimIfDue(ctx context.Context) {
 	reclaimer, ok := w.claimer.(ExpiredReclaimer)
 	if !ok {
 		return

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -9,6 +9,8 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/log"
 )
 
+const defaultReclaimInterval = 30 * time.Second
+
 type TaskClaimer interface {
 	ClaimNext(ctx context.Context) (*models.TaskRun, error)
 }
@@ -20,11 +22,13 @@ type ExpiredReclaimer interface {
 }
 
 type Worker struct {
-	claimer      TaskClaimer
-	pool         *Pool
-	pollInterval time.Duration
-	executor     TaskExecutor
-	wakeups      <-chan struct{}
+	claimer         TaskClaimer
+	pool            *Pool
+	pollInterval    time.Duration
+	reclaimInterval time.Duration
+	lastReclaim     time.Time
+	executor        TaskExecutor
+	wakeups         <-chan struct{}
 }
 
 func NewWorker(claimer TaskClaimer, pool *Pool, pollInterval time.Duration, executor TaskExecutor) *Worker {
@@ -42,10 +46,12 @@ func NewWorker(claimer TaskClaimer, pool *Pool, pollInterval time.Duration, exec
 	}
 
 	return &Worker{
-		claimer:      claimer,
-		pool:         pool,
-		pollInterval: pollInterval,
-		executor:     executor,
+		claimer:         claimer,
+		pool:            pool,
+		pollInterval:    pollInterval,
+		reclaimInterval: defaultReclaimInterval,
+		lastReclaim:     initialLastReclaim(time.Now(), defaultReclaimInterval),
+		executor:        executor,
 	}
 }
 
@@ -54,7 +60,18 @@ func (w *Worker) WithWakeups(ch <-chan struct{}) *Worker {
 	return w
 }
 
+func (w *Worker) WithReclaimInterval(interval time.Duration) *Worker {
+	if interval <= 0 {
+		interval = defaultReclaimInterval
+	}
+	w.reclaimInterval = interval
+	w.lastReclaim = initialLastReclaim(time.Now(), interval)
+	return w
+}
+
 func (w *Worker) Run(ctx context.Context) error {
+	previousClaimIdle := false
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -63,11 +80,7 @@ func (w *Worker) Run(ctx context.Context) error {
 		default:
 		}
 
-		if reclaimer, ok := w.claimer.(ExpiredReclaimer); ok {
-			if err := reclaimer.ReclaimExpired(ctx); err != nil && ctx.Err() == nil {
-				log.Error("failed to reclaim expired tasks", "error", err)
-			}
-		}
+		w.reclaimIfDue(ctx, previousClaimIdle)
 
 		task, err := w.claimer.ClaimNext(ctx)
 		if err != nil {
@@ -77,6 +90,7 @@ func (w *Worker) Run(ctx context.Context) error {
 			}
 			log.Error("failed to claim next task", "error", err)
 		}
+		previousClaimIdle = err == nil && task == nil
 
 		if err != nil || task == nil {
 			if sleepErr := waitForWork(ctx, w.wakeups, w.pollInterval); sleepErr != nil {
@@ -96,6 +110,35 @@ func (w *Worker) Run(ctx context.Context) error {
 			return err
 		}
 	}
+}
+
+func (w *Worker) reclaimIfDue(ctx context.Context, previousClaimIdle bool) {
+	if !previousClaimIdle {
+		return
+	}
+	reclaimer, ok := w.claimer.(ExpiredReclaimer)
+	if !ok {
+		return
+	}
+	if time.Since(w.lastReclaim) < w.reclaimInterval {
+		return
+	}
+
+	w.lastReclaim = time.Now()
+	if err := reclaimer.ReclaimExpired(ctx); err != nil && ctx.Err() == nil {
+		log.Error("failed to reclaim expired tasks", "error", err)
+	}
+}
+
+func initialLastReclaim(now time.Time, interval time.Duration) time.Time {
+	return now.Add(-interval).Add(randomReclaimOffset(interval))
+}
+
+func randomReclaimOffset(interval time.Duration) time.Duration {
+	if interval <= 0 {
+		return 0
+	}
+	return time.Duration(rand.Int64N(int64(interval)))
 }
 
 func waitForWork(ctx context.Context, wakeups <-chan struct{}, d time.Duration) error {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -65,6 +65,34 @@ func TestWorkerRunContinuesAfterClaimErrors(t *testing.T) {
 	}
 }
 
+func TestWorkerRunThrottlesReclaimUntilPreviousIdleClaim(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	claimer := &reclaimingSequenceClaimer{
+		sequenceClaimer: sequenceClaimer{
+			responses: []claimerResponse{
+				{},
+				{},
+				{task: &models.TaskRun{ID: uuid.New()}},
+			},
+		},
+	}
+
+	worker := NewWorker(claimer, NewPool(1), time.Millisecond, func(_ context.Context, _ *models.TaskRun) {
+		cancel()
+	}).WithReclaimInterval(time.Hour)
+	worker.lastReclaim = time.Now().Add(-2 * time.Hour)
+
+	if err := worker.Run(ctx); err != nil {
+		t.Fatalf("worker run failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&claimer.reclaims); got != 1 {
+		t.Fatalf("expected 1 reclaim attempt, got %d", got)
+	}
+}
+
 func TestSleepWithContextHandlesTinyDurations(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
@@ -95,4 +123,14 @@ func (s *sequenceClaimer) ClaimNext(context.Context) (*models.TaskRun, error) {
 	resp := s.responses[0]
 	s.responses = s.responses[1:]
 	return resp.task, resp.err
+}
+
+type reclaimingSequenceClaimer struct {
+	sequenceClaimer
+	reclaims int32
+}
+
+func (s *reclaimingSequenceClaimer) ReclaimExpired(context.Context) error {
+	atomic.AddInt32(&s.reclaims, 1)
+	return nil
 }

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -65,15 +65,14 @@ func TestWorkerRunContinuesAfterClaimErrors(t *testing.T) {
 	}
 }
 
-func TestWorkerRunThrottlesReclaimUntilPreviousIdleClaim(t *testing.T) {
+func TestWorkerRunReclaimsWhenDueBeforeBusyClaimLoop(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	claimer := &reclaimingSequenceClaimer{
 		sequenceClaimer: sequenceClaimer{
 			responses: []claimerResponse{
-				{},
-				{},
+				{task: &models.TaskRun{ID: uuid.New()}},
 				{task: &models.TaskRun{ID: uuid.New()}},
 			},
 		},

--- a/pkg/dqlite/dqlite.go
+++ b/pkg/dqlite/dqlite.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
@@ -19,8 +20,12 @@ import (
 	"gorm.io/gorm/schema"
 )
 
-// DriverName is the default driver name for dqlite.
-const DriverName = "dqlite"
+const (
+	// DriverName is the default driver name for dqlite.
+	DriverName = "dqlite"
+
+	dqliteBusyTimeout = 5 * time.Second
+)
 
 type Dialector struct {
 	DriverName string
@@ -41,9 +46,13 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 		dialector.DriverName = DriverName
 	}
 
+	supportsSQLPragmas := true
 	if dialector.Conn != nil {
 		db.ConnPool = dialector.Conn
 	} else {
+		// go-dqlite rejects SQL PRAGMA statements with SQLITE_AUTH; configure
+		// the busy timeout through its native node option instead.
+		supportsSQLPragmas = false
 		logFunc := func(l client.LogLevel, format string, a ...interface{}) {
 			// log info by default
 			fn := log.Info
@@ -66,6 +75,7 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 			app.WithAddress(env.Variables().NodeAddress),
 			app.WithCluster(env.Variables().DatabaseNodes),
 			app.WithLogFunc(logFunc),
+			app.WithBusyTimeout(dqliteBusyTimeout),
 		)
 		if err != nil {
 			return err
@@ -81,6 +91,12 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 		}
 
 		db.ConnPool = conn
+	}
+
+	if supportsSQLPragmas {
+		if err := setConnectionPragmas(context.Background(), db.ConnPool); err != nil {
+			return err
+		}
 	}
 
 	var version string
@@ -105,6 +121,18 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 		db.ClauseBuilders[k] = v
 	}
 	return
+}
+
+func setConnectionPragmas(ctx context.Context, conn gorm.ConnPool) error {
+	for _, stmt := range []string{
+		"PRAGMA busy_timeout=5000",
+		"PRAGMA synchronous=NORMAL",
+	} {
+		if _, err := conn.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("%s: %w", stmt, err)
+		}
+	}
+	return nil
 }
 
 func (dialector Dialector) ClauseBuilders() map[string]clause.ClauseBuilder {

--- a/pkg/dqlite/dqlite_test.go
+++ b/pkg/dqlite/dqlite_test.go
@@ -1,0 +1,28 @@
+package dqlite
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestDialectorAppliesConnectionPragmas(t *testing.T) {
+	conn, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	_, err = gorm.Open(Dialector{Conn: conn}, &gorm.Config{})
+	require.NoError(t, err)
+
+	var busyTimeout int
+	require.NoError(t, conn.QueryRowContext(context.Background(), "SELECT * FROM pragma_busy_timeout").Scan(&busyTimeout))
+	require.Equal(t, 5000, busyTimeout)
+
+	var synchronous int
+	require.NoError(t, conn.QueryRowContext(context.Background(), "PRAGMA synchronous").Scan(&synchronous))
+	require.Equal(t, 1, synchronous)
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -46,7 +46,7 @@ type Environment struct {
 	NodeAddress                   string        `default:"127.0.0.1:9001" split_words:"true"`
 	NodeLabels                    string        `default:"" split_words:"true"`
 	DatabaseNodes                 []string      `default:"" split_words:"true"`
-	APIExternalURL                string `envconfig:"API_EXTERNAL_URL" default:""`
+	APIExternalURL                string        `envconfig:"API_EXTERNAL_URL" default:""`
 	DatabasePath                  string        `default:"/var/lib/caesium/dqlite" split_words:"true"`
 	DatabaseType                  string        `default:"internal" split_words:"true"`
 	DatabaseDSN                   string        `default:"host=postgres user=postgres password=postgres dbname=caesium port=5432 sslmode=disable" split_words:"true"`
@@ -58,6 +58,7 @@ type Environment struct {
 	ExecutionMode                 string        `default:"local" split_words:"true"`
 	WorkerEnabled                 bool          `default:"true" split_words:"true"`
 	WorkerPollInterval            time.Duration `default:"2s" split_words:"true"`
+	WorkerReclaimInterval         time.Duration `default:"30s" split_words:"true"`
 	WorkerLeaseTTL                time.Duration `default:"5m" split_words:"true"`
 	WorkerPoolSize                int           `default:"4" split_words:"true"`
 	AtomPollInterval              time.Duration `default:"1s" split_words:"true"`


### PR DESCRIPTION
## Summary

Implements Phase 0 from `docs/design-database-locking-fix.md` to reduce distributed-mode database lock storms.

- Configures dqlite with a 5s busy timeout via go-dqlite's native `app.WithBusyTimeout` path and keeps SQL PRAGMA setup covered for injected sqlite connections.
- Adds bounded SQLITE_BUSY/LOCKED retry around `ClaimNext` and `ReclaimExpired`, including retry metrics.
- Throttles expired-lease reclaim with the new `CAESIUM_WORKER_RECLAIM_INTERVAL` setting and per-worker stagger.
- Adds `caesium_db_busy_retries_total` and `caesium_reclaim_duration_seconds` metrics, harness support, and docs updates.

## Notes

During validation, go-dqlite v3.0.3 returned `not authorized` for direct SQL `PRAGMA busy_timeout=5000` and `PRAGMA synchronous=NORMAL` on app-owned dqlite connections. The busy timeout is therefore applied through go-dqlite's supported native node option rather than by silently ignoring SQL PRAGMA failures.

## Validation

- `just lint`
- `just unit-test`