### PR TITLE
[codex] Add Phase 4 database shard router

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This directory mixes current-source operator documentation with design records a
 - [job-schema-reference.md](job-schema-reference.md): Generated schema reference from `pkg/jobdef`.
 - [backfill.md](backfill.md): Backfill behavior across API, CLI, and UI.
 - [parallel-execution-operations.md](parallel-execution-operations.md): Distributed execution configuration, rollout, and troubleshooting.
+- [database-sharding.md](database-sharding.md): Phase 4 database shard layout, routing contract, and constraints.
 - [open_lineage.md](open_lineage.md): OpenLineage configuration, transports, and observability.
 - [kubernetes-deployment.md](kubernetes-deployment.md): Deploying Caesium to Kubernetes with Helm.
 - [airflow-parity.md](airflow-parity.md): Implemented Airflow-style authoring and operator semantics.

--- a/docs/database-sharding.md
+++ b/docs/database-sharding.md
@@ -1,0 +1,50 @@
+# Database Sharding
+
+Caesium keeps dqlite as the built-in storage layer. Horizontal write scaling is
+implemented by opening multiple databases on the same dqlite cluster and routing
+run-scoped writes by job run ID.
+
+`CAESIUM_DATABASE_SHARDS` defaults to `1`. At that value, the hot and cold
+routes alias the catalog database and runtime behavior is unchanged. Values
+greater than `1` are the Phase 4 sharding path and require
+`CAESIUM_DATABASE_TYPE=internal`.
+
+## Database Layout
+
+| Database | Tables | Routing |
+| --- | --- | --- |
+| `caesium` | `atoms`, `triggers`, `jobs`, `tasks`, `task_edges`, `callbacks`, `backfills`, `task_cache`, `api_keys`, `audit_logs`, `notification_channels`, `notification_policies` | Catalog tables stay in the catalog database. |
+| `caesium_hot_00` ... `caesium_hot_NN` | `job_runs`, `task_runs`, `callback_runs`, `execution_events` | Hot lifecycle tables route by `hash(job_run_id) % CAESIUM_DATABASE_SHARDS`. |
+| `caesium_history` | Terminal `job_runs`, child `task_runs`, `callback_runs`, and `execution_events` after archival | Cold-history route. The archiver moves terminal runs here once implemented. |
+
+All rows for a single job run must live on one hot shard. That keeps task
+registration, claim, completion, retry, callback, and event writes
+transactionally local without dqlite `ATTACH`, which is intentionally not
+available.
+
+## Router Contract
+
+The data-layer router in `pkg/db` exposes:
+
+- `Catalog()` for write-light definitions, auth, notifications, and operator
+  tables.
+- `HotShardForRun(runID)` for run lifecycle rows.
+- `Cold()` for archived terminal run history.
+- `RouteTable(table, runID)` for table-aware dispatch.
+
+The shard hash is stable for a fixed shard count. Increasing
+`CAESIUM_DATABASE_SHARDS` does not rebalance existing hot rows; run-scoped
+lookups must use the shard count that was active when the run was created until
+a rebalancer is designed.
+
+## Constraints
+
+Hot and cold shard migrations disable GORM foreign-key constraint creation for
+cross-database relationships. Catalog records such as jobs and tasks remain the
+source of truth, while hot shard rows reference them by ID and application code
+performs the consistency checks that cannot be enforced across dqlite
+databases.
+
+Event sequence values are shard-local once `execution_events` moves to hot
+shards. APIs that expose global event streams must merge by timestamp or add a
+global cursor before sharded event storage is enabled for production traffic.

--- a/docs/design-database-locking-fix.md
+++ b/docs/design-database-locking-fix.md
@@ -199,17 +199,21 @@ Goal: scale to the "Large" deployment shape — 100–500 worker nodes and tens 
 
 The unlock is that `App.Open(name)` on a single dqlite cluster opens an independent database with its own engine thread and write queue on the leader. Sharding the hot tables across N databases linearly multiplies write throughput on the same Raft cluster. Cross-database `ATTACH` is intentionally disabled in dqlite (see [canonical/dqlite#441](https://github.com/canonical/dqlite/issues/441)), so each shard must be transactionally self-contained — manageable for our schema because DAG state is naturally per-job.
 
-- [ ] **Define the shard boundary and routing key.**
+Status: Phase 4 foundation is underway. The current implementation adds named dqlite database opens, `CAESIUM_DATABASE_SHARDS`, the `pkg/db.Router` routing primitive, and the table-placement contract in `docs/database-sharding.md`. Runtime call sites still need to migrate from the compatibility catalog connection to router-aware run-scoped paths before `CAESIUM_DATABASE_SHARDS>1` is production-ready.
+
+- [x] **Define the shard boundary and routing key.**
   - Hot, write-heavy tables (`task_runs`, `events`, optionally `job_runs`) shard by `hash(job_run_id) % N`. All rows for a given run live in one shard so per-run transactions stay local.
   - Catalog tables (`jobs`, `triggers`, `atoms`, `tasks`, `secrets`, `users`) stay in the **catalog** database (`caesium`). They're write-light and read-heavy; replication via standbys covers them fine.
   - History tables (`task_runs`, `events` for terminal runs) move to a **cold** database (`caesium_history`) on a configurable lag. The hot path never scans cold rows.
   - Acceptance: a written-down schema doc enumerates which table lives in which database, and the runtime routes accordingly.
+  - Status: table placement and routing-key contract are documented in `docs/database-sharding.md`; runtime call-site migration is covered by the router and per-shard milestones below.
 
 - [ ] **Build a shard router in the data layer.**
   - Files: `pkg/db/db.go`, new `pkg/db/router.go`.
   - Replace the single `*gorm.DB` returned by `Connection()` with a `Router` that dispatches by table + shard key. Most call sites get the catalog DB; run-scoped sites get the run's hot shard.
   - Static shard count `CAESIUM_DATABASE_SHARDS` (default 1, so this is a no-op until operators opt in). Power-of-two recommended for clean rebalancing later.
   - Acceptance: at `CAESIUM_DATABASE_SHARDS=1` the system is byte-identical to today; at `CAESIUM_DATABASE_SHARDS=8`, 50 concurrent runs distribute across 8 hot shards roughly evenly.
+  - Status: `pkg/db.Router`, `db.DefaultRouter()`, named dqlite database opens, and router unit tests are implemented. Compatibility `db.Connection()` still returns the catalog DB while run-scoped call sites are migrated incrementally.
   - Risk: high. This is the largest refactor in the plan; gate behind a feature flag and ship the router with shards=1 first to flush out call-site mistakes before any deployment turns it up.
 
 - [ ] **Per-shard ClaimNext and ReclaimExpired.**

--- a/docs/parallel-execution-operations.md
+++ b/docs/parallel-execution-operations.md
@@ -24,6 +24,7 @@ This guide covers runtime configuration, rollout, and troubleshooting for parall
 | `CAESIUM_WORKER_LEASE_TTL` | `5m` | Lease duration for claimed tasks before reclaim. |
 | `CAESIUM_DATABASE_MAX_OPEN_CONNS` | `4` | Max SQL connections per node for dqlite/PostgreSQL. |
 | `CAESIUM_DATABASE_MAX_IDLE_CONNS` | `2` | Max idle SQL connections per node for dqlite/PostgreSQL. |
+| `CAESIUM_DATABASE_SHARDS` | `1` | Number of dqlite hot write shards. Values greater than `1` are Phase 4 horizontal-scaling mode and require the internal dqlite backend. |
 | `CAESIUM_DATABASE_VOTERS` | `3` | Target dqlite voter count. Must be odd and at least 3. |
 | `CAESIUM_DATABASE_STANDBYS` | `3` | Target dqlite standby count for failover headroom. Extra nodes settle as spares. |
 | `CAESIUM_INTERNAL_WAKEUP_TOKEN` | `""` | Shared bearer token required for cross-node wakeups via `POST /internal/wakeup`. |
@@ -38,6 +39,8 @@ Use three stable control-plane nodes as voters. Add up to three standby nodes wh
 Set the same `CAESIUM_DATABASE_VOTERS` and `CAESIUM_DATABASE_STANDBYS` values on every node. For a 10-node deployment, the recommended shape is 3 voters, 3 standbys, and 4 spares.
 
 Distributed wakeups use the dqlite cluster membership list, not `CAESIUM_DATABASE_NODES`, so spare workers receive wakeup hints after they join. Set the same `CAESIUM_INTERNAL_WAKEUP_TOKEN` on every node. The sender uses `Authorization: Bearer <token>` and receivers reject missing or incorrect tokens.
+
+`CAESIUM_DATABASE_SHARDS=1` keeps every table in the catalog database. Higher shard counts open `caesium_hot_XX` databases on the same dqlite cluster and route run lifecycle rows by job run ID. See [database-sharding.md](database-sharding.md) for the table map and router contract.
 
 ## Rollout Procedure (Distributed Mode)
 

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -18,12 +20,16 @@ import (
 const (
 	defaultMaxOpenConns = 4
 	defaultMaxIdleConns = 2
+
+	catalogDatabaseName = "caesium"
+	historyDatabaseName = "caesium_history"
+	hotShardNameFormat  = "caesium_hot_%02d"
 )
 
 var (
-	once sync.Once
-	gdb  *gorm.DB
-	err  error
+	routerOnce    sync.Once
+	defaultRouter *Router
+	routerErr     error
 )
 
 func gormLogLevel() gormlogger.LogLevel {
@@ -38,47 +44,126 @@ func gormLogLevel() gormlogger.LogLevel {
 }
 
 func Connection() *gorm.DB {
-	once.Do(func() {
-		dbType := env.Variables().DatabaseType
+	return DefaultRouter().Catalog()
+}
 
-		log.Info("establishing db connection", "type", dbType)
-
-		cfg := &gorm.Config{
-			Logger: NewLogger().LogMode(gormLogLevel()),
-		}
-
-		switch dbType {
-		case "postgres":
-			gdb, err = gorm.Open(
-				postgres.Open(env.Variables().DatabaseDSN),
-				cfg,
-			)
-		case "internal":
-			fallthrough
-		case dqlite.DriverName:
-			fallthrough
-		default:
-			gdb, err = gorm.Open(
-				dqlite.Open(""),
-				cfg,
-			)
-		}
-
-		if err != nil {
-			log.Fatal("failed to connect to database", "error", err)
-		}
-
-		if sqlDB, err := gdb.DB(); err == nil {
-			configureConnectionPool(sqlDB, env.Variables().DatabaseMaxOpenConns, env.Variables().DatabaseMaxIdleConns)
-		}
-
-		if dbType == "internal" || dbType == dqlite.DriverName {
-			// Enable foreign key enforcement for SQLite-based databases.
-			gdb.Exec("PRAGMA foreign_keys = ON")
+// DefaultRouter returns the process-wide database router.
+func DefaultRouter() *Router {
+	routerOnce.Do(func() {
+		defaultRouter, routerErr = openRouterFromEnv()
+		if routerErr != nil {
+			log.Fatal("failed to connect to database", "error", routerErr)
 		}
 	})
 
-	return gdb
+	return defaultRouter
+}
+
+func openRouterFromEnv() (*Router, error) {
+	vars := env.Variables()
+	dbType := strings.ToLower(strings.TrimSpace(vars.DatabaseType))
+	shardCount := vars.DatabaseShards
+	if shardCount <= 0 {
+		shardCount = 1
+	}
+	if shardCount > 1 && !isInternalDqlite(dbType) {
+		return nil, fmt.Errorf("CAESIUM_DATABASE_SHARDS > 1 requires the internal dqlite database backend")
+	}
+
+	catalog, err := openConnection(catalogDatabaseName, true)
+	if err != nil {
+		return nil, err
+	}
+
+	hot := make([]*gorm.DB, shardCount)
+	if shardCount == 1 {
+		hot[0] = catalog
+	} else {
+		for idx := range hot {
+			conn, err := openConnection(fmt.Sprintf(hotShardNameFormat, idx), false)
+			if err != nil {
+				return nil, err
+			}
+			hot[idx] = conn
+		}
+	}
+
+	cold := catalog
+	if shardCount > 1 {
+		cold, err = openConnection(historyDatabaseName, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	router, err := NewRouter(catalog, hot, cold)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info(
+		"database router initialized",
+		"type", vars.DatabaseType,
+		"shards", router.ShardCount(),
+	)
+	return router, nil
+}
+
+func openConnection(databaseName string, enforceForeignKeys bool) (*gorm.DB, error) {
+	vars := env.Variables()
+	dbType := strings.ToLower(strings.TrimSpace(vars.DatabaseType))
+
+	log.Info("establishing db connection", "type", vars.DatabaseType, "database", databaseName)
+
+	cfg := &gorm.Config{
+		Logger: NewLogger().LogMode(gormLogLevel()),
+	}
+	if !enforceForeignKeys {
+		cfg.DisableForeignKeyConstraintWhenMigrating = true
+	}
+
+	var (
+		conn *gorm.DB
+		err  error
+	)
+	switch dbType {
+	case "postgres":
+		conn, err = gorm.Open(
+			postgres.Open(vars.DatabaseDSN),
+			cfg,
+		)
+	case "internal":
+		fallthrough
+	case dqlite.DriverName:
+		fallthrough
+	default:
+		conn, err = gorm.Open(
+			dqlite.Open(databaseName),
+			cfg,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if sqlDB, err := conn.DB(); err == nil {
+		configureConnectionPool(sqlDB, vars.DatabaseMaxOpenConns, vars.DatabaseMaxIdleConns)
+	}
+
+	if isInternalDqlite(dbType) && enforceForeignKeys {
+		// Enable foreign key enforcement for SQLite-based catalog databases.
+		conn.Exec("PRAGMA foreign_keys = ON")
+	}
+	return conn, nil
+}
+
+func isInternalDqlite(dbType string) bool {
+	switch strings.ToLower(strings.TrimSpace(dbType)) {
+	case "", "internal", dqlite.DriverName:
+		return true
+	default:
+		return false
+	}
 }
 
 func configureConnectionPool(sqlDB *sql.DB, maxOpen, maxIdle int) {
@@ -100,14 +185,23 @@ func configureConnectionPool(sqlDB *sql.DB, maxOpen, maxIdle int) {
 }
 
 func Migrate() (err error) {
-	for _, model := range models.All {
-		if err = Connection().AutoMigrate(model); err != nil {
+	router := DefaultRouter()
+	if err = migrateModels(router.Catalog(), models.All...); err != nil {
+		return err
+	}
+	if router.ShardCount() > 1 {
+		for _, shard := range router.HotShards() {
+			if err = migrateModels(shard, hotPathModels()...); err != nil {
+				return err
+			}
+		}
+		if err = migrateModels(router.Cold(), hotPathModels()...); err != nil {
 			return
 		}
 	}
 
 	var triggers []models.Trigger
-	if err = Connection().Where("type = ?", models.TriggerTypeHTTP).Find(&triggers).Error; err != nil {
+	if err = router.Catalog().Where("type = ?", models.TriggerTypeHTTP).Find(&triggers).Error; err != nil {
 		return
 	}
 	for idx := range triggers {
@@ -115,7 +209,7 @@ func Migrate() (err error) {
 		if err = trigger.ApplyDerivedFields(); err != nil {
 			return
 		}
-		if err = Connection().
+		if err = router.Catalog().
 			Model(&models.Trigger{}).
 			Where("id = ?", trigger.ID).
 			Update("normalized_path", trigger.NormalizedPath).
@@ -124,4 +218,22 @@ func Migrate() (err error) {
 		}
 	}
 	return
+}
+
+func migrateModels(conn *gorm.DB, models ...interface{}) error {
+	for _, model := range models {
+		if err := conn.AutoMigrate(model); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func hotPathModels() []interface{} {
+	return []interface{}{
+		&models.JobRun{},
+		&models.TaskRun{},
+		&models.CallbackRun{},
+		&models.ExecutionEvent{},
+	}
 }

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -196,28 +196,28 @@ func Migrate() (err error) {
 			}
 		}
 		if err = migrateModels(router.Cold(), hotPathModels()...); err != nil {
-			return
+			return err
 		}
 	}
 
 	var triggers []models.Trigger
 	if err = router.Catalog().Where("type = ?", models.TriggerTypeHTTP).Find(&triggers).Error; err != nil {
-		return
+		return err
 	}
 	for idx := range triggers {
 		trigger := &triggers[idx]
 		if err = trigger.ApplyDerivedFields(); err != nil {
-			return
+			return err
 		}
 		if err = router.Catalog().
 			Model(&models.Trigger{}).
 			Where("id = ?", trigger.ID).
 			Update("normalized_path", trigger.NormalizedPath).
 			Error; err != nil {
-			return
+			return err
 		}
 	}
-	return
+	return nil
 }
 
 func migrateModels(conn *gorm.DB, models ...interface{}) error {

--- a/pkg/db/router.go
+++ b/pkg/db/router.go
@@ -1,0 +1,157 @@
+package db
+
+import (
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// DatabaseRole identifies the logical database tier for a table.
+type DatabaseRole string
+
+const (
+	DatabaseRoleCatalog DatabaseRole = "catalog"
+	DatabaseRoleHot     DatabaseRole = "hot"
+	DatabaseRoleCold    DatabaseRole = "cold"
+)
+
+var hotTables = map[string]struct{}{
+	"job_runs":         {},
+	"task_runs":        {},
+	"callback_runs":    {},
+	"execution_events": {},
+}
+
+// Router owns the catalog, hot-shard, and cold-history database handles.
+//
+// The default shard count is one, in which case every route returns the catalog
+// connection and existing single-database behavior is preserved.
+type Router struct {
+	catalog *gorm.DB
+	hot     []*gorm.DB
+	cold    *gorm.DB
+}
+
+// NewRouter constructs a Router from already-opened connections. Tests and
+// non-dqlite callers can use this directly; production code should normally use
+// DefaultRouter().
+func NewRouter(catalog *gorm.DB, hot []*gorm.DB, cold *gorm.DB) (*Router, error) {
+	if catalog == nil {
+		return nil, errors.New("db router requires a catalog connection")
+	}
+	if len(hot) == 0 {
+		hot = []*gorm.DB{catalog}
+	}
+	for idx, shard := range hot {
+		if shard == nil {
+			return nil, fmt.Errorf("db router hot shard %d is nil", idx)
+		}
+	}
+	if cold == nil {
+		cold = catalog
+	}
+
+	return &Router{
+		catalog: catalog,
+		hot:     append([]*gorm.DB(nil), hot...),
+		cold:    cold,
+	}, nil
+}
+
+// Catalog returns the write-light catalog database.
+func (r *Router) Catalog() *gorm.DB {
+	if r == nil {
+		return nil
+	}
+	return r.catalog
+}
+
+// Cold returns the cold-history database. With one shard it aliases Catalog().
+func (r *Router) Cold() *gorm.DB {
+	if r == nil {
+		return nil
+	}
+	return r.cold
+}
+
+// HotShards returns a copy of the hot shard connection slice.
+func (r *Router) HotShards() []*gorm.DB {
+	if r == nil {
+		return nil
+	}
+	return append([]*gorm.DB(nil), r.hot...)
+}
+
+// ShardCount returns the number of hot shards.
+func (r *Router) ShardCount() int {
+	if r == nil || len(r.hot) == 0 {
+		return 0
+	}
+	return len(r.hot)
+}
+
+// HotShard returns a hot shard by index.
+func (r *Router) HotShard(index int) (*gorm.DB, error) {
+	if r == nil || len(r.hot) == 0 {
+		return nil, errors.New("db router has no hot shards")
+	}
+	if index < 0 || index >= len(r.hot) {
+		return nil, fmt.Errorf("hot shard index %d out of range [0,%d)", index, len(r.hot))
+	}
+	return r.hot[index], nil
+}
+
+// ShardForRunID maps a job run ID to a stable hot-shard index.
+func (r *Router) ShardForRunID(runID uuid.UUID) int {
+	if r == nil || len(r.hot) <= 1 {
+		return 0
+	}
+	h := fnv.New32a()
+	_, _ = h.Write(runID[:])
+	return int(h.Sum32() % uint32(len(r.hot)))
+}
+
+// HotShardForRun returns the hot shard that owns a run's lifecycle rows.
+func (r *Router) HotShardForRun(runID uuid.UUID) (*gorm.DB, int, error) {
+	shard := r.ShardForRunID(runID)
+	conn, err := r.HotShard(shard)
+	return conn, shard, err
+}
+
+// Database returns the connection for a logical role. Hot routes require a
+// non-zero run ID so all rows in one run stay transactionally local.
+func (r *Router) Database(role DatabaseRole, runID uuid.UUID) (*gorm.DB, int, error) {
+	switch role {
+	case DatabaseRoleCatalog:
+		return r.Catalog(), -1, nil
+	case DatabaseRoleCold:
+		return r.Cold(), -1, nil
+	case DatabaseRoleHot:
+		if runID == uuid.Nil {
+			return nil, -1, errors.New("hot database route requires a run ID")
+		}
+		return r.HotShardForRun(runID)
+	default:
+		return nil, -1, fmt.Errorf("unknown database role %q", role)
+	}
+}
+
+// RouteTable returns the database for a table. Hot tables require runID;
+// catalog tables ignore it.
+func (r *Router) RouteTable(table string, runID uuid.UUID) (*gorm.DB, DatabaseRole, int, error) {
+	normalized := normalizeTableName(table)
+	if _, ok := hotTables[normalized]; ok {
+		conn, shard, err := r.Database(DatabaseRoleHot, runID)
+		return conn, DatabaseRoleHot, shard, err
+	}
+	conn, _, err := r.Database(DatabaseRoleCatalog, uuid.Nil)
+	return conn, DatabaseRoleCatalog, -1, err
+}
+
+func normalizeTableName(table string) string {
+	return strings.ToLower(strings.TrimSpace(table))
+}

--- a/pkg/db/router_test.go
+++ b/pkg/db/router_test.go
@@ -1,0 +1,118 @@
+package db
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestRouterSingleShardAliasesCatalog(t *testing.T) {
+	catalog := openTestDB(t, "catalog")
+	router, err := NewRouter(catalog, nil, nil)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, router.ShardCount())
+	require.Same(t, catalog, router.Catalog())
+	require.Same(t, catalog, router.Cold())
+
+	runID := uuid.New()
+	hot, shard, err := router.HotShardForRun(runID)
+	require.NoError(t, err)
+	require.Equal(t, 0, shard)
+	require.Same(t, catalog, hot)
+
+	routed, role, routedShard, err := router.RouteTable("task_runs", runID)
+	require.NoError(t, err)
+	require.Equal(t, DatabaseRoleHot, role)
+	require.Equal(t, 0, routedShard)
+	require.Same(t, catalog, routed)
+
+	routed, role, routedShard, err = router.RouteTable("jobs", uuid.Nil)
+	require.NoError(t, err)
+	require.Equal(t, DatabaseRoleCatalog, role)
+	require.Equal(t, -1, routedShard)
+	require.Same(t, catalog, routed)
+}
+
+func TestRouterRoutesCatalogHotAndCold(t *testing.T) {
+	catalog := openTestDB(t, "catalog")
+	cold := openTestDB(t, "cold")
+	hot := make([]*gorm.DB, 4)
+	for idx := range hot {
+		hot[idx] = openTestDB(t, fmt.Sprintf("hot-%d", idx))
+	}
+	router, err := NewRouter(catalog, hot, cold)
+	require.NoError(t, err)
+
+	require.Same(t, catalog, router.Catalog())
+	require.Same(t, cold, router.Cold())
+
+	runID := uuid.MustParse("2dc7d34e-3b32-4877-9578-c34b33e8f499")
+	expectedShard := router.ShardForRunID(runID)
+	routed, role, shard, err := router.RouteTable("execution_events", runID)
+	require.NoError(t, err)
+	require.Equal(t, DatabaseRoleHot, role)
+	require.Equal(t, expectedShard, shard)
+	require.Same(t, hot[expectedShard], routed)
+
+	routed, role, shard, err = router.RouteTable("atoms", uuid.Nil)
+	require.NoError(t, err)
+	require.Equal(t, DatabaseRoleCatalog, role)
+	require.Equal(t, -1, shard)
+	require.Same(t, catalog, routed)
+
+	routed, shard, err = router.Database(DatabaseRoleCold, uuid.Nil)
+	require.NoError(t, err)
+	require.Equal(t, -1, shard)
+	require.Same(t, cold, routed)
+}
+
+func TestRouterHotRouteRequiresRunID(t *testing.T) {
+	catalog := openTestDB(t, "catalog")
+	router, err := NewRouter(catalog, []*gorm.DB{catalog, openTestDB(t, "hot")}, nil)
+	require.NoError(t, err)
+
+	_, _, _, err = router.RouteTable("task_runs", uuid.Nil)
+	require.Error(t, err)
+}
+
+func TestRouterDistributesRunIDsAcrossShards(t *testing.T) {
+	catalog := openTestDB(t, "catalog")
+	hot := make([]*gorm.DB, 8)
+	for idx := range hot {
+		hot[idx] = openTestDB(t, fmt.Sprintf("hot-%d", idx))
+	}
+	router, err := NewRouter(catalog, hot, nil)
+	require.NoError(t, err)
+
+	counts := make([]int, router.ShardCount())
+	for idx := 0; idx < 50; idx++ {
+		runID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(fmt.Sprintf("run-%02d", idx)))
+		counts[router.ShardForRunID(runID)]++
+	}
+
+	used := 0
+	maxCount := 0
+	for _, count := range counts {
+		if count > 0 {
+			used++
+		}
+		if count > maxCount {
+			maxCount = count
+		}
+	}
+	require.GreaterOrEqual(t, used, 6)
+	require.LessOrEqual(t, maxCount, 14)
+}
+
+func openTestDB(t *testing.T, name string) *gorm.DB {
+	t.Helper()
+
+	conn, err := gorm.Open(sqlite.Open("file:"+name+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	return conn
+}

--- a/pkg/dqlite/dqlite.go
+++ b/pkg/dqlite/dqlite.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -27,10 +28,12 @@ const (
 	// DriverName is the default driver name for dqlite.
 	DriverName = "dqlite"
 
-	dqliteBusyTimeout = 5 * time.Second
+	defaultDatabaseName = "caesium"
+	dqliteBusyTimeout   = 5 * time.Second
 )
 
 var (
+	appMu      sync.Mutex
 	currentApp atomic.Pointer[dqliteapp.App]
 
 	ErrNoNativeApp = errors.New("dqlite: native app is not active")
@@ -54,6 +57,7 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 	if dialector.DriverName == "" {
 		dialector.DriverName = DriverName
 	}
+	databaseName := databaseNameFromDSN(dialector.DSN)
 
 	supportsSQLPragmas := true
 	if dialector.Conn != nil {
@@ -80,29 +84,15 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 			fn("dqlite", dqliteLogFields(l, msg)...)
 		}
 
-		vars := env.Variables()
-		dqApp, err := dqliteapp.New(
-			vars.DatabasePath,
-			dqliteapp.WithAddress(vars.NodeAddress),
-			dqliteapp.WithCluster(vars.DatabaseNodes),
-			dqliteapp.WithVoters(vars.DatabaseVoters),
-			dqliteapp.WithStandBys(vars.DatabaseStandbys),
-			dqliteapp.WithLogFunc(logFunc),
-			dqliteapp.WithBusyTimeout(dqliteBusyTimeout),
-		)
+		dqApp, err := nativeApp(context.Background(), logFunc)
 		if err != nil {
 			return err
 		}
 
-		if err := dqApp.Ready(context.Background()); err != nil {
-			return err
-		}
-
-		conn, err := dqApp.Open(context.Background(), "caesium")
+		conn, err := dqApp.Open(context.Background(), databaseName)
 		if err != nil {
 			return err
 		}
-		currentApp.Store(dqApp)
 
 		db.ConnPool = conn
 	}
@@ -135,6 +125,48 @@ func (dialector Dialector) Initialize(db *gorm.DB) (err error) {
 		db.ClauseBuilders[k] = v
 	}
 	return
+}
+
+func databaseNameFromDSN(dsn string) string {
+	name := strings.TrimSpace(dsn)
+	if name == "" {
+		return defaultDatabaseName
+	}
+	return name
+}
+
+func nativeApp(ctx context.Context, logFunc func(client.LogLevel, string, ...interface{})) (*dqliteapp.App, error) {
+	if dqApp := currentApp.Load(); dqApp != nil {
+		return dqApp, nil
+	}
+
+	appMu.Lock()
+	defer appMu.Unlock()
+
+	if dqApp := currentApp.Load(); dqApp != nil {
+		return dqApp, nil
+	}
+
+	vars := env.Variables()
+	dqApp, err := dqliteapp.New(
+		vars.DatabasePath,
+		dqliteapp.WithAddress(vars.NodeAddress),
+		dqliteapp.WithCluster(vars.DatabaseNodes),
+		dqliteapp.WithVoters(vars.DatabaseVoters),
+		dqliteapp.WithStandBys(vars.DatabaseStandbys),
+		dqliteapp.WithLogFunc(logFunc),
+		dqliteapp.WithBusyTimeout(dqliteBusyTimeout),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := dqApp.Ready(ctx); err != nil {
+		return nil, err
+	}
+
+	currentApp.Store(dqApp)
+	return dqApp, nil
 }
 
 func dqliteLogFields(level client.LogLevel, msg string) []interface{} {

--- a/pkg/dqlite/dqlite_test.go
+++ b/pkg/dqlite/dqlite_test.go
@@ -31,6 +31,12 @@ func TestDialectorAppliesConnectionPragmas(t *testing.T) {
 	require.Equal(t, 1, synchronous)
 }
 
+func TestDatabaseNameFromDSN(t *testing.T) {
+	require.Equal(t, defaultDatabaseName, databaseNameFromDSN(""))
+	require.Equal(t, defaultDatabaseName, databaseNameFromDSN("  "))
+	require.Equal(t, "caesium_hot_03", databaseNameFromDSN(" caesium_hot_03 "))
+}
+
 func TestClusterRequiresNativeApp(t *testing.T) {
 	_, err := Cluster(context.Background())
 	require.True(t, errors.Is(err, ErrNoNativeApp))

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -33,6 +33,12 @@ func Process() error {
 
 func validate() error {
 	dbType := strings.ToLower(strings.TrimSpace(variables.DatabaseType))
+	if variables.DatabaseShards < 1 {
+		return fmt.Errorf("CAESIUM_DATABASE_SHARDS must be greater than or equal to 1")
+	}
+	if variables.DatabaseShards > 1 && dbType != "" && dbType != "internal" && dbType != "dqlite" {
+		return fmt.Errorf("CAESIUM_DATABASE_SHARDS greater than 1 requires CAESIUM_DATABASE_TYPE=internal")
+	}
 	if dbType == "" || dbType == "internal" || dbType == "dqlite" {
 		if variables.DatabaseVoters < 3 || variables.DatabaseVoters%2 == 0 {
 			return fmt.Errorf("CAESIUM_DATABASE_VOTERS must be an odd number greater than or equal to 3")
@@ -76,6 +82,7 @@ type Environment struct {
 	DatabaseDSN                   string        `default:"host=postgres user=postgres password=postgres dbname=caesium port=5432 sslmode=disable" split_words:"true"`
 	DatabaseMaxOpenConns          int           `default:"4" split_words:"true"`
 	DatabaseMaxIdleConns          int           `default:"2" split_words:"true"`
+	DatabaseShards                int           `default:"1" split_words:"true"`
 	DatabaseVoters                int           `default:"3" split_words:"true"`
 	DatabaseStandbys              int           `default:"3" split_words:"true"`
 	DatabaseConsoleEnabled        bool          `default:"false" split_words:"true"`

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -19,6 +19,7 @@ func (s *EnvTestSuite) TestProcess() {
 	assert.Equal(s.T(), "info", Variables().LogLevel)
 	assert.Equal(s.T(), 4, Variables().DatabaseMaxOpenConns)
 	assert.Equal(s.T(), 2, Variables().DatabaseMaxIdleConns)
+	assert.Equal(s.T(), 1, Variables().DatabaseShards)
 	assert.Equal(s.T(), 3, Variables().DatabaseVoters)
 	assert.Equal(s.T(), 3, Variables().DatabaseStandbys)
 	assert.Equal(s.T(), 15*time.Second, Variables().WorkerPollInterval)


### PR DESCRIPTION
## Summary

Adds the Phase 4 database sharding foundation for the distributed locking remediation plan.

- Adds `CAESIUM_DATABASE_SHARDS` with validation and default `1` compatibility behavior.
- Reworks the database bootstrap path around `db.DefaultRouter()` while keeping `db.Connection()` as the catalog compatibility connection.
- Adds `pkg/db.Router` for catalog, hot-shard, and cold-history database routing by `job_run_id`.
- Adds named dqlite database opening support so the same native dqlite app can open `caesium`, hot shard databases, and `caesium_history`.
- Documents the shard boundary and updates the Phase 4 implementation progress.

## Impact

Default behavior remains unchanged at `CAESIUM_DATABASE_SHARDS=1`. Higher shard counts are still a foundation path, not production-ready, until run-scoped call sites are migrated to the router-aware hot-shard paths.

## Validation

- `just unit-test`
- `git diff --check`