### PR TITLE
Fix just k8s-distributed: deploy fresh image builds via local registry

### DIFF
--- a/justfile
+++ b/justfile
@@ -30,6 +30,12 @@ sock := env("CAESIUM_SOCK", default_sock)
 port := env("CAESIUM_PORT", "8080")
 auth_mode := env("CAESIUM_AUTH_MODE", "none")
 
+# Local Docker registry used by `just k8s-distributed` to push freshly-built
+# images into the cluster's containerd. Port 5050 sidesteps the macOS
+# AirPlay Receiver, which binds 5000 by default.
+k8s_registry_port := env("CAESIUM_K8S_REGISTRY_PORT", "5050")
+k8s_registry_name := "caesium-dev-registry"
+
 validate-platform:
     @if [ "{{ platform }}" != "linux/amd64" ] && [ "{{ platform }}" != "linux/arm64" ]; then \
       echo "Unsupported CAESIUM_PLATFORM '{{ platform }}' (supported: linux/amd64, linux/arm64)"; \
@@ -278,21 +284,50 @@ helm-template:
 helm-test:
     helm test caesium --timeout 120s
 
-# Deploy Caesium in a distributed 3-node Raft cluster on local Kubernetes
-k8s-distributed: build-release
+# Spin up the local dev registry and configure the cluster's containerd to
+# pull from it via host.docker.internal. Idempotent. Targets Docker Desktop
+# Kubernetes; other clusters (Kind, Minikube) need different wiring.
+k8s-registry-up:
     @if ! kubectl cluster-info >/dev/null 2>&1; then echo "Error: Kubernetes cluster not reachable. Ensure Docker Desktop K8s or Kind is running." && exit 1; fi
-    # Load image into cluster (Docker Desktop K8s sees local images by default, but this ensures it's fresh)
-    # Note: For Kind, you'd use 'kind load docker-image'
-    helm upgrade --install caesium ./helm/caesium \
-        --set replicaCount=3 \
-        --set image.repository={{ local_image_ref }} \
-        --set image.tag={{ tag }} \
-        --set image.pullPolicy=IfNotPresent \
-        --set config.extraEnv[0].name=CAESIUM_EXECUTION_MODE \
-        --set config.extraEnv[0].value=distributed \
-        --set kubernetes.engine.enabled=true \
-        --set persistence.enabled=false \
-        --wait
+    @ctx="$(kubectl config current-context)"; \
+        if [ "$ctx" != "docker-desktop" ]; then \
+            echo "Warning: detected context '$ctx'. This helper is verified on Docker Desktop. Other clusters may need different setup."; \
+        fi
+    @if ! {{ container_cli }} ps --filter name=^/{{ k8s_registry_name }}$ --format '{{ "{{.Names}}" }}' | grep -q .; then \
+        echo "Starting local registry on 127.0.0.1:{{ k8s_registry_port }}..."; \
+        {{ container_cli }} run -d --restart=always --name {{ k8s_registry_name }} \
+            -p 127.0.0.1:{{ k8s_registry_port }}:5000 registry:2 >/dev/null; \
+    else \
+        echo "Local registry {{ k8s_registry_name }} already running."; \
+    fi
+    @./scripts/k8s-registry-bypass.sh {{ k8s_registry_port }}
+
+# Tear down the local dev registry (does not affect deployed pods).
+k8s-registry-down:
+    -{{ container_cli }} rm -f {{ k8s_registry_name }}
+
+# Deploy Caesium in a distributed 3-node Raft cluster on local Kubernetes.
+# Tags the image with a unique dev tag, pushes to the local registry, and
+# helm-deploys with pullPolicy=Always so each invocation rolls out the freshly
+# built bits. See `k8s-registry-up` for the registry/containerd wiring.
+k8s-distributed: build-release k8s-registry-up
+    @dev_tag="dev-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"; \
+        if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then \
+            dev_tag="${dev_tag}-dirty-$(date +%s)"; \
+        fi; \
+        echo "Pushing image to local dev registry as ${dev_tag}..."; \
+        {{ container_cli }} tag {{ local_image_ref }}:{{ tag }} localhost:{{ k8s_registry_port }}/{{ image }}:${dev_tag}; \
+        {{ container_cli }} push localhost:{{ k8s_registry_port }}/{{ image }}:${dev_tag} >/dev/null; \
+        helm upgrade --install caesium ./helm/caesium \
+            --set replicaCount=3 \
+            --set image.repository=host.docker.internal:{{ k8s_registry_port }}/{{ image }} \
+            --set image.tag=${dev_tag} \
+            --set image.pullPolicy=Always \
+            --set config.extraEnv[0].name=CAESIUM_EXECUTION_MODE \
+            --set config.extraEnv[0].value=distributed \
+            --set kubernetes.engine.enabled=true \
+            --set persistence.enabled=false \
+            --wait
     @echo "Caesium distributed cluster is ready."
 
 # Stop the local Kubernetes deployment

--- a/justfile
+++ b/justfile
@@ -293,10 +293,13 @@ k8s-registry-up:
         if [ "$ctx" != "docker-desktop" ]; then \
             echo "Warning: detected context '$ctx'. This helper is verified on Docker Desktop. Other clusters may need different setup."; \
         fi
-    @if ! {{ container_cli }} ps --filter name=^/{{ k8s_registry_name }}$ --format '{{ "{{.Names}}" }}' | grep -q .; then \
+    @if ! {{ container_cli }} inspect {{ k8s_registry_name }} >/dev/null 2>&1; then \
         echo "Starting local registry on 127.0.0.1:{{ k8s_registry_port }}..."; \
         {{ container_cli }} run -d --restart=always --name {{ k8s_registry_name }} \
             -p 127.0.0.1:{{ k8s_registry_port }}:5000 registry:2 >/dev/null; \
+    elif [ "$({{ container_cli }} inspect -f '{{ "{{.State.Running}}" }}' {{ k8s_registry_name }})" != "true" ]; then \
+        echo "Restarting stopped local registry {{ k8s_registry_name }}..."; \
+        {{ container_cli }} start {{ k8s_registry_name }} >/dev/null; \
     else \
         echo "Local registry {{ k8s_registry_name }} already running."; \
     fi

--- a/scripts/k8s-registry-bypass.sh
+++ b/scripts/k8s-registry-bypass.sh
@@ -8,10 +8,27 @@
 # local registry is unreachable. We write a hosts.toml under
 # `/etc/containerd/certs.d/host.docker.internal:<port>/` on the node;
 # containerd 1.5+ picks the per-host file up dynamically.
+#
+# The privileged pod takes ~5–10s to schedule, run, and clean up. Since
+# this script is in the `k8s-distributed` dependency chain, that adds up
+# across the dev loop. We cache successful runs per (cluster UID, port)
+# and skip the pod when the marker is fresh — recreating the cluster
+# rotates the UID and invalidates the cache automatically. Set
+# CAESIUM_K8S_REGISTRY_BYPASS_FORCE=1 to bypass the cache.
 set -euo pipefail
 
 port="${1:-5050}"
 pod="caesium-registry-bypass"
+
+cluster_uid="$(kubectl get ns kube-system -o jsonpath='{.metadata.uid}' 2>/dev/null || echo unknown)"
+marker_dir="${TMPDIR:-/tmp}/caesium-k8s-registry-bypass"
+marker="${marker_dir}/${cluster_uid}.${port}.done"
+
+if [ -z "${CAESIUM_K8S_REGISTRY_BYPASS_FORCE:-}" ] && [ -f "$marker" ]; then
+    echo "  Bypass already configured for this cluster (cache: $marker)"
+    exit 0
+fi
+
 node="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
 
 # Drop any leftover pod from a previous run.
@@ -74,4 +91,6 @@ if [ "${phase:-}" != "Succeeded" ]; then
     exit 1
 fi
 
+mkdir -p "$marker_dir"
+: >"$marker"
 echo "  $(echo "$logs" | tail -n 1)"

--- a/scripts/k8s-registry-bypass.sh
+++ b/scripts/k8s-registry-bypass.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Configure the cluster's containerd to bypass Docker Desktop's catch-all
+# pull-through mirror for our local dev registry, so kubelet can pull
+# `host.docker.internal:<port>/...` images directly.
+#
+# Docker Desktop Kubernetes ships a `_default` hosts.toml that points all
+# pulls at an internal registry-mirror. Without a per-host override, our
+# local registry is unreachable. We write a hosts.toml under
+# `/etc/containerd/certs.d/host.docker.internal:<port>/` on the node;
+# containerd 1.5+ picks the per-host file up dynamically.
+set -euo pipefail
+
+port="${1:-5050}"
+pod="caesium-registry-bypass"
+node="$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')"
+
+# Drop any leftover pod from a previous run.
+kubectl delete pod "$pod" --ignore-not-found --grace-period=0 --force >/dev/null 2>&1 || true
+
+cat <<EOF | kubectl apply -f - >/dev/null
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${pod}
+spec:
+  hostNetwork: true
+  hostPID: true
+  restartPolicy: Never
+  nodeName: ${node}
+  containers:
+  - name: bypass
+    image: busybox
+    command:
+    - sh
+    - -c
+    - |
+      set -e
+      target="/host/etc/containerd/certs.d/host.docker.internal:${port}"
+      mkdir -p "\$target"
+      cat > "\$target/hosts.toml" <<TOML
+      server = "http://host.docker.internal:${port}"
+
+      [host."http://host.docker.internal:${port}"]
+      capabilities = ["pull", "resolve"]
+      skip_verify = true
+      TOML
+      echo "Wrote \$target/hosts.toml"
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - name: host
+      mountPath: /host
+  volumes:
+  - name: host
+    hostPath:
+      path: /
+EOF
+
+# Wait until the pod terminates (success or failure).
+for _ in $(seq 1 30); do
+    phase="$(kubectl get pod "$pod" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+    case "$phase" in
+        Succeeded|Failed) break ;;
+    esac
+    sleep 1
+done
+
+logs="$(kubectl logs "$pod" 2>/dev/null || true)"
+kubectl delete pod "$pod" --ignore-not-found --grace-period=0 --force >/dev/null 2>&1 || true
+
+if [ "${phase:-}" != "Succeeded" ]; then
+    echo "Failed to configure containerd bypass (pod phase: ${phase:-unknown})." >&2
+    [ -n "$logs" ] && echo "$logs" >&2
+    exit 1
+fi
+
+echo "  $(echo "$logs" | tail -n 1)"


### PR DESCRIPTION
## Summary

`just k8s-distributed` was silently deploying stale image builds on Docker Desktop's Kubernetes, which surfaced as "I rebuilt the UI but the topology map still looks blacked out" while running [PR #159](https://github.com/caesium-cloud/caesium/pull/159) on a port-forwarded cluster.

### What was broken

Docker Desktop's Kubernetes (1.24+) runs on a containerd that's isolated from the host Docker daemon. The previous recipe baked an image into host Docker, then ran `helm upgrade` with `image.tag=latest` and `pullPolicy=IfNotPresent`. Two failure modes stack:

1. **Helm sees no diff.** Same tag every build → no rollout, pods keep running whatever image they already have.
2. **Even on first install, the cluster doesn't see the build.** Containerd has its own image cache and Docker Desktop also routes every pull through a catch-all mirror at `registry-mirror:1273`. Host Docker images don't propagate, so the cluster either uses a stale cached `:latest` or fails to resolve.

### What this changes

A small local push-through registry that the cluster pulls from:

- `k8s-registry-up` (new recipe) spins up `registry:2` on `127.0.0.1:5050` (port 5050 to dodge macOS AirPlay Receiver) and writes a per-host `hosts.toml` under `/etc/containerd/certs.d/host.docker.internal:5050/` on the cluster node via a one-off privileged pod (`scripts/k8s-registry-bypass.sh`). That bypasses the catch-all mirror for our registry hostname. Idempotent.
- `k8s-distributed` now:
  - Computes a unique image tag per build: `dev-<git-sha>[-dirty-<timestamp>]`.
  - `docker push`es to `localhost:5050/caesium:<tag>`.
  - Helm-installs with `image.repository=host.docker.internal:5050/caesium`, that unique tag, and `pullPolicy=Always`.
- `k8s-registry-down` (new recipe) tears the registry container down.

Because the tag changes every dirty-tree build, Helm always rolls out and the cluster always pulls the freshly-pushed bits.

### Why `host.docker.internal:5050` for pull and `localhost:5050` for push

Same registry, different hostnames for different network namespaces. The host can't reach `host.docker.internal` directly (it's a Docker-internal alias), so we push to `localhost:5050`. The cluster pods can't reach the host's `localhost`, so we pull via `host.docker.internal:5050`. The registry stores blobs by content hash and indexes by `repo:tag` — the hostname is just for routing, so push under one name and pull under another resolves to the same content.

### Caveats

This is verified on Docker Desktop's Kubernetes. Kind/Minikube would need different wiring (Kind in particular wants the registry attached to the `kind` Docker network and uses a different hostname). The recipe prints a warning if the kube context isn't `docker-desktop`. Generalizing to those is a follow-up.

## Test plan

- [x] `just k8s-down`, then `just k8s-distributed` from a clean cluster — installs successfully, all 3 pods running.
- [x] Pod image SHA matches the freshly-built host image SHA (`2061082c…` in both Docker daemon and `kubectl get pod ... -o jsonpath='{...imageID}'`).
- [x] `/health` returns healthy via `kubectl port-forward service/caesium 8080:8080`.
- [x] Re-running `k8s-registry-up` is idempotent (registry already running → no-op; hosts.toml re-written cleanly).
- [ ] Re-run `k8s-distributed` with dirty tree → new timestamp tag → rolling update kicks off and pods cycle to the new image SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)