### PR TITLE
Route UI styling through design tokens for theme parity

### DIFF
--- a/ui/src/components/command-menu.tsx
+++ b/ui/src/components/command-menu.tsx
@@ -104,7 +104,7 @@ export function CommandMenu() {
                 className="flex items-center justify-between"
               >
                 <div className="flex items-center">
-                  <Circle className="mr-2 h-4 w-4 text-blue-500" />
+                  <Circle className="mr-2 h-4 w-4 text-running" />
                   <span>{job.alias}</span>
                   <span className="ml-2 text-xs text-muted-foreground font-mono">{shortId(job.id)}</span>
                 </div>

--- a/ui/src/components/logs/LogBadge.tsx
+++ b/ui/src/components/logs/LogBadge.tsx
@@ -10,7 +10,7 @@ export function LogBadge({ children, className }: LogBadgeProps) {
   return (
     <span
       className={cn(
-        "rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-slate-300",
+        "rounded-md border border-graphite/60 bg-midnight px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-text-2",
         className,
       )}
     >

--- a/ui/src/components/logs/LogEmptyState.tsx
+++ b/ui/src/components/logs/LogEmptyState.tsx
@@ -5,10 +5,10 @@ interface LogEmptyStateProps {
 
 export function LogEmptyState({ title, body }: LogEmptyStateProps) {
   return (
-    <div className="absolute inset-0 flex items-center justify-center bg-slate-950/96 px-6 text-center">
+    <div className="absolute inset-0 flex items-center justify-center bg-obsidian/95 px-6 text-center">
       <div className="max-w-sm space-y-2">
-        <div className="text-sm font-semibold text-slate-100">{title}</div>
-        <div className="text-xs leading-relaxed text-slate-400">{body}</div>
+        <div className="text-sm font-semibold text-text-1">{title}</div>
+        <div className="text-xs leading-relaxed text-text-3">{body}</div>
       </div>
     </div>
   );

--- a/ui/src/components/logs/LogSearchInput.tsx
+++ b/ui/src/components/logs/LogSearchInput.tsx
@@ -17,16 +17,16 @@ export function LogSearchInput({
   return (
     <div
       className={cn(
-        "flex min-w-[180px] flex-1 items-center gap-2 rounded-md border border-slate-800 bg-slate-900/80 px-2.5 py-1.5",
+        "flex min-w-[180px] flex-1 items-center gap-2 rounded-md border border-graphite/50 bg-midnight/60 px-2.5 py-1.5",
         className,
       )}
     >
-      <Search className="h-3.5 w-3.5 shrink-0 text-slate-500" />
+      <Search className="h-3.5 w-3.5 shrink-0 text-text-4" />
       <input
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full bg-transparent text-xs text-slate-100 outline-none placeholder:text-slate-500"
+        className="w-full bg-transparent text-xs text-text-1 outline-none placeholder:text-text-4"
       />
     </div>
   );

--- a/ui/src/components/logs/LogShell.tsx
+++ b/ui/src/components/logs/LogShell.tsx
@@ -26,7 +26,7 @@ export function LogShell({
   className,
 }: LogShellProps) {
   return (
-    <div className={cn("flex h-full min-h-0 flex-col bg-slate-950", className)}>
+    <div className={cn("flex h-full min-h-0 flex-col bg-obsidian", className)}>
       {banner}
       {toolbar}
       <div className="relative flex-1 overflow-hidden">

--- a/ui/src/components/logs/LogToolbar.tsx
+++ b/ui/src/components/logs/LogToolbar.tsx
@@ -11,7 +11,7 @@ export function LogToolbar({ children, status, className }: LogToolbarProps) {
   return (
     <div
       className={cn(
-        "flex flex-wrap items-center gap-2 border-b border-slate-800 bg-slate-950/80 px-3 py-2",
+        "flex flex-wrap items-center gap-2 border-b border-graphite/50 bg-obsidian/80 px-3 py-2",
         className,
       )}
     >

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -15,11 +15,11 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80",
         success:
-          "border-transparent bg-green-500 text-white shadow hover:bg-green-500/80",
+          "border-transparent bg-success text-background shadow hover:bg-success/80",
         running:
           "border-transparent bg-caesium-cyan text-caesium-void shadow hover:bg-caesium-cyan/80",
         cached:
-          "border-teal-500/35 bg-teal-500/10 text-teal-700 shadow-none hover:bg-teal-500/15 dark:text-teal-200",
+          "border-cached/35 bg-cached/10 text-cached shadow-none hover:bg-cached/15",
         outline: "text-foreground",
       },
     },

--- a/ui/src/features/auth/LoginPage.tsx
+++ b/ui/src/features/auth/LoginPage.tsx
@@ -57,48 +57,14 @@ export function LoginPage({ onLogin }: LoginPageProps) {
   );
 
   return (
-    <div
-      style={{
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        minHeight: "100vh",
-        background: "var(--background, #09090b)",
-        color: "var(--foreground, #fafafa)",
-      }}
-    >
+    <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
       <form
         onSubmit={handleSubmit}
-        style={{
-          display: "flex",
-          flexDirection: "column",
-          gap: "1rem",
-          width: "100%",
-          maxWidth: "400px",
-          padding: "2rem",
-          border: "1px solid var(--border, #27272a)",
-          borderRadius: "0.5rem",
-          background: "var(--card, #0a0a0a)",
-        }}
+        className="flex w-full max-w-[400px] flex-col gap-4 rounded-lg border border-border bg-card p-8"
       >
-        <h1
-          style={{
-            fontSize: "1.25rem",
-            fontWeight: 600,
-            textAlign: "center",
-            marginBottom: "0.5rem",
-          }}
-        >
-          Caesium
-        </h1>
+        <h1 className="mb-2 text-center text-xl font-semibold">Caesium</h1>
 
-        <p
-          style={{
-            fontSize: "0.875rem",
-            textAlign: "center",
-            opacity: 0.7,
-          }}
-        >
+        <p className="text-center text-sm text-muted-foreground">
           Enter your API key to continue
         </p>
 
@@ -109,54 +75,22 @@ export function LoginPage({ onLogin }: LoginPageProps) {
           placeholder="csk_live_..."
           autoFocus
           autoComplete="off"
-          style={{
-            padding: "0.5rem 0.75rem",
-            borderRadius: "0.375rem",
-            border: "1px solid var(--border, #27272a)",
-            background: "var(--input, #09090b)",
-            color: "inherit",
-            fontSize: "0.875rem",
-            fontFamily: "monospace",
-          }}
+          className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground outline-none transition focus:border-primary"
         />
 
         {error && (
-          <p
-            style={{
-              fontSize: "0.8rem",
-              color: "var(--destructive, #ef4444)",
-              margin: 0,
-            }}
-          >
-            {error}
-          </p>
+          <p className="m-0 text-[0.8rem] text-destructive">{error}</p>
         )}
 
         <button
           type="submit"
           disabled={loading}
-          style={{
-            padding: "0.5rem 1rem",
-            borderRadius: "0.375rem",
-            border: "none",
-            background: "var(--primary, #fafafa)",
-            color: "var(--primary-foreground, #09090b)",
-            fontWeight: 500,
-            cursor: loading ? "not-allowed" : "pointer",
-            opacity: loading ? 0.6 : 1,
-          }}
+          className="rounded-md border-none bg-primary px-4 py-2 font-medium text-primary-foreground transition disabled:cursor-not-allowed disabled:opacity-60"
         >
           {loading ? "Verifying..." : "Sign In"}
         </button>
 
-        <p
-          style={{
-            fontSize: "0.75rem",
-            textAlign: "center",
-            opacity: 0.5,
-            margin: 0,
-          }}
-        >
+        <p className="m-0 text-center text-xs text-muted-foreground">
           Key is stored in memory only and cleared on tab close
         </p>
       </form>

--- a/ui/src/features/database/DatabaseConsolePage.tsx
+++ b/ui/src/features/database/DatabaseConsolePage.tsx
@@ -240,7 +240,7 @@ export function DatabaseConsolePage() {
       <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
         <div className="space-y-2">
           <div className="flex items-center gap-3">
-            <div className="rounded-2xl border border-primary/30 bg-primary/10 p-3 shadow-[0_0_40px_rgba(0,180,216,0.18)]">
+            <div className="rounded-2xl border border-primary/30 bg-primary/10 p-3 shadow-[0_0_40px_hsl(var(--cyan)/0.18)]">
               <TerminalSquare className="h-5 w-5 text-primary" />
             </div>
             <div>
@@ -253,7 +253,7 @@ export function DatabaseConsolePage() {
           <div className="flex flex-wrap items-center gap-2 text-xs">
             <Badge variant="secondary">{schema?.dialect ?? "database"}</Badge>
             {schema?.version ? <Badge variant="outline">v{schema.version}</Badge> : null}
-            <Badge variant="outline" className="border-emerald-500/30 text-emerald-300">
+            <Badge variant="outline" className="border-success/30 text-success">
               read-only
             </Badge>
             <span className="rounded-full border border-border/70 bg-background/80 px-3 py-1 font-mono text-muted-foreground">
@@ -282,7 +282,7 @@ export function DatabaseConsolePage() {
       </div>
 
       {databaseConsoleUnavailable ? (
-        <Card className="border-amber-500/30 bg-amber-500/5">
+        <Card className="border-warning/30 bg-warning/5">
           <CardHeader>
             <CardTitle className="text-base">Database Console Disabled</CardTitle>
           </CardHeader>
@@ -298,26 +298,26 @@ export function DatabaseConsolePage() {
       <div className="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_360px]">
         <div className="space-y-6">
           <Card className="overflow-hidden border-border/70 bg-card/90 shadow-2xl shadow-black/10">
-            <CardHeader className="border-b border-border/70 bg-[linear-gradient(135deg,rgba(15,23,42,0.98),rgba(30,41,59,0.96))] p-0">
-              <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+            <CardHeader className="border-b border-border/70 bg-gradient-to-br from-obsidian/95 to-midnight/95 p-0">
+              <div className="flex items-center justify-between border-b border-graphite/40 px-4 py-3">
                 <div className="flex items-center gap-2">
-                  <span className="h-3 w-3 rounded-full bg-rose-400/90" />
-                  <span className="h-3 w-3 rounded-full bg-amber-400/90" />
-                  <span className="h-3 w-3 rounded-full bg-emerald-400/90" />
+                  <span className="h-3 w-3 rounded-full bg-danger/90" />
+                  <span className="h-3 w-3 rounded-full bg-warning/90" />
+                  <span className="h-3 w-3 rounded-full bg-success/90" />
                 </div>
-                <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-slate-400">
+                <div className="flex items-center gap-2 text-xs uppercase tracking-[0.3em] text-text-3">
                   <Database className="h-3.5 w-3.5" />
                   Operator SQL
                 </div>
               </div>
-              <div className="flex items-center justify-between px-4 py-3 text-sm text-slate-300">
+              <div className="flex items-center justify-between px-4 py-3 text-sm text-text-2">
                 <div className="flex items-center gap-2 font-mono">
-                  <span className="text-emerald-400">caesium@db</span>
-                  <ArrowRight className="h-3.5 w-3.5 text-slate-500" />
+                  <span className="text-success">caesium@db</span>
+                  <ArrowRight className="h-3.5 w-3.5 text-text-4" />
                   <span>{schema?.dialect ?? "query"}</span>
                 </div>
                 <div className="flex items-center gap-2 text-xs">
-                  <label className="font-medium text-slate-400" htmlFor="query-limit">
+                  <label className="font-medium text-text-3" htmlFor="query-limit">
                     Row cap
                   </label>
                   <input
@@ -327,17 +327,17 @@ export function DatabaseConsolePage() {
                     max={1000}
                     value={limit}
                     onChange={(event) => handleLimitChange(event.target.value)}
-                    className="w-20 rounded-md border border-white/10 bg-slate-950/70 px-2 py-1 font-mono text-slate-100 outline-none ring-0 transition focus:border-primary"
+                    className="w-20 rounded-md border border-graphite/40 bg-midnight/70 px-2 py-1 font-mono text-text-1 outline-none ring-0 transition focus:border-primary"
                   />
                 </div>
               </div>
             </CardHeader>
-            <CardContent className="space-y-4 bg-[linear-gradient(180deg,rgba(2,6,23,0.98),rgba(15,23,42,0.98))] p-4">
+            <CardContent className="space-y-4 bg-gradient-to-b from-void/95 to-obsidian/95 p-4">
               <div
                 ref={editorSurfaceRef}
-                className="relative rounded-2xl border border-white/10 bg-slate-950/70 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]"
+                className="relative rounded-2xl border border-graphite/40 bg-midnight/70 shadow-[inset_0_1px_0_hsl(var(--text-1)/0.04)]"
               >
-                <div className="border-b border-white/10 px-4 py-2 text-xs uppercase tracking-[0.28em] text-slate-500">
+                <div className="border-b border-graphite/40 px-4 py-2 text-xs uppercase tracking-[0.28em] text-text-4">
                   Query
                 </div>
                 <textarea
@@ -354,13 +354,13 @@ export function DatabaseConsolePage() {
                   onSelect={(event) => setCursorPosition(event.currentTarget.selectionStart)}
                   spellCheck={false}
                   disabled={databaseConsoleUnavailable}
-                  className="min-h-[220px] w-full resize-y bg-transparent px-4 py-4 font-mono text-sm leading-6 text-slate-100 outline-none placeholder:text-slate-500"
+                  className="min-h-[220px] w-full resize-y bg-transparent px-4 py-4 font-mono text-sm leading-6 text-text-1 outline-none placeholder:text-text-4"
                   placeholder="SELECT * FROM job_runs ORDER BY started_at DESC LIMIT 25;"
                 />
 
                 {autocompleteVisible && suggestions.length > 0 ? (
                   <div
-                    className="absolute z-20 w-80 overflow-hidden rounded-2xl border border-primary/20 bg-slate-950/95 shadow-[0_24px_80px_rgba(2,6,23,0.45)] backdrop-blur"
+                    className="absolute z-20 w-80 overflow-hidden rounded-2xl border border-primary/20 bg-midnight/95 shadow-[0_24px_80px_hsl(var(--void)/0.45)] backdrop-blur"
                     style={{ top: autocompletePosition.top, left: autocompletePosition.left }}
                   >
                     <div className="max-h-60 overflow-auto p-2">
@@ -377,11 +377,11 @@ export function DatabaseConsolePage() {
                               "flex items-center justify-between rounded-xl px-3 py-2 text-left font-mono text-sm transition",
                               index === activeSuggestionIndex
                                 ? "bg-primary/15 text-primary"
-                                : "text-slate-200 hover:bg-white/5",
+                                : "text-text-2 hover:bg-graphite/30",
                             )}
                           >
                             <span className="truncate pr-3">{suggestion.label}</span>
-                            <span className="shrink-0 text-[10px] uppercase tracking-[0.2em] text-slate-500">
+                            <span className="shrink-0 text-[10px] uppercase tracking-[0.2em] text-text-4">
                               {suggestion.detail}
                             </span>
                           </button>
@@ -399,10 +399,10 @@ export function DatabaseConsolePage() {
                     type="button"
                     onClick={() => applySnippet(snippet.sql)}
                     disabled={databaseConsoleUnavailable}
-                    className="rounded-full border border-white/10 bg-white/5 px-3 py-1.5 text-left transition hover:border-primary/40 hover:bg-primary/10"
+                    className="rounded-full border border-graphite/40 bg-graphite/20 px-3 py-1.5 text-left transition hover:border-primary/40 hover:bg-primary/10"
                   >
-                    <div className="text-sm font-medium text-slate-100">{snippet.label}</div>
-                    <div className="text-xs text-slate-400">{snippet.description}</div>
+                    <div className="text-sm font-medium text-text-1">{snippet.label}</div>
+                    <div className="text-xs text-text-3">{snippet.description}</div>
                   </button>
                 ))}
               </div>

--- a/ui/src/features/jobs/BackfillsView.tsx
+++ b/ui/src/features/jobs/BackfillsView.tsx
@@ -14,7 +14,7 @@ interface BackfillsViewProps {
 function renderBackfillStatus(backfill: Backfill) {
   if (backfill.status === "running" && backfill.cancel_requested_at) {
     return (
-      <Badge variant="outline" className="border-amber-500/40 text-amber-300">
+      <Badge variant="outline" className="border-warning/40 text-warning">
         Cancelling
       </Badge>
     );

--- a/ui/src/features/jobs/JobDAG.tsx
+++ b/ui/src/features/jobs/JobDAG.tsx
@@ -157,7 +157,7 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
             const outputCount = sourceRun?.output ? Object.keys(sourceRun.output).length : 0;
             const hasOutputs = outputCount > 0;
             const isBranchSkipped = targetStatus === 'skipped' && sourceStatus === 'succeeded';
-            const stroke = isBranchSkipped ? '#64748b' : edgeColor(sourceStatus);
+            const stroke = isBranchSkipped ? 'hsl(var(--text-3))' : edgeColor(sourceStatus);
             const sourceName = sourceTask?.name || e.from;
             const targetName = targetTask?.name || e.to;
             const contractSchema = sourceTask?.name && targetTask?.input_schema
@@ -259,17 +259,17 @@ function normalizeTaskStatus(status?: string) {
 function edgeColor(status: string) {
     switch (status) {
         case 'running':
-            return '#00b4d8';
+            return 'hsl(var(--running))';
         case 'succeeded':
-            return '#10b981';
+            return 'hsl(var(--success))';
         case 'cached':
-            return '#14b8a6';
+            return 'hsl(var(--cached))';
         case 'failed':
-            return '#f97316';
+            return 'hsl(var(--danger))';
         case 'skipped':
-            return '#f59e0b';
+            return 'hsl(var(--warning))';
         default:
-            return '#64748b';
+            return 'hsl(var(--text-3))';
     }
 }
 
@@ -277,18 +277,18 @@ function EdgeDetails({ edge }: { edge: EdgeDetailsState }) {
     return (
         <div className="space-y-5">
             <div className="flex flex-wrap items-center gap-2">
-                <span className="rounded-full border border-emerald-500/35 bg-emerald-500/10 px-2.5 py-1 text-xs font-semibold text-emerald-700 dark:text-emerald-300">
+                <span className="rounded-full border border-success/35 bg-success/10 px-2.5 py-1 text-xs font-semibold text-success">
                     {edge.outputCount} {edge.outputCount === 1 ? 'output' : 'outputs'}
                 </span>
                 <span
                     className={`inline-flex items-center rounded-full border px-2 py-1 ${
                         edge.contractDefined
-                            ? 'border-blue-500/35 bg-blue-500/10'
-                            : 'border-slate-400/35 bg-slate-500/10'
+                            ? 'border-running/35 bg-running/10'
+                            : 'border-text-3/30 bg-text-3/10'
                     }`}
                     title={edge.contractDefined ? 'Consumer requirements declared' : 'No consumer requirements declared'}
                 >
-                    <ShieldCheck className={`h-3 w-3 ${edge.contractDefined ? 'text-blue-400' : 'text-slate-500'}`} />
+                    <ShieldCheck className={`h-3 w-3 ${edge.contractDefined ? 'text-running' : 'text-text-3'}`} />
                 </span>
             </div>
 
@@ -377,7 +377,7 @@ function SchemaPreview({
                             <span className="font-mono font-semibold text-foreground">{key}</span>
                             <span className="font-mono text-muted-foreground">{type}</span>
                             {isRequired ? (
-                                <span className="rounded border border-blue-500/35 bg-blue-500/10 px-1.5 py-0.5 text-[10px] font-semibold text-blue-700 dark:text-blue-300">
+                                <span className="rounded border border-running/35 bg-running/10 px-1.5 py-0.5 text-[10px] font-semibold text-running">
                                     required
                                 </span>
                             ) : null}

--- a/ui/src/features/jobs/LogViewer.tsx
+++ b/ui/src/features/jobs/LogViewer.tsx
@@ -286,22 +286,22 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
       : null;
 
   const banner = error && status === "skipped" ? (
-    <div className="border-b border-slate-500/20 bg-slate-500/10 px-4 py-2.5">
+    <div className="border-b border-text-3/20 bg-text-3/10 px-4 py-2.5">
       <div className="flex items-start gap-3">
-        <SkipForward className="mt-0.5 h-3.5 w-3.5 shrink-0 text-slate-400" />
+        <SkipForward className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-3" />
         <div className="min-w-0">
-          <div className="text-[10px] font-bold uppercase tracking-wider text-slate-400">Skipped</div>
-          <div className="font-mono text-[10px] leading-relaxed text-slate-400/80">{error}</div>
+          <div className="text-[10px] font-bold uppercase tracking-wider text-text-3">Skipped</div>
+          <div className="font-mono text-[10px] leading-relaxed text-text-3/80">{error}</div>
         </div>
       </div>
     </div>
   ) : error ? (
-    <div className="border-b border-red-500/20 bg-red-500/10 px-4 py-2.5">
+    <div className="border-b border-danger/20 bg-danger/10 px-4 py-2.5">
       <div className="flex items-start gap-3">
-        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-red-400" />
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-danger" />
         <div className="min-w-0">
-          <div className="text-[10px] font-bold uppercase tracking-wider text-red-400">Task Error</div>
-          <div className="font-mono text-[10px] leading-relaxed text-red-300">{error}</div>
+          <div className="text-[10px] font-bold uppercase tracking-wider text-danger">Task Error</div>
+          <div className="font-mono text-[10px] leading-relaxed text-danger/90">{error}</div>
         </div>
       </div>
     </div>
@@ -313,13 +313,13 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
         <>
           <LogBadge>{renderStateLabel(logState)}</LogBadge>
           {logSource === "live" && (
-            <LogBadge className="border-emerald-500/30 bg-emerald-500/10 text-emerald-200">Live</LogBadge>
+            <LogBadge className="border-success/30 bg-success/10 text-success">Live</LogBadge>
           )}
           {logSource === "persisted" && (
-            <LogBadge className="border-blue-500/30 bg-blue-500/10 text-blue-200">Retained</LogBadge>
+            <LogBadge className="border-running/30 bg-running/10 text-running">Retained</LogBadge>
           )}
           {logTruncated && (
-            <LogBadge className="border-amber-500/30 bg-amber-500/10 text-amber-200">Truncated</LogBadge>
+            <LogBadge className="border-warning/30 bg-warning/10 text-warning">Truncated</LogBadge>
           )}
         </>
       }
@@ -337,8 +337,8 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
         className={cn(
           "rounded-md border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors",
           caseSensitive
-            ? "border-cyan-500/40 bg-cyan-500/10 text-cyan-200"
-            : "border-slate-700 bg-slate-900 text-slate-400 hover:border-slate-600 hover:text-slate-200",
+            ? "border-cyan/40 bg-cyan/10 text-cyan-glow"
+            : "border-graphite/60 bg-midnight text-text-3 hover:border-graphite hover:text-text-1",
         )}
       >
         Aa
@@ -347,7 +347,7 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
       <Button
         type="button"
         variant="ghost"
-        className="h-7 gap-1.5 px-2 text-[10px] font-semibold uppercase tracking-wide text-slate-300 hover:bg-slate-800 hover:text-slate-50"
+        className="h-7 gap-1.5 px-2 text-[10px] font-semibold uppercase tracking-wide text-text-2 hover:bg-graphite/40 hover:text-text-1"
         onClick={handleCopy}
         disabled={!hasVisibleOutput}
       >
@@ -370,12 +370,12 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
       emptyState={filteredEmptyState || emptyState}
       hasVisibleOutput={hasVisibleOutput}
     >
-      <div ref={terminalRef} className="h-full w-full overflow-hidden bg-slate-950 px-3 py-2" />
+      <div ref={terminalRef} className="h-full w-full overflow-hidden bg-obsidian px-3 py-2" />
       <pre data-testid="task-log-plaintext" className="sr-only">
         {filterResult.renderedText}
       </pre>
       {transportError && (
-        <div className="absolute inset-x-0 top-0 border-b border-red-500/20 bg-red-500/10 px-4 py-2.5 text-[11px] text-red-200">
+        <div className="absolute inset-x-0 top-0 border-b border-danger/20 bg-danger/10 px-4 py-2.5 text-[11px] text-danger">
           {transportError}
         </div>
       )}

--- a/ui/src/features/jobs/RunTimeline.tsx
+++ b/ui/src/features/jobs/RunTimeline.tsx
@@ -1,20 +1,19 @@
 import { useState } from "react";
 import type { TaskRun } from "@/lib/api";
 import { shortId } from "@/lib/utils";
+import { statusMeta } from "@/lib/status";
 
 interface Props {
   tasks: TaskRun[];
   runStartedAt: string;
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  succeeded: "#22c55e",
-  cached: "#14b8a6",
-  failed: "#ef4444",
-  running: "#00b4d8",
-  skipped: "#a3a3a3",
-  pending: "#6b7280",
-};
+// Statuses surfaced in the timeline legend, in display order.
+const LEGEND_STATUSES = ["succeeded", "cached", "failed", "running", "skipped", "queued"] as const;
+
+function colorFor(status: string): string {
+  return statusMeta(status).fg;
+}
 
 function formatMs(ms: number): string {
   if (ms < 1000) return `${ms}ms`;
@@ -76,7 +75,7 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
             y={i * ROW_H}
             width={LABEL_W + BAR_AREA + 20}
             height={ROW_H}
-            fill={i % 2 === 0 ? "transparent" : "rgba(128,128,128,0.04)"}
+            fill={i % 2 === 0 ? "transparent" : "hsl(var(--text-3) / 0.04)"}
           />
         ))}
 
@@ -90,7 +89,7 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
               y1={0}
               x2={x}
               y2={svgHeight - 28}
-              stroke="rgba(128,128,128,0.15)"
+              stroke="hsl(var(--text-3) / 0.18)"
               strokeDasharray="3,3"
             />
           );
@@ -100,7 +99,7 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
         {taskTimes.map(({ task, start, end }, i) => {
           const barX = LABEL_W + (start / maxEnd) * BAR_AREA;
           const barW = Math.max(2, ((end - start) / maxEnd) * BAR_AREA);
-          const color = STATUS_COLORS[task.status] ?? STATUS_COLORS.pending;
+          const color = colorFor(task.status);
           const label = task.image
             ? task.image.split("/").pop()?.split(":")[0] ?? shortId(task.atom_id)
             : shortId(task.atom_id);
@@ -126,7 +125,7 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
                 y={i * ROW_H + BAR_Y_OFFSET}
                 width={BAR_AREA}
                 height={BAR_H}
-                fill="rgba(128,128,128,0.08)"
+                fill="hsl(var(--text-3) / 0.1)"
                 rx={3}
               />
 
@@ -157,7 +156,7 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
                   y={i * ROW_H + BAR_Y_OFFSET + BAR_H / 2 + 4}
                   textAnchor="middle"
                   fontSize={9}
-                  fill="white"
+                  fill="hsl(var(--background))"
                   fontWeight="600"
                 >
                   {formatMs(duration)}
@@ -181,13 +180,13 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
           y1={svgHeight - 28}
           x2={LABEL_W + BAR_AREA}
           y2={svgHeight - 28}
-          stroke="rgba(128,128,128,0.3)"
+          stroke="hsl(var(--text-3) / 0.35)"
         />
         {ticks.map((tick, i) => {
           const x = LABEL_W + (tick / maxEnd) * BAR_AREA;
           return (
             <g key={i}>
-              <line x1={x} y1={svgHeight - 28} x2={x} y2={svgHeight - 22} stroke="rgba(128,128,128,0.4)" />
+              <line x1={x} y1={svgHeight - 28} x2={x} y2={svgHeight - 22} stroke="hsl(var(--text-3) / 0.45)" />
               <text
                 x={x}
                 y={svgHeight - 10}
@@ -205,10 +204,10 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
 
       {/* Legend */}
       <div className="flex flex-wrap gap-4 mt-3 px-1">
-        {Object.entries(STATUS_COLORS).map(([status, color]) => (
+        {LEGEND_STATUSES.map((status) => (
           <div key={status} className="flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: color, opacity: 0.75 }} />
-            {status}
+            <span className="inline-block w-3 h-3 rounded-sm" style={{ backgroundColor: colorFor(status), opacity: 0.75 }} />
+            {status === "queued" ? "pending" : status}
           </div>
         ))}
       </div>

--- a/ui/src/features/jobs/TaskDetailPanel.tsx
+++ b/ui/src/features/jobs/TaskDetailPanel.tsx
@@ -219,25 +219,25 @@ export function TaskDetailPanel({
             <div className="p-4 space-y-4">
               {/* Error banner */}
               {runTask?.error && status === "skipped" ? (
-                <div className="rounded-lg border border-slate-500/20 bg-slate-500/10 px-3 py-2.5 flex gap-3 items-start">
-                  <SkipForward className="w-4 h-4 text-slate-400 shrink-0 mt-0.5" />
+                <div className="rounded-lg border border-text-3/20 bg-text-3/10 px-3 py-2.5 flex gap-3 items-start">
+                  <SkipForward className="w-4 h-4 text-text-3 shrink-0 mt-0.5" />
                   <div className="flex flex-col gap-1 min-w-0">
-                    <span className="text-[10px] font-bold text-slate-400 uppercase tracking-wider">
+                    <span className="text-[10px] font-bold text-text-3 uppercase tracking-wider">
                       Skipped
                     </span>
-                    <span className="text-xs text-slate-400/80 font-mono leading-relaxed break-all">
+                    <span className="text-xs text-text-3/80 font-mono leading-relaxed break-all">
                       {runTask.error}
                     </span>
                   </div>
                 </div>
               ) : runTask?.error ? (
-                <div className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2.5 flex gap-3 items-start">
-                  <AlertTriangle className="w-4 h-4 text-red-500 shrink-0 mt-0.5" />
+                <div className="rounded-lg border border-danger/20 bg-danger/10 px-3 py-2.5 flex gap-3 items-start">
+                  <AlertTriangle className="w-4 h-4 text-danger shrink-0 mt-0.5" />
                   <div className="flex flex-col gap-1 min-w-0">
-                    <span className="text-[10px] font-bold text-red-500 uppercase tracking-wider">
+                    <span className="text-[10px] font-bold text-danger uppercase tracking-wider">
                       Error
                     </span>
-                    <span className="text-xs text-red-400 font-mono leading-relaxed break-all">
+                    <span className="text-xs text-danger/90 font-mono leading-relaxed break-all">
                       {runTask.error}
                     </span>
                   </div>
@@ -245,16 +245,16 @@ export function TaskDetailPanel({
               ) : null}
 
               {cached ? (
-                <div className="rounded-lg border border-teal-500/30 bg-teal-500/10 px-3 py-2.5 flex gap-3 items-start">
-                  <Archive className="w-4 h-4 text-teal-500 shrink-0 mt-0.5" />
+                <div className="rounded-lg border border-cached/30 bg-cached/10 px-3 py-2.5 flex gap-3 items-start">
+                  <Archive className="w-4 h-4 text-cached shrink-0 mt-0.5" />
                   <div className="flex flex-1 flex-col gap-1 min-w-0">
-                    <span className="text-[10px] font-bold text-teal-700 dark:text-teal-300 uppercase tracking-wider">
+                    <span className="text-[10px] font-bold text-cached uppercase tracking-wider">
                       Reused successful output
                     </span>
-                    <span className="text-xs text-teal-700 dark:text-teal-300">
+                    <span className="text-xs text-cached">
                       This task completed from cache, so no new container had to run for this step.
                     </span>
-                    <div className="flex flex-wrap items-center gap-2 text-xs text-teal-700 dark:text-teal-300">
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-cached">
                       {runTask?.cache_origin_run_id ? (
                         <Link to="/jobs/$jobId/runs/$runId" params={{ jobId, runId: runTask.cache_origin_run_id }} className="font-mono hover:underline">
                           Source run {runTask.cache_origin_run_id.slice(0, 8)}
@@ -340,16 +340,16 @@ export function TaskDetailPanel({
 function StatusDot({ status }: { status: string }) {
   const color =
     status === "succeeded" || status === "completed"
-      ? "bg-emerald-400 shadow-emerald-400/50"
+      ? "bg-success shadow-success/50"
       : status === "cached"
-        ? "bg-teal-400 shadow-teal-400/50"
+        ? "bg-cached shadow-cached/50"
       : status === "failed"
-        ? "bg-red-400 shadow-red-400/50"
+        ? "bg-danger shadow-danger/50"
         : status === "running"
-          ? "bg-blue-400 shadow-blue-400/50 animate-pulse"
+          ? "bg-running shadow-running/50 animate-pulse"
           : status === "skipped"
-            ? "bg-slate-400"
-            : "bg-slate-500";
+            ? "bg-text-3"
+            : "bg-text-4";
 
   return (
     <span

--- a/ui/src/features/jobs/TaskMetadataPanel.tsx
+++ b/ui/src/features/jobs/TaskMetadataPanel.tsx
@@ -146,14 +146,14 @@ interface SchemaViolationsSectionProps {
 function SchemaViolationsSection({ violations }: SchemaViolationsSectionProps) {
   return (
     <div className="md:col-span-2">
-      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-amber-600">Schema Violations</div>
-      <div className="rounded-md border border-amber-200 bg-amber-50 p-2 dark:border-amber-900 dark:bg-amber-950/30">
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-warning">Schema Violations</div>
+      <div className="rounded-md border border-warning/30 bg-warning/10 p-2">
         {violations.map((v, i) => (
           <div key={i} className="flex gap-2 font-mono text-xs">
             {v.key && (
-              <span className="font-semibold text-amber-700 dark:text-amber-400">{v.key}:</span>
+              <span className="font-semibold text-warning">{v.key}:</span>
             )}
-            <span className="text-amber-800 dark:text-amber-300">{v.message}</span>
+            <span className="text-warning/90">{v.message}</span>
           </div>
         ))}
       </div>

--- a/ui/src/features/jobs/__tests__/JobDAG.test.tsx
+++ b/ui/src/features/jobs/__tests__/JobDAG.test.tsx
@@ -189,7 +189,7 @@ describe("JobDAG", () => {
 
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-output-count", "2");
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-contract-defined", "true");
-    expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-stroke", "#64748b");
+    expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-stroke", "hsl(var(--text-3))");
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-dasharray", "6 3");
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-animated", "false");
   });

--- a/ui/src/features/jobs/components/BranchNode.tsx
+++ b/ui/src/features/jobs/components/BranchNode.tsx
@@ -26,27 +26,27 @@ export const BranchNode = memo(({ data }: NodeProps) => {
     switch (status) {
       case 'completed':
       case 'succeeded':
-        return <CheckCircle2 data-testid="status-icon-succeeded" className="w-5 h-5 text-green-400 fill-green-500/10" />;
+        return <CheckCircle2 data-testid="status-icon-succeeded" className="w-5 h-5 text-success fill-success/10" />;
       case 'failed':
-        return <XCircle data-testid="status-icon-failed" className="w-5 h-5 text-red-400 fill-red-500/10" />;
+        return <XCircle data-testid="status-icon-failed" className="w-5 h-5 text-danger fill-danger/10" />;
       case 'running':
-        return <Activity data-testid="status-icon-running" className="w-5 h-5 text-blue-400 animate-spin" />;
+        return <Activity data-testid="status-icon-running" className="w-5 h-5 text-running animate-spin" />;
       case 'skipped':
-        return <SkipForward data-testid="status-icon-skipped" className="w-5 h-5 text-slate-400" />;
+        return <SkipForward data-testid="status-icon-skipped" className="w-5 h-5 text-text-3" />;
       case 'pending':
-        return <Clock data-testid="status-icon-pending" className="w-5 h-5 text-slate-500" />;
+        return <Clock data-testid="status-icon-pending" className="w-5 h-5 text-text-4" />;
       default:
-        return <Circle data-testid="status-icon-unknown" className="w-5 h-5 text-slate-600" />;
+        return <Circle data-testid="status-icon-unknown" className="w-5 h-5 text-text-4" />;
     }
   };
 
   const getEngineIcon = () => {
     const e = (engine || atom?.engine || '').toLowerCase();
-    if (e.includes('docker')) return <Container data-testid="engine-icon-docker" className="w-3.5 h-3.5 text-amber-400" />;
-    if (e.includes('kubernetes') || e.includes('k8s')) return <Cloud data-testid="engine-icon-kubernetes" className="w-3.5 h-3.5 text-amber-400" />;
-    if (e.includes('podman')) return <Zap data-testid="engine-icon-podman" className="w-3.5 h-3.5 text-amber-400" />;
-    if (e.includes('wasm')) return <Zap data-testid="engine-icon-wasm" className="w-3.5 h-3.5 text-amber-400" />;
-    return <Settings data-testid="engine-icon-unknown" className="w-3.5 h-3.5 text-amber-400" />;
+    if (e.includes('docker')) return <Container data-testid="engine-icon-docker" className="w-3.5 h-3.5 text-gold" />;
+    if (e.includes('kubernetes') || e.includes('k8s')) return <Cloud data-testid="engine-icon-kubernetes" className="w-3.5 h-3.5 text-gold" />;
+    if (e.includes('podman')) return <Zap data-testid="engine-icon-podman" className="w-3.5 h-3.5 text-gold" />;
+    if (e.includes('wasm')) return <Zap data-testid="engine-icon-wasm" className="w-3.5 h-3.5 text-gold" />;
+    return <Settings data-testid="engine-icon-unknown" className="w-3.5 h-3.5 text-gold" />;
   };
 
   const getProcessedCommand = () => {
@@ -75,15 +75,15 @@ export const BranchNode = memo(({ data }: NodeProps) => {
     switch (status) {
       case 'completed':
       case 'succeeded':
-        return 'border-amber-400/50 bg-[linear-gradient(160deg,hsl(38_92%_50%/0.18),hsl(160_84%_36%/0.15)_30%,hsl(var(--node-surface)/0.95)_78%)] shadow-[0_0_24px_rgba(245,158,11,0.18)]';
+        return 'border-gold/50 bg-[linear-gradient(160deg,hsl(var(--gold)/0.18),hsl(var(--success)/0.15)_30%,hsl(var(--node-surface)/0.95)_78%)] shadow-[0_0_24px_hsl(var(--gold)/0.18)]';
       case 'failed':
-        return 'border-red-400/50 bg-[linear-gradient(160deg,hsl(38_92%_50%/0.14),hsl(8_86%_58%/0.18)_34%,hsl(var(--node-surface)/0.95)_80%)] shadow-[0_0_24px_rgba(248,113,113,0.16)]';
+        return 'border-danger/50 bg-[linear-gradient(160deg,hsl(var(--gold)/0.14),hsl(var(--danger)/0.18)_34%,hsl(var(--node-surface)/0.95)_80%)] shadow-[0_0_24px_hsl(var(--danger)/0.16)]';
       case 'running':
-        return 'border-amber-400/70 bg-[linear-gradient(155deg,hsl(38_92%_50%/0.28),hsl(38_92%_50%/0.12)_36%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_30px_rgba(245,158,11,0.28)]';
+        return 'border-gold/70 bg-[linear-gradient(155deg,hsl(var(--gold)/0.28),hsl(var(--gold)/0.12)_36%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_30px_hsl(var(--gold)/0.28)]';
       case 'skipped':
-        return 'border-slate-500/30 bg-[linear-gradient(155deg,hsl(38_92%_50%/0.04),hsl(var(--node-surface)/0.92)_32%)] shadow-none opacity-60';
+        return 'border-text-3/30 bg-[linear-gradient(155deg,hsl(var(--gold)/0.04),hsl(var(--node-surface)/0.92)_32%)] shadow-none opacity-60';
       default:
-        return 'border-amber-400/35 bg-[linear-gradient(155deg,hsl(38_92%_50%/0.18),hsl(38_92%_50%/0.08)_32%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_22px_rgba(245,158,11,0.14)]';
+        return 'border-gold/35 bg-[linear-gradient(155deg,hsl(var(--gold)/0.18),hsl(var(--gold)/0.08)_32%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_22px_hsl(var(--gold)/0.14)]';
     }
   };
 
@@ -101,13 +101,13 @@ export const BranchNode = memo(({ data }: NodeProps) => {
         isSelected ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''
       )}
     >
-      <Handle type="target" position={Position.Left} className="h-3 w-3 border-2 border-dag-bg bg-amber-400" />
+      <Handle type="target" position={Position.Left} className="h-3 w-3 border-2 border-dag-bg bg-gold" />
 
       <div className="flex h-full flex-col gap-2">
         {/* Row 1: Image & Status */}
         <div className="flex min-h-[44px] items-start justify-between gap-3">
           <div className="flex items-center gap-2 overflow-hidden">
-            <div className="rounded-lg border border-amber-400/30 bg-amber-500/10 p-1.5 shadow-inner shadow-amber-400/10">
+            <div className="rounded-lg border border-gold/30 bg-gold/10 p-1.5 shadow-inner shadow-gold/10">
               {getEngineIcon()}
             </div>
             <div className="flex flex-col min-w-0">
@@ -115,7 +115,7 @@ export const BranchNode = memo(({ data }: NodeProps) => {
                 {shortImage(atom?.image)}
               </span>
               <div className="flex items-center gap-1">
-                <span className="rounded border border-amber-400/50 bg-amber-400/15 px-1 text-[8px] font-black tracking-tighter text-amber-400">
+                <span className="rounded border border-gold/50 bg-gold/15 px-1 text-[8px] font-black tracking-tighter text-gold">
                   BRANCH
                 </span>
                 <span className="truncate text-[9px] font-mono text-muted-foreground">
@@ -140,29 +140,29 @@ export const BranchNode = memo(({ data }: NodeProps) => {
           className={cn(
             "custom-scrollbar h-[72px] overflow-y-auto rounded-lg border px-2.5 py-1.5 shadow-inner",
             error && status !== 'skipped'
-              ? "border-red-500/20 bg-red-500/10"
+              ? "border-danger/20 bg-danger/10"
               : error && status === 'skipped'
-                ? "border-slate-500/20 bg-slate-500/5"
-                : "border-amber-400/20 bg-muted/70",
-            isShell && !error && "border-amber-400/30"
+                ? "border-text-3/20 bg-text-3/5"
+                : "border-gold/20 bg-muted/70",
+            isShell && !error && "border-gold/30"
           )}
         >
           {error && status === 'skipped' ? (
             <div className="flex gap-2 items-start">
-              <SkipForward className="w-3.5 h-3.5 text-slate-400 shrink-0 mt-0.5" />
+              <SkipForward className="w-3.5 h-3.5 text-text-3 shrink-0 mt-0.5" />
               <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="text-[8px] font-bold text-slate-400/80 uppercase tracking-wider">Skipped</span>
-                <span className="text-[9px] text-slate-400/70 font-mono leading-relaxed break-all line-clamp-3">
+                <span className="text-[8px] font-bold text-text-3/80 uppercase tracking-wider">Skipped</span>
+                <span className="text-[9px] text-text-3/70 font-mono leading-relaxed break-all line-clamp-3">
                   {error}
                 </span>
               </div>
             </div>
           ) : error ? (
             <div className="flex gap-2 items-start">
-              <AlertTriangle className="w-3.5 h-3.5 text-red-500 shrink-0 mt-0.5" />
+              <AlertTriangle className="w-3.5 h-3.5 text-danger shrink-0 mt-0.5" />
               <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="text-[8px] font-bold text-red-500/80 uppercase tracking-wider">Error Details</span>
-                <span className="text-[9px] text-red-400/90 font-mono leading-relaxed break-all line-clamp-3">
+                <span className="text-[8px] font-bold text-danger/80 uppercase tracking-wider">Error Details</span>
+                <span className="text-[9px] text-danger/90 font-mono leading-relaxed break-all line-clamp-3">
                   {error}
                 </span>
               </div>
@@ -171,7 +171,7 @@ export const BranchNode = memo(({ data }: NodeProps) => {
             <div className="flex flex-col gap-1">
               {commandArray.map((arg: string, i: number) => (
                 <div key={i} className="flex items-start gap-2 group">
-                  <GitBranch className="mt-0.5 h-2.5 w-2.5 shrink-0 text-amber-400/70" />
+                  <GitBranch className="mt-0.5 h-2.5 w-2.5 shrink-0 text-gold/70" />
                   <span className="break-all font-mono text-[10px] leading-relaxed text-foreground/70 transition-colors group-hover:text-foreground">
                     {arg}
                   </span>
@@ -180,14 +180,14 @@ export const BranchNode = memo(({ data }: NodeProps) => {
             </div>
           ) : (
             <div className="flex h-full items-center gap-2 opacity-50">
-              <TerminalIcon className="h-3 w-3 text-amber-400/55" />
+              <TerminalIcon className="h-3 w-3 text-gold/55" />
               <span className="text-[10px] font-mono italic text-muted-foreground">no command</span>
             </div>
           )}
         </div>
       </div>
 
-      <Handle type="source" position={Position.Right} className="h-3 w-3 border-2 border-dag-bg bg-amber-400" />
+      <Handle type="source" position={Position.Right} className="h-3 w-3 border-2 border-dag-bg bg-gold" />
     </div>
   );
 });

--- a/ui/src/features/jobs/components/DataFlowEdge.tsx
+++ b/ui/src/features/jobs/components/DataFlowEdge.tsx
@@ -43,14 +43,14 @@ export const DataFlowEdge = memo(({
           >
             <button
               type="button"
-              className="flex items-center gap-1.5 rounded-full border border-slate-400/35 bg-slate-950/80 px-2.5 py-1 shadow-sm backdrop-blur-sm transition-colors hover:border-slate-300/45 hover:bg-slate-900/90"
+              className="flex items-center gap-1.5 rounded-full border border-border/50 bg-card/90 px-2.5 py-1 shadow-sm backdrop-blur-sm transition-colors hover:border-border hover:bg-card"
               onClick={onOpenDetails}
               title="View edge data details"
             >
               {outputCount > 0 ? (
                 <>
-                  <ArrowRight className="h-2.5 w-2.5 text-emerald-400" />
-                  <span className="text-[9px] font-bold tabular-nums text-emerald-300">
+                  <ArrowRight className="h-2.5 w-2.5 text-success" />
+                  <span className="text-[9px] font-bold tabular-nums text-success">
                     {outputCount} {outputCount === 1 ? 'output' : 'outputs'}
                   </span>
                 </>
@@ -58,12 +58,12 @@ export const DataFlowEdge = memo(({
               <div
                 className={`rounded-full border px-1.5 py-0.5 ${
                   contractDefined
-                    ? 'border-blue-500/35 bg-blue-500/10'
-                    : 'border-slate-500/30 bg-slate-500/10'
+                    ? 'border-running/35 bg-running/10'
+                    : 'border-text-3/30 bg-text-3/10'
                 }`}
                 title={contractDefined ? 'Data contract defined' : 'No data contract defined'}
               >
-                <ShieldCheck className={`h-2.5 w-2.5 ${contractDefined ? 'text-blue-400' : 'text-slate-500'}`} />
+                <ShieldCheck className={`h-2.5 w-2.5 ${contractDefined ? 'text-running' : 'text-text-3'}`} />
               </div>
             </button>
           </div>

--- a/ui/src/features/jobs/components/TaskNode.tsx
+++ b/ui/src/features/jobs/components/TaskNode.tsx
@@ -26,29 +26,29 @@ export const TaskNode = memo(({ data }: NodeProps) => {
     switch (status) {
       case 'completed':
       case 'succeeded':
-        return <CheckCircle2 data-testid="status-icon-succeeded" className="w-5 h-5 text-green-400 fill-green-500/10" />;
+        return <CheckCircle2 data-testid="status-icon-succeeded" className="w-5 h-5 text-success fill-success/10" />;
       case 'failed':
-        return <XCircle data-testid="status-icon-failed" className="w-5 h-5 text-red-400 fill-red-500/10" />;
+        return <XCircle data-testid="status-icon-failed" className="w-5 h-5 text-danger fill-danger/10" />;
       case 'cached':
-        return <Archive data-testid="status-icon-cached" className="w-5 h-5 text-teal-300 fill-teal-400/10" />;
+        return <Archive data-testid="status-icon-cached" className="w-5 h-5 text-cached fill-cached/10" />;
       case 'running':
-        return <Activity data-testid="status-icon-running" className="w-5 h-5 text-blue-400 animate-spin" />;
+        return <Activity data-testid="status-icon-running" className="w-5 h-5 text-running animate-spin" />;
       case 'skipped':
-        return <SkipForward data-testid="status-icon-skipped" className="w-5 h-5 text-slate-400" />;
+        return <SkipForward data-testid="status-icon-skipped" className="w-5 h-5 text-text-3" />;
       case 'pending':
-        return <Clock data-testid="status-icon-pending" className="w-5 h-5 text-slate-500" />;
+        return <Clock data-testid="status-icon-pending" className="w-5 h-5 text-text-4" />;
       default:
-        return <Circle data-testid="status-icon-unknown" className="w-5 h-5 text-slate-600" />;
+        return <Circle data-testid="status-icon-unknown" className="w-5 h-5 text-text-4" />;
     }
   };
 
   const getEngineIcon = () => {
     const e = (engine || atom?.engine || '').toLowerCase();
-    if (e.includes('docker')) return <Container data-testid="engine-icon-docker" className="w-3.5 h-3.5 text-blue-400" />;
-    if (e.includes('kubernetes') || e.includes('k8s')) return <Cloud data-testid="engine-icon-kubernetes" className="w-3.5 h-3.5 text-blue-400" />;
-    if (e.includes('podman')) return <Zap data-testid="engine-icon-podman" className="w-3.5 h-3.5 text-purple-400" />;
-    if (e.includes('wasm')) return <Zap data-testid="engine-icon-wasm" className="w-3.5 h-3.5 text-yellow-400" />;
-    return <Settings data-testid="engine-icon-unknown" className="w-3.5 h-3.5 text-slate-500" />;
+    if (e.includes('docker')) return <Container data-testid="engine-icon-docker" className="w-3.5 h-3.5 text-running" />;
+    if (e.includes('kubernetes') || e.includes('k8s')) return <Cloud data-testid="engine-icon-kubernetes" className="w-3.5 h-3.5 text-running" />;
+    if (e.includes('podman')) return <Zap data-testid="engine-icon-podman" className="w-3.5 h-3.5 text-accent" />;
+    if (e.includes('wasm')) return <Zap data-testid="engine-icon-wasm" className="w-3.5 h-3.5 text-warning" />;
+    return <Settings data-testid="engine-icon-unknown" className="w-3.5 h-3.5 text-text-3" />;
   };
 
   const getProcessedCommand = () => {
@@ -77,17 +77,17 @@ export const TaskNode = memo(({ data }: NodeProps) => {
     switch (status) {
       case 'completed':
       case 'succeeded':
-        return 'border-emerald-400/45 bg-[linear-gradient(160deg,hsl(var(--caesium-cyan)/0.16),hsl(160_84%_36%/0.2)_30%,hsl(var(--node-surface)/0.95)_78%)] shadow-[0_0_24px_rgba(16,185,129,0.16)]';
+        return 'border-success/45 bg-[linear-gradient(160deg,hsl(var(--caesium-cyan)/0.16),hsl(var(--success)/0.2)_30%,hsl(var(--node-surface)/0.95)_78%)] shadow-[0_0_24px_hsl(var(--success)/0.16)]';
       case 'failed':
-        return 'border-red-400/50 bg-[linear-gradient(160deg,hsl(var(--caesium-cyan)/0.14),hsl(8_86%_58%/0.18)_34%,hsl(var(--node-surface)/0.95)_80%)] shadow-[0_0_24px_rgba(248,113,113,0.16)]';
+        return 'border-danger/50 bg-[linear-gradient(160deg,hsl(var(--caesium-cyan)/0.14),hsl(var(--danger)/0.18)_34%,hsl(var(--node-surface)/0.95)_80%)] shadow-[0_0_24px_hsl(var(--danger)/0.16)]';
       case 'running':
-        return 'border-caesium-cyan/70 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.28),hsl(var(--caesium-cyan)/0.12)_36%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_30px_rgba(0,180,216,0.28)]';
+        return 'border-caesium-cyan/70 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.28),hsl(var(--caesium-cyan)/0.12)_36%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_30px_hsl(var(--caesium-cyan)/0.28)]';
       case 'cached':
-        return 'border-dashed border-teal-400/55 bg-[linear-gradient(155deg,rgba(45,212,191,0.16),rgba(56,189,248,0.08)_34%,hsl(var(--node-surface)/0.95)_78%)] shadow-[0_0_24px_rgba(45,212,191,0.14)]';
+        return 'border-dashed border-cached/55 bg-[linear-gradient(155deg,hsl(var(--cached)/0.16),hsl(var(--caesium-cyan)/0.08)_34%,hsl(var(--node-surface)/0.95)_78%)] shadow-[0_0_24px_hsl(var(--cached)/0.14)]';
       case 'skipped':
-        return 'border-slate-500/30 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.06),hsl(var(--node-surface)/0.92)_32%)] shadow-none opacity-60';
+        return 'border-text-3/30 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.06),hsl(var(--node-surface)/0.92)_32%)] shadow-none opacity-60';
       default:
-        return 'border-caesium-cyan/35 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.18),hsl(var(--caesium-cyan)/0.08)_32%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_22px_rgba(0,180,216,0.14)]';
+        return 'border-caesium-cyan/35 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.18),hsl(var(--caesium-cyan)/0.08)_32%,hsl(var(--node-surface)/0.94)_78%)] shadow-[0_0_22px_hsl(var(--caesium-cyan)/0.14)]';
     }
   };
 
@@ -146,39 +146,39 @@ export const TaskNode = memo(({ data }: NodeProps) => {
           className={cn(
             "custom-scrollbar h-[72px] overflow-y-auto rounded-lg border px-2.5 py-1.5 shadow-inner",
             error && status !== 'skipped'
-              ? "border-red-500/20 bg-red-500/10"
+              ? "border-danger/20 bg-danger/10"
               : error && status === 'skipped'
-                ? "border-slate-500/20 bg-slate-500/5"
+                ? "border-text-3/20 bg-text-3/5"
                 : "border-caesium-cyan/20 bg-muted/70",
             isShell && !error && "border-caesium-cyan/30"
           )}
         >
           {error && status === 'skipped' ? (
             <div className="flex gap-2 items-start">
-              <SkipForward className="w-3.5 h-3.5 text-slate-400 shrink-0 mt-0.5" />
+              <SkipForward className="w-3.5 h-3.5 text-text-3 shrink-0 mt-0.5" />
               <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="text-[8px] font-bold text-slate-400/80 uppercase tracking-wider">Skipped</span>
-                <span className="text-[9px] text-slate-400/70 font-mono leading-relaxed break-all line-clamp-3">
+                <span className="text-[8px] font-bold text-text-3/80 uppercase tracking-wider">Skipped</span>
+                <span className="text-[9px] text-text-3/70 font-mono leading-relaxed break-all line-clamp-3">
                   {error}
                 </span>
               </div>
             </div>
           ) : error ? (
             <div className="flex gap-2 items-start">
-              <AlertTriangle className="w-3.5 h-3.5 text-red-500 shrink-0 mt-0.5" />
+              <AlertTriangle className="w-3.5 h-3.5 text-danger shrink-0 mt-0.5" />
               <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="text-[8px] font-bold text-red-500/80 uppercase tracking-wider">Error Details</span>
-                <span className="text-[9px] text-red-400/90 font-mono leading-relaxed break-all line-clamp-3">
+                <span className="text-[8px] font-bold text-danger/80 uppercase tracking-wider">Error Details</span>
+                <span className="text-[9px] text-danger/90 font-mono leading-relaxed break-all line-clamp-3">
                   {error}
                 </span>
               </div>
             </div>
           ) : status === 'cached' ? (
             <div className="flex gap-2 items-start">
-              <Archive className="w-3.5 h-3.5 text-teal-300 shrink-0 mt-0.5" />
+              <Archive className="w-3.5 h-3.5 text-cached shrink-0 mt-0.5" />
               <div className="flex flex-col gap-0.5 min-w-0">
-                <span className="text-[8px] font-bold text-teal-200/90 uppercase tracking-wider">Reused Result</span>
-                <span className="text-[9px] text-teal-100/85 font-mono leading-relaxed line-clamp-3">
+                <span className="text-[8px] font-bold text-cached/90 uppercase tracking-wider">Reused Result</span>
+                <span className="text-[9px] text-cached/85 font-mono leading-relaxed line-clamp-3">
                   Successful output restored from cache. No container started.
                 </span>
               </div>

--- a/ui/src/features/logs/LogConsolePage.tsx
+++ b/ui/src/features/logs/LogConsolePage.tsx
@@ -25,23 +25,23 @@ import {
 import { useLogStream, type LogEntry } from "./useLogStream";
 
 const LEVEL_COLORS: Record<string, string> = {
-  debug: "text-slate-400 bg-slate-400/10",
-  info: "text-blue-400 bg-blue-400/10",
-  warn: "text-yellow-400 bg-yellow-400/10",
-  error: "text-red-400 bg-red-400/10",
-  dpanic: "text-red-500 bg-red-500/10",
-  panic: "text-red-600 bg-red-600/10",
-  fatal: "text-red-700 bg-red-700/10",
+  debug: "text-text-3 bg-text-3/10",
+  info: "text-running bg-running/10",
+  warn: "text-warning bg-warning/10",
+  error: "text-danger bg-danger/10",
+  dpanic: "text-danger bg-danger/15",
+  panic: "text-danger bg-danger/20",
+  fatal: "text-danger bg-danger/25",
 };
 
 const LEVEL_DOT_COLORS: Record<string, string> = {
-  debug: "fill-slate-400",
-  info: "fill-blue-400",
-  warn: "fill-yellow-400",
-  error: "fill-red-400",
-  dpanic: "fill-red-500",
-  panic: "fill-red-600",
-  fatal: "fill-red-700",
+  debug: "fill-[hsl(var(--text-3))]",
+  info: "fill-[hsl(var(--running))]",
+  warn: "fill-[hsl(var(--warning))]",
+  error: "fill-[hsl(var(--danger))]",
+  dpanic: "fill-[hsl(var(--danger))]",
+  panic: "fill-[hsl(var(--danger))]",
+  fatal: "fill-[hsl(var(--danger))]",
 };
 
 const LEVELS = ["debug", "info", "warn", "error"] as const;
@@ -144,8 +144,8 @@ export function LogConsolePage() {
           <LogBadge
             className={
               connected
-                ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
-                : "border-red-500/30 bg-red-500/10 text-red-300"
+                ? "border-success/30 bg-success/10 text-success"
+                : "border-danger/30 bg-danger/10 text-danger"
             }
           >
             {connected ? (
@@ -165,7 +165,7 @@ export function LogConsolePage() {
       }
     >
       {/* Level filter */}
-      <div className="flex items-center rounded-md border border-slate-700 overflow-hidden">
+      <div className="flex items-center rounded-md border border-graphite/60 overflow-hidden">
         {LEVELS.map((lvl) => (
           <button
             key={lvl}
@@ -174,7 +174,7 @@ export function LogConsolePage() {
               "px-2.5 py-1 text-xs font-medium capitalize transition-colors",
               minLevel === lvl
                 ? "bg-primary text-primary-foreground"
-                : "bg-slate-900 text-slate-400 hover:bg-slate-800 hover:text-slate-200",
+                : "bg-midnight text-text-3 hover:bg-graphite/40 hover:text-text-1",
             )}
           >
             {lvl}
@@ -186,7 +186,7 @@ export function LogConsolePage() {
       <select
         value={levelData?.level ?? "info"}
         onChange={(e) => setLevelMutation.mutate({ level: e.target.value })}
-        className="h-7 rounded-md border border-slate-700 bg-slate-900 px-2 text-xs text-slate-300"
+        className="h-7 rounded-md border border-graphite/60 bg-midnight px-2 text-xs text-text-2"
         title="Server log level"
       >
         {LEVELS.map((lvl) => (
@@ -208,7 +208,7 @@ export function LogConsolePage() {
         <Button
           variant="ghost"
           size="sm"
-          className="h-7 px-2 text-xs text-slate-300 hover:bg-slate-800 hover:text-slate-50"
+          className="h-7 px-2 text-xs text-text-2 hover:bg-graphite/40 hover:text-text-1"
           onClick={paused ? resume : pause}
         >
           {paused ? <Play className="h-3 w-3 mr-1" /> : <Pause className="h-3 w-3 mr-1" />}
@@ -217,7 +217,7 @@ export function LogConsolePage() {
         <Button
           variant="ghost"
           size="sm"
-          className="h-7 px-2 text-xs text-slate-300 hover:bg-slate-800 hover:text-slate-50"
+          className="h-7 px-2 text-xs text-text-2 hover:bg-graphite/40 hover:text-text-1"
           onClick={clear}
         >
           <Trash2 className="h-3 w-3 mr-1" />
@@ -293,17 +293,17 @@ function LogRow({
   onToggle: () => void;
 }) {
   const ts = new Date(entry.ts).toISOString().slice(11, 23); // HH:mm:ss.SSS
-  const dotColor = LEVEL_DOT_COLORS[entry.level] ?? "fill-slate-400";
-  const badgeColor = LEVEL_COLORS[entry.level] ?? "text-slate-400 bg-slate-400/10";
+  const dotColor = LEVEL_DOT_COLORS[entry.level] ?? "fill-[hsl(var(--text-3))]";
+  const badgeColor = LEVEL_COLORS[entry.level] ?? "text-text-3 bg-text-3/10";
   const hasFields = entry.fields && Object.keys(entry.fields).length > 0;
 
   return (
     <>
       <tr
-        className="hover:bg-white/5 cursor-pointer border-b border-white/5"
+        className="hover:bg-graphite/30 cursor-pointer border-b border-graphite/30"
         onClick={hasFields ? onToggle : undefined}
       >
-        <td className="py-0.5 px-2 text-slate-500 whitespace-nowrap align-top w-[85px]">
+        <td className="py-0.5 px-2 text-text-4 whitespace-nowrap align-top w-[85px]">
           {ts}
         </td>
         <td className="py-0.5 px-1 align-top w-[52px]">
@@ -312,17 +312,17 @@ function LogRow({
             {entry.level}
           </span>
         </td>
-        <td className="py-0.5 px-2 text-slate-200 break-all align-top">
+        <td className="py-0.5 px-2 text-text-1 break-all align-top">
           {entry.msg}
           {entry.caller && (
-            <span className="ml-2 text-slate-600">{entry.caller}</span>
+            <span className="ml-2 text-text-4">{entry.caller}</span>
           )}
         </td>
       </tr>
       {expanded && hasFields && (
-        <tr className="bg-white/[0.02]">
+        <tr className="bg-graphite/15">
           <td colSpan={3} className="px-4 py-2">
-            <pre className="text-[11px] text-slate-400 whitespace-pre-wrap break-all">
+            <pre className="text-[11px] text-text-3 whitespace-pre-wrap break-all">
               {JSON.stringify(entry.fields, null, 2)}
             </pre>
           </td>

--- a/ui/src/features/stats/components/FailureAtomsChart.tsx
+++ b/ui/src/features/stats/components/FailureAtomsChart.tsx
@@ -30,32 +30,32 @@ export function FailureAtomsChart({ data }: FailureAtomsChartProps) {
         layout="vertical" 
         margin={{ top: 5, right: 30, left: 10, bottom: 5 }}
       >
-        <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="var(--graphite)" opacity={0.3} />
+        <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="hsl(var(--graphite))" opacity={0.3} />
         <XAxis type="number" hide />
-        <YAxis 
-          dataKey="atom_name" 
-          type="category" 
-          stroke="var(--text-3)"
+        <YAxis
+          dataKey="atom_name"
+          type="category"
+          stroke="hsl(var(--text-3))"
           fontSize={11}
           tickLine={false}
           axisLine={false}
           width={100}
         />
-        <Tooltip 
-          cursor={{ fill: 'var(--graphite)', opacity: 0.1 }}
-          contentStyle={{ 
-            backgroundColor: 'var(--midnight)',
-            borderColor: 'var(--graphite)',
-            color: 'var(--text-1)',
+        <Tooltip
+          cursor={{ fill: 'hsl(var(--graphite))', opacity: 0.1 }}
+          contentStyle={{
+            backgroundColor: 'hsl(var(--midnight))',
+            borderColor: 'hsl(var(--graphite))',
+            color: 'hsl(var(--text-1))',
             borderRadius: '8px',
           }}
           itemStyle={{ fontSize: '12px' }}
           formatter={(value, _name, props) => [value, `Failures (${props.payload.alias})`]}
         />
-        <Bar 
-          dataKey="failure_count" 
-          fill="var(--danger)" 
-          radius={[0, 4, 4, 0]} 
+        <Bar
+          dataKey="failure_count"
+          fill="hsl(var(--danger))"
+          radius={[0, 4, 4, 0]}
           barSize={20}
         >
           {data.map((_, index) => (

--- a/ui/src/features/stats/components/TrendChart.tsx
+++ b/ui/src/features/stats/components/TrendChart.tsx
@@ -48,61 +48,61 @@ export function TrendChart({ data }: TrendChartProps) {
   return (
     <ResponsiveContainer width="100%" height={350}>
       <ComposedChart data={chartData} margin={{ top: 20, right: 20, bottom: 20, left: 20 }}>
-        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--graphite)" opacity={0.3} />
-        <XAxis 
-          dataKey="name" 
+        <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--graphite))" opacity={0.3} />
+        <XAxis
+          dataKey="name"
           tickFormatter={formatDateLabel}
-          stroke="var(--text-3)"
+          stroke="hsl(var(--text-3))"
           fontSize={12}
           tickLine={false}
           axisLine={false}
         />
-        <YAxis 
+        <YAxis
           yAxisId="left"
-          stroke="var(--text-3)"
+          stroke="hsl(var(--text-3))"
           fontSize={12}
           tickLine={false}
           axisLine={false}
           allowDecimals={false}
         />
-        <YAxis 
+        <YAxis
           yAxisId="right"
           orientation="right"
-          stroke="var(--text-3)"
+          stroke="hsl(var(--text-3))"
           fontSize={12}
           tickLine={false}
           axisLine={false}
           domain={[0, 100]}
           tickFormatter={(v) => `${v}%`}
         />
-        <Tooltip 
-          contentStyle={{ 
-            backgroundColor: 'var(--midnight)',
-            borderColor: 'var(--graphite)',
-            color: 'var(--text-1)',
+        <Tooltip
+          contentStyle={{
+            backgroundColor: 'hsl(var(--midnight))',
+            borderColor: 'hsl(var(--graphite))',
+            color: 'hsl(var(--text-1))',
             borderRadius: '8px',
           }}
           itemStyle={{ fontSize: '12px' }}
         />
-        <Legend 
-          verticalAlign="top" 
-          align="right" 
+        <Legend
+          verticalAlign="top"
+          align="right"
           wrapperStyle={{ paddingBottom: '20px', fontSize: '12px' }}
         />
-        <Bar 
-          yAxisId="left" 
-          dataKey="runs" 
-          name="Run Volume" 
-          fill="var(--cyan-glow)" 
-          radius={[4, 4, 0, 0]} 
+        <Bar
+          yAxisId="left"
+          dataKey="runs"
+          name="Run Volume"
+          fill="hsl(var(--cyan-glow))"
+          radius={[4, 4, 0, 0]}
           opacity={0.6}
         />
-        <Line 
-          yAxisId="right" 
-          type="monotone" 
-          dataKey="rate" 
-          name="Success Rate" 
-          stroke="var(--success)" 
+        <Line
+          yAxisId="right"
+          type="monotone"
+          dataKey="rate"
+          name="Success Rate"
+          stroke="hsl(var(--success))"
           strokeWidth={2}
           dot={false}
           activeDot={{ r: 4, strokeWidth: 0 }}

--- a/ui/src/features/system/SystemPage.tsx
+++ b/ui/src/features/system/SystemPage.tsx
@@ -321,8 +321,8 @@ function ClusterTopology({ nodes }: { nodes: Node[] }) {
     <svg viewBox="0 0 220 220" className="w-full h-[220px]">
       <defs>
         <radialGradient id="topo-glow" cx="0.5" cy="0.5" r="0.5">
-          <stop offset="0%" stopColor="var(--cyan)" stopOpacity="0.3" />
-          <stop offset="100%" stopColor="var(--cyan)" stopOpacity="0" />
+          <stop offset="0%" stopColor="hsl(var(--cyan))" stopOpacity="0.3" />
+          <stop offset="100%" stopColor="hsl(var(--cyan))" stopOpacity="0" />
         </radialGradient>
       </defs>
       {/* connections */}
@@ -333,14 +333,14 @@ function ClusterTopology({ nodes }: { nodes: Node[] }) {
           <line key={`${i}-${j}`}
             x1={cx + Math.cos(a1) * R} y1={cy + Math.sin(a1) * R}
             x2={cx + Math.cos(a2) * R} y2={cy + Math.sin(a2) * R}
-            stroke="var(--cyan)" strokeOpacity="0.3" strokeWidth="1" strokeDasharray="2 3"
+            stroke="hsl(var(--cyan))" strokeOpacity="0.3" strokeWidth="1" strokeDasharray="2 3"
           />
         );
       }))}
       {/* center label */}
       <circle cx={cx} cy={cy} r="40" fill="url(#topo-glow)" />
-      <text x={cx} y={cy - 2} textAnchor="middle" fontSize="9" fill="var(--text-3)" style={{ letterSpacing: "0.18em", textTransform: "uppercase", fontWeight: 600 }}>quorum</text>
-      <text x={cx} y={cy + 12} textAnchor="middle" fontSize="14" fill="var(--text-1)" fontWeight="500" className="font-mono">{nodes.length}/{nodes.length}</text>
+      <text x={cx} y={cy - 2} textAnchor="middle" fontSize="9" fill="hsl(var(--text-3))" style={{ letterSpacing: "0.18em", textTransform: "uppercase", fontWeight: 600 }}>quorum</text>
+      <text x={cx} y={cy + 12} textAnchor="middle" fontSize="14" fill="hsl(var(--text-1))" fontWeight="500" className="font-mono">{nodes.length}/{nodes.length}</text>
       {/* nodes */}
       {nodes.map((n, i) => {
         const angle = (i / nodes.length) * Math.PI * 2 - Math.PI / 2;
@@ -350,9 +350,9 @@ function ClusterTopology({ nodes }: { nodes: Node[] }) {
         const isLeader = i === 0;
         return (
           <g key={n.address}>
-            <circle cx={x} cy={y} r="14" fill={isLeader ? "var(--gold)" : "var(--cyan)"} opacity="0.18" />
-            <circle cx={x} cy={y} r="8" fill={isLeader ? "var(--gold)" : "var(--cyan)"} stroke="var(--midnight)" strokeWidth="2" />
-            <text x={x} y={y + Math.sin(angle) * 24 + (Math.sin(angle) > 0 ? 8 : -2)} textAnchor="middle" fontSize="9" fill="var(--text-2)" className="font-mono">{n.address.split(":")[0]}</text>
+            <circle cx={x} cy={y} r="14" fill={isLeader ? "hsl(var(--gold))" : "hsl(var(--cyan))"} opacity="0.18" />
+            <circle cx={x} cy={y} r="8" fill={isLeader ? "hsl(var(--gold))" : "hsl(var(--cyan))"} stroke="hsl(var(--midnight))" strokeWidth="2" />
+            <text x={x} y={y + Math.sin(angle) * 24 + (Math.sin(angle) > 0 ? 8 : -2)} textAnchor="middle" fontSize="9" fill="hsl(var(--text-2))" className="font-mono">{n.address.split(":")[0]}</text>
           </g>
         );
       })}

--- a/ui/src/features/triggers/TriggersPage.tsx
+++ b/ui/src/features/triggers/TriggersPage.tsx
@@ -472,7 +472,7 @@ export function TriggersPage() {
                 </div>
 
                 {isExpanded && (
-                  <div className="border-t border-graphite/20 bg-black/20 px-5 py-4 space-y-4">
+                  <div className="border-t border-graphite/20 bg-obsidian/40 px-5 py-4 space-y-4">
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
                       <div className="col-span-2 md:col-span-1">
                         <p className="text-[10px] uppercase tracking-widest font-bold text-text-4 mb-1">Full ID</p>
@@ -625,8 +625,8 @@ export function TriggersPage() {
             </div>
 
             <div className="rounded-md border border-graphite/30 bg-midnight/40 px-3 py-2.5 text-xs text-text-3">
-              Param mappings use simple JSONPath expressions like <code className="mx-1 rounded bg-black/40 border border-graphite/40 px-1 py-0.5 text-[10px] text-text-2 font-mono">$.ref</code> and
-              <code className="mx-1 rounded bg-black/40 border border-graphite/40 px-1 py-0.5 text-[10px] text-text-2 font-mono">$</code> for the whole payload.
+              Param mappings use simple JSONPath expressions like <code className="mx-1 rounded bg-void/60 border border-graphite/40 px-1 py-0.5 text-[10px] text-text-2 font-mono">$.ref</code> and
+              <code className="mx-1 rounded bg-void/60 border border-graphite/40 px-1 py-0.5 text-[10px] text-text-2 font-mono">$</code> for the whole payload.
             </div>
 
             {formError && <p className="text-sm text-danger font-medium">{formError}</p>}


### PR DESCRIPTION
## Summary

Several pieces of recently-shipped UI were rendering with broken colors — most visibly the "blacked out" bars in Stats and the cluster topology map on System. The root cause is mechanical: the CSS variables in [index.css](ui/src/index.css) are stored as raw HSL value triplets (e.g. `--cyan: 191 100% 47%`), so they only resolve to a color when wrapped in `hsl(...)`. A handful of inline styles and SVG attributes were using `var(--token)` directly, producing an invalid value that browsers render as black/transparent.

While in there, this also routes the rest of the UI's hardcoded color literals through the existing token system so theme switching works end-to-end.

### What changed

**P0 — fixes the user-visible blacked-out bug**
- Wrap raw `var(--…)` in `hsl(...)` in Stats charts (TrendChart, FailureAtomsChart), the cluster topology SVG (SystemPage), and the Login page (also reflowed onto Tailwind utilities since the form was 100% inline-styled).

**P1 — routes status colors through `statusMeta`/semantic tokens**
- [RunTimeline.tsx](ui/src/features/jobs/RunTimeline.tsx): hex `STATUS_COLORS` map → `statusMeta(status).fg`. Grid/axis `rgba(128,128,128,…)` literals → `hsl(var(--text-3) / α)`. In-bar duration label switches from hardcoded `white` to `bg`-tone for legibility on light status fills.
- [JobDAG.tsx](ui/src/features/jobs/JobDAG.tsx): `edgeColor()` now returns `hsl(var(--running))` etc. Skipped-branch fallback uses `--text-3`.
- [badge.tsx](ui/src/components/ui/badge.tsx): `success` variant → `bg-success`, `cached` variant → `bg-cached` (was `bg-green-500`/`bg-teal-500`).

**P1 — log surfaces and database console**
- [LogShell](ui/src/components/logs/LogShell.tsx), [LogToolbar](ui/src/components/logs/LogToolbar.tsx), [LogSearchInput](ui/src/components/logs/LogSearchInput.tsx), [LogEmptyState](ui/src/components/logs/LogEmptyState.tsx), [LogBadge](ui/src/components/logs/LogBadge.tsx): converted from `bg-slate-950` / `border-slate-800` etc. to `bg-obsidian` / `bg-midnight` / `border-graphite`.
- [LogConsolePage](ui/src/features/logs/LogConsolePage.tsx): level color maps + toolbar/row classes onto tokens. `info` → `running`, `warn` → `warning`, `error`/`panic`/`fatal` → `danger`.
- [LogViewer](ui/src/features/jobs/LogViewer.tsx): banners, status pills (Live/Retained/Truncated), and toolbar buttons onto tokens. The xterm terminal palette stays hardcoded dark — terminals are conventionally dark, and adapting it requires re-creating the xterm instance on theme change. Deferred.
- [DatabaseConsolePage](ui/src/features/database/DatabaseConsolePage.tsx): keeps the operator-console aesthetic but replaces `slate-950` / `bg-[linear-gradient(...,rgba(15,23,42,…))]` / `border-white/10` with `bg-obsidian` / `bg-gradient-to-* from-obsidian` / `border-graphite`.

**P2 — chromatic palette → semantic tokens**
- [TaskNode](ui/src/features/jobs/components/TaskNode.tsx) and [BranchNode](ui/src/features/jobs/components/BranchNode.tsx): status icons (`text-green-400`, `text-red-400`, …) → `text-success`/`text-danger`/`text-running`/`text-cached`/`text-text-3`. Frozen `hsl(38_92%_50%/0.18)` literals in the gradients → `hsl(var(--gold)/0.18)` etc., so light/dark theme actually adapts. Box shadows go from `rgba(245,158,11,…)` to `hsl(var(--gold)/α)`.
- [DataFlowEdge](ui/src/features/jobs/components/DataFlowEdge.tsx) + JobDAG `EdgeDetails` badges: `border-emerald-500/35` etc. → `border-success/35`.
- [TaskDetailPanel](ui/src/features/jobs/TaskDetailPanel.tsx): error/skipped/cached banners and `StatusDot` onto tokens.
- [TaskMetadataPanel](ui/src/features/jobs/TaskMetadataPanel.tsx): schema-violation amber-* → `warning`.
- [BackfillsView](ui/src/features/jobs/BackfillsView.tsx) cancelling badge → `warning`. [command-menu](ui/src/components/command-menu.tsx) job dot `text-blue-500` → `text-running`. [TriggersPage](ui/src/features/triggers/TriggersPage.tsx) `bg-black/{20,40}` → `bg-obsidian/40` and `bg-void/60`.
- Updated the JobDAG edge-color test expectation to match the tokenised stroke.

Net diff: -67 lines across 24 files.

## Test plan

- [x] `npm run build` (tsc + vite) — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 79/79 passing
- [x] Manual visual check: Stats page bars/grid render in brand cyan/gold/green/red, not black
- [x] Manual visual check: System cluster topology nodes/edges render in cyan/gold, not black
- [x] Manual visual check: Login page renders against the brand background
- [x] Manual visual check: Toggle light/dark — Database Console, Log Console, DAG node gradients, status dots all adapt

🤖 Generated with [Claude Code](https://claude.com/claude-code)