### PR TITLE
[codex] Implement phase 2 database locking fixes

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,7 +2,10 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -19,8 +22,10 @@ import (
 	"github.com/labstack/echo/v5"
 )
 
+type InternalWakeupHandler func(ctx context.Context, id string, ttl int)
+
 // Start launches Caesium's API.
-func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) error {
+func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, wakeupHandler InternalWakeupHandler) error {
 	e := echo.New()
 	vars := env.Variables()
 	configureIPExtractor(e, vars)
@@ -28,6 +33,7 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 	// health
 	e.GET("/health", Health)
 	e.GET("/auth/status", authStatus(vars))
+	registerInternalWakeup(e, vars, wakeupHandler)
 
 	// metrics
 	e.Use(echoprometheus.NewMiddleware("caesium"))
@@ -45,6 +51,64 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 		Address: fmt.Sprintf(":%v", vars.Port),
 	}
 	return sc.Start(ctx, e)
+}
+
+type internalWakeupRequest struct {
+	ID  string `json:"id,omitempty"`
+	TTL int    `json:"ttl,omitempty"`
+}
+
+func registerInternalWakeup(e *echo.Echo, vars env.Environment, handler InternalWakeupHandler) {
+	token := strings.TrimSpace(vars.InternalWakeupToken)
+	if token == "" || handler == nil {
+		return
+	}
+
+	e.POST("/internal/wakeup", func(c *echo.Context) error {
+		if !authorizedInternalWakeup(c.Request(), token) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+		}
+
+		var req internalWakeupRequest
+		if c.Request().Body != nil {
+			err := json.NewDecoder(c.Request().Body).Decode(&req)
+			if err != nil && err != io.EOF {
+				return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+			}
+		}
+		if req.TTL < 0 {
+			req.TTL = 0
+		}
+		if req.TTL > 8 {
+			req.TTL = 8
+		}
+
+		handler(c.Request().Context(), req.ID, req.TTL)
+		return c.NoContent(http.StatusNoContent)
+	})
+}
+
+func authorizedInternalWakeup(req *http.Request, token string) bool {
+	if token == "" {
+		return false
+	}
+
+	if constantTimeEqual(req.Header.Get("X-Caesium-Wakeup-Token"), token) {
+		return true
+	}
+
+	auth := strings.TrimSpace(req.Header.Get("Authorization"))
+	if len(auth) > len("Bearer ") && strings.EqualFold(auth[:len("Bearer ")], "Bearer ") {
+		return constantTimeEqual(strings.TrimSpace(auth[len("Bearer "):]), token)
+	}
+	return false
+}
+
+func constantTimeEqual(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }
 
 func authStatus(vars env.Environment) echo.HandlerFunc {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -89,6 +92,42 @@ func TestRegisterMetricsProtectedWhenAuthEnabled(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "caesium_")
+}
+
+func TestRegisterInternalWakeupRequiresToken(t *testing.T) {
+	e := echo.New()
+	var called atomic.Bool
+	var gotID string
+	var gotTTL int
+	registerInternalWakeup(e, env.Environment{InternalWakeupToken: "secret"}, func(_ context.Context, id string, ttl int) {
+		called.Store(true)
+		gotID = id
+		gotTTL = ttl
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/wakeup", strings.NewReader(`{"id":"abc","ttl":2}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusUnauthorized, rec.Code)
+	require.False(t, called.Load())
+
+	req = httptest.NewRequest(http.MethodPost, "/internal/wakeup", strings.NewReader(`{"id":"abc","ttl":2}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	req.Header.Set("Authorization", "Bearer secret")
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.True(t, called.Load())
+	require.Equal(t, "abc", gotID)
+	require.Equal(t, 2, gotTTL)
+}
+
+func TestRegisterInternalWakeupSkippedWhenDisabled(t *testing.T) {
+	e := echo.New()
+	registerInternalWakeup(e, env.Environment{}, func(context.Context, string, int) {})
+
+	require.False(t, hasRoute(e, http.MethodPost, "/internal/wakeup"))
 }
 
 func performRequest(t *testing.T, handler echo.HandlerFunc, method, path string) *httptest.ResponseRecorder {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -37,6 +37,8 @@ const (
 	short   = "Start a caesium scheduling instance"
 	long    = "This command starts a caesium scheduling instance"
 	example = "caesium start"
+
+	dqliteWakeupPeerCacheTTL = 5 * time.Second
 )
 
 var (
@@ -106,7 +108,10 @@ func start(cmd *cobra.Command, args []string) error {
 				Token:      vars.InternalWakeupToken,
 				FanoutMode: vars.WakeupFanoutMode,
 				Signaler:   wakeupSignaler,
-				Resolver:   dqliteWakeupPeerResolver(vars.NodeAddress, vars.Port),
+				Resolver: worker.NewCachedWakeupPeerResolver(
+					dqliteWakeupPeerResolver(vars.NodeAddress, vars.Port),
+					dqliteWakeupPeerCacheTTL,
+				),
 			})
 			internalWakeupHandler = func(ctx context.Context, id string, ttl int) {
 				distributedWakeups.HandleRemote(ctx, worker.WakeupMessage{ID: id, TTL: ttl})

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -26,6 +26,7 @@ import (
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
 	"github.com/caesium-cloud/caesium/internal/worker"
 	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/spf13/cobra"
@@ -95,6 +96,31 @@ func start(cmd *cobra.Command, args []string) error {
 	runsvc.New(ctx).SetBus(bus)
 
 	vars := env.Variables()
+	distributedMode := strings.EqualFold(strings.TrimSpace(vars.ExecutionMode), "distributed")
+	wakeupSignaler := worker.NewWakeupSignaler()
+	var distributedWakeups *worker.DistributedWakeups
+	var internalWakeupHandler api.InternalWakeupHandler
+	if distributedMode {
+		if strings.TrimSpace(vars.InternalWakeupToken) != "" {
+			distributedWakeups = worker.NewDistributedWakeups(worker.DistributedWakeupConfig{
+				Token:      vars.InternalWakeupToken,
+				FanoutMode: vars.WakeupFanoutMode,
+				Signaler:   wakeupSignaler,
+				Resolver:   dqliteWakeupPeerResolver(vars.NodeAddress, vars.Port),
+			})
+			internalWakeupHandler = func(ctx context.Context, id string, ttl int) {
+				distributedWakeups.HandleRemote(ctx, worker.WakeupMessage{ID: id, TTL: ttl})
+			}
+			go func() {
+				log.Info("launching distributed wakeup fanout", "mode", vars.WakeupFanoutMode)
+				if err := distributedWakeups.Start(ctx, bus); err != nil && ctx.Err() == nil {
+					log.Error("distributed wakeup fanout exited", "error", err)
+				}
+			}()
+		} else {
+			log.Warn("distributed wakeups disabled; set CAESIUM_INTERNAL_WAKEUP_TOKEN to enable cross-node wakeups")
+		}
+	}
 
 	// --- Authentication & Authorization ---
 	authSvc, auditor, limiter := initAuth(ctx, vars)
@@ -119,6 +145,12 @@ func start(cmd *cobra.Command, args []string) error {
 		vars.WorkerReclaimInterval,
 		"worker_lease_ttl",
 		vars.WorkerLeaseTTL,
+		"database_voters",
+		vars.DatabaseVoters,
+		"database_standbys",
+		vars.DatabaseStandbys,
+		"wakeup_fanout_mode",
+		vars.WakeupFanoutMode,
 		"node_labels",
 		vars.NodeLabels,
 	)
@@ -202,7 +234,7 @@ func start(cmd *cobra.Command, args []string) error {
 
 	go func() {
 		log.Info("spinning up api")
-		errs <- api.Start(ctx, bus, authSvc, auditor, limiter)
+		errs <- api.Start(ctx, bus, authSvc, auditor, limiter, internalWakeupHandler)
 	}()
 
 	go func() {
@@ -210,7 +242,7 @@ func start(cmd *cobra.Command, args []string) error {
 		errs <- executor.Start(ctx)
 	}()
 
-	if vars.WorkerEnabled && strings.EqualFold(strings.TrimSpace(vars.ExecutionMode), "distributed") {
+	if vars.WorkerEnabled && distributedMode {
 		go func() {
 			poolSize := vars.WorkerPoolSize
 			if poolSize < 1 {
@@ -236,10 +268,15 @@ func start(cmd *cobra.Command, args []string) error {
 			store := run.Default()
 			claimer := worker.NewClaimer(vars.NodeAddress, store, vars.WorkerLeaseTTL, worker.ParseNodeLabels(vars.NodeLabels))
 			executorFn := worker.NewRuntimeExecutor(store, vars.TaskTimeout, vars.WorkerLeaseTTL, vars.TaskFailurePolicy)
-			wakeups := worker.SubscribeWakeups(ctx, bus)
+			wakeups := worker.SubscribeWakeups(ctx, bus, wakeupSignaler.C())
 			w := worker.NewWorker(claimer, worker.NewPool(poolSize), vars.WorkerPollInterval, executorFn).
 				WithReclaimInterval(vars.WorkerReclaimInterval).
 				WithWakeups(wakeups)
+			if usesInternalDqlite(vars.DatabaseType) {
+				w = w.WithReclaimGate(worker.ReclaimGateFunc(func(ctx context.Context) (bool, error) {
+					return dqlite.IsLocalLeader(ctx)
+				}))
+			}
 			errs <- w.Run(ctx)
 		}()
 	} else {
@@ -255,6 +292,38 @@ func start(cmd *cobra.Command, args []string) error {
 	defer shutdown()
 
 	return <-errs
+}
+
+func usesInternalDqlite(databaseType string) bool {
+	switch strings.ToLower(strings.TrimSpace(databaseType)) {
+	case "", "internal", "dqlite":
+		return true
+	default:
+		return false
+	}
+}
+
+func dqliteWakeupPeerResolver(localNodeAddress string, apiPort int) worker.WakeupPeerResolver {
+	return worker.WakeupPeerResolverFunc(func(ctx context.Context) ([]string, error) {
+		nodes, err := dqlite.Cluster(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		peers := make([]string, 0, len(nodes))
+		for _, node := range nodes {
+			if node.Address == "" || node.Address == localNodeAddress {
+				continue
+			}
+			wakeupURL, err := worker.WakeupURLForNodeAddress(node.Address, apiPort)
+			if err != nil {
+				log.Warn("skipping dqlite peer for wakeup fanout", "address", node.Address, "error", err)
+				continue
+			}
+			peers = append(peers, wakeupURL)
+		}
+		return peers, nil
+	})
 }
 
 // initAuth sets up authentication services based on CAESIUM_AUTH_MODE.

--- a/docs/design-database-locking-fix.md
+++ b/docs/design-database-locking-fix.md
@@ -135,7 +135,7 @@ Goal: collapse N transactions into 1 where possible; replace read-then-write wit
 
 Goal: bound the Raft cost as worker count grows, and reduce the need for tight polling once write contention is no longer the bottleneck. This is the "Medium" deployment shape from the [Scaling target](#scaling-target).
 
-- [ ] **Adopt the spare-role topology so worker count is decoupled from Raft cost.**
+- [x] **Adopt the spare-role topology so worker count is decoupled from Raft cost.**
   - Files: `pkg/dqlite/dqlite.go:64-69`, `pkg/env/env.go`, `cmd/start/start.go`.
   - Today `app.New` is called with `WithAddress` and `WithCluster` only, accepting the dqlite library defaults. Add `app.WithVoters(3)` and `app.WithStandbys(3)` so the leader's `RolesAdjustmentFrequency` (default 30s) keeps exactly 3 voters and 3 standbys; every additional node automatically settles as a Spare. Spares don't replicate the Raft log and don't vote, but still act as leader-aware SQL clients via `app.Open` — i.e. fully functional Caesium worker nodes.
   - Add `CAESIUM_DATABASE_VOTERS` (default 3) and `CAESIUM_DATABASE_STANDBYS` (default 3); operators tune these for their HA target. Voter count must be odd and ≥ 3.
@@ -143,7 +143,7 @@ Goal: bound the Raft cost as worker count grows, and reduce the need for tight p
   - Acceptance: a 10-node test cluster shows exactly 3 nodes with `RAFT_VOTER`, ≤3 with `RAFT_STANDBY`, and the rest with `RAFT_SPARE` in `dqlite-dump-cluster` (or equivalent client API). Killing a voter triggers promotion of a standby within `2 × RolesAdjustmentFrequency`.
   - Risk: low. Defaults match the library defaults; behaviour is unchanged for existing 3-node deployments. Larger clusters benefit immediately because Raft replication stops scaling with worker count.
 
-- [ ] **Introduce distributed wakeups for task readiness.**
+- [x] **Introduce distributed wakeups for task readiness.**
   - Files: `cmd/start/start.go:235-236`, new `internal/worker/wakeup_distributed.go`.
   - On task-ready / lease-expired events, fanout an HTTP `POST /internal/wakeup` to peer node addresses (discovered via dqlite's cluster client API, **not** `env.Variables().DatabaseNodes` — that only contains bootstrap peers, not spares). Recommend reusing the existing internal HTTP server and TLS / auth story rather than adding a UDP path; the message is one packet per event and HTTP overhead is negligible at this rate.
   - Receiving node signals its local wakeup channel.
@@ -152,14 +152,14 @@ Goal: bound the Raft cost as worker count grows, and reduce the need for tight p
   - Acceptance: registering tasks on node A causes node B to claim within `<200ms` instead of waiting for the next poll. In a 50-node test cluster, gossip mode delivers wakeups to ≥99% of peers within `<500ms`.
   - Risk: medium. Network failures must not block event publication; treat wakeups as best-effort hints, not deliveries. Gossip implementation must be tested for partition tolerance.
 
-- [ ] **Make `ReclaimExpired` a leader-only responsibility.**
+- [x] **Make `ReclaimExpired` a leader-only responsibility.**
   - Files: `internal/worker/claimer.go:162`, `cmd/start/start.go`.
   - Option A (preferred): use the dqlite client's `Leader()` lookup to check if this node hosts the current Raft leader; non-leaders skip reclaim entirely. Re-check on a short interval so failover takes over reclaim within `~2 × RolesAdjustmentFrequency`.
   - Option B (fallback): add a `cluster_locks` row with `name='reclaim_expired'`, `held_by`, `expires_at`; nodes try to acquire via a CAS UPDATE, only the holder runs reclaim. Useful if leader detection proves flaky.
   - Acceptance: in a 10-node cluster, reclaim transactions execute on exactly one node at a time. Failover within `2 × RolesAdjustmentFrequency` if the leader dies.
   - Risk: medium. Must handle leader churn cleanly; option B is simpler but adds a hot row.
 
-- [ ] **Raise default poll interval from 2s to 15s** (only after distributed wakeups land).
+- [x] **Raise default poll interval from 2s to 15s** (only after distributed wakeups land).
   - Files: `pkg/env/env.go:60`, `internal/worker/worker.go:38`.
   - Acceptance: end-to-end run latency unchanged within 5% versus baseline once wakeups are in place; cluster-wide DB QPS for the `task_runs` table drops by an order of magnitude.
   - Risk: low after wakeups; high without them. Strictly gated on prior checkbox.

--- a/docs/parallel-execution-operations.md
+++ b/docs/parallel-execution-operations.md
@@ -19,13 +19,25 @@ This guide covers runtime configuration, rollout, and troubleshooting for parall
 | `CAESIUM_EXECUTION_MODE` | `local` | `local` or `distributed` execution model. |
 | `CAESIUM_WORKER_ENABLED` | `true` | Enables distributed worker loop on this node. |
 | `CAESIUM_WORKER_POOL_SIZE` | `4` | Max concurrent claimed tasks per node. |
-| `CAESIUM_WORKER_POLL_INTERVAL` | `2s` | Poll cadence for new claimable tasks. |
+| `CAESIUM_WORKER_POLL_INTERVAL` | `15s` | Fallback poll cadence for new claimable tasks. Distributed wakeups should handle normal claim latency. |
 | `CAESIUM_WORKER_RECLAIM_INTERVAL` | `30s` | Minimum interval between expired-lease reclaim attempts. |
 | `CAESIUM_WORKER_LEASE_TTL` | `5m` | Lease duration for claimed tasks before reclaim. |
 | `CAESIUM_DATABASE_MAX_OPEN_CONNS` | `4` | Max SQL connections per node for dqlite/PostgreSQL. |
 | `CAESIUM_DATABASE_MAX_IDLE_CONNS` | `2` | Max idle SQL connections per node for dqlite/PostgreSQL. |
+| `CAESIUM_DATABASE_VOTERS` | `3` | Target dqlite voter count. Must be odd and at least 3. |
+| `CAESIUM_DATABASE_STANDBYS` | `3` | Target dqlite standby count for failover headroom. Extra nodes settle as spares. |
+| `CAESIUM_INTERNAL_WAKEUP_TOKEN` | `""` | Shared bearer token required for cross-node wakeups via `POST /internal/wakeup`. |
+| `CAESIUM_WAKEUP_FANOUT_MODE` | `full` | Wakeup fanout strategy: `full` for every peer, or `gossip` for large clusters. |
 | `CAESIUM_NODE_ADDRESS` | `127.0.0.1:9001` | Logical node identity written to `task_runs.claimed_by`. |
 | `CAESIUM_NODE_LABELS` | `""` | Optional node labels (`k=v,k2=v2`) for task `nodeSelector` affinity. |
+
+## Dqlite Topology
+
+Use three stable control-plane nodes as voters. Add up to three standby nodes when you want fast failover without increasing quorum size. All remaining worker nodes can join the same dqlite cluster as spares; spares do not replicate the Raft log or vote, but they still open the Caesium database and claim work through the dqlite leader.
+
+Set the same `CAESIUM_DATABASE_VOTERS` and `CAESIUM_DATABASE_STANDBYS` values on every node. For a 10-node deployment, the recommended shape is 3 voters, 3 standbys, and 4 spares.
+
+Distributed wakeups use the dqlite cluster membership list, not `CAESIUM_DATABASE_NODES`, so spare workers receive wakeup hints after they join. Set the same `CAESIUM_INTERNAL_WAKEUP_TOKEN` on every node. The sender uses `Authorization: Bearer <token>` and receivers reject missing or incorrect tokens.
 
 ## Rollout Procedure (Distributed Mode)
 
@@ -67,7 +79,7 @@ Use metrics:
 - Increase `CAESIUM_MAX_PARALLEL_TASKS` for better local mode utilization.
 - Increase `CAESIUM_WORKER_LEASE_TTL` for long-running tasks to reduce reclaim churn.
 - Increase `CAESIUM_WORKER_RECLAIM_INTERVAL` to reduce reclaim write pressure.
-- Decrease `CAESIUM_WORKER_POLL_INTERVAL` for lower claim latency (at higher DB pressure).
+- Keep `CAESIUM_WORKER_POLL_INTERVAL` high enough to act as a fallback, not the primary coordination path. Lower it only when distributed wakeups are disabled or unhealthy.
 - Use `CAESIUM_NODE_LABELS` + task `nodeSelector` to place specialized workloads.
 
 ## Troubleshooting

--- a/internal/worker/wakeup.go
+++ b/internal/worker/wakeup.go
@@ -6,20 +6,83 @@ import (
 	"github.com/caesium-cloud/caesium/internal/event"
 )
 
-func SubscribeWakeups(ctx context.Context, bus event.Bus) <-chan struct{} {
-	if bus == nil {
+type WakeupSignaler struct {
+	ch chan struct{}
+}
+
+func NewWakeupSignaler() *WakeupSignaler {
+	return &WakeupSignaler{ch: make(chan struct{}, 1)}
+}
+
+func (s *WakeupSignaler) Signal() {
+	if s == nil {
+		return
+	}
+	select {
+	case s.ch <- struct{}{}:
+	default:
+	}
+}
+
+func (s *WakeupSignaler) C() <-chan struct{} {
+	if s == nil {
+		return nil
+	}
+	return s.ch
+}
+
+func SubscribeWakeups(ctx context.Context, bus event.Bus, extra ...<-chan struct{}) <-chan struct{} {
+	hasSource := bus != nil
+	for _, ch := range extra {
+		if ch != nil {
+			hasSource = true
+			break
+		}
+	}
+	if !hasSource {
 		return nil
 	}
 
-	events, err := bus.Subscribe(ctx, event.Filter{
-		Types: []event.Type{
-			event.TypeTaskReady,
-			event.TypeTaskLeaseExpired,
-			event.TypeRunStarted,
-		},
-	})
-	if err != nil {
-		return nil
+	signals := make(chan struct{}, 1)
+
+	if bus != nil {
+		events, err := bus.Subscribe(ctx, event.Filter{Types: wakeupEventTypes()})
+		if err != nil {
+			return nil
+		}
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case _, ok := <-events:
+					if !ok {
+						return
+					}
+					sendWakeupSignal(signals)
+				}
+			}
+		}()
+	}
+
+	for _, source := range extra {
+		source := source
+		if source == nil {
+			continue
+		}
+		go func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case _, ok := <-source:
+					if !ok {
+						return
+					}
+					sendWakeupSignal(signals)
+				}
+			}
+		}()
 	}
 
 	ch := make(chan struct{}, 1)
@@ -29,10 +92,7 @@ func SubscribeWakeups(ctx context.Context, bus event.Bus) <-chan struct{} {
 			select {
 			case <-ctx.Done():
 				return
-			case _, ok := <-events:
-				if !ok {
-					return
-				}
+			case <-signals:
 				select {
 				case ch <- struct{}{}:
 				default:
@@ -42,4 +102,19 @@ func SubscribeWakeups(ctx context.Context, bus event.Bus) <-chan struct{} {
 	}()
 
 	return ch
+}
+
+func sendWakeupSignal(ch chan<- struct{}) {
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}
+
+func wakeupEventTypes() []event.Type {
+	return []event.Type{
+		event.TypeTaskReady,
+		event.TypeTaskLeaseExpired,
+		event.TypeRunStarted,
+	}
 }

--- a/internal/worker/wakeup_distributed.go
+++ b/internal/worker/wakeup_distributed.go
@@ -1,0 +1,281 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"math/rand/v2"
+	"net"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+)
+
+const (
+	WakeupFanoutFull   = "full"
+	WakeupFanoutGossip = "gossip"
+
+	defaultWakeupHTTPTimeout = 750 * time.Millisecond
+	defaultWakeupGossipTTL   = 3
+	maxSeenWakeupIDs         = 2048
+	seenWakeupIDTTL          = 5 * time.Minute
+)
+
+type WakeupPeerResolver interface {
+	WakeupPeers(ctx context.Context) ([]string, error)
+}
+
+type WakeupPeerResolverFunc func(context.Context) ([]string, error)
+
+func (f WakeupPeerResolverFunc) WakeupPeers(ctx context.Context) ([]string, error) {
+	return f(ctx)
+}
+
+func WakeupURLForNodeAddress(nodeAddress string, apiPort int) (string, error) {
+	if apiPort <= 0 {
+		apiPort = 8080
+	}
+
+	host, _, err := net.SplitHostPort(nodeAddress)
+	if err != nil {
+		host = strings.TrimSpace(nodeAddress)
+	}
+	if host == "" {
+		return "", fmt.Errorf("empty host in node address %q", nodeAddress)
+	}
+	if strings.HasPrefix(host, "@") {
+		return "", fmt.Errorf("abstract unix dqlite address %q cannot be used for HTTP wakeups", nodeAddress)
+	}
+
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, strconv.Itoa(apiPort)),
+		Path:   "/internal/wakeup",
+	}).String(), nil
+}
+
+type DistributedWakeupConfig struct {
+	Token      string
+	FanoutMode string
+	Signaler   *WakeupSignaler
+	Resolver   WakeupPeerResolver
+	HTTPClient *http.Client
+}
+
+type DistributedWakeups struct {
+	token      string
+	mode       string
+	signaler   *WakeupSignaler
+	resolver   WakeupPeerResolver
+	httpClient *http.Client
+
+	seenMu sync.Mutex
+	seen   map[string]time.Time
+	now    func() time.Time
+}
+
+type WakeupMessage struct {
+	ID  string `json:"id,omitempty"`
+	TTL int    `json:"ttl,omitempty"`
+}
+
+func NewDistributedWakeups(cfg DistributedWakeupConfig) *DistributedWakeups {
+	signaler := cfg.Signaler
+	if signaler == nil {
+		signaler = NewWakeupSignaler()
+	}
+	resolver := cfg.Resolver
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: defaultWakeupHTTPTimeout}
+	}
+
+	return &DistributedWakeups{
+		token:      strings.TrimSpace(cfg.Token),
+		mode:       normalizeWakeupFanoutMode(cfg.FanoutMode),
+		signaler:   signaler,
+		resolver:   resolver,
+		httpClient: client,
+		seen:       make(map[string]time.Time),
+		now:        time.Now,
+	}
+}
+
+func normalizeWakeupFanoutMode(mode string) string {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case WakeupFanoutGossip:
+		return WakeupFanoutGossip
+	default:
+		return WakeupFanoutFull
+	}
+}
+
+func (d *DistributedWakeups) Start(ctx context.Context, bus event.Bus) error {
+	if d == nil || bus == nil || d.token == "" {
+		return nil
+	}
+
+	events, err := bus.Subscribe(ctx, event.Filter{Types: wakeupEventTypes()})
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-events:
+			if !ok {
+				return nil
+			}
+			id := uuid.NewString()
+			d.remember(id)
+			ttl := 0
+			if d.mode == WakeupFanoutGossip {
+				ttl = defaultWakeupGossipTTL
+			}
+			go d.broadcast(ctx, WakeupMessage{ID: id, TTL: ttl})
+		}
+	}
+}
+
+func (d *DistributedWakeups) HandleRemote(ctx context.Context, msg WakeupMessage) {
+	if d == nil {
+		return
+	}
+	if msg.ID == "" {
+		msg.ID = uuid.NewString()
+	}
+	if !d.remember(msg.ID) {
+		return
+	}
+
+	d.signaler.Signal()
+	if d.mode == WakeupFanoutGossip && msg.TTL > 0 {
+		msg.TTL--
+		go d.broadcast(ctx, msg)
+	}
+}
+
+func (d *DistributedWakeups) broadcast(ctx context.Context, msg WakeupMessage) {
+	if d == nil || d.token == "" || d.resolver == nil {
+		return
+	}
+
+	peers, err := d.resolver.WakeupPeers(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Warn("failed to resolve wakeup peers", "error", err)
+		}
+		return
+	}
+	peers = d.selectPeers(peers)
+	if len(peers) == 0 {
+		return
+	}
+
+	var wg sync.WaitGroup
+	for _, peer := range peers {
+		peer := peer
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			d.postWakeup(ctx, peer, msg)
+		}()
+	}
+	wg.Wait()
+}
+
+func (d *DistributedWakeups) selectPeers(peers []string) []string {
+	if len(peers) == 0 {
+		return nil
+	}
+	selected := append([]string(nil), peers...)
+	if d.mode != WakeupFanoutGossip {
+		return selected
+	}
+
+	for i := len(selected) - 1; i > 0; i-- {
+		j := rand.IntN(i + 1)
+		selected[i], selected[j] = selected[j], selected[i]
+	}
+	limit := gossipFanout(len(selected))
+	if limit >= len(selected) {
+		return selected
+	}
+	return selected[:limit]
+}
+
+func gossipFanout(peerCount int) int {
+	if peerCount <= 1 {
+		return peerCount
+	}
+	return int(math.Ceil(math.Log2(float64(peerCount)))) + 1
+}
+
+func (d *DistributedWakeups) postWakeup(ctx context.Context, peer string, msg WakeupMessage) {
+	body, err := json.Marshal(msg)
+	if err != nil {
+		log.Warn("failed to marshal wakeup message", "error", err)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, peer, bytes.NewReader(body))
+	if err != nil {
+		log.Warn("failed to create wakeup request", "peer", peer, "error", err)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+d.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := d.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Debug("distributed wakeup failed", "peer", peer, "error", err)
+		}
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		log.Debug("distributed wakeup returned non-success status", "peer", peer, "status", resp.StatusCode)
+	}
+}
+
+func (d *DistributedWakeups) remember(id string) bool {
+	if id == "" {
+		return true
+	}
+
+	d.seenMu.Lock()
+	defer d.seenMu.Unlock()
+
+	now := d.now()
+	if seenAt, ok := d.seen[id]; ok && now.Sub(seenAt) < seenWakeupIDTTL {
+		return false
+	}
+	d.seen[id] = now
+
+	if len(d.seen) > maxSeenWakeupIDs {
+		for seenID, seenAt := range d.seen {
+			if now.Sub(seenAt) >= seenWakeupIDTTL || len(d.seen) > maxSeenWakeupIDs {
+				delete(d.seen, seenID)
+			}
+			if len(d.seen) <= maxSeenWakeupIDs {
+				break
+			}
+		}
+	}
+	return true
+}

--- a/internal/worker/wakeup_distributed.go
+++ b/internal/worker/wakeup_distributed.go
@@ -84,9 +84,57 @@ type DistributedWakeups struct {
 	now    func() time.Time
 }
 
+type cachedWakeupPeerResolver struct {
+	resolver WakeupPeerResolver
+	ttl      time.Duration
+	now      func() time.Time
+
+	mu       sync.Mutex
+	cacheSet bool
+	peers    []string
+	expires  time.Time
+}
+
 type WakeupMessage struct {
 	ID  string `json:"id,omitempty"`
 	TTL int    `json:"ttl,omitempty"`
+}
+
+func NewCachedWakeupPeerResolver(resolver WakeupPeerResolver, ttl time.Duration) WakeupPeerResolver {
+	if resolver == nil || ttl <= 0 {
+		return resolver
+	}
+	return &cachedWakeupPeerResolver{
+		resolver: resolver,
+		ttl:      ttl,
+		now:      time.Now,
+	}
+}
+
+func (r *cachedWakeupPeerResolver) WakeupPeers(ctx context.Context) ([]string, error) {
+	now := r.now()
+
+	r.mu.Lock()
+	if r.cacheSet && now.Before(r.expires) {
+		peers := append([]string(nil), r.peers...)
+		r.mu.Unlock()
+		return peers, nil
+	}
+	r.mu.Unlock()
+
+	peers, err := r.resolver.WakeupPeers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cached := append([]string(nil), peers...)
+	r.mu.Lock()
+	r.peers = cached
+	r.expires = r.now().Add(r.ttl)
+	r.cacheSet = true
+	r.mu.Unlock()
+
+	return append([]string(nil), cached...), nil
 }
 
 func NewDistributedWakeups(cfg DistributedWakeupConfig) *DistributedWakeups {
@@ -163,7 +211,7 @@ func (d *DistributedWakeups) HandleRemote(ctx context.Context, msg WakeupMessage
 	d.signaler.Signal()
 	if d.mode == WakeupFanoutGossip && msg.TTL > 0 {
 		msg.TTL--
-		go d.broadcast(ctx, msg)
+		go d.broadcast(context.WithoutCancel(ctx), msg)
 	}
 }
 
@@ -184,16 +232,12 @@ func (d *DistributedWakeups) broadcast(ctx context.Context, msg WakeupMessage) {
 		return
 	}
 
-	var wg sync.WaitGroup
 	for _, peer := range peers {
 		peer := peer
-		wg.Add(1)
 		go func() {
-			defer wg.Done()
 			d.postWakeup(ctx, peer, msg)
 		}()
 	}
-	wg.Wait()
 }
 
 func (d *DistributedWakeups) selectPeers(peers []string) []string {

--- a/internal/worker/wakeup_distributed_test.go
+++ b/internal/worker/wakeup_distributed_test.go
@@ -21,6 +21,40 @@ func TestWakeupURLForNodeAddress(t *testing.T) {
 	require.Equal(t, "http://[fd00::12]:8080/internal/wakeup", u)
 }
 
+func TestCachedWakeupPeerResolverCachesWithinTTL(t *testing.T) {
+	now := time.Unix(100, 0)
+	var calls atomic.Int32
+
+	resolver := &cachedWakeupPeerResolver{
+		resolver: WakeupPeerResolverFunc(func(context.Context) ([]string, error) {
+			if calls.Add(1) == 1 {
+				return []string{"peer-a"}, nil
+			}
+			return []string{"peer-b"}, nil
+		}),
+		ttl: 5 * time.Second,
+		now: func() time.Time {
+			return now
+		},
+	}
+
+	peers, err := resolver.WakeupPeers(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"peer-a"}, peers)
+
+	peers[0] = "mutated"
+	peers, err = resolver.WakeupPeers(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"peer-a"}, peers)
+	require.Equal(t, int32(1), calls.Load())
+
+	now = now.Add(6 * time.Second)
+	peers, err = resolver.WakeupPeers(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"peer-b"}, peers)
+	require.Equal(t, int32(2), calls.Load())
+}
+
 func TestDistributedWakeupsBroadcastFullFanout(t *testing.T) {
 	const token = "shared-secret"
 	var hits atomic.Int32
@@ -39,7 +73,9 @@ func TestDistributedWakeupsBroadcastFullFanout(t *testing.T) {
 
 	d.broadcast(context.Background(), WakeupMessage{ID: "wakeup-1"})
 
-	require.Equal(t, int32(2), hits.Load())
+	require.Eventually(t, func() bool {
+		return hits.Load() == 2
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestDistributedWakeupsHandleRemoteSignalsOncePerID(t *testing.T) {
@@ -63,6 +99,35 @@ func TestDistributedWakeupsHandleRemoteSignalsOncePerID(t *testing.T) {
 	case <-time.After(50 * time.Millisecond):
 		// expected
 	}
+}
+
+func TestDistributedWakeupsHandleRemoteGossipDetachesRequestContext(t *testing.T) {
+	const token = "shared-secret"
+	var hits atomic.Int32
+
+	signaler := NewWakeupSignaler()
+	server := wakeupTestServer(t, token, &hits)
+	d := NewDistributedWakeups(DistributedWakeupConfig{
+		Token:      token,
+		FanoutMode: WakeupFanoutGossip,
+		Signaler:   signaler,
+		Resolver: WakeupPeerResolverFunc(func(ctx context.Context) ([]string, error) {
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return []string{server.URL}, nil
+		}),
+		HTTPClient: server.Client(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	d.HandleRemote(ctx, WakeupMessage{ID: "wakeup-ctx", TTL: 1})
+
+	assertSignal(t, signaler.C(), "remote wakeup")
+	require.Eventually(t, func() bool {
+		return hits.Load() == 1
+	}, time.Second, 10*time.Millisecond)
 }
 
 func TestDistributedWakeupsGossipSelectsLogarithmicFanout(t *testing.T) {

--- a/internal/worker/wakeup_distributed_test.go
+++ b/internal/worker/wakeup_distributed_test.go
@@ -1,0 +1,90 @@
+package worker
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWakeupURLForNodeAddress(t *testing.T) {
+	u, err := WakeupURLForNodeAddress("10.0.0.12:9001", 8080)
+	require.NoError(t, err)
+	require.Equal(t, "http://10.0.0.12:8080/internal/wakeup", u)
+
+	u, err = WakeupURLForNodeAddress("[fd00::12]:9001", 8080)
+	require.NoError(t, err)
+	require.Equal(t, "http://[fd00::12]:8080/internal/wakeup", u)
+}
+
+func TestDistributedWakeupsBroadcastFullFanout(t *testing.T) {
+	const token = "shared-secret"
+	var hits atomic.Int32
+
+	serverA := wakeupTestServer(t, token, &hits)
+	serverB := wakeupTestServer(t, token, &hits)
+
+	d := NewDistributedWakeups(DistributedWakeupConfig{
+		Token:      token,
+		FanoutMode: WakeupFanoutFull,
+		Resolver: WakeupPeerResolverFunc(func(context.Context) ([]string, error) {
+			return []string{serverA.URL, serverB.URL}, nil
+		}),
+		HTTPClient: serverA.Client(),
+	})
+
+	d.broadcast(context.Background(), WakeupMessage{ID: "wakeup-1"})
+
+	require.Equal(t, int32(2), hits.Load())
+}
+
+func TestDistributedWakeupsHandleRemoteSignalsOncePerID(t *testing.T) {
+	signaler := NewWakeupSignaler()
+	d := NewDistributedWakeups(DistributedWakeupConfig{
+		Token:      "shared-secret",
+		FanoutMode: WakeupFanoutFull,
+		Signaler:   signaler,
+		Resolver: WakeupPeerResolverFunc(func(context.Context) ([]string, error) {
+			return nil, nil
+		}),
+	})
+
+	d.HandleRemote(context.Background(), WakeupMessage{ID: "wakeup-1"})
+	assertSignal(t, signaler.C(), "first remote wakeup")
+
+	d.HandleRemote(context.Background(), WakeupMessage{ID: "wakeup-1"})
+	select {
+	case <-signaler.C():
+		t.Fatal("duplicate wakeup ID should not signal twice")
+	case <-time.After(50 * time.Millisecond):
+		// expected
+	}
+}
+
+func TestDistributedWakeupsGossipSelectsLogarithmicFanout(t *testing.T) {
+	d := NewDistributedWakeups(DistributedWakeupConfig{
+		Token:      "shared-secret",
+		FanoutMode: WakeupFanoutGossip,
+	})
+
+	peers := []string{"a", "b", "c", "d", "e", "f", "g", "h"}
+	selected := d.selectPeers(peers)
+
+	require.Len(t, selected, gossipFanout(len(peers)))
+	require.Less(t, len(selected), len(peers))
+}
+
+func wakeupTestServer(t *testing.T, token string, hits *atomic.Int32) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer "+token, r.Header.Get("Authorization"))
+		hits.Add(1)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}

--- a/internal/worker/wakeup_test.go
+++ b/internal/worker/wakeup_test.go
@@ -48,6 +48,17 @@ func TestSubscribeWakeups_WakesOnRunStarted(t *testing.T) {
 	assertSignal(t, ch, "TypeRunStarted")
 }
 
+func TestSubscribeWakeups_WakesOnExternalSignal(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	signaler := NewWakeupSignaler()
+	ch := SubscribeWakeups(ctx, nil, signaler.C())
+
+	signaler.Signal()
+	assertSignal(t, ch, "external signal")
+}
+
 func TestSubscribeWakeups_IgnoresIrrelevantEvents(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -9,7 +9,10 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/log"
 )
 
-const defaultReclaimInterval = 30 * time.Second
+const (
+	defaultPollInterval    = 15 * time.Second
+	defaultReclaimInterval = 30 * time.Second
+)
 
 type TaskClaimer interface {
 	ClaimNext(ctx context.Context) (*models.TaskRun, error)
@@ -21,12 +24,23 @@ type ExpiredReclaimer interface {
 	ReclaimExpired(ctx context.Context) error
 }
 
+type ReclaimGate interface {
+	CanReclaim(ctx context.Context) (bool, error)
+}
+
+type ReclaimGateFunc func(context.Context) (bool, error)
+
+func (f ReclaimGateFunc) CanReclaim(ctx context.Context) (bool, error) {
+	return f(ctx)
+}
+
 type Worker struct {
 	claimer         TaskClaimer
 	pool            *Pool
 	pollInterval    time.Duration
 	reclaimInterval time.Duration
 	lastReclaim     time.Time
+	reclaimGate     ReclaimGate
 	executor        TaskExecutor
 	wakeups         <-chan struct{}
 }
@@ -39,7 +53,7 @@ func NewWorker(claimer TaskClaimer, pool *Pool, pollInterval time.Duration, exec
 		pool = NewPool(1)
 	}
 	if pollInterval <= 0 {
-		pollInterval = 2 * time.Second
+		pollInterval = defaultPollInterval
 	}
 	if executor == nil {
 		executor = func(context.Context, *models.TaskRun) {}
@@ -57,6 +71,11 @@ func NewWorker(claimer TaskClaimer, pool *Pool, pollInterval time.Duration, exec
 
 func (w *Worker) WithWakeups(ch <-chan struct{}) *Worker {
 	w.wakeups = ch
+	return w
+}
+
+func (w *Worker) WithReclaimGate(gate ReclaimGate) *Worker {
+	w.reclaimGate = gate
 	return w
 }
 
@@ -119,6 +138,18 @@ func (w *Worker) reclaimIfDue(ctx context.Context) {
 	}
 
 	w.lastReclaim = time.Now()
+	if w.reclaimGate != nil {
+		canReclaim, err := w.reclaimGate.CanReclaim(ctx)
+		if err != nil {
+			if ctx.Err() == nil {
+				log.Warn("failed to evaluate reclaim leadership", "error", err)
+			}
+			return
+		}
+		if !canReclaim {
+			return
+		}
+	}
 	if err := reclaimer.ReclaimExpired(ctx); err != nil && ctx.Err() == nil {
 		log.Error("failed to reclaim expired tasks", "error", err)
 	}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -92,6 +92,33 @@ func TestWorkerRunReclaimsWhenDueBeforeBusyClaimLoop(t *testing.T) {
 	}
 }
 
+func TestWorkerRunSkipsReclaimWhenGateDenies(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	claimer := &reclaimingSequenceClaimer{
+		sequenceClaimer: sequenceClaimer{
+			responses: []claimerResponse{{task: &models.TaskRun{ID: uuid.New()}}},
+		},
+	}
+
+	worker := NewWorker(claimer, NewPool(1), time.Millisecond, func(_ context.Context, _ *models.TaskRun) {
+		cancel()
+	}).WithReclaimInterval(time.Hour).
+		WithReclaimGate(ReclaimGateFunc(func(context.Context) (bool, error) {
+			return false, nil
+		}))
+	worker.lastReclaim = time.Now().Add(-2 * time.Hour)
+
+	if err := worker.Run(ctx); err != nil {
+		t.Fatalf("worker run failed: %v", err)
+	}
+
+	if got := atomic.LoadInt32(&claimer.reclaims); got != 0 {
+		t.Fatalf("expected no reclaim attempt, got %d", got)
+	}
+}
+
 func TestSleepWithContextHandlesTinyDurations(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/pkg/dqlite/dqlite.go
+++ b/pkg/dqlite/dqlite.go
@@ -2,14 +2,16 @@ package dqlite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
-	"github.com/canonical/go-dqlite/v3/app"
+	dqliteapp "github.com/canonical/go-dqlite/v3/app"
 	"github.com/canonical/go-dqlite/v3/client"
 	_ "github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
@@ -25,6 +27,12 @@ const (
 	DriverName = "dqlite"
 
 	dqliteBusyTimeout = 5 * time.Second
+)
+
+var (
+	currentApp atomic.Pointer[dqliteapp.App]
+
+	ErrNoNativeApp = errors.New("dqlite: native app is not active")
 )
 
 type Dialector struct {
@@ -70,25 +78,29 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 			fn("dqlite", "msg", fmt.Sprintf(format, a...), "source", "dqlite")
 		}
 
-		app, err := app.New(
-			env.Variables().DatabasePath,
-			app.WithAddress(env.Variables().NodeAddress),
-			app.WithCluster(env.Variables().DatabaseNodes),
-			app.WithLogFunc(logFunc),
-			app.WithBusyTimeout(dqliteBusyTimeout),
+		vars := env.Variables()
+		dqApp, err := dqliteapp.New(
+			vars.DatabasePath,
+			dqliteapp.WithAddress(vars.NodeAddress),
+			dqliteapp.WithCluster(vars.DatabaseNodes),
+			dqliteapp.WithVoters(vars.DatabaseVoters),
+			dqliteapp.WithStandBys(vars.DatabaseStandbys),
+			dqliteapp.WithLogFunc(logFunc),
+			dqliteapp.WithBusyTimeout(dqliteBusyTimeout),
 		)
 		if err != nil {
 			return err
 		}
 
-		if err := app.Ready(context.Background()); err != nil {
+		if err := dqApp.Ready(context.Background()); err != nil {
 			return err
 		}
 
-		conn, err := app.Open(context.Background(), "caesium")
+		conn, err := dqApp.Open(context.Background(), "caesium")
 		if err != nil {
 			return err
 		}
+		currentApp.Store(dqApp)
 
 		db.ConnPool = conn
 	}
@@ -133,6 +145,68 @@ func setConnectionPragmas(ctx context.Context, conn gorm.ConnPool) error {
 		}
 	}
 	return nil
+}
+
+// ClusterNode is a dqlite cluster member visible to the current native app.
+type ClusterNode struct {
+	ID       uint64
+	Address  string
+	Role     string
+	IsLeader bool
+}
+
+// Cluster returns the current dqlite cluster membership from the leader.
+func Cluster(ctx context.Context) ([]ClusterNode, error) {
+	dqApp := currentApp.Load()
+	if dqApp == nil {
+		return nil, ErrNoNativeApp
+	}
+
+	cli, err := dqApp.FindLeader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = cli.Close() }()
+
+	leader, err := cli.Leader(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nodes, err := cli.Cluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster := make([]ClusterNode, 0, len(nodes))
+	for _, node := range nodes {
+		cluster = append(cluster, ClusterNode{
+			ID:       node.ID,
+			Address:  node.Address,
+			Role:     node.Role.String(),
+			IsLeader: leader != nil && node.ID == leader.ID,
+		})
+	}
+	return cluster, nil
+}
+
+// IsLocalLeader reports whether this process hosts the current dqlite leader.
+func IsLocalLeader(ctx context.Context) (bool, error) {
+	dqApp := currentApp.Load()
+	if dqApp == nil {
+		return false, ErrNoNativeApp
+	}
+
+	cli, err := dqApp.FindLeader(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = cli.Close() }()
+
+	leader, err := cli.Leader(ctx)
+	if err != nil {
+		return false, err
+	}
+	return leader != nil && leader.Address == dqApp.Address(), nil
 }
 
 func (dialector Dialector) ClauseBuilders() map[string]clause.ClauseBuilder {

--- a/pkg/dqlite/dqlite_test.go
+++ b/pkg/dqlite/dqlite_test.go
@@ -3,6 +3,7 @@ package dqlite
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -25,4 +26,13 @@ func TestDialectorAppliesConnectionPragmas(t *testing.T) {
 	var synchronous int
 	require.NoError(t, conn.QueryRowContext(context.Background(), "PRAGMA synchronous").Scan(&synchronous))
 	require.Equal(t, 1, synchronous)
+}
+
+func TestClusterRequiresNativeApp(t *testing.T) {
+	_, err := Cluster(context.Background())
+	require.True(t, errors.Is(err, ErrNoNativeApp))
+
+	isLeader, err := IsLocalLeader(context.Background())
+	require.False(t, isLeader)
+	require.True(t, errors.Is(err, ErrNoNativeApp))
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -3,6 +3,7 @@ package env
 import (
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/caesium-cloud/caesium/pkg/log"
@@ -18,10 +19,33 @@ func Process() error {
 	if err := envconfig.Process("caesium", variables); err != nil {
 		return fmt.Errorf("failed to process environment variables: %w", err)
 	}
+	if err := validate(); err != nil {
+		return err
+	}
 
 	// set the log level
 	if err := log.SetLevel(variables.LogLevel); err != nil {
 		return fmt.Errorf("failed to set log level: %w", err)
+	}
+
+	return nil
+}
+
+func validate() error {
+	dbType := strings.ToLower(strings.TrimSpace(variables.DatabaseType))
+	if dbType == "" || dbType == "internal" || dbType == "dqlite" {
+		if variables.DatabaseVoters < 3 || variables.DatabaseVoters%2 == 0 {
+			return fmt.Errorf("CAESIUM_DATABASE_VOTERS must be an odd number greater than or equal to 3")
+		}
+		if variables.DatabaseStandbys < 0 {
+			return fmt.Errorf("CAESIUM_DATABASE_STANDBYS must be greater than or equal to 0")
+		}
+	}
+
+	switch strings.ToLower(strings.TrimSpace(variables.WakeupFanoutMode)) {
+	case "", "full", "gossip":
+	default:
+		return fmt.Errorf("CAESIUM_WAKEUP_FANOUT_MODE must be one of: full, gossip")
 	}
 
 	return nil
@@ -52,6 +76,8 @@ type Environment struct {
 	DatabaseDSN                   string        `default:"host=postgres user=postgres password=postgres dbname=caesium port=5432 sslmode=disable" split_words:"true"`
 	DatabaseMaxOpenConns          int           `default:"4" split_words:"true"`
 	DatabaseMaxIdleConns          int           `default:"2" split_words:"true"`
+	DatabaseVoters                int           `default:"3" split_words:"true"`
+	DatabaseStandbys              int           `default:"3" split_words:"true"`
 	DatabaseConsoleEnabled        bool          `default:"false" split_words:"true"`
 	ManualTriggerAPIKey           string        `envconfig:"MANUAL_TRIGGER_API_KEY" default:""`
 	MaxParallelTasks              int           `split_words:"true"`
@@ -59,10 +85,12 @@ type Environment struct {
 	TaskTimeout                   time.Duration `default:"0" split_words:"true"`
 	ExecutionMode                 string        `default:"local" split_words:"true"`
 	WorkerEnabled                 bool          `default:"true" split_words:"true"`
-	WorkerPollInterval            time.Duration `default:"2s" split_words:"true"`
+	WorkerPollInterval            time.Duration `default:"15s" split_words:"true"`
 	WorkerReclaimInterval         time.Duration `default:"30s" split_words:"true"`
 	WorkerLeaseTTL                time.Duration `default:"5m" split_words:"true"`
 	WorkerPoolSize                int           `default:"4" split_words:"true"`
+	InternalWakeupToken           string        `default:"" split_words:"true"`
+	WakeupFanoutMode              string        `default:"full" split_words:"true"`
 	AtomPollInterval              time.Duration `default:"1s" split_words:"true"`
 	JobdefGitEnabled              bool          `envconfig:"JOBDEF_GIT_ENABLED" default:"false"`
 	JobdefGitOnce                 bool          `envconfig:"JOBDEF_GIT_ONCE" default:"false"`

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -3,6 +3,7 @@ package env
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -18,6 +19,10 @@ func (s *EnvTestSuite) TestProcess() {
 	assert.Equal(s.T(), "info", Variables().LogLevel)
 	assert.Equal(s.T(), 4, Variables().DatabaseMaxOpenConns)
 	assert.Equal(s.T(), 2, Variables().DatabaseMaxIdleConns)
+	assert.Equal(s.T(), 3, Variables().DatabaseVoters)
+	assert.Equal(s.T(), 3, Variables().DatabaseStandbys)
+	assert.Equal(s.T(), 15*time.Second, Variables().WorkerPollInterval)
+	assert.Equal(s.T(), "full", Variables().WakeupFanoutMode)
 }
 
 func (s *EnvTestSuite) TestProcessInvalidTypeFailure() {


### PR DESCRIPTION
## Summary
- add configurable dqlite voter/standby topology and expose dqlite cluster/leader helpers
- add authenticated distributed worker wakeups with full and gossip fanout
- gate expired-lease reclaim to the dqlite leader and raise the fallback poll interval to 15s
- mark Phase 2 progress complete in the database locking design doc and document new ops settings

## Why
Phase 2 reduces cross-node polling pressure and bounds Raft replication cost as worker count grows. The previous distributed path relied on local-only wakeups plus tight polling, and every worker could attempt expired-lease reclaim.

## Impact
Operators can tune CAESIUM_DATABASE_VOTERS and CAESIUM_DATABASE_STANDBYS, enable cross-node wakeups with CAESIUM_INTERNAL_WAKEUP_TOKEN, and use CAESIUM_WAKEUP_FANOUT_MODE=full or gossip. In distributed mode, reclaim runs only on the current dqlite leader for the internal dqlite backend.

## Validation
- just lint
- just unit-test