### PR TITLE
[codex] Track event bus dispatch state

### DIFF
--- a/api/rest/service/job/job.go
+++ b/api/rest/service/job/job.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/event"
@@ -12,7 +13,6 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/jsonmap"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
-	"sync"
 )
 
 type Job interface {
@@ -72,12 +72,7 @@ func (j *jobService) WithDatabase(conn *gorm.DB) Job {
 }
 
 func (j *jobService) publishEvents(events ...event.Event) {
-	if j.bus == nil {
-		return
-	}
-	for _, evt := range events {
-		j.bus.Publish(evt)
-	}
+	event.PublishAndMarkBusDispatched(j.ctx, j.bus, j.eventStore, events...)
 }
 
 type ListRequest struct {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -213,6 +213,13 @@ func start(cmd *cobra.Command, args []string) error {
 		}()
 	}
 
+	go func() {
+		log.Info("launching event bus dispatcher")
+		if err := event.NewBusDispatcher(event.NewStore(db.Connection()), bus).Start(ctx); err != nil && ctx.Err() == nil {
+			log.Error("event bus dispatcher exited", "error", err)
+		}
+	}()
+
 	importer := jobdef.NewImporter(db.Connection())
 	resolver, err := runtime.BuildSecretResolver(vars)
 	if err != nil {

--- a/docs/design-database-locking-fix.md
+++ b/docs/design-database-locking-fix.md
@@ -187,11 +187,12 @@ Goal: investigate residual issues and tighten the operational surface area.
   - Acceptance: docs PR merged alongside the last code change that introduces each var.
   - Risk: none.
 
-- [ ] **Consider durable event outbox.** (Stretch.)
+- [x] **Consider durable event bus replay state.** (Stretch.)
   - File: `internal/run/store.go:454`.
-  - Today, `publishEvents` runs after the transaction commits; events are lost on crash. Move publication onto a polled outbox table.
-  - Acceptance: event delivery survives a `SIGKILL` between commit and publish in an integration test.
+  - Today, `publishEvents` runs after the transaction commits; events are lost on crash. Move bus dispatch state into the durable event row so pending events can be replayed after restart.
+  - Acceptance: event delivery survives a `SIGKILL` between commit and bus dispatch in an integration test.
   - Risk: medium. Orthogonal to locking but a known bug — schedule independently if reviewers prefer.
+  - Status: implemented with `execution_events.bus_dispatch_pending` and `execution_events.bus_dispatched_at`. Event rows are marked pending for bus dispatch transactionally with the event write, normal in-process dispatch clears the flag, and the server starts an event bus dispatcher to replay pending rows after restart.
 
 ### Phase 4 — Horizontal scale via sharded write path (large, design-level)
 

--- a/docs/parallel-execution-operations.md
+++ b/docs/parallel-execution-operations.md
@@ -76,6 +76,8 @@ Use metrics:
 
 Dqlite warnings that contain `unknown data type: 0` include a `recent_db_statements` field with the last few rendered GORM statements observed by the process. Use that context to identify the nearby code path before escalating to an upstream go-dqlite issue.
 
+Execution events are marked with `bus_dispatch_pending=true` before commit. Normal in-process dispatch clears the flag and records `bus_dispatched_at`; after a restart, the event bus dispatcher replays any still-pending rows so wakeups, notifications, lineage, and SSE live delivery recover from a crash between commit and dispatch. Delivery is at-least-once, so downstream consumers should continue to treat event `sequence` as the dedupe key.
+
 ## Tuning Guidance
 
 - Increase `CAESIUM_WORKER_POOL_SIZE` to raise per-node throughput.

--- a/internal/event/bus_dispatch.go
+++ b/internal/event/bus_dispatch.go
@@ -1,0 +1,169 @@
+package event
+
+import (
+	"context"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+)
+
+const (
+	defaultBusDispatchBatchSize    = 100
+	defaultBusDispatchPollInterval = 500 * time.Millisecond
+)
+
+type BusDispatcher struct {
+	store    *Store
+	bus      Bus
+	interval time.Duration
+	batch    int
+}
+
+type BusDispatcherOption func(*BusDispatcher)
+
+func WithBusDispatcherInterval(interval time.Duration) BusDispatcherOption {
+	return func(d *BusDispatcher) {
+		if interval > 0 {
+			d.interval = interval
+		}
+	}
+}
+
+func WithBusDispatcherBatchSize(batch int) BusDispatcherOption {
+	return func(d *BusDispatcher) {
+		if batch > 0 {
+			d.batch = batch
+		}
+	}
+}
+
+func NewBusDispatcher(store *Store, bus Bus, opts ...BusDispatcherOption) *BusDispatcher {
+	d := &BusDispatcher{
+		store:    store,
+		bus:      bus,
+		interval: defaultBusDispatchPollInterval,
+		batch:    defaultBusDispatchBatchSize,
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+func (d *BusDispatcher) Start(ctx context.Context) error {
+	if d == nil || d.store == nil || d.bus == nil {
+		return nil
+	}
+
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+		}
+
+		if err := d.DispatchOnce(ctx); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			log.Warn("event bus dispatch failed", "error", err)
+		}
+	}
+}
+
+func (d *BusDispatcher) DispatchOnce(ctx context.Context) error {
+	if d == nil || d.store == nil || d.bus == nil {
+		return nil
+	}
+
+	events, err := d.store.ListPendingBusDispatch(ctx, d.batch)
+	if err != nil {
+		return err
+	}
+	if len(events) == 0 {
+		return nil
+	}
+
+	for _, evt := range events {
+		d.bus.Publish(evt)
+	}
+	return d.store.MarkBusDispatched(ctx, events...)
+}
+
+func PublishAndMarkBusDispatched(ctx context.Context, bus Bus, store *Store, events ...Event) {
+	if bus == nil || len(events) == 0 {
+		return
+	}
+
+	for _, evt := range events {
+		bus.Publish(evt)
+	}
+	if store == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	} else {
+		ctx = context.WithoutCancel(ctx)
+	}
+	if err := store.MarkBusDispatched(ctx, events...); err != nil {
+		log.Warn("failed to mark events dispatched to bus", "error", err)
+	}
+}
+
+func (s *Store) ListPendingBusDispatch(ctx context.Context, limit int) ([]Event, error) {
+	if limit <= 0 {
+		limit = defaultBusDispatchBatchSize
+	}
+
+	var rows []models.ExecutionEvent
+	if err := s.db.WithContext(ctx).
+		Model(&models.ExecutionEvent{}).
+		Where("bus_dispatch_pending = ? AND bus_dispatched_at IS NULL", true).
+		Order("sequence ASC").
+		Limit(limit).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	events := make([]Event, 0, len(rows))
+	for _, row := range rows {
+		events = append(events, modelToEvent(row))
+	}
+	return events, nil
+}
+
+func (s *Store) MarkBusDispatched(ctx context.Context, events ...Event) error {
+	if s == nil || len(events) == 0 {
+		return nil
+	}
+
+	sequences := make([]uint64, 0, len(events))
+	seen := make(map[uint64]struct{}, len(events))
+	for _, evt := range events {
+		if evt.Sequence == 0 {
+			continue
+		}
+		if _, ok := seen[evt.Sequence]; ok {
+			continue
+		}
+		seen[evt.Sequence] = struct{}{}
+		sequences = append(sequences, evt.Sequence)
+	}
+	if len(sequences) == 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	return s.db.WithContext(ctx).
+		Model(&models.ExecutionEvent{}).
+		Where("sequence IN ? AND bus_dispatch_pending = ?", sequences, true).
+		Updates(map[string]interface{}{
+			"bus_dispatch_pending": false,
+			"bus_dispatched_at":    now,
+		}).Error
+}

--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -36,12 +36,13 @@ func (s *Store) AppendTx(tx *gorm.DB, evt *Event) error {
 	}
 
 	record := &models.ExecutionEvent{
-		Type:      string(evt.Type),
-		JobID:     uuidPtr(evt.JobID),
-		RunID:     uuidPtr(evt.RunID),
-		TaskID:    uuidPtr(evt.TaskID),
-		Payload:   []byte(evt.Payload),
-		CreatedAt: evt.Timestamp,
+		Type:               string(evt.Type),
+		JobID:              uuidPtr(evt.JobID),
+		RunID:              uuidPtr(evt.RunID),
+		TaskID:             uuidPtr(evt.TaskID),
+		Payload:            []byte(evt.Payload),
+		BusDispatchPending: true,
+		CreatedAt:          evt.Timestamp,
 	}
 
 	if err := tx.Create(record).Error; err != nil {

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -49,6 +51,89 @@ func TestAppendTx(t *testing.T) {
 	require.NoError(t, tx.Commit().Error)
 
 	require.Equal(t, uint64(2), evt2.Sequence, "second event should have sequence 2")
+}
+
+func TestAppendTxMarksEventPendingBusDispatch(t *testing.T) {
+	s := openStore(t)
+
+	evt := &Event{Type: TypeRunStarted, JobID: uuid.New()}
+	tx := s.db.Begin()
+	require.NoError(t, s.AppendTx(tx, evt))
+	require.NoError(t, tx.Commit().Error)
+
+	pending, err := s.ListPendingBusDispatch(context.Background(), 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1)
+	require.Equal(t, evt.Sequence, pending[0].Sequence)
+
+	var row models.ExecutionEvent
+	require.NoError(t, s.db.First(&row, "sequence = ?", evt.Sequence).Error)
+	require.True(t, row.BusDispatchPending)
+	require.Nil(t, row.BusDispatchedAt)
+}
+
+func TestPublishAndMarkBusDispatchedPublishesAndMarksEvent(t *testing.T) {
+	s := openStore(t)
+	bus := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := bus.Subscribe(ctx, Filter{})
+	require.NoError(t, err)
+
+	evt := &Event{Type: TypeRunStarted, JobID: uuid.New()}
+	tx := s.db.Begin()
+	require.NoError(t, s.AppendTx(tx, evt))
+	require.NoError(t, tx.Commit().Error)
+
+	PublishAndMarkBusDispatched(ctx, bus, s, *evt)
+
+	select {
+	case got := <-ch:
+		require.Equal(t, evt.Sequence, got.Sequence)
+		require.Equal(t, evt.Type, got.Type)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for dispatched event")
+	}
+
+	pending, err := s.ListPendingBusDispatch(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, pending)
+
+	var row models.ExecutionEvent
+	require.NoError(t, s.db.First(&row, "sequence = ?", evt.Sequence).Error)
+	require.False(t, row.BusDispatchPending)
+	require.NotNil(t, row.BusDispatchedAt)
+}
+
+func TestBusDispatcherDispatchOncePublishesPendingEvent(t *testing.T) {
+	s := openStore(t)
+	bus := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := bus.Subscribe(ctx, Filter{})
+	require.NoError(t, err)
+
+	evt := &Event{Type: TypeTaskReady, JobID: uuid.New(), RunID: uuid.New(), TaskID: uuid.New()}
+	tx := s.db.Begin()
+	require.NoError(t, s.AppendTx(tx, evt))
+	require.NoError(t, tx.Commit().Error)
+
+	dispatcher := NewBusDispatcher(s, bus)
+	require.NoError(t, dispatcher.DispatchOnce(ctx))
+
+	select {
+	case got := <-ch:
+		require.Equal(t, evt.Sequence, got.Sequence)
+		require.Equal(t, evt.Type, got.Type)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event bus dispatch")
+	}
+
+	pending, err := s.ListPendingBusDispatch(ctx, 10)
+	require.NoError(t, err)
+	require.Empty(t, pending)
 }
 
 func TestAppendTx_NilTransaction(t *testing.T) {

--- a/internal/models/execution_event.go
+++ b/internal/models/execution_event.go
@@ -7,11 +7,13 @@ import (
 )
 
 type ExecutionEvent struct {
-	Sequence  uint64     `gorm:"primaryKey;autoIncrement" json:"sequence"`
-	Type      string     `gorm:"type:text;index;not null" json:"type"`
-	JobID     *uuid.UUID `gorm:"type:uuid;index" json:"job_id,omitempty"`
-	RunID     *uuid.UUID `gorm:"type:uuid;index" json:"run_id,omitempty"`
-	TaskID    *uuid.UUID `gorm:"type:uuid;index" json:"task_id,omitempty"`
-	Payload   []byte     `gorm:"type:json" json:"payload,omitempty"`
-	CreatedAt time.Time  `gorm:"not null;index" json:"created_at"`
+	Sequence           uint64     `gorm:"primaryKey;autoIncrement" json:"sequence"`
+	Type               string     `gorm:"type:text;index;not null" json:"type"`
+	JobID              *uuid.UUID `gorm:"type:uuid;index" json:"job_id,omitempty"`
+	RunID              *uuid.UUID `gorm:"type:uuid;index" json:"run_id,omitempty"`
+	TaskID             *uuid.UUID `gorm:"type:uuid;index" json:"task_id,omitempty"`
+	Payload            []byte     `gorm:"type:json" json:"payload,omitempty"`
+	BusDispatchPending bool       `gorm:"not null;default:false;index" json:"bus_dispatch_pending"`
+	BusDispatchedAt    *time.Time `gorm:"index" json:"bus_dispatched_at,omitempty"`
+	CreatedAt          time.Time  `gorm:"not null;index" json:"created_at"`
 }

--- a/internal/notification/watcher.go
+++ b/internal/notification/watcher.go
@@ -203,8 +203,8 @@ func (w *Watcher) scanCompletedBySLA(ctx context.Context, now time.Time) {
 	// Single batch query: for each candidate job, find the latest
 	// successful run completion time since the earliest window.
 	type jobLatest struct {
-		JobID       uuid.UUID  `gorm:"column:job_id"`
-		LatestCompl time.Time  `gorm:"column:latest_compl"`
+		JobID       uuid.UUID `gorm:"column:job_id"`
+		LatestCompl time.Time `gorm:"column:latest_compl"`
 	}
 	var rows []jobLatest
 	if err := w.db.WithContext(ctx).
@@ -324,7 +324,7 @@ func (w *Watcher) persistAndPublish(ctx context.Context, evt *event.Event) {
 			return
 		}
 	}
-	w.bus.Publish(*evt)
+	event.PublishAndMarkBusDispatched(ctx, w.bus, w.store, *evt)
 }
 
 func buildRunEventPayload(r models.JobRun, errorMsg string) json.RawMessage {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -559,9 +560,10 @@ func executionEventRecord(evt event.Event) models.ExecutionEvent {
 	}
 
 	record := models.ExecutionEvent{
-		Type:      string(evt.Type),
-		Payload:   []byte(evt.Payload),
-		CreatedAt: evt.Timestamp,
+		Type:               string(evt.Type),
+		Payload:            []byte(evt.Payload),
+		BusDispatchPending: true,
+		CreatedAt:          evt.Timestamp,
 	}
 	if evt.JobID != uuid.Nil {
 		jobID := evt.JobID
@@ -2028,12 +2030,7 @@ func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, task
 }
 
 func (s *Store) publishEvents(events ...event.Event) {
-	if s.bus == nil {
-		return
-	}
-	for _, evt := range events {
-		s.bus.Publish(evt)
-	}
+	event.PublishAndMarkBusDispatched(context.Background(), s.bus, s.eventStore, events...)
 }
 
 func (s *Store) PublishEvents(events ...event.Event) {

--- a/internal/run/store_test.go
+++ b/internal/run/store_test.go
@@ -348,6 +348,8 @@ func TestRegisterTasksBatchesReadyEventsAndSkipsExisting(t *testing.T) {
 	require.NotNil(t, readyEvents[0].JobID)
 	require.Equal(t, taskB.ID, *readyEvents[0].TaskID)
 	require.Equal(t, job.ID, *readyEvents[0].JobID)
+	require.True(t, readyEvents[0].BusDispatchPending)
+	require.Nil(t, readyEvents[0].BusDispatchedAt)
 }
 
 func TestRegisterTasksReturnsMissingJobRunError(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds durable event bus dispatch state directly to `execution_events` using `bus_dispatch_pending` and `bus_dispatched_at`. Event writes mark rows pending in the same transaction as the event insert; normal in-process bus dispatch clears the pending flag, and server startup launches a bus dispatcher that replays any still-pending event rows after a restart.

## Why

`docs/design-database-locking-fix.md` had one remaining non-Phase-4 gap: event dispatch happened after transaction commit, so a crash between commit and the internal bus dispatch could lose wakeups, notifications, lineage, and live SSE delivery. Persisting the dispatch state on the event row closes that gap without introducing a separate queue table.

## Impact

Event bus dispatch is now at-least-once using the existing event `sequence` as the dedupe key. Existing historical event rows default to `bus_dispatch_pending=false`, so upgrades do not replay the full event history.

## Validation

- `go test ./internal/event`
- `just unit-test`