### PR TITLE
Make just k8s-distributed runnable end-to-end

### DIFF
--- a/docs/examples-k8s/data-contracts.job.yaml
+++ b/docs/examples-k8s/data-contracts.job.yaml
@@ -1,0 +1,104 @@
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: k8s-data-contracts-demo
+  labels:
+    team: platform
+    runtime: kubernetes
+    scenario: schema-validation
+  annotations:
+    owner: platform-oncall
+    purpose: "Demonstrates outputSchema/inputSchema data contracts under the Kubernetes engine"
+  schemaValidation: warn
+trigger:
+  type: cron
+  configuration:
+    cron: "*/15 * * * *"
+    timezone: "UTC"
+steps:
+  - name: extract
+    engine: kubernetes
+    image: alpine:3.23
+    outputSchema:
+      type: object
+      properties:
+        row_count:  { type: integer }
+        source:     { type: string }
+        format:     { type: string }
+      required: [row_count, source, format]
+    command:
+      - sh
+      - -c
+      - |
+        echo "Extracting data from warehouse..."
+        sleep 1
+        ROW_COUNT=$((RANDOM % 9000 + 1000))
+        echo "Extracted $ROW_COUNT rows"
+        echo '##caesium::output {"row_count": "'$ROW_COUNT'", "source": "warehouse-prod", "format": "parquet"}'
+
+  - name: transform
+    engine: kubernetes
+    image: alpine:3.23
+    dependsOn: [extract]
+    inputSchema:
+      extract:
+        required: [row_count, source]
+        properties:
+          row_count: { type: integer }
+          source:    { type: string }
+    outputSchema:
+      type: object
+      properties:
+        processed_rows: { type: integer }
+        output_path:    { type: string }
+        transform_id:   { type: string }
+      required: [processed_rows, output_path, transform_id]
+    command:
+      - sh
+      - -c
+      - |
+        echo "Transforming $CAESIUM_OUTPUT_EXTRACT_ROW_COUNT rows from $CAESIUM_OUTPUT_EXTRACT_SOURCE..."
+        sleep 1
+        PROCESSED=$((CAESIUM_OUTPUT_EXTRACT_ROW_COUNT * 85 / 100))
+        echo "Kept $PROCESSED rows after deduplication"
+        echo '##caesium::output {"processed_rows": "'$PROCESSED'", "output_path": "/data/transformed.parquet", "transform_id": "txn-'$(date +%s)'"}'
+
+  - name: load
+    engine: kubernetes
+    image: alpine:3.23
+    dependsOn: [transform]
+    inputSchema:
+      transform:
+        required: [processed_rows, output_path]
+        properties:
+          processed_rows: { type: integer }
+    outputSchema:
+      type: object
+      properties:
+        rows_written:  { type: integer }
+        destination:   { type: string }
+        duration_ms:   { type: integer }
+      required: [rows_written, destination, duration_ms]
+    command:
+      - sh
+      - -c
+      - |
+        echo "Loading $CAESIUM_OUTPUT_TRANSFORM_PROCESSED_ROWS rows from $CAESIUM_OUTPUT_TRANSFORM_OUTPUT_PATH..."
+        sleep 1
+        echo "Wrote to analytics-db"
+        echo '##caesium::output {"rows_written": "unknown", "destination": "analytics-db", "duration_ms": "412"}'
+
+  - name: notify
+    engine: kubernetes
+    image: alpine:3.23
+    dependsOn: [load]
+    command:
+      - sh
+      - -c
+      - |
+        echo "Pipeline complete!"
+        echo "  Destination : $CAESIUM_OUTPUT_LOAD_DESTINATION"
+        echo "  Rows written: $CAESIUM_OUTPUT_LOAD_ROWS_WRITTEN"
+        echo "  Duration    : ${CAESIUM_OUTPUT_LOAD_DURATION_MS}ms"
+        echo "Done."

--- a/docs/examples-k8s/fanout-join.job.yaml
+++ b/docs/examples-k8s/fanout-join.job.yaml
@@ -1,0 +1,53 @@
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: k8s-fanout-join-demo
+  labels:
+    team: platform
+    runtime: kubernetes
+    scenario: dag-join
+  annotations:
+    owner: platform-oncall
+    purpose: "Exercise fan-out/fan-in DAG rendering using the Kubernetes engine"
+trigger:
+  type: cron
+  configuration:
+    cron: "*/5 * * * *"
+    timezone: "UTC"
+steps:
+  - name: bootstrap
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo bootstrap && date"]
+    env:
+      PIPELINE_ID: k8s-fanout-join-demo
+      RUN_MODE: hydrated
+    next:
+      - lint
+      - unit-test
+  - name: lint
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo lint branch"]
+    dependsOn: bootstrap
+    next: package
+  - name: unit-test
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo unit-test branch"]
+    dependsOn: bootstrap
+    next: package
+  - name: package
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo packaging build artifacts"]
+    dependsOn:
+      - lint
+      - unit-test
+    next: publish
+  - name: publish
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo publishing artifacts"]
+    dependsOn: package

--- a/docs/examples-k8s/log-streaming.job.yaml
+++ b/docs/examples-k8s/log-streaming.job.yaml
@@ -1,0 +1,54 @@
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: k8s-log-streaming-demo
+  labels:
+    team: platform
+    runtime: kubernetes
+    scenario: log-streaming
+  annotations:
+    owner: platform-oncall
+    purpose: "Exercise live log streaming, ANSI color, and retained logs from a Kubernetes pod"
+trigger:
+  type: http
+  configuration:
+    path: "/hooks/demo/k8s-log-streaming"
+    secret: "log-demo-secret"
+steps:
+  - name: emit-live-logs
+    engine: kubernetes
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        total_batches=45
+        batch=1
+
+        echo "Starting log streaming showcase from a Kubernetes pod"
+        echo "This task emits colored text, plain text, and JSON over ~45 seconds"
+
+        while [ "$batch" -le "$total_batches" ]; do
+          ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          rows=$((batch * 125))
+          latency_ms=$((25 + batch * 9))
+
+          printf '\033[36m[%s] phase=stream batch=%02d status=running\033[0m\n' "$ts" "$batch"
+          printf 'batch=%02d rows=%04d latency_ms=%03d worker=demo-pod\n' "$batch" "$rows" "$latency_ms"
+          printf '\033[32mmetrics rows_processed=%04d throughput_rps=%03d\033[0m\n' "$rows" "$((40 + batch * 3))"
+
+          if [ $((batch % 4)) -eq 0 ]; then
+            printf '\033[33mwarning batch=%02d upstream_latency_ms=%03d retryable=true\033[0m\n' "$batch" "$((latency_ms + 40))"
+          fi
+
+          if [ $((batch % 6)) -eq 0 ]; then
+            printf '{"timestamp":"%s","level":"info","batch":%d,"status":"streaming","rows":%d}\n' "$ts" "$batch" "$rows"
+          fi
+
+          sleep 1
+          batch=$((batch + 1))
+        done
+
+        echo '##caesium::output {"batches_emitted": "45", "log_profile": "streaming-demo"}'
+        printf '\033[35mstream complete: retained logs should remain available after pod cleanup\033[0m\n'

--- a/docs/examples-k8s/minimal.job.yaml
+++ b/docs/examples-k8s/minimal.job.yaml
@@ -1,0 +1,28 @@
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: k8s-nightly-etl
+  labels:
+    team: platform
+    runtime: kubernetes
+  annotations:
+    purpose: "Minimal sequential ETL using the in-cluster Kubernetes engine"
+trigger:
+  type: cron
+  configuration:
+    cron: "*/5 * * * *"
+    timezone: "UTC"
+steps:
+  - name: extract
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo extracting data"]
+  - name: transform
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo transforming data"]
+  - name: load
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo loading data"]

--- a/docs/examples-k8s/task-outputs.job.yaml
+++ b/docs/examples-k8s/task-outputs.job.yaml
@@ -1,0 +1,94 @@
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: k8s-task-outputs-demo
+  labels:
+    team: platform
+    runtime: kubernetes
+    scenario: data-passing
+  annotations:
+    owner: platform-oncall
+    purpose: "Exercise structured task output passing between Kubernetes-engine steps"
+trigger:
+  type: cron
+  configuration:
+    cron: "*/10 * * * *"
+    timezone: "UTC"
+steps:
+  - name: extract
+    engine: kubernetes
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        echo "Extracting data from source..."
+        sleep 1
+        ROW_COUNT=$((RANDOM % 9000 + 1000))
+        echo "Extracted $ROW_COUNT rows"
+        echo '##caesium::output {"row_count": "'$ROW_COUNT'", "source": "warehouse-prod", "format": "parquet"}'
+    next:
+      - transform-a
+      - transform-b
+
+  - name: transform-a
+    engine: kubernetes
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        echo "Transform A: received $CAESIUM_OUTPUT_EXTRACT_ROW_COUNT rows from $CAESIUM_OUTPUT_EXTRACT_SOURCE"
+        sleep 1
+        PROCESSED=$((CAESIUM_OUTPUT_EXTRACT_ROW_COUNT * 80 / 100))
+        echo "Processed $PROCESSED rows (80% pass rate)"
+        echo '##caesium::output {"processed_rows": "'$PROCESSED'", "transform": "enrichment"}'
+    dependsOn: extract
+    next: load
+
+  - name: transform-b
+    engine: kubernetes
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        echo "Transform B: aggregating $CAESIUM_OUTPUT_EXTRACT_ROW_COUNT rows from $CAESIUM_OUTPUT_EXTRACT_SOURCE"
+        sleep 2
+        GROUPS=$((CAESIUM_OUTPUT_EXTRACT_ROW_COUNT / 100))
+        echo "Aggregated into $GROUPS groups"
+        echo '##caesium::output {"group_count": "'$GROUPS'", "transform": "aggregation"}'
+    dependsOn: extract
+    next: load
+
+  - name: load
+    engine: kubernetes
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        echo "Loading results from upstream transforms..."
+        echo "  Transform A: $CAESIUM_OUTPUT_TRANSFORM_A_PROCESSED_ROWS rows ($CAESIUM_OUTPUT_TRANSFORM_A_TRANSFORM)"
+        echo "  Transform B: $CAESIUM_OUTPUT_TRANSFORM_B_GROUP_COUNT groups ($CAESIUM_OUTPUT_TRANSFORM_B_TRANSFORM)"
+        sleep 1
+        TOTAL=$((CAESIUM_OUTPUT_TRANSFORM_A_PROCESSED_ROWS + CAESIUM_OUTPUT_TRANSFORM_B_GROUP_COUNT))
+        echo "Loaded $TOTAL total records to destination"
+        echo '##caesium::output {"total_loaded": "'$TOTAL'", "destination": "analytics-db"}'
+    dependsOn:
+      - transform-a
+      - transform-b
+    next: notify
+
+  - name: notify
+    engine: kubernetes
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        echo "Pipeline complete!"
+        echo "  Loaded $CAESIUM_OUTPUT_LOAD_TOTAL_LOADED records to $CAESIUM_OUTPUT_LOAD_DESTINATION"
+        echo "Done."
+    dependsOn: load

--- a/docs/job-definitions.md
+++ b/docs/job-definitions.md
@@ -10,6 +10,8 @@ just hydrate
 
 The command mounts `docs/examples/` into a short-lived CLI container and applies each manifest via the REST API.
 
+For the in-cluster Kubernetes deployment (`just k8s-distributed`), use `just k8s-hydrate` instead. It loads a parallel set of manifests under `docs/examples-k8s/` whose steps declare `engine: kubernetes`, so each step runs as a pod inside the cluster rather than against the host Docker daemon (which is unreachable from cluster pods).
+
 ## Minimal Example
 
 ```yaml

--- a/internal/jobdef/examples_test.go
+++ b/internal/jobdef/examples_test.go
@@ -23,28 +23,41 @@ func TestExamplesSuite(t *testing.T) {
 }
 
 func (s *ExamplesSuite) TestExampleManifestsConformToSchema() {
-	root := filepath.Join("..", "..", "docs", "examples")
-	entries, err := os.ReadDir(root)
-	s.Require().NoError(err)
-
-	var files []string
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		if filepath.Ext(entry.Name()) != ".yaml" && filepath.Ext(entry.Name()) != ".yml" {
-			continue
-		}
-		files = append(files, entry.Name())
+	roots := []string{
+		filepath.Join("..", "..", "docs", "examples"),
+		filepath.Join("..", "..", "docs", "examples-k8s"),
 	}
-	sort.Strings(files)
-	s.Require().NotEmpty(files, "expected at least one example manifest")
+
+	type manifest struct {
+		root string
+		name string
+	}
+	var files []manifest
+	for _, root := range roots {
+		entries, err := os.ReadDir(root)
+		s.Require().NoErrorf(err, "read examples dir %s", root)
+		var local []string
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			if filepath.Ext(entry.Name()) != ".yaml" && filepath.Ext(entry.Name()) != ".yml" {
+				continue
+			}
+			local = append(local, entry.Name())
+		}
+		sort.Strings(local)
+		s.Require().NotEmptyf(local, "expected at least one example manifest in %s", root)
+		for _, name := range local {
+			files = append(files, manifest{root: root, name: name})
+		}
+	}
 
 	seenAliases := make(map[string]string)
-	for _, file := range files {
-		path := filepath.Join(root, file)
+	for _, m := range files {
+		path := filepath.Join(m.root, m.name)
 		data, err := os.ReadFile(path)
-		s.Require().NoErrorf(err, "read example %s", file)
+		s.Require().NoErrorf(err, "read example %s", path)
 
 		dec := yaml.NewDecoder(bytes.NewReader(data))
 		docCount := 0
@@ -54,19 +67,19 @@ func (s *ExamplesSuite) TestExampleManifestsConformToSchema() {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			s.Require().NoErrorf(err, "decode %s doc %d", file, docCount)
+			s.Require().NoErrorf(err, "decode %s doc %d", path, docCount)
 			if def.APIVersion == "" && def.Kind == "" && def.Metadata.Alias == "" && len(def.Steps) == 0 {
 				continue
 			}
-			s.Require().NoErrorf(def.Validate(), "validate %s doc %d", file, docCount)
-			s.NotEmptyf(def.Metadata.Alias, "alias required in %s doc %d", file, docCount)
+			s.Require().NoErrorf(def.Validate(), "validate %s doc %d", path, docCount)
+			s.NotEmptyf(def.Metadata.Alias, "alias required in %s doc %d", path, docCount)
 
 			if previous, ok := seenAliases[def.Metadata.Alias]; ok {
-				s.Failf("duplicate example alias", "alias %q is used in both %s and %s", def.Metadata.Alias, previous, file)
+				s.Failf("duplicate example alias", "alias %q is used in both %s and %s", def.Metadata.Alias, previous, path)
 			}
-			seenAliases[def.Metadata.Alias] = file
+			seenAliases[def.Metadata.Alias] = path
 			docCount++
 		}
-		s.Greaterf(docCount, 0, "expected at least one definition in %s", file)
+		s.Greaterf(docCount, 0, "expected at least one definition in %s", path)
 	}
 }

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -350,12 +350,18 @@ func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskR
 		return err
 	}
 
-	if err := e.monitorTask(taskCtx, taskRun, engine, a); err != nil {
-		return err
+	finalAtom, monitorErr := e.monitorTask(taskCtx, taskRun, engine, a)
+	if monitorErr != nil {
+		return monitorErr
 	}
+	// monitorTask returns the post-Wait atom snapshot whose Result/State
+	// reflect actual execution. The original `a` from Create() is pre-execution
+	// state and would report Result=Unknown for the kubernetes engine.
+	a = finalAtom
 
 	// Parse structured task output and branch markers in a single pass
-	// over the log stream (no full buffering).
+	// over the log stream (no full buffering). Logs must be fetched before
+	// engine.Stop runs, because Stop tears down the underlying container/pod.
 	var taskOutput map[string]string
 	var branchSelections []string
 	var logSnapshot *run.TaskLogSnapshot
@@ -379,6 +385,10 @@ func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskR
 				}
 			}
 		}
+	}
+
+	if stopErr := engine.Stop(&atom.EngineStopRequest{ID: a.ID(), Force: true}); stopErr != nil {
+		log.Warn("failed to stop atom after task completion", "task_id", taskRun.TaskID, "atom_id", a.ID(), "error", stopErr)
 	}
 
 	// Runtime schema validation: if the task declares an outputSchema and the job has
@@ -469,7 +479,12 @@ func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobd
 	}
 }
 
-func (e *runtimeExecutor) monitorTask(ctx context.Context, taskRun *models.TaskRun, engine atom.Engine, a atom.Atom) error {
+// monitorTask blocks until the engine reports the atom has terminated and
+// returns the post-Wait atom snapshot, periodically renewing the worker lease.
+// The caller is responsible for stopping/cleaning up the atom — monitorTask
+// only intervenes with engine.Stop on a deadline-exceeded timeout, so that
+// the caller can read logs from the live container/pod before teardown.
+func (e *runtimeExecutor) monitorTask(ctx context.Context, taskRun *models.TaskRun, engine atom.Engine, a atom.Atom) (atom.Atom, error) {
 	ticker := time.NewTicker(leaseRenewInterval(e.workerLeaseTTL))
 	defer ticker.Stop()
 
@@ -490,17 +505,16 @@ func (e *runtimeExecutor) monitorTask(ctx context.Context, taskRun *models.TaskR
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				if stopErr := engine.Stop(&atom.EngineStopRequest{ID: a.ID(), Force: true}); stopErr != nil {
-					return fmt.Errorf("task %s timed out after %s and failed to stop atom %s: %w", taskRun.TaskID, e.taskTimeout, a.ID(), stopErr)
+					return a, fmt.Errorf("task %s timed out after %s and failed to stop atom %s: %w", taskRun.TaskID, e.taskTimeout, a.ID(), stopErr)
 				}
-				return fmt.Errorf("task %s timed out after %s", taskRun.TaskID, e.taskTimeout)
+				return a, fmt.Errorf("task %s timed out after %s", taskRun.TaskID, e.taskTimeout)
 			}
-			return ctx.Err()
+			return a, ctx.Err()
 		case result := <-waitResult:
 			if result.err != nil {
-				return result.err
+				return a, result.err
 			}
-			a = result.atom
-			return engine.Stop(&atom.EngineStopRequest{ID: a.ID(), Force: true})
+			return result.atom, nil
 		case <-ticker.C:
 			if err := e.renewLease(taskRun); err != nil {
 				log.Error("failed to renew worker task lease", "run_id", taskRun.JobRunID, "task_id", taskRun.TaskID, "error", err)

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -481,9 +481,16 @@ func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobd
 
 // monitorTask blocks until the engine reports the atom has terminated and
 // returns the post-Wait atom snapshot, periodically renewing the worker lease.
-// The caller is responsible for stopping/cleaning up the atom — monitorTask
-// only intervenes with engine.Stop on a deadline-exceeded timeout, so that
-// the caller can read logs from the live container/pod before teardown.
+//
+// On the success path the caller is responsible for stopping/cleaning up the
+// atom — monitorTask intentionally leaves it running so the caller can read
+// logs from the live container/pod before teardown.
+//
+// On any error path (deadline exceeded, parent cancellation, engine.Wait
+// failure) monitorTask makes a best-effort engine.Stop before returning, so
+// failures don't leak orphaned containers/pods. The Stop uses a detached
+// context inside each engine implementation so cleanup still runs even when
+// the parent context has been cancelled.
 func (e *runtimeExecutor) monitorTask(ctx context.Context, taskRun *models.TaskRun, engine atom.Engine, a atom.Atom) (atom.Atom, error) {
 	ticker := time.NewTicker(leaseRenewInterval(e.workerLeaseTTL))
 	defer ticker.Stop()
@@ -500,18 +507,29 @@ func (e *runtimeExecutor) monitorTask(ctx context.Context, taskRun *models.TaskR
 		}{atom: next, err: err}
 	}()
 
+	stopAtom := func() error {
+		return engine.Stop(&atom.EngineStopRequest{ID: a.ID(), Force: true})
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
+			stopErr := stopAtom()
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				if stopErr := engine.Stop(&atom.EngineStopRequest{ID: a.ID(), Force: true}); stopErr != nil {
+				if stopErr != nil {
 					return a, fmt.Errorf("task %s timed out after %s and failed to stop atom %s: %w", taskRun.TaskID, e.taskTimeout, a.ID(), stopErr)
 				}
 				return a, fmt.Errorf("task %s timed out after %s", taskRun.TaskID, e.taskTimeout)
 			}
+			if stopErr != nil {
+				log.Warn("failed to stop atom after task cancellation", "task_id", taskRun.TaskID, "atom_id", a.ID(), "error", stopErr)
+			}
 			return a, ctx.Err()
 		case result := <-waitResult:
 			if result.err != nil {
+				if stopErr := stopAtom(); stopErr != nil {
+					log.Warn("failed to stop atom after engine wait error", "task_id", taskRun.TaskID, "atom_id", a.ID(), "error", stopErr)
+				}
 				return a, result.err
 			}
 			return result.atom, nil

--- a/internal/worker/runtime_executor_test.go
+++ b/internal/worker/runtime_executor_test.go
@@ -1,10 +1,15 @@
 package worker
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/atom"
 	jobdeftestutil "github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
@@ -15,6 +20,79 @@ import (
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
+
+// TestMonitorTaskReturnsPostWaitAtom locks in the contract that monitorTask
+// returns the atom snapshot produced by engine.Wait, not the pre-Wait atom
+// it was handed. Regression guard: if monitorTask reverts to discarding the
+// Wait result, executeTask would record TaskRun.Result from the pre-execution
+// pod state — which the kubernetes engine reports as "unknown" (Pending phase),
+// causing every k8s task to fail with the "task X failed with result \"unknown\""
+// error users hit on `just k8s-distributed`.
+func TestMonitorTaskReturnsPostWaitAtom(t *testing.T) {
+	preExec := &fakeMonitorAtom{id: "pod-1", result: atom.Unknown}
+	postExec := &fakeMonitorAtom{id: "pod-1", result: atom.Success}
+
+	engine := &fakeMonitorEngine{waitResult: postExec}
+	executor := &runtimeExecutor{}
+	taskRun := &models.TaskRun{ID: uuid.New(), TaskID: uuid.New(), JobRunID: uuid.New()}
+
+	got, err := executor.monitorTask(context.Background(), taskRun, engine, preExec)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, atom.Success, got.Result(), "monitorTask must return the atom from Wait, not the pre-Wait input")
+	require.Zero(t, engine.stopCalls, "monitorTask must not call engine.Stop on success — caller stops the atom after reading logs")
+}
+
+func TestMonitorTaskReturnsInputAtomOnWaitError(t *testing.T) {
+	preExec := &fakeMonitorAtom{id: "pod-1", result: atom.Unknown}
+	engine := &fakeMonitorEngine{waitErr: errors.New("watch closed")}
+	executor := &runtimeExecutor{}
+	taskRun := &models.TaskRun{ID: uuid.New(), TaskID: uuid.New(), JobRunID: uuid.New()}
+
+	got, err := executor.monitorTask(context.Background(), taskRun, engine, preExec)
+	require.Error(t, err)
+	require.Same(t, preExec, got, "on Wait error monitorTask should return the input atom so the caller can still call Stop with its ID")
+}
+
+type fakeMonitorAtom struct {
+	id     string
+	result atom.Result
+}
+
+func (a *fakeMonitorAtom) ID() string           { return a.id }
+func (a *fakeMonitorAtom) State() atom.State    { return atom.Stopped }
+func (a *fakeMonitorAtom) Result() atom.Result  { return a.result }
+func (a *fakeMonitorAtom) CreatedAt() time.Time { return time.Time{} }
+func (a *fakeMonitorAtom) StartedAt() time.Time { return time.Time{} }
+func (a *fakeMonitorAtom) StoppedAt() time.Time { return time.Time{} }
+func (a *fakeMonitorAtom) Engine() atom.Engine  { return nil }
+
+type fakeMonitorEngine struct {
+	waitResult atom.Atom
+	waitErr    error
+	stopCalls  int
+}
+
+func (e *fakeMonitorEngine) Get(*atom.EngineGetRequest) (atom.Atom, error)   { return e.waitResult, nil }
+func (e *fakeMonitorEngine) List(*atom.EngineListRequest) ([]atom.Atom, error) {
+	return nil, nil
+}
+func (e *fakeMonitorEngine) Create(*atom.EngineCreateRequest) (atom.Atom, error) {
+	return e.waitResult, nil
+}
+func (e *fakeMonitorEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
+	if e.waitErr != nil {
+		return nil, e.waitErr
+	}
+	return e.waitResult, nil
+}
+func (e *fakeMonitorEngine) Stop(*atom.EngineStopRequest) error {
+	e.stopCalls++
+	return nil
+}
+func (e *fakeMonitorEngine) Logs(*atom.EngineLogsRequest) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
 
 func TestLeaseRenewInterval(t *testing.T) {
 	tests := []struct {

--- a/internal/worker/runtime_executor_test.go
+++ b/internal/worker/runtime_executor_test.go
@@ -52,6 +52,28 @@ func TestMonitorTaskReturnsInputAtomOnWaitError(t *testing.T) {
 	got, err := executor.monitorTask(context.Background(), taskRun, engine, preExec)
 	require.Error(t, err)
 	require.Same(t, preExec, got, "on Wait error monitorTask should return the input atom so the caller can still call Stop with its ID")
+	require.Equal(t, 1, engine.stopCalls, "monitorTask must clean up the atom on Wait error to avoid leaking the underlying container/pod")
+}
+
+// TestMonitorTaskStopsAtomOnContextCancel pins that monitorTask cleans up the
+// atom when the parent context is cancelled mid-execution. Without this the
+// worker can leak running pods/containers when a task is cancelled (e.g. by
+// shutdown signal) before engine.Wait observes a terminal phase.
+func TestMonitorTaskStopsAtomOnContextCancel(t *testing.T) {
+	preExec := &fakeMonitorAtom{id: "pod-1", result: atom.Unknown}
+	// Block Wait until ctx is cancelled — simulates a pod that never reaches
+	// a terminal phase before the task is cancelled.
+	engine := &fakeMonitorEngine{waitBlocks: true}
+	executor := &runtimeExecutor{}
+	taskRun := &models.TaskRun{ID: uuid.New(), TaskID: uuid.New(), JobRunID: uuid.New()}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	got, err := executor.monitorTask(ctx, taskRun, engine, preExec)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Same(t, preExec, got)
+	require.Equal(t, 1, engine.stopCalls, "monitorTask must clean up the atom on context cancellation to avoid leaks")
 }
 
 type fakeMonitorAtom struct {
@@ -70,10 +92,11 @@ func (a *fakeMonitorAtom) Engine() atom.Engine  { return nil }
 type fakeMonitorEngine struct {
 	waitResult atom.Atom
 	waitErr    error
+	waitBlocks bool
 	stopCalls  int
 }
 
-func (e *fakeMonitorEngine) Get(*atom.EngineGetRequest) (atom.Atom, error)   { return e.waitResult, nil }
+func (e *fakeMonitorEngine) Get(*atom.EngineGetRequest) (atom.Atom, error) { return e.waitResult, nil }
 func (e *fakeMonitorEngine) List(*atom.EngineListRequest) ([]atom.Atom, error) {
 	return nil, nil
 }
@@ -81,6 +104,10 @@ func (e *fakeMonitorEngine) Create(*atom.EngineCreateRequest) (atom.Atom, error)
 	return e.waitResult, nil
 }
 func (e *fakeMonitorEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
+	if e.waitBlocks {
+		<-req.Context.Done()
+		return nil, req.Context.Err()
+	}
 	if e.waitErr != nil {
 		return nil, e.waitErr
 	}

--- a/justfile
+++ b/justfile
@@ -346,10 +346,13 @@ k8s-port-forward:
 k8s-logs:
     kubectl logs -l app.kubernetes.io/name=caesium --all-containers=true -f --tail=100
 
-# Hydrate example jobs into the Kubernetes-hosted Caesium instance
+# Hydrate example jobs into the Kubernetes-hosted Caesium instance.
+# Uses examples-k8s/ (engine: kubernetes) so the steps run as pods inside
+# the cluster — the docker-engine examples in docs/examples/ would fail
+# here because pods don't have access to the host Docker daemon.
 k8s-hydrate:
     {{ container_cli }} run --platform {{ platform }} \
         --rm \
         --network=host \
-        -v {{ repo_dir }}/docs/examples:/examples:ro \
+        -v {{ repo_dir }}/docs/examples-k8s:/examples:ro \
         {{ local_image_ref }}:{{ tag }} job apply --server http://host.docker.internal:{{ port }} --path /examples


### PR DESCRIPTION
## Summary

Currently `just k8s-distributed && just k8s-hydrate` produces a cluster where every sample task fails with `task X failed with result \"unknown\"`. This PR fixes the underlying executor bug and ships a parallel sample-job set that's actually runnable inside the cluster.

## What changed

### Fix: distributed worker now reports the correct task result

`internal/worker/runtime_executor.go` — `monitorTask` was reassigning `a = result.atom` to its local parameter, so `executeTask` kept calling `a.Result()` on the pre-execution atom returned by `engine.Create`. For a Kubernetes pod that's still in `Pending` phase, `kubernetes.Atom.Result()` returns `atom.Unknown`, which trips `IsSuccessfulTaskResult` and fails the task with `task X failed with result \"unknown\"`.

Why nobody had hit this before:
- **Docker masked it.** A freshly created docker container has `State.ExitCode == 0`, and `resultMap[0] = atom.Success` — so the pre-Wait atom accidentally reports success.
- **The in-process executor was correct.** `internal/job/job.go` reassigns `a = result.atom` in the same scope, so the caller sees the updated atom.
- **CI never exercised the broken path.** The k8s integration test runs with `replicaCount: 1` (no `CAESIUM_EXECUTION_MODE=distributed`), so it goes through the in-process executor. Only `just k8s-distributed` triggers the worker path.

The fix:
- `monitorTask` now returns `(atom.Atom, error)` so the post-`Wait` snapshot propagates to the caller.
- `engine.Stop` moved out of `monitorTask`'s success path into `executeTask`, **after** logs are read. This matches the in-process executor and ensures `##caesium::output` markers are captured before the container/pod is torn down (a latent bug for docker, where `Stop` removes the container).

### New: docs/examples-k8s/ sample set

The existing `docs/examples/` jobs all declare `engine: docker`, which can't work inside a cluster (pods have no host Docker socket). Added a parallel `docs/examples-k8s/` directory of five sample jobs with `engine: kubernetes`:

- `minimal.job.yaml` — basic 3-step ETL
- `fanout-join.job.yaml` — fan-out / fan-in DAG
- `task-outputs.job.yaml` — structured output passing
- `data-contracts.job.yaml` — schema validation
- `log-streaming.job.yaml` — long-running HTTP-triggered streaming demo

`just k8s-hydrate` now mounts `docs/examples-k8s/` instead of `docs/examples/`. The directories are siblings (not subdirs) so `just hydrate` continues to work for local docker dev without picking up k8s manifests.

## Tests

- `internal/jobdef/examples_test.go` — extended to validate both example directories and enforce alias uniqueness across them, so schema regressions in the new manifests are caught.
- `internal/worker/runtime_executor_test.go` — added `TestMonitorTaskReturnsPostWaitAtom` (regression test pinning that the returned atom is the one from `Wait`, not the input) and `TestMonitorTaskReturnsInputAtomOnWaitError`.
- `just unit-test` passes.

## End-to-end verification

After `just k8s-distributed && just k8s-hydrate`, the cron-fired `k8s-task-outputs-demo` run completed cleanly:

```
extract     → output={row_count: 9792, source: warehouse-prod, format: parquet}
transform-a → output={processed_rows: 7833, transform: enrichment}
transform-b → output={group_count: 97, transform: aggregation}
load        → output={total_loaded: 7930, destination: analytics-db}
```

`7833 + 97 = 7930` proves the load step received both upstream values via `\$CAESIUM_OUTPUT_TRANSFORM_A_PROCESSED_ROWS` + `\$CAESIUM_OUTPUT_TRANSFORM_B_GROUP_COUNT` — confirming task result reporting, log-marker capture, and output env-var propagation all work in distributed k8s mode.

## Test plan

- [x] CI passes (unit tests, k8s integration test, lint)
- [x] On a Docker Desktop k8s cluster: `just k8s-distributed && just k8s-hydrate` and confirm cron-fired runs reach `succeeded` instead of failing with `result \"unknown\"`
- [x] Confirm docker integration tests still pass — the `engine.Stop`-after-`Logs` reorder also affects the docker code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)