### PR TITLE
Add Phase 0 load harness and per-category write counters

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,12 +31,14 @@ These files are useful context, but each should be treated according to its stat
 - [design-event-triggers.md](design-event-triggers.md)
 - [design-concurrency-priority.md](design-concurrency-priority.md)
 - [design-database-locking-fix.md](design-database-locking-fix.md)
+- [design-scaling-job-execution.md](design-scaling-job-execution.md)
 - [design-sla-management.md](design-sla-management.md)
 - [design-task-templates.md](design-task-templates.md)
 - [design-helm-kubernetes-deployment.md](design-helm-kubernetes-deployment.md)
 - [design-incremental-execution.md](design-incremental-execution.md)
 - [design-parallel-job-execution.md](design-parallel-job-execution.md)
 - [brainstorm-differentiators.md](brainstorm-differentiators.md)
+- [load-baseline-2026-05-23.md](load-baseline-2026-05-23.md): Phase 0 load harness baseline measurement output.
 
 ## Historical Notes
 

--- a/docs/load-baseline-2026-05-23.md
+++ b/docs/load-baseline-2026-05-23.md
@@ -1,0 +1,209 @@
+# Caesium Load Baseline — 2026-05-23
+
+> **Phase 0 deliverable.** This document records the Phase 0 baseline measurements
+> as described in `docs/design-scaling-job-execution.md`. It serves as the
+> comparison baseline for Phase 1 and Phase 2 work.
+
+## Environment
+
+| Parameter | Value |
+|---|---|
+| Date | 2026-05-23 |
+| Caesium commit | `bda2491` (master, pre-Phase-0) |
+| Measurement host | macOS Darwin 25.5.0 (sandbox, single-node) |
+| dqlite topology | Single-node (no Raft quorum; leader is the only voter) |
+| Storage | In-container tmpfs (no NVMe; latency is purely software) |
+| Worker pool | Default (local Docker engine, no kubernetes) |
+| CAESIUM_DATABASE_SHARDS | 1 (sharding PR #157 not yet deployed in this config) |
+
+## Sandbox Limitation
+
+The sandbox environment does **not** have a running Caesium server with a live
+dqlite cluster, NVMe storage, or a multi-node Raft configuration. Therefore
+this document captures:
+
+1. **Instrumented scaffolding verified to compile and vet cleanly** — the
+   `caesium_db_writes_total{category}` counters are wired into all relevant
+   write paths and the `just load-test` recipe is ready to run.
+
+2. **Analytical write-category breakdown** derived from reading the source, as
+   a substitute for empirical measurement. This breakdown is reproducible and
+   should closely predict the empirical outcome; it gives a directional answer
+   to "which category dominates" before a real cluster run.
+
+3. **Guidance for the first real-cluster run** so the Phase 1 team knows what
+   to expect and what to look for.
+
+---
+
+## Analytical Write-Category Breakdown
+
+Per task lifecycle in the current codebase (single successful path, no retries,
+no branch tasks, no cache hits):
+
+| Operation | Write site | Category | Count per task |
+|---|---|---|---|
+| RegisterTasks INSERT | `store.go:RegisterTasks` | `task_run_insert` | 1 |
+| task_ready event INSERT (for root/ready tasks) | `store.go:appendTaskReadyEventTx` / inline | `event_insert` | 1 |
+| ClaimNext UPDATE (status→running, claimed_by, lease) | `claimer.go:claimNextSingleStatementTx` | `task_run_status` | 1 |
+| task_claimed event INSERT | `claimer.go:recordTaskClaimedEventTx` | `event_insert` | 1 |
+| StartTaskClaimed UPDATE (runtime_id, started_at) | `store.go:StartTaskClaimed` | `task_run_status` | 1 |
+| task_started event INSERT | `store.go:recordTaskEventTx` | `event_insert` | 1 |
+| Lease renewal UPDATEs (while task runs) | `runtime_executor.go:renewLease` | `lease_renewal` | ≥1 (leaseTTL/2 interval) |
+| CompleteTask: task UPDATE (status→succeeded) | `store.go:completeTask` | `task_run_status` | 1 |
+| CompleteTask: successor outstanding_predecessors UPDATE (per successor) | `store.go:completeTask` | `task_run_status` | N (fan-out) |
+| task_succeeded event INSERT | `store.go:recordTaskEventTx` | `event_insert` | 1 |
+| task_ready events for newly-ready successors | `store.go:appendTaskReadyEventTx` | `event_insert` | ≤N (fan-out) |
+
+### Per-task write totals (single successful task, no branches, fan-out=1)
+
+| Category | Count |
+|---|---|
+| `task_run_insert` | 1 |
+| `task_run_status` | 3 (claim + start + complete) |
+| `event_insert` | 4 (task_ready + task_claimed + task_started + task_succeeded) |
+| `lease_renewal` | ~2–4 (for a 1-second task with default 5-min TTL) |
+| `callback` | 0 (no callbacks in synthetic load) |
+| `command` | 0 (reserved, not yet used) |
+| `checkpoint` | 0 (reserved, Phase 2) |
+| **TOTAL** | **~10–12** |
+
+### Expected distribution for 10 jobs × 1 root + 4×2 fan-out + 1 join = 10 tasks each (fan-out=4, depth=3)
+
+Tasks per run: 1 root + 4 lane-1 + 4 lane-2 + 1 join = **10 tasks per run**
+
+Per run:
+- `task_run_insert`: 10
+- `task_run_status`: ~38 (10 claim + 10 start + 10 complete + 8 predecessor-counter UPDATEs for the join)
+- `event_insert`: ~40–50 (10 ready + 10 claimed + 10 started + 10 succeeded + ~10 ready events for successors)
+- `lease_renewal`: ~20–40 (10 tasks × ~2–4 renewals each)
+- TOTAL per run: **~108–138 writes**
+
+Across 10 concurrent runs: **~1080–1380 total writes** for the default
+`just load-test` workload.
+
+### Predicted dominant category
+
+Based on the breakdown above:
+
+> **`event_insert` is the predicted dominant write category**, slightly ahead
+> of `task_run_status`. Both are in the 35–40% range per run. `lease_renewal`
+> is the clear third place at ~15–25% depending on task duration.
+
+The `task_run_insert` category (one INSERT per task) accounts for only ~9% of
+total writes and is NOT the bottleneck — it fires once per task, not per
+transition.
+
+**Implication for Phase 1 sequencing:**
+
+- **1.1 Event coalescing** is the highest-leverage Phase 1 change. If
+  `event_insert` and `task_run_status` are each ~35%, the combined
+  "per-transition" write budget is ~70% of total DB writes. Event coalescing
+  (batching multiple INSERTs within a single `CompleteTask` call) can reduce
+  the `event_insert` count by 3–5× for fan-out completions.
+- **1.2 Lease renewal batching** targets `lease_renewal` which is the third
+  largest category. With pool-size=16 workers, batching 16 renewals into one
+  UPDATE reduces lease-renewal DB writes by ~16×.
+- **1.3 Catalog cache** targets read QPS but doesn't appear in the write
+  counters measured here; it's lower priority for write-ceiling work.
+
+---
+
+## Empirical Run — To Be Completed in Real Cluster
+
+The table below is a template for the first real-cluster run using
+`just load-test`. Fill it in once a live server with Docker engine is available:
+
+| Metric | Value |
+|---|---|
+| `caesium_db_writes_total{category="task_run_insert"}` (delta) | — |
+| `caesium_db_writes_total{category="task_run_status"}` (delta) | — |
+| `caesium_db_writes_total{category="event_insert"}` (delta) | — |
+| `caesium_db_writes_total{category="lease_renewal"}` (delta) | — |
+| Dominant category | — |
+| Peak task_run_status/s | — |
+| Peak event_insert/s | — |
+| End-to-end p50 per run | — |
+| End-to-end p99 per run | — |
+| `caesium_db_busy_retries_total` (delta) | — |
+| dqlite leader CPU at saturation | — |
+| dqlite leader RSS at saturation | — |
+| `caesium_worker_claims_total` (delta) | — |
+| Writes per claim | — |
+
+### How to run
+
+```sh
+# Start the server (requires Docker):
+just run
+
+# In another terminal, run the load harness with defaults
+# (10 jobs × fan-out 4 × depth 3 × 1s tasks, serial):
+just load-test
+
+# Higher throughput: 20 jobs, concurrency 4, 2s tasks:
+CAESIUM_LOAD_JOBS=20 \
+CAESIUM_LOAD_CONCURRENCY=4 \
+CAESIUM_LOAD_TASK_DURATION=2s \
+just load-test
+
+# The report is written to docs/load-baseline-YYYY-MM-DD.md automatically.
+```
+
+---
+
+## Write Counter Wiring — Completeness Checklist
+
+The following write paths now increment `caesium_db_writes_total`:
+
+- [x] `store.go:RegisterTasks` — `task_run_insert` per new task_run row
+- [x] `store.go:RegisterTasks` — `event_insert` per task_ready event for zero-predecessor tasks
+- [x] `store.go:StartTask` — `task_run_status`
+- [x] `store.go:StartTaskClaimed` — `task_run_status`
+- [x] `store.go:completeTask` — `task_run_status` (completed task update)
+- [x] `store.go:completeTask` — `task_run_status` per successor outstanding_predecessors UPDATE
+- [x] `store.go:cacheHitTask` — `task_run_status` (completed task update, cache path)
+- [x] `store.go:cacheHitTask` — `task_run_status` per successor outstanding_predecessors UPDATE
+- [x] `store.go:failTask` — `task_run_status`
+- [x] `store.go:retryTask` — `task_run_status`
+- [x] `store.go:markTaskSkippedTx` — `task_run_status`
+- [x] `store.go:SkipTask` — `task_run_status`
+- [x] `store.go:skipTaskAndDescendantsTx` — `task_run_status` per successor outstanding_predecessors UPDATE
+- [x] `store.go:recordTaskEventTx` — `event_insert` (all task-lifecycle events: started, succeeded, failed, skipped, cached, retrying)
+- [x] `store.go:appendTaskReadyEventTx` — `event_insert` (task_ready events)
+- [x] `store.go:retryTask` — `event_insert` (task_ready event emitted inline)
+- [x] `claimer.go:ClaimNext` — `task_run_status` (claim UPDATE)
+- [x] `claimer.go:recordTaskClaimedEventTx` — `event_insert`
+- [x] `claimer.go:ReclaimExpired` — `task_run_status` (batch reset of expired claims)
+- [x] `claimer.go:ReclaimExpired` — `event_insert` (lease_expired + task_ready per reclaimed task)
+- [x] `runtime_executor.go:renewLease` — `lease_renewal`
+- [x] `callback.go:invokeCallback` — `callback` (CREATE callback_run)
+- [x] `callback.go:completeCallbackRun` — `callback` (UPDATE callback_run)
+- [ ] `command` — reserved; no `run_commands` table yet (Phase 2)
+- [ ] `checkpoint` — reserved; no `run_checkpoints` table yet (Phase 2)
+
+---
+
+## Phase 1 Sequencing Recommendation
+
+Based on the analytical breakdown:
+
+1. **Start with 1.1 Event coalescing** — `event_insert` is predicted to be the
+   dominant category (35–40% of all writes). A 3–5× reduction here is the
+   single largest lever.
+
+2. **Follow with 1.2 Lease renewal batching** — `lease_renewal` is the
+   third-largest category (~15–25%). With a typical pool size of 16 workers,
+   batching reduces this by ~16×, paying outsized dividends at higher pool
+   sizes.
+
+3. **Defer 1.3 Catalog cache** — it targets read QPS and does not appear in
+   the write metrics measured here. Start it in parallel with 1.2 if
+   engineering bandwidth allows, but don't block Phase 1 completion on it.
+
+4. **Gate Phase 2 on real measurements.** If after Phase 1 the dominant
+   remaining category is `task_run_status` (CompleteTask's predecessor-counter
+   UPDATEs and claim/start transitions), that confirms Phase 2's run-owner
+   design is the right next step — it eliminates per-transition DB writes
+   entirely. If the write rate has already moved past the throughput target,
+   Phase 2 can be deferred.

--- a/internal/callback/callback.go
+++ b/internal/callback/callback.go
@@ -294,6 +294,7 @@ func (d *Dispatcher) invokeCallback(ctx context.Context, cb models.Callback, met
 	if err := d.db.WithContext(ctx).Create(runRecord).Error; err != nil {
 		return fmt.Errorf("record callback run: %w", err)
 	}
+	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryCallback).Inc()
 
 	handler, ok := lookupHandler(cb.Type)
 	if !ok {
@@ -335,8 +336,12 @@ func (d *Dispatcher) completeCallbackRun(ctx context.Context, id uuid.UUID, stat
 	if errMsg != "" {
 		updates["error"] = errMsg
 	}
-	return d.db.WithContext(ctx).
+	if err := d.db.WithContext(ctx).
 		Model(&models.CallbackRun{}).
 		Where("id = ?", id).
-		Updates(updates).Error
+		Updates(updates).Error; err != nil {
+		return err
+	}
+	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryCallback).Inc()
+	return nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -8,6 +8,17 @@ import (
 
 var registerOnce sync.Once
 
+// DBWriteCategory constants for use with DBWritesTotal.
+const (
+	DBWriteCategoryTaskRunInsert  = "task_run_insert"
+	DBWriteCategoryTaskRunStatus  = "task_run_status"
+	DBWriteCategoryEventInsert    = "event_insert"
+	DBWriteCategoryLeaseRenewal   = "lease_renewal"
+	DBWriteCategoryCallback       = "callback"
+	DBWriteCategoryCommand        = "command"
+	DBWriteCategoryCheckpoint     = "checkpoint"
+)
+
 var (
 	JobRunsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -202,6 +213,22 @@ var (
 		},
 		[]string{"path", "reason"},
 	)
+
+	// DBWritesTotal counts durable database writes by category. Categories:
+	//   task_run_insert   – new task_runs row (RegisterTasks)
+	//   task_run_status   – status UPDATE on task_runs (claim, start, complete, fail, skip, retry)
+	//   event_insert      – new execution_events row
+	//   lease_renewal     – UPDATE task_runs SET claim_expires_at (worker heartbeat)
+	//   callback          – INSERT or UPDATE on callback_runs
+	//   command           – reserved for future run_commands table writes
+	//   checkpoint        – reserved for future run_checkpoints table writes
+	DBWritesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_db_writes_total",
+			Help: "Total durable database writes by category (task_run_insert, task_run_status, event_insert, lease_renewal, callback, command, checkpoint).",
+		},
+		[]string{"category"},
+	)
 )
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
@@ -232,6 +259,7 @@ func Register() {
 			AuthKeyAgeSeconds,
 			AuditLogEntriesTotal,
 			WebhookAuthFailuresTotal,
+			DBWritesTotal,
 		)
 	})
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -527,6 +527,7 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 			if err := tx.Create(&records).Error; err != nil {
 				return err
 			}
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunInsert).Add(float64(len(records)))
 			if len(readyEvents) > 0 {
 				eventRecords := make([]models.ExecutionEvent, 0, len(readyEvents))
 				for _, evt := range readyEvents {
@@ -535,6 +536,7 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 				if err := tx.Create(&eventRecords).Error; err != nil {
 					return err
 				}
+				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Add(float64(len(eventRecords)))
 				for idx := range readyEvents {
 					readyEvents[idx].Sequence = eventRecords[idx].Sequence
 					readyEvents[idx].Timestamp = eventRecords[idx].CreatedAt
@@ -595,6 +597,7 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 				}).Error; err != nil {
 				return err
 			}
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 			if s.eventStore != nil {
 				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID)
 				if err != nil {
@@ -633,6 +636,7 @@ func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy s
 			if result.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 			if s.eventStore != nil {
 				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID)
 				if err != nil {
@@ -767,6 +771,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 			if enforceClaim && resultUpdate.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 			// Load the task model for edge traversal and branch detection.
 			var taskModel models.Task
@@ -822,6 +827,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 					UpdateColumn("outstanding_predecessors", gorm.Expr("CASE WHEN outstanding_predecessors > 0 THEN outstanding_predecessors - 1 ELSE 0 END")).Error; err != nil {
 					return err
 				}
+				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 				var successor models.TaskRun
 				if err := tx.Where("job_run_id = ? AND task_id = ?", runID, edge.ToTaskID).First(&successor).Error; err == nil &&
@@ -975,6 +981,7 @@ func (s *Store) appendTaskReadyEventTx(tx *gorm.DB, runID, taskID uuid.UUID, pen
 	if err := s.eventStore.AppendTx(tx, &evt); err != nil {
 		return err
 	}
+	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
 	*pendingEvents = append(*pendingEvents, evt)
 	return nil
 }
@@ -997,6 +1004,7 @@ func (s *Store) markTaskSkippedTx(tx *gorm.DB, runID, taskID uuid.UUID, reason s
 	if result.RowsAffected == 0 {
 		return false, nil
 	}
+	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 	if s.eventStore != nil {
 		evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID)
@@ -1193,6 +1201,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 			if enforceClaim && resultUpdate.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 			if status == TaskStatusFailed {
 				if s.eventStore != nil {
@@ -1276,6 +1285,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 					UpdateColumn("outstanding_predecessors", gorm.Expr("CASE WHEN outstanding_predecessors > 0 THEN outstanding_predecessors - 1 ELSE 0 END")).Error; err != nil {
 					return err
 				}
+				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 				var successor models.TaskRun
 				if err := tx.Where("job_run_id = ? AND task_id = ?", runID, edge.ToTaskID).First(&successor).Error; err == nil &&
@@ -1366,6 +1376,7 @@ func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, r
 				UpdateColumn("outstanding_predecessors", gorm.Expr("CASE WHEN outstanding_predecessors > 0 THEN outstanding_predecessors - 1 ELSE 0 END")).Error; err != nil {
 				return skipped, err
 			}
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 			var successor models.TaskRun
 			if err := tx.Where("job_run_id = ? AND task_id = ?", runID, edge.ToTaskID).First(&successor).Error; err != nil {
@@ -1455,6 +1466,7 @@ func (s *Store) failTask(runID, taskID uuid.UUID, failure error, claimedBy strin
 		if enforceClaim && resultUpdate.RowsAffected == 0 {
 			return ErrTaskClaimMismatch
 		}
+		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 		if s.eventStore != nil {
 			evt, err := s.recordTaskEventTx(tx, event.TypeTaskFailed, runID, taskID)
@@ -1513,6 +1525,7 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 		if enforceClaim && resultUpdate.RowsAffected == 0 {
 			return ErrTaskClaimMismatch
 		}
+		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 
 		if s.eventStore != nil {
 			evt, err := s.recordTaskEventTx(tx, event.TypeTaskRetrying, runID, taskID)
@@ -1538,6 +1551,7 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 				if err := s.eventStore.AppendTx(tx, &readyEvt); err != nil {
 					return err
 				}
+				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
 				pendingEvents = append(pendingEvents, readyEvt)
 			}
 		}
@@ -1567,6 +1581,7 @@ func (s *Store) SkipTask(runID, taskID uuid.UUID, reason string) error {
 			}).Error; err != nil {
 			return err
 		}
+		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 		if s.eventStore != nil {
 			evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID)
 			if err != nil {
@@ -2025,6 +2040,7 @@ func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, task
 		if err := s.eventStore.AppendTx(db, &evt); err != nil {
 			return nil, err
 		}
+		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
 	}
 	return &evt, nil
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -434,7 +434,9 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 	}
 
 	var pendingEvents []event.Event
+	var counts dbWriteCounts
 	err := withStoreBusyRetry(func() error {
+		counts.reset()
 		var attemptEvents []event.Event
 		err := s.db.Transaction(func(tx *gorm.DB) error {
 			existingTaskIDs := make([]uuid.UUID, 0)
@@ -527,7 +529,7 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 			if err := tx.Create(&records).Error; err != nil {
 				return err
 			}
-			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunInsert).Add(float64(len(records)))
+			counts.taskRunInsert += len(records)
 			if len(readyEvents) > 0 {
 				eventRecords := make([]models.ExecutionEvent, 0, len(readyEvents))
 				for _, evt := range readyEvents {
@@ -536,7 +538,7 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 				if err := tx.Create(&eventRecords).Error; err != nil {
 					return err
 				}
-				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Add(float64(len(eventRecords)))
+				counts.eventInsert += len(eventRecords)
 				for idx := range readyEvents {
 					readyEvents[idx].Sequence = eventRecords[idx].Sequence
 					readyEvents[idx].Timestamp = eventRecords[idx].CreatedAt
@@ -551,6 +553,7 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 		return err
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return err
@@ -584,7 +587,9 @@ func executionEventRecord(evt event.Event) models.ExecutionEvent {
 
 func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 	var pendingEvents []event.Event
+	var counts dbWriteCounts
 	err := withStoreBusyRetry(func() error {
+		counts.reset()
 		attemptEvents := make([]event.Event, 0, 1)
 		err := s.db.Transaction(func(tx *gorm.DB) error {
 			now := time.Now().UTC()
@@ -597,9 +602,9 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 				}).Error; err != nil {
 				return err
 			}
-			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+			counts.taskRunStatus++
 			if s.eventStore != nil {
-				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID)
+				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID, &counts)
 				if err != nil {
 					return err
 				}
@@ -613,6 +618,7 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 		return err
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return err
@@ -620,7 +626,9 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 
 func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy string) error {
 	var pendingEvents []event.Event
+	var counts dbWriteCounts
 	err := withStoreBusyRetry(func() error {
+		counts.reset()
 		attemptEvents := make([]event.Event, 0, 1)
 		err := s.db.Transaction(func(tx *gorm.DB) error {
 			now := time.Now().UTC()
@@ -636,9 +644,9 @@ func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy s
 			if result.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
-			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+			counts.taskRunStatus++
 			if s.eventStore != nil {
-				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID)
+				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID, &counts)
 				if err != nil {
 					return err
 				}
@@ -652,6 +660,7 @@ func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy s
 		return err
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return err
@@ -714,7 +723,9 @@ func (s *Store) CacheHitTaskClaimed(runID, taskID uuid.UUID, source CacheHitSour
 func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, result, claimedBy string, enforceClaim bool, output map[string]string, branchSelections []string) ([]uuid.UUID, error) {
 	var pendingEvents []event.Event
 	var skippedTaskIDs []uuid.UUID
+	var counts dbWriteCounts
 	err := withStoreBusyRetry(func() error {
+		counts.reset()
 		attemptEvents := make([]event.Event, 0, 8)
 		attemptSkippedTaskIDs := make([]uuid.UUID, 0)
 
@@ -771,7 +782,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 			if enforceClaim && resultUpdate.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
-			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+			counts.taskRunStatus++
 
 			// Load the task model for edge traversal and branch detection.
 			var taskModel models.Task
@@ -814,7 +825,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 				// Branch filtering: skip successors not selected by the branch.
 				if branchSelectedIDs != nil && !branchSelectedIDs[edge.ToTaskID] {
 					reason := fmt.Sprintf("not selected by branch task %s", taskID)
-					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, reason, &attemptEvents)
+					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, reason, &attemptEvents, &counts)
 					if err != nil {
 						return err
 					}
@@ -827,7 +838,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 					UpdateColumn("outstanding_predecessors", gorm.Expr("CASE WHEN outstanding_predecessors > 0 THEN outstanding_predecessors - 1 ELSE 0 END")).Error; err != nil {
 					return err
 				}
-				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+				counts.taskRunStatus++
 
 				var successor models.TaskRun
 				if err := tx.Where("job_run_id = ? AND task_id = ?", runID, edge.ToTaskID).First(&successor).Error; err == nil &&
@@ -837,14 +848,14 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 						return err
 					}
 					if shouldRun {
-						if err := s.appendTaskReadyEventTx(tx, runID, edge.ToTaskID, &attemptEvents); err != nil {
+						if err := s.appendTaskReadyEventTx(tx, runID, edge.ToTaskID, &attemptEvents, &counts); err != nil {
 							return err
 						}
 						continue
 					}
 
 					skipRuleReason := fmt.Sprintf("trigger rule %q not satisfied", rule)
-					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, skipRuleReason, &attemptEvents)
+					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, skipRuleReason, &attemptEvents, &counts)
 					if err != nil {
 						return err
 					}
@@ -853,7 +864,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 			}
 
 			if s.eventStore != nil {
-				evt, err := s.recordTaskEventTx(tx, event.TypeTaskCached, runID, taskID)
+				evt, err := s.recordTaskEventTx(tx, event.TypeTaskCached, runID, taskID, &counts)
 				if err != nil {
 					return err
 				}
@@ -869,6 +880,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 		return err
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return skippedTaskIDs, err
@@ -961,7 +973,7 @@ func (s *Store) successorEdgesTx(tx *gorm.DB, task models.Task) ([]models.TaskEd
 	return nil, err
 }
 
-func (s *Store) appendTaskReadyEventTx(tx *gorm.DB, runID, taskID uuid.UUID, pendingEvents *[]event.Event) error {
+func (s *Store) appendTaskReadyEventTx(tx *gorm.DB, runID, taskID uuid.UUID, pendingEvents *[]event.Event, counts *dbWriteCounts) error {
 	if s.eventStore == nil {
 		return nil
 	}
@@ -981,12 +993,12 @@ func (s *Store) appendTaskReadyEventTx(tx *gorm.DB, runID, taskID uuid.UUID, pen
 	if err := s.eventStore.AppendTx(tx, &evt); err != nil {
 		return err
 	}
-	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
+	counts.eventInsert++
 	*pendingEvents = append(*pendingEvents, evt)
 	return nil
 }
 
-func (s *Store) markTaskSkippedTx(tx *gorm.DB, runID, taskID uuid.UUID, reason string, pendingEvents *[]event.Event) (bool, error) {
+func (s *Store) markTaskSkippedTx(tx *gorm.DB, runID, taskID uuid.UUID, reason string, pendingEvents *[]event.Event, counts *dbWriteCounts) (bool, error) {
 	result := tx.Model(&models.TaskRun{}).
 		Where("job_run_id = ? AND task_id = ? AND status = ?", runID, taskID, string(TaskStatusPending)).
 		Updates(map[string]interface{}{
@@ -1004,10 +1016,10 @@ func (s *Store) markTaskSkippedTx(tx *gorm.DB, runID, taskID uuid.UUID, reason s
 	if result.RowsAffected == 0 {
 		return false, nil
 	}
-	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+	counts.taskRunStatus++
 
 	if s.eventStore != nil {
-		evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID)
+		evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID, counts)
 		if err != nil {
 			return false, err
 		}
@@ -1118,7 +1130,9 @@ func (s *Store) shouldRunTaskTx(tx *gorm.DB, runID, taskID uuid.UUID) (bool, str
 func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, enforceClaim bool, output map[string]string, branchSelections []string) ([]uuid.UUID, error) {
 	var pendingEvents []event.Event
 	var skippedTaskIDs []uuid.UUID
+	var counts dbWriteCounts
 	err := withStoreBusyRetry(func() error {
+		counts.reset()
 		attemptEvents := make([]event.Event, 0, 8)
 		attemptSkippedTaskIDs := make([]uuid.UUID, 0)
 
@@ -1201,11 +1215,11 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 			if enforceClaim && resultUpdate.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
-			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+			counts.taskRunStatus++
 
 			if status == TaskStatusFailed {
 				if s.eventStore != nil {
-					evt, err := s.recordTaskEventTx(tx, event.TypeTaskFailed, runID, taskID)
+					evt, err := s.recordTaskEventTx(tx, event.TypeTaskFailed, runID, taskID, &counts)
 					if err != nil {
 						return err
 					}
@@ -1272,7 +1286,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 				// Branch filtering: skip successors not selected by the branch.
 				if branchSelectedIDs != nil && !branchSelectedIDs[edge.ToTaskID] {
 					reason := fmt.Sprintf("not selected by branch task %s", taskID)
-					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, reason, &attemptEvents)
+					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, reason, &attemptEvents, &counts)
 					if err != nil {
 						return err
 					}
@@ -1285,7 +1299,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 					UpdateColumn("outstanding_predecessors", gorm.Expr("CASE WHEN outstanding_predecessors > 0 THEN outstanding_predecessors - 1 ELSE 0 END")).Error; err != nil {
 					return err
 				}
-				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+				counts.taskRunStatus++
 
 				var successor models.TaskRun
 				if err := tx.Where("job_run_id = ? AND task_id = ?", runID, edge.ToTaskID).First(&successor).Error; err == nil &&
@@ -1295,14 +1309,14 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 						return err
 					}
 					if shouldRun {
-						if err := s.appendTaskReadyEventTx(tx, runID, edge.ToTaskID, &attemptEvents); err != nil {
+						if err := s.appendTaskReadyEventTx(tx, runID, edge.ToTaskID, &attemptEvents, &counts); err != nil {
 							return err
 						}
 						continue
 					}
 
 					skipRuleReason := fmt.Sprintf("trigger rule %q not satisfied", rule)
-					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, skipRuleReason, &attemptEvents)
+					skipped, err := s.skipTaskAndDescendantsTx(tx, runID, edge.ToTaskID, skipRuleReason, &attemptEvents, &counts)
 					if err != nil {
 						return err
 					}
@@ -1311,7 +1325,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 			}
 
 			if s.eventStore != nil {
-				evt, err := s.recordTaskEventTx(tx, event.TypeTaskSucceeded, runID, taskID)
+				evt, err := s.recordTaskEventTx(tx, event.TypeTaskSucceeded, runID, taskID, &counts)
 				if err != nil {
 					return err
 				}
@@ -1327,6 +1341,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 		return err
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return skippedTaskIDs, err
@@ -1336,7 +1351,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 // skipped within the given transaction. Descendants are only skipped once all
 // of their predecessors are terminal and their trigger rules remain
 // unsatisfied.
-func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, reason string, pendingEvents *[]event.Event) ([]uuid.UUID, error) {
+func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, reason string, pendingEvents *[]event.Event, counts *dbWriteCounts) ([]uuid.UUID, error) {
 	type queuedSkip struct {
 		taskID uuid.UUID
 		reason string
@@ -1349,7 +1364,7 @@ func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, r
 		current := queue[0]
 		queue = queue[1:]
 
-		markedSkipped, err := s.markTaskSkippedTx(tx, runID, current.taskID, current.reason, pendingEvents)
+		markedSkipped, err := s.markTaskSkippedTx(tx, runID, current.taskID, current.reason, pendingEvents, counts)
 		if err != nil {
 			return skipped, err
 		}
@@ -1376,7 +1391,7 @@ func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, r
 				UpdateColumn("outstanding_predecessors", gorm.Expr("CASE WHEN outstanding_predecessors > 0 THEN outstanding_predecessors - 1 ELSE 0 END")).Error; err != nil {
 				return skipped, err
 			}
-			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+			counts.taskRunStatus++
 
 			var successor models.TaskRun
 			if err := tx.Where("job_run_id = ? AND task_id = ?", runID, edge.ToTaskID).First(&successor).Error; err != nil {
@@ -1391,7 +1406,7 @@ func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, r
 				return skipped, err
 			}
 			if shouldRun {
-				if err := s.appendTaskReadyEventTx(tx, runID, edge.ToTaskID, pendingEvents); err != nil {
+				if err := s.appendTaskReadyEventTx(tx, runID, edge.ToTaskID, pendingEvents, counts); err != nil {
 					return skipped, err
 				}
 				continue
@@ -1444,6 +1459,7 @@ func (s *Store) failTask(runID, taskID uuid.UUID, failure error, claimedBy strin
 	}
 
 	pendingEvents := make([]event.Event, 0, 1)
+	var counts dbWriteCounts
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		updateQuery := tx.Model(&models.TaskRun{}).
 			Where("job_run_id = ? AND task_id = ?", runID, taskID)
@@ -1466,10 +1482,10 @@ func (s *Store) failTask(runID, taskID uuid.UUID, failure error, claimedBy strin
 		if enforceClaim && resultUpdate.RowsAffected == 0 {
 			return ErrTaskClaimMismatch
 		}
-		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+		counts.taskRunStatus++
 
 		if s.eventStore != nil {
-			evt, err := s.recordTaskEventTx(tx, event.TypeTaskFailed, runID, taskID)
+			evt, err := s.recordTaskEventTx(tx, event.TypeTaskFailed, runID, taskID, &counts)
 			if err != nil {
 				return err
 			}
@@ -1478,6 +1494,7 @@ func (s *Store) failTask(runID, taskID uuid.UUID, failure error, claimedBy strin
 		return nil
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return err
@@ -1495,6 +1512,7 @@ func (s *Store) RetryTaskClaimed(runID, taskID uuid.UUID, attempt int, claimedBy
 
 func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string, enforceClaim bool) error {
 	pendingEvents := make([]event.Event, 0, 2)
+	var counts dbWriteCounts
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		updateQuery := tx.Model(&models.TaskRun{}).
 			Where("job_run_id = ? AND task_id = ?", runID, taskID)
@@ -1525,10 +1543,10 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 		if enforceClaim && resultUpdate.RowsAffected == 0 {
 			return ErrTaskClaimMismatch
 		}
-		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+		counts.taskRunStatus++
 
 		if s.eventStore != nil {
-			evt, err := s.recordTaskEventTx(tx, event.TypeTaskRetrying, runID, taskID)
+			evt, err := s.recordTaskEventTx(tx, event.TypeTaskRetrying, runID, taskID, &counts)
 			if err != nil {
 				return err
 			}
@@ -1551,7 +1569,7 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 				if err := s.eventStore.AppendTx(tx, &readyEvt); err != nil {
 					return err
 				}
-				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
+				counts.eventInsert++
 				pendingEvents = append(pendingEvents, readyEvt)
 			}
 		}
@@ -1559,6 +1577,7 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 		return nil
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return err
@@ -1567,6 +1586,7 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 func (s *Store) SkipTask(runID, taskID uuid.UUID, reason string) error {
 	now := time.Now().UTC()
 	pendingEvents := make([]event.Event, 0, 1)
+	var counts dbWriteCounts
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.TaskRun{}).
 			Where("job_run_id = ? AND task_id = ? AND status = ?", runID, taskID, string(TaskStatusPending)).
@@ -1581,9 +1601,9 @@ func (s *Store) SkipTask(runID, taskID uuid.UUID, reason string) error {
 			}).Error; err != nil {
 			return err
 		}
-		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+		counts.taskRunStatus++
 		if s.eventStore != nil {
-			evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID)
+			evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID, &counts)
 			if err != nil {
 				return err
 			}
@@ -1592,6 +1612,7 @@ func (s *Store) SkipTask(runID, taskID uuid.UUID, reason string) error {
 		return nil
 	})
 	if err == nil {
+		counts.commit()
 		s.publishEvents(pendingEvents...)
 	}
 	return err
@@ -2002,7 +2023,7 @@ func convertCallbackRunModel(model *models.CallbackRun) *CallbackRun {
 	}
 }
 
-func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, taskID uuid.UUID) (*event.Event, error) {
+func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, taskID uuid.UUID, counts *dbWriteCounts) (*event.Event, error) {
 	var taskRun models.TaskRun
 	if err := db.Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&taskRun).Error; err != nil {
 		log.Error("failed to fetch task run for event", "error", err, "run_id", runID, "task_id", taskID)
@@ -2040,7 +2061,7 @@ func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, task
 		if err := s.eventStore.AppendTx(db, &evt); err != nil {
 			return nil, err
 		}
-		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
+		counts.eventInsert++
 	}
 	return &evt, nil
 }
@@ -2051,6 +2072,33 @@ func (s *Store) publishEvents(events ...event.Event) {
 
 func (s *Store) PublishEvents(events ...event.Event) {
 	s.publishEvents(events...)
+}
+
+// dbWriteCounts accumulates per-category DB write counts during a single retry
+// attempt. Must be reset() at the start of each retry closure and commit()'d
+// only after the retry returns nil; otherwise transactions retried due to
+// busy/locked errors will over-count.
+type dbWriteCounts struct {
+	taskRunInsert int
+	taskRunStatus int
+	eventInsert   int
+	callback      int
+	leaseRenewal  int
+}
+
+func (c *dbWriteCounts) reset() { *c = dbWriteCounts{} }
+
+func (c *dbWriteCounts) commit() {
+	add := func(category string, n int) {
+		if n > 0 {
+			metrics.DBWritesTotal.WithLabelValues(category).Add(float64(n))
+		}
+	}
+	add(metrics.DBWriteCategoryTaskRunInsert, c.taskRunInsert)
+	add(metrics.DBWriteCategoryTaskRunStatus, c.taskRunStatus)
+	add(metrics.DBWriteCategoryEventInsert, c.eventInsert)
+	add(metrics.DBWriteCategoryCallback, c.callback)
+	add(metrics.DBWriteCategoryLeaseRenewal, c.leaseRenewal)
 }
 
 func withStoreBusyRetry(fn func() error) error {
@@ -2227,6 +2275,7 @@ func (s *Store) PredecessorHashes(runID, taskID uuid.UUID) ([]string, error) {
 func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 	pendingEvents := make([]event.Event, 0, 2)
 	var jobID uuid.UUID
+	var counts dbWriteCounts
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
 		// 1. Verify the run exists and is in a terminal state (failed/succeeded).
@@ -2315,7 +2364,7 @@ func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 
 			// If all predecessors are already done, emit a task_ready event.
 			if outstanding == 0 {
-				if err := s.appendTaskReadyEventTx(tx, runID, taskID, &pendingEvents); err != nil {
+				if err := s.appendTaskReadyEventTx(tx, runID, taskID, &pendingEvents, &counts); err != nil {
 					return err
 				}
 			}
@@ -2350,6 +2399,7 @@ func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 		return nil, err
 	}
 
+	counts.commit()
 	s.publishEvents(pendingEvents...)
 
 	// Track this run in the active set so Complete() will decrement the gauge.

--- a/internal/run/store_metrics_test.go
+++ b/internal/run/store_metrics_test.go
@@ -40,6 +40,7 @@ func (s *StoreMetricsSuite) SetupTest() {
 	metrics.JobsActive.Reset()
 	metrics.CallbackRunsTotal.Reset()
 	metrics.TriggerFiresTotal.Reset()
+	metrics.DBWritesTotal.Reset()
 }
 
 func (s *StoreMetricsSuite) TearDownTest() {
@@ -217,6 +218,62 @@ func (s *StoreMetricsSuite) TestCompleteResumedRunDoesNotDecrementGauge() {
 	// Counter should still record the completion.
 	ctr := s.counterValue(metrics.JobRunsTotal, jobID.String(), "succeeded")
 	s.Equal(float64(1), ctr)
+}
+
+func (s *StoreMetricsSuite) TestDBWritesTotalIncrements() {
+	jobID := uuid.New()
+	run, err := s.store.Start(jobID, nil)
+	s.Require().NoError(err)
+
+	atomID := uuid.New()
+	taskID := uuid.New()
+	task := &models.Task{ID: taskID, JobID: jobID, AtomID: atomID}
+	atom := &models.Atom{ID: atomID, Engine: models.AtomEngineDocker, Image: "busybox:1.36.1"}
+	s.Require().NoError(s.db.Create(task).Error)
+	s.Require().NoError(s.db.Create(atom).Error)
+
+	// RegisterTasks: should produce task_run_insert = 1.
+	s.Require().NoError(s.store.RegisterTask(run.ID, task, atom, 0))
+	s.Equal(float64(1), s.dbWriteValue(metrics.DBWriteCategoryTaskRunInsert))
+
+	// StartTask: should produce task_run_status = 1.
+	s.Require().NoError(s.store.StartTask(run.ID, taskID, "container-1"))
+	s.Equal(float64(1), s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus))
+
+	// CompleteTask: should produce task_run_status += 1.
+	s.Require().NoError(s.store.CompleteTask(run.ID, taskID, "ok", nil, nil))
+	s.GreaterOrEqual(s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus), float64(2))
+
+	// event_insert should be non-zero from task_ready + task_started + task_succeeded events.
+	s.Greater(s.dbWriteValue(metrics.DBWriteCategoryEventInsert), float64(0))
+}
+
+func (s *StoreMetricsSuite) TestDBWritesTotalFailTask() {
+	jobID := uuid.New()
+	run, err := s.store.Start(jobID, nil)
+	s.Require().NoError(err)
+
+	atomID := uuid.New()
+	taskID := uuid.New()
+	task := &models.Task{ID: taskID, JobID: jobID, AtomID: atomID}
+	atom := &models.Atom{ID: atomID, Engine: models.AtomEngineDocker, Image: "busybox:1.36.1"}
+	s.Require().NoError(s.db.Create(task).Error)
+	s.Require().NoError(s.db.Create(atom).Error)
+	s.Require().NoError(s.store.RegisterTask(run.ID, task, atom, 0))
+	s.Require().NoError(s.store.StartTask(run.ID, taskID, "container-1"))
+
+	beforeStatus := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
+	s.Require().NoError(s.store.FailTask(run.ID, taskID, fmt.Errorf("crash")))
+	afterStatus := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
+	s.Equal(float64(1), afterStatus-beforeStatus, "FailTask should produce exactly one task_run_status write")
+}
+
+func (s *StoreMetricsSuite) dbWriteValue(category string) float64 {
+	var m dto.Metric
+	counter, err := metrics.DBWritesTotal.GetMetricWithLabelValues(category)
+	s.Require().NoError(err)
+	s.Require().NoError(counter.(prometheus.Metric).Write(&m))
+	return m.GetCounter().GetValue()
 }
 
 func (s *StoreMetricsSuite) counterValue(vec *prometheus.CounterVec, labels ...string) float64 {

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -106,6 +106,7 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 	}
 	if claimed != nil {
 		metrics.WorkerClaimsTotal.WithLabelValues(c.nodeID).Inc()
+		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 	}
 	c.store.PublishEvents(pendingEvents...)
 
@@ -194,6 +195,7 @@ func (c *Claimer) recordTaskClaimedEventTx(tx *gorm.DB, claimed *models.TaskRun,
 	if err := c.store.RecordEventTx(tx, &evt); err != nil {
 		return nil, err
 	}
+	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
 	return &evt, nil
 }
 
@@ -294,6 +296,9 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 			if result.Error != nil {
 				return result.Error
 			}
+			if result.RowsAffected > 0 {
+				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Add(float64(result.RowsAffected))
+			}
 
 			for _, taskRun := range expired {
 				var jobRun models.JobRun
@@ -310,6 +315,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				if err := c.store.RecordEventTx(tx, &leaseEvt); err != nil {
 					return err
 				}
+				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
 				attemptEvents = append(attemptEvents, leaseEvt)
 
 				readyEvt := event.Event{
@@ -322,6 +328,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				if err := c.store.RecordEventTx(tx, &readyEvt); err != nil {
 					return err
 				}
+				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
 				attemptEvents = append(attemptEvents, readyEvt)
 			}
 			attemptReclaimedCount = result.RowsAffected

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -20,6 +20,26 @@ import (
 
 const defaultLeaseTTL = 5 * time.Minute
 
+// dbWriteCounts accumulates per-category DB write counts during a single retry
+// attempt. Must be reset() at the start of each retry closure and commit()'d
+// only after the retry returns nil; otherwise transactions retried due to
+// busy/locked errors will over-count.
+type dbWriteCounts struct {
+	taskRunStatus int
+	eventInsert   int
+}
+
+func (c *dbWriteCounts) reset() { *c = dbWriteCounts{} }
+
+func (c *dbWriteCounts) commit() {
+	if c.taskRunStatus > 0 {
+		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Add(float64(c.taskRunStatus))
+	}
+	if c.eventInsert > 0 {
+		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Add(float64(c.eventInsert))
+	}
+}
+
 type Claimer struct {
 	nodeID            string
 	nodeLabels        map[string]string
@@ -74,6 +94,7 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 
 	var claimed *models.TaskRun
 	pendingEvents := make([]event.Event, 0, 1)
+	var counts dbWriteCounts
 
 	err := withBusyRetry(ctx, c.busyRetryBackoffs, func() error {
 		if err := ctx.Err(); err != nil {
@@ -83,10 +104,11 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 		now := time.Now().UTC()
 		leaseExpiry := now.Add(c.leaseTTL)
 		claimed = nil
+		counts.reset()
 		attemptEvents := make([]event.Event, 0, 1)
 
 		err := c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			claimedTask, evt, err := c.claimNextTx(tx, now, leaseExpiry)
+			claimedTask, evt, err := c.claimNextTx(tx, now, leaseExpiry, &counts)
 			if err != nil {
 				return err
 			}
@@ -107,13 +129,14 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 	if claimed != nil {
 		metrics.WorkerClaimsTotal.WithLabelValues(c.nodeID).Inc()
 		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+		counts.commit()
 	}
 	c.store.PublishEvents(pendingEvents...)
 
 	return claimed, nil
 }
 
-func (c *Claimer) claimNextTx(tx *gorm.DB, now, leaseExpiry time.Time) (*models.TaskRun, *event.Event, error) {
+func (c *Claimer) claimNextTx(tx *gorm.DB, now, leaseExpiry time.Time, counts *dbWriteCounts) (*models.TaskRun, *event.Event, error) {
 	claimed, jobID, err := c.claimNextSingleStatementTx(tx, now, leaseExpiry)
 	if err != nil {
 		return nil, nil, err
@@ -121,7 +144,7 @@ func (c *Claimer) claimNextTx(tx *gorm.DB, now, leaseExpiry time.Time) (*models.
 	if claimed == nil {
 		return nil, nil, nil
 	}
-	evt, err := c.recordTaskClaimedEventTx(tx, claimed, jobID)
+	evt, err := c.recordTaskClaimedEventTx(tx, claimed, jobID, counts)
 	return claimed, evt, err
 }
 
@@ -180,7 +203,7 @@ type claimedTaskRunRow struct {
 	ClaimJobID uuid.UUID `gorm:"column:claim_job_id"`
 }
 
-func (c *Claimer) recordTaskClaimedEventTx(tx *gorm.DB, claimed *models.TaskRun, jobID uuid.UUID) (*event.Event, error) {
+func (c *Claimer) recordTaskClaimedEventTx(tx *gorm.DB, claimed *models.TaskRun, jobID uuid.UUID, counts *dbWriteCounts) (*event.Event, error) {
 	if claimed == nil {
 		return nil, nil
 	}
@@ -195,7 +218,7 @@ func (c *Claimer) recordTaskClaimedEventTx(tx *gorm.DB, claimed *models.TaskRun,
 	if err := c.store.RecordEventTx(tx, &evt); err != nil {
 		return nil, err
 	}
-	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
+	counts.eventInsert++
 	return &evt, nil
 }
 
@@ -263,12 +286,14 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 
 	pendingEvents := make([]event.Event, 0, 8)
 	var reclaimedCount int64
+	var counts dbWriteCounts
 	err := withBusyRetry(ctx, c.busyRetryBackoffs, func() error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
 
 		now := time.Now().UTC()
+		counts.reset()
 		attemptEvents := make([]event.Event, 0, 8)
 		var attemptReclaimedCount int64
 
@@ -296,9 +321,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 			if result.Error != nil {
 				return result.Error
 			}
-			if result.RowsAffected > 0 {
-				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Add(float64(result.RowsAffected))
-			}
+			counts.taskRunStatus += int(result.RowsAffected)
 
 			for _, taskRun := range expired {
 				var jobRun models.JobRun
@@ -315,7 +338,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				if err := c.store.RecordEventTx(tx, &leaseEvt); err != nil {
 					return err
 				}
-				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
+				counts.eventInsert++
 				attemptEvents = append(attemptEvents, leaseEvt)
 
 				readyEvt := event.Event{
@@ -328,7 +351,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				if err := c.store.RecordEventTx(tx, &readyEvt); err != nil {
 					return err
 				}
-				metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Inc()
+				counts.eventInsert++
 				attemptEvents = append(attemptEvents, readyEvt)
 			}
 			attemptReclaimedCount = result.RowsAffected
@@ -341,6 +364,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 		return err
 	}, c.observeBusyRetry)
 	if err == nil {
+		counts.commit()
 		if reclaimedCount > 0 {
 			metrics.WorkerLeaseExpirationsTotal.WithLabelValues(c.nodeID).Add(float64(reclaimedCount))
 		}

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -547,9 +547,13 @@ func (e *runtimeExecutor) renewLease(taskRun *models.TaskRun) error {
 	}
 
 	nextExpiry := time.Now().UTC().Add(e.workerLeaseTTL)
-	return e.store.DB().Model(&models.TaskRun{}).
+	if err := e.store.DB().Model(&models.TaskRun{}).
 		Where("id = ? AND claimed_by = ?", taskRun.ID, taskRun.ClaimedBy).
-		Update("claim_expires_at", nextExpiry).Error
+		Update("claim_expires_at", nextExpiry).Error; err != nil {
+		return err
+	}
+	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryLeaseRenewal).Inc()
+	return nil
 }
 
 func leaseRenewInterval(leaseTTL time.Duration) time.Duration {

--- a/justfile
+++ b/justfile
@@ -337,6 +337,34 @@ k8s-distributed: build-release k8s-registry-up
 k8s-down:
     helm uninstall caesium
 
+# Run the Phase 0 load harness against a locally-running Caesium server.
+# Expects the server to already be up (just run) and reachable at CAESIUM_LOAD_SERVER.
+# Writes a JSON/markdown report to docs/load-baseline-YYYY-MM-DD.md by default.
+#
+# Key env vars (all have defaults):
+#   CAESIUM_LOAD_SERVER        — server URL (default: http://127.0.0.1:8080)
+#   CAESIUM_LOAD_JOBS          — number of synthetic jobs (default: 10)
+#   CAESIUM_LOAD_FAN_OUT       — DAG fan-out width per layer (default: 4)
+#   CAESIUM_LOAD_DEPTH         — DAG depth / number of layers (default: 3)
+#   CAESIUM_LOAD_TASK_DURATION — per-task sleep duration (default: 1s)
+#   CAESIUM_LOAD_CONCURRENCY   — runs triggered in parallel (default: 1)
+#   CAESIUM_MANUAL_TRIGGER_API_KEY — API key if auth is enabled
+#
+load-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    report_file="${CAESIUM_LOAD_OUTPUT:-docs/load-baseline-$(date +%Y-%m-%d).md}"
+    echo "Running load harness — report will be written to ${report_file}"
+    go run ./test/load/harness.go \
+        -server "${CAESIUM_LOAD_SERVER:-http://127.0.0.1:8080}" \
+        -jobs "${CAESIUM_LOAD_JOBS:-10}" \
+        -fan-out "${CAESIUM_LOAD_FAN_OUT:-4}" \
+        -depth "${CAESIUM_LOAD_DEPTH:-3}" \
+        -task-duration "${CAESIUM_LOAD_TASK_DURATION:-1s}" \
+        -concurrency "${CAESIUM_LOAD_CONCURRENCY:-1}" \
+        -api-key "${CAESIUM_MANUAL_TRIGGER_API_KEY:-}" \
+        -output "${report_file}"
+
 # Port-forward to the Caesium service (run in background or separate terminal)
 k8s-port-forward:
     @echo "Port-forwarding Caesium UI to http://localhost:{{ port }}..."

--- a/test/load/harness.go
+++ b/test/load/harness.go
@@ -100,8 +100,9 @@ type stepDef struct {
 // Final layer: one join task that depends on all layer depth-1 tasks.
 // All tasks sleep for taskDuration seconds and emit one caesium::output line.
 func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
-	// Use floating-point seconds so sub-second durations are honored; busybox
-	// sleep accepts decimal values. Floor at 1ms so we never emit "sleep 0".
+	// Use floating-point seconds so sub-second durations are honored;
+	// busybox:1.36.1 sleep accepts decimal values. Floor at 1ms so we never
+	// emit "sleep 0".
 	sleepSec := taskDuration.Seconds()
 	if sleepSec < 0.001 {
 		sleepSec = 0.001

--- a/test/load/harness.go
+++ b/test/load/harness.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"os"
 	"sort"
@@ -68,11 +67,11 @@ func defaultConfig() config {
 
 // jobDef is the minimal YAML-equivalent payload we send to the server.
 type jobDef struct {
-	APIVersion string      `json:"apiVersion"`
-	Kind       string      `json:"kind"`
-	Metadata   jobMeta     `json:"metadata"`
-	Trigger    triggerDef  `json:"trigger"`
-	Steps      []stepDef   `json:"steps"`
+	APIVersion string     `json:"apiVersion"`
+	Kind       string     `json:"kind"`
+	Metadata   jobMeta    `json:"metadata"`
+	Trigger    triggerDef `json:"trigger"`
+	Steps      []stepDef  `json:"steps"`
 }
 
 type jobMeta struct {
@@ -101,9 +100,11 @@ type stepDef struct {
 // Final layer: one join task that depends on all layer depth-1 tasks.
 // All tasks sleep for taskDuration seconds and emit one caesium::output line.
 func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
-	sleepSec := int(math.Ceil(taskDuration.Seconds()))
-	if sleepSec < 1 {
-		sleepSec = 1
+	// Use floating-point seconds so sub-second durations are honored; busybox
+	// sleep accepts decimal values. Floor at 1ms so we never emit "sleep 0".
+	sleepSec := taskDuration.Seconds()
+	if sleepSec < 0.001 {
+		sleepSec = 0.001
 	}
 
 	// Single-step fast path.
@@ -112,7 +113,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 			{
 				Name:    "task-root",
 				Image:   "busybox:1.36.1",
-				Command: []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
+				Command: []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
 			},
 		}
 	}
@@ -128,7 +129,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 	steps = append(steps, stepDef{
 		Name:    rootName,
 		Image:   "busybox:1.36.1",
-		Command: []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"step\":\"root\"}'", sleepSec)},
+		Command: []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"step\":\"root\"}'", sleepSec)},
 		Next:    rootNexts,
 	})
 
@@ -146,7 +147,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 			steps = append(steps, stepDef{
 				Name:      name,
 				Image:     "busybox:1.36.1",
-				Command:   []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
+				Command:   []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
 				DependsOn: dependsOn,
 				Next:      []string{nextName},
 			})
@@ -168,7 +169,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 		steps = append(steps, stepDef{
 			Name:      name,
 			Image:     "busybox:1.36.1",
-			Command:   []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
+			Command:   []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
 			DependsOn: dependsOn,
 			Next:      []string{"task-join"},
 		})
@@ -178,7 +179,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 	steps = append(steps, stepDef{
 		Name:      "task-join",
 		Image:     "busybox:1.36.1",
-		Command:   []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
+		Command:   []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
 		DependsOn: joinDeps,
 	})
 
@@ -256,28 +257,6 @@ func (c *client) applyJob(ctx context.Context, def jobDef) (string, error) {
 	return "", fmt.Errorf("job %s not found in apply response", def.Metadata.Alias)
 }
 
-// triggerHTTP fires a manual HTTP trigger for the given alias.
-func (c *client) triggerHTTP(ctx context.Context, route string) (string, error) {
-	resp, err := c.do(ctx, http.MethodPost, route, nil)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	raw, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode >= 300 {
-		return "", fmt.Errorf("trigger %s: HTTP %d: %s", route, resp.StatusCode, strings.TrimSpace(string(raw)))
-	}
-
-	var result struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(raw, &result); err != nil {
-		return "", fmt.Errorf("parse trigger response: %w", err)
-	}
-	return result.ID, nil
-}
-
 // getRunStatus returns the status of a job run.
 func (c *client) getRunStatus(ctx context.Context, runID string) (string, error) {
 	resp, err := c.do(ctx, http.MethodGet, "/v1/runs/"+runID, nil)
@@ -328,6 +307,11 @@ func parseCounter(text, metricName string, labels map[string]string) float64 {
 		if !strings.HasPrefix(line, metricName) {
 			continue
 		}
+		// Reject prefix-only matches (e.g., `caesium_db_writes_total_bucket`
+		// would otherwise match `caesium_db_writes_total`).
+		if rest := line[len(metricName):]; len(rest) > 0 && rest[0] != '{' && rest[0] != ' ' && rest[0] != '\t' {
+			continue
+		}
 
 		allMatch := true
 		for k, v := range labels {
@@ -355,16 +339,16 @@ func parseCounter(text, metricName string, labels map[string]string) float64 {
 }
 
 type metricSample struct {
-	ts              time.Time
-	taskRunInsert   float64
-	taskRunStatus   float64
-	eventInsert     float64
-	leaseRenewal    float64
-	callback        float64
-	command         float64
-	checkpoint      float64
-	dbBusyRetries   float64
-	claimsTotal     float64
+	ts            time.Time
+	taskRunInsert float64
+	taskRunStatus float64
+	eventInsert   float64
+	leaseRenewal  float64
+	callback      float64
+	command       float64
+	checkpoint    float64
+	dbBusyRetries float64
+	claimsTotal   float64
 }
 
 func sampleMetrics(ctx context.Context, c *client) (metricSample, error) {
@@ -390,12 +374,12 @@ func sampleMetrics(ctx context.Context, c *client) (metricSample, error) {
 // ---------------------------------------------------------------------------
 
 type runResult struct {
-	runID     string
-	alias     string
-	startedAt time.Time
+	runID      string
+	alias      string
+	startedAt  time.Time
 	finishedAt time.Time
-	status    string
-	err       error
+	status     string
+	err        error
 }
 
 // ---------------------------------------------------------------------------
@@ -496,11 +480,9 @@ func (h *harness) run(ctx context.Context) (*report, error) {
 	pending.Store(int64(h.cfg.jobCount))
 
 	sem := make(chan struct{}, h.cfg.concurrency)
-	errCh := make(chan error, h.cfg.jobCount)
 
-	for i, j := range jobs {
+	for _, j := range jobs {
 		j := j
-		_ = i
 		sem <- struct{}{}
 		go func() {
 			defer func() { <-sem }()
@@ -509,9 +491,6 @@ func (h *harness) run(ctx context.Context) (*report, error) {
 			results = append(results, rr)
 			resultsMu.Unlock()
 			pending.Add(-1)
-			if rr.err != nil {
-				errCh <- rr.err
-			}
 		}()
 	}
 
@@ -669,23 +648,23 @@ func (h *harness) triggerAndWait(ctx context.Context, alias, triggerPath string)
 // ---------------------------------------------------------------------------
 
 type report struct {
-	cfg           config
-	totalDuration time.Duration
-	runsSucceeded int
-	runsFailed    int
-	runsTimeout   int
+	cfg               config
+	totalDuration     time.Duration
+	runsSucceeded     int
+	runsFailed        int
+	runsTimeout       int
 	runsTriggerFailed int
 
 	// Delta counts (end - baseline).
-	deltaTaskRunInsert  float64
-	deltaTaskRunStatus  float64
-	deltaEventInsert    float64
-	deltaLeaseRenewal   float64
-	deltaCallback       float64
-	deltaCommand        float64
-	deltaCheckpoint     float64
-	deltaDBBusyRetries  float64
-	deltaClaimsTotal    float64
+	deltaTaskRunInsert float64
+	deltaTaskRunStatus float64
+	deltaEventInsert   float64
+	deltaLeaseRenewal  float64
+	deltaCallback      float64
+	deltaCommand       float64
+	deltaCheckpoint    float64
+	deltaDBBusyRetries float64
+	deltaClaimsTotal   float64
 
 	// Per-second rates during the run.
 	peakTaskRunStatusPerSec float64
@@ -693,10 +672,10 @@ type report struct {
 	peakLeaseRenewalPerSec  float64
 
 	// Task latency (approximated from run duration and task count).
-	totalTasks      int
-	taskDuration    time.Duration
-	endToEndP50     time.Duration
-	endToEndP99     time.Duration
+	totalTasks   int
+	taskDuration time.Duration
+	endToEndP50  time.Duration
+	endToEndP99  time.Duration
 
 	// Intermediate samples for rate computation.
 	samples []metricSample

--- a/test/load/harness.go
+++ b/test/load/harness.go
@@ -1,0 +1,957 @@
+// Package load provides a synthetic load harness for measuring Caesium's
+// per-shard write throughput and per-write-category distribution.
+//
+// The harness generates parameterized DAG workloads (fan-out width, depth,
+// task duration) against a running Caesium server, waits for completion, and
+// samples prometheus metrics throughout.
+//
+// Usage:
+//
+//	go run ./test/load [flags]
+//
+// The harness is not an integration test — it runs against an already-started
+// Caesium server reachable at CAESIUM_LOAD_SERVER (default http://127.0.0.1:8080).
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"text/tabwriter"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+type config struct {
+	serverURL    string
+	jobCount     int
+	fanOut       int
+	depth        int
+	taskDuration time.Duration
+	concurrency  int
+	sampleRate   time.Duration
+	outputFile   string
+	apiKey       string
+}
+
+func defaultConfig() config {
+	return config{
+		serverURL:    envOrDefault("CAESIUM_LOAD_SERVER", "http://127.0.0.1:8080"),
+		jobCount:     envIntOrDefault("CAESIUM_LOAD_JOBS", 10),
+		fanOut:       envIntOrDefault("CAESIUM_LOAD_FAN_OUT", 4),
+		depth:        envIntOrDefault("CAESIUM_LOAD_DEPTH", 3),
+		taskDuration: envDurOrDefault("CAESIUM_LOAD_TASK_DURATION", 1*time.Second),
+		concurrency:  envIntOrDefault("CAESIUM_LOAD_CONCURRENCY", 1),
+		sampleRate:   envDurOrDefault("CAESIUM_LOAD_SAMPLE_RATE", 5*time.Second),
+		outputFile:   envOrDefault("CAESIUM_LOAD_OUTPUT", ""),
+		apiKey:       envOrDefault("CAESIUM_MANUAL_TRIGGER_API_KEY", ""),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Job definition shapes
+// ---------------------------------------------------------------------------
+
+// jobDef is the minimal YAML-equivalent payload we send to the server.
+type jobDef struct {
+	APIVersion string      `json:"apiVersion"`
+	Kind       string      `json:"kind"`
+	Metadata   jobMeta     `json:"metadata"`
+	Trigger    triggerDef  `json:"trigger"`
+	Steps      []stepDef   `json:"steps"`
+}
+
+type jobMeta struct {
+	Alias string `json:"alias"`
+}
+
+type triggerDef struct {
+	HTTP *httpTrigger `json:"http,omitempty"`
+}
+
+type httpTrigger struct {
+	Route string `json:"route"`
+}
+
+type stepDef struct {
+	Name      string   `json:"name"`
+	Image     string   `json:"image"`
+	Command   []string `json:"command,omitempty"`
+	Next      []string `json:"next,omitempty"`
+	DependsOn []string `json:"dependsOn,omitempty"`
+}
+
+// buildDAGSteps builds a width×depth fan-out DAG.
+// Layer 0: one root task.
+// Layers 1..depth-1: fanOut tasks each.
+// Final layer: one join task that depends on all layer depth-1 tasks.
+// All tasks sleep for taskDuration seconds and emit one caesium::output line.
+func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
+	sleepSec := int(math.Ceil(taskDuration.Seconds()))
+	if sleepSec < 1 {
+		sleepSec = 1
+	}
+
+	// Single-step fast path.
+	if depth <= 1 || fanOut <= 1 {
+		return []stepDef{
+			{
+				Name:    "task-root",
+				Image:   "busybox:1.36.1",
+				Command: []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
+			},
+		}
+	}
+
+	var steps []stepDef
+
+	// Root task.
+	rootName := "task-root"
+	rootNexts := make([]string, 0, fanOut)
+	for w := 0; w < fanOut; w++ {
+		rootNexts = append(rootNexts, fmt.Sprintf("task-l1-w%d", w))
+	}
+	steps = append(steps, stepDef{
+		Name:    rootName,
+		Image:   "busybox:1.36.1",
+		Command: []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"step\":\"root\"}'", sleepSec)},
+		Next:    rootNexts,
+	})
+
+	// Middle layers.
+	for d := 1; d < depth-1; d++ {
+		for w := 0; w < fanOut; w++ {
+			name := fmt.Sprintf("task-l%d-w%d", d, w)
+			nextName := fmt.Sprintf("task-l%d-w%d", d+1, w)
+			var dependsOn []string
+			if d == 1 {
+				dependsOn = []string{rootName}
+			} else {
+				dependsOn = []string{fmt.Sprintf("task-l%d-w%d", d-1, w)}
+			}
+			steps = append(steps, stepDef{
+				Name:      name,
+				Image:     "busybox:1.36.1",
+				Command:   []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
+				DependsOn: dependsOn,
+				Next:      []string{nextName},
+			})
+		}
+	}
+
+	// Final fan-in layer: one task per width lane collapsing into join.
+	joinDeps := make([]string, 0, fanOut)
+	lastLayerIdx := depth - 1
+	for w := 0; w < fanOut; w++ {
+		name := fmt.Sprintf("task-l%d-w%d", lastLayerIdx, w)
+		joinDeps = append(joinDeps, name)
+		var dependsOn []string
+		if lastLayerIdx == 1 {
+			dependsOn = []string{rootName}
+		} else {
+			dependsOn = []string{fmt.Sprintf("task-l%d-w%d", lastLayerIdx-1, w)}
+		}
+		steps = append(steps, stepDef{
+			Name:      name,
+			Image:     "busybox:1.36.1",
+			Command:   []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
+			DependsOn: dependsOn,
+			Next:      []string{"task-join"},
+		})
+	}
+
+	// Join task.
+	steps = append(steps, stepDef{
+		Name:      "task-join",
+		Image:     "busybox:1.36.1",
+		Command:   []string{"sh", "-c", fmt.Sprintf("sleep %d && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
+		DependsOn: joinDeps,
+	})
+
+	return steps
+}
+
+// ---------------------------------------------------------------------------
+// Caesium REST client
+// ---------------------------------------------------------------------------
+
+type client struct {
+	base   string
+	apiKey string
+	http   *http.Client
+}
+
+func newClient(base, apiKey string) *client {
+	return &client{
+		base:   strings.TrimRight(base, "/"),
+		apiKey: apiKey,
+		http:   &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+func (c *client) do(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+	var r io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		r = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.base+path, r)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.apiKey != "" {
+		req.Header.Set("X-API-Key", c.apiKey)
+	}
+	return c.http.Do(req)
+}
+
+func (c *client) applyJob(ctx context.Context, def jobDef) (string, error) {
+	body := map[string][]jobDef{"jobs": {def}}
+	resp, err := c.do(ctx, http.MethodPost, "/v1/jobs/apply", body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("apply job %s: HTTP %d: %s", def.Metadata.Alias, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+
+	// Parse out the ID of the upserted job.
+	var result struct {
+		Jobs []struct {
+			ID    string `json:"id"`
+			Alias string `json:"alias"`
+		} `json:"jobs"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("parse apply response: %w", err)
+	}
+	for _, j := range result.Jobs {
+		if j.Alias == def.Metadata.Alias {
+			return j.ID, nil
+		}
+	}
+	return "", fmt.Errorf("job %s not found in apply response", def.Metadata.Alias)
+}
+
+// triggerHTTP fires a manual HTTP trigger for the given alias.
+func (c *client) triggerHTTP(ctx context.Context, route string) (string, error) {
+	resp, err := c.do(ctx, http.MethodPost, route, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("trigger %s: HTTP %d: %s", route, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+
+	var result struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("parse trigger response: %w", err)
+	}
+	return result.ID, nil
+}
+
+// getRunStatus returns the status of a job run.
+func (c *client) getRunStatus(ctx context.Context, runID string) (string, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/v1/runs/"+runID, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("get run %s: HTTP %d: %s", runID, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+
+	var result struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", fmt.Errorf("parse run status: %w", err)
+	}
+	return result.Status, nil
+}
+
+// fetchMetrics returns the raw Prometheus text from /metrics.
+func (c *client) fetchMetrics(ctx context.Context) (string, error) {
+	resp, err := c.do(ctx, http.MethodGet, "/metrics", nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	return string(raw), err
+}
+
+// ---------------------------------------------------------------------------
+// Metrics parsing
+// ---------------------------------------------------------------------------
+
+// parseCounter extracts a float64 counter value from Prometheus text output
+// for metrics matching the given name and labels. Labels is a map of key→value
+// pairs that must all be present in the metric line.
+func parseCounter(text, metricName string, labels map[string]string) float64 {
+	var total float64
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "#") || line == "" {
+			continue
+		}
+		if !strings.HasPrefix(line, metricName) {
+			continue
+		}
+
+		allMatch := true
+		for k, v := range labels {
+			needle := fmt.Sprintf(`%s="%s"`, k, v)
+			if !strings.Contains(line, needle) {
+				allMatch = false
+				break
+			}
+		}
+		if !allMatch {
+			continue
+		}
+
+		// Value is the last token after the label set.
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		var val float64
+		if _, err := fmt.Sscanf(parts[len(parts)-1], "%f", &val); err == nil {
+			total += val
+		}
+	}
+	return total
+}
+
+type metricSample struct {
+	ts              time.Time
+	taskRunInsert   float64
+	taskRunStatus   float64
+	eventInsert     float64
+	leaseRenewal    float64
+	callback        float64
+	command         float64
+	checkpoint      float64
+	dbBusyRetries   float64
+	claimsTotal     float64
+}
+
+func sampleMetrics(ctx context.Context, c *client) (metricSample, error) {
+	text, err := c.fetchMetrics(ctx)
+	if err != nil {
+		return metricSample{}, err
+	}
+	s := metricSample{ts: time.Now()}
+	s.taskRunInsert = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "task_run_insert"})
+	s.taskRunStatus = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "task_run_status"})
+	s.eventInsert = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "event_insert"})
+	s.leaseRenewal = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "lease_renewal"})
+	s.callback = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "callback"})
+	s.command = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "command"})
+	s.checkpoint = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "checkpoint"})
+	s.dbBusyRetries = parseCounter(text, "caesium_db_busy_retries_total", nil)
+	s.claimsTotal = parseCounter(text, "caesium_worker_claims_total", nil)
+	return s, nil
+}
+
+// ---------------------------------------------------------------------------
+// Run result
+// ---------------------------------------------------------------------------
+
+type runResult struct {
+	runID     string
+	alias     string
+	startedAt time.Time
+	finishedAt time.Time
+	status    string
+	err       error
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+type harness struct {
+	cfg    config
+	client *client
+}
+
+func newHarness(cfg config) *harness {
+	return &harness{
+		cfg:    cfg,
+		client: newClient(cfg.serverURL, cfg.apiKey),
+	}
+}
+
+// waitForServer blocks until the server returns 200 on /health or ctx expires.
+func (h *harness) waitForServer(ctx context.Context) error {
+	tick := time.NewTicker(500 * time.Millisecond)
+	defer tick.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-tick.C:
+			resp, err := h.client.do(ctx, http.MethodGet, "/health", nil)
+			if err == nil && resp.StatusCode == http.StatusOK {
+				resp.Body.Close()
+				return nil
+			}
+			if resp != nil {
+				resp.Body.Close()
+			}
+		}
+	}
+}
+
+// applyJobs registers all synthetic DAG jobs on the server and returns a
+// slice of (alias, route) pairs for triggering.
+func (h *harness) applyJobs(ctx context.Context) ([]struct{ alias, route string }, error) {
+	cfg := h.cfg
+	steps := buildDAGSteps(cfg.fanOut, cfg.depth, cfg.taskDuration)
+
+	results := make([]struct{ alias, route string }, 0, cfg.jobCount)
+	for i := 0; i < cfg.jobCount; i++ {
+		alias := fmt.Sprintf("load-test-job-%d", i)
+		route := fmt.Sprintf("/load/%s", alias)
+		def := jobDef{
+			APIVersion: "v1",
+			Kind:       "Job",
+			Metadata:   jobMeta{Alias: alias},
+			Trigger:    triggerDef{HTTP: &httpTrigger{Route: route}},
+			Steps:      steps,
+		}
+		if _, err := h.client.applyJob(ctx, def); err != nil {
+			return nil, fmt.Errorf("apply job %d: %w", i, err)
+		}
+		results = append(results, struct{ alias, route string }{alias, "/v1/jobs/" + alias + "/trigger"})
+	}
+	return results, nil
+}
+
+// run executes the full load harness and returns a report.
+func (h *harness) run(ctx context.Context) (*report, error) {
+	fmt.Println("Waiting for server to be ready...")
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	if err := h.waitForServer(waitCtx); err != nil {
+		cancel()
+		return nil, fmt.Errorf("server not reachable: %w", err)
+	}
+	cancel()
+	fmt.Printf("Server ready at %s\n", h.cfg.serverURL)
+
+	fmt.Printf("Applying %d synthetic jobs (fan-out=%d, depth=%d, task-duration=%s)...\n",
+		h.cfg.jobCount, h.cfg.fanOut, h.cfg.depth, h.cfg.taskDuration)
+	jobs, err := h.applyJobs(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("apply jobs: %w", err)
+	}
+	fmt.Printf("Applied %d jobs.\n", len(jobs))
+
+	// Sample baseline metrics.
+	baselineSample, err := sampleMetrics(ctx, h.client)
+	if err != nil {
+		return nil, fmt.Errorf("baseline metrics sample: %w", err)
+	}
+
+	startTime := time.Now()
+	fmt.Printf("Triggering %d runs (concurrency=%d)...\n", h.cfg.jobCount, h.cfg.concurrency)
+
+	var (
+		resultsMu sync.Mutex
+		results   []runResult
+		pending   atomic.Int64
+	)
+	pending.Store(int64(h.cfg.jobCount))
+
+	sem := make(chan struct{}, h.cfg.concurrency)
+	errCh := make(chan error, h.cfg.jobCount)
+
+	for i, j := range jobs {
+		j := j
+		_ = i
+		sem <- struct{}{}
+		go func() {
+			defer func() { <-sem }()
+			rr := h.triggerAndWait(ctx, j.alias, j.route)
+			resultsMu.Lock()
+			results = append(results, rr)
+			resultsMu.Unlock()
+			pending.Add(-1)
+			if rr.err != nil {
+				errCh <- rr.err
+			}
+		}()
+	}
+
+	// Periodic metric sampling.
+	var samples []metricSample
+	ticker := time.NewTicker(h.cfg.sampleRate)
+	defer ticker.Stop()
+
+	for pending.Load() > 0 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-ticker.C:
+			s, err := sampleMetrics(ctx, h.client)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warn: metrics sample failed: %v\n", err)
+				continue
+			}
+			samples = append(samples, s)
+			remaining := pending.Load()
+			fmt.Printf("  [%s] %d runs remaining...\n", time.Since(startTime).Round(time.Second), remaining)
+		}
+	}
+
+	// Drain sem.
+	for i := 0; i < h.cfg.concurrency; i++ {
+		sem <- struct{}{}
+	}
+
+	endSample, err := sampleMetrics(ctx, h.client)
+	if err != nil {
+		return nil, fmt.Errorf("final metrics sample: %w", err)
+	}
+
+	totalDuration := time.Since(startTime)
+
+	return buildReport(h.cfg, results, baselineSample, endSample, samples, totalDuration), nil
+}
+
+// triggerAndWait fires a job run via its HTTP trigger and polls until terminal.
+func (h *harness) triggerAndWait(ctx context.Context, alias, triggerPath string) runResult {
+	rr := runResult{alias: alias, startedAt: time.Now()}
+
+	// Try HTTP trigger first; fall back to POST /v1/jobs/:alias/run.
+	var runID string
+	var err error
+
+	triggerResp, trigErr := h.client.do(ctx, http.MethodPost, triggerPath, nil)
+	if trigErr == nil && triggerResp.StatusCode < 300 {
+		raw, _ := io.ReadAll(triggerResp.Body)
+		triggerResp.Body.Close()
+		var result struct {
+			ID string `json:"id"`
+		}
+		if jErr := json.Unmarshal(raw, &result); jErr == nil && result.ID != "" {
+			runID = result.ID
+		}
+	} else if triggerResp != nil {
+		triggerResp.Body.Close()
+	}
+
+	if runID == "" {
+		// Fallback: POST /v1/jobs/:alias/run using alias lookup.
+		// First look up the job to get its ID.
+		jobResp, lookupErr := h.client.do(ctx, http.MethodGet, "/v1/jobs?alias="+alias, nil)
+		if lookupErr == nil && jobResp.StatusCode < 300 {
+			raw, _ := io.ReadAll(jobResp.Body)
+			jobResp.Body.Close()
+			var jobList struct {
+				Jobs []struct {
+					ID string `json:"id"`
+				} `json:"jobs"`
+			}
+			if jErr := json.Unmarshal(raw, &jobList); jErr == nil && len(jobList.Jobs) > 0 {
+				jobID := jobList.Jobs[0].ID
+				runResp, runErr := h.client.do(ctx, http.MethodPost, "/v1/jobs/"+jobID+"/run", nil)
+				if runErr == nil && runResp.StatusCode < 300 {
+					raw, _ := io.ReadAll(runResp.Body)
+					runResp.Body.Close()
+					var runResult struct {
+						ID string `json:"id"`
+					}
+					if jErr := json.Unmarshal(raw, &runResult); jErr == nil {
+						runID = runResult.ID
+					}
+				} else if runResp != nil {
+					runResp.Body.Close()
+					err = fmt.Errorf("fallback trigger %s: HTTP %d", alias, runResp.StatusCode)
+				}
+			}
+			if jobResp != nil {
+				jobResp.Body.Close()
+			}
+		} else {
+			if jobResp != nil {
+				jobResp.Body.Close()
+			}
+		}
+	}
+
+	if runID == "" {
+		if err == nil {
+			if trigErr != nil {
+				err = fmt.Errorf("trigger %s: %w", alias, trigErr)
+			} else {
+				err = fmt.Errorf("trigger %s: could not obtain run ID", alias)
+			}
+		}
+		rr.err = err
+		rr.finishedAt = time.Now()
+		rr.status = "trigger_failed"
+		return rr
+	}
+
+	rr.runID = runID
+
+	// Poll until terminal.
+	const pollInterval = 2 * time.Second
+	const maxWait = 30 * time.Minute
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			rr.err = ctx.Err()
+			rr.finishedAt = time.Now()
+			rr.status = "canceled"
+			return rr
+		case <-time.After(pollInterval):
+		}
+
+		status, pollErr := h.client.getRunStatus(ctx, runID)
+		if pollErr != nil {
+			// Transient; keep polling.
+			continue
+		}
+		switch status {
+		case "succeeded", "failed":
+			rr.status = status
+			rr.finishedAt = time.Now()
+			if status == "failed" {
+				rr.err = errors.New("run ended with status: failed")
+			}
+			return rr
+		}
+	}
+
+	rr.err = fmt.Errorf("run %s timed out after %s", runID, maxWait)
+	rr.finishedAt = time.Now()
+	rr.status = "timeout"
+	return rr
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+type report struct {
+	cfg           config
+	totalDuration time.Duration
+	runsSucceeded int
+	runsFailed    int
+	runsTimeout   int
+	runsTriggerFailed int
+
+	// Delta counts (end - baseline).
+	deltaTaskRunInsert  float64
+	deltaTaskRunStatus  float64
+	deltaEventInsert    float64
+	deltaLeaseRenewal   float64
+	deltaCallback       float64
+	deltaCommand        float64
+	deltaCheckpoint     float64
+	deltaDBBusyRetries  float64
+	deltaClaimsTotal    float64
+
+	// Per-second rates during the run.
+	peakTaskRunStatusPerSec float64
+	peakEventInsertPerSec   float64
+	peakLeaseRenewalPerSec  float64
+
+	// Task latency (approximated from run duration and task count).
+	totalTasks      int
+	taskDuration    time.Duration
+	endToEndP50     time.Duration
+	endToEndP99     time.Duration
+
+	// Intermediate samples for rate computation.
+	samples []metricSample
+}
+
+func buildReport(
+	cfg config,
+	results []runResult,
+	baseline, end metricSample,
+	samples []metricSample,
+	totalDuration time.Duration,
+) *report {
+	r := &report{
+		cfg:           cfg,
+		totalDuration: totalDuration,
+		samples:       samples,
+	}
+
+	// Tally run statuses and end-to-end durations.
+	durations := make([]time.Duration, 0, len(results))
+	for _, rr := range results {
+		switch rr.status {
+		case "succeeded":
+			r.runsSucceeded++
+		case "failed":
+			r.runsFailed++
+		case "timeout":
+			r.runsTimeout++
+		default:
+			r.runsTriggerFailed++
+		}
+		if !rr.finishedAt.IsZero() && !rr.startedAt.IsZero() {
+			durations = append(durations, rr.finishedAt.Sub(rr.startedAt))
+		}
+	}
+
+	// End-to-end latency percentiles.
+	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
+	if len(durations) > 0 {
+		r.endToEndP50 = durations[len(durations)/2]
+		r.endToEndP99 = durations[int(float64(len(durations))*0.99)]
+	}
+
+	// Delta counters.
+	r.deltaTaskRunInsert = end.taskRunInsert - baseline.taskRunInsert
+	r.deltaTaskRunStatus = end.taskRunStatus - baseline.taskRunStatus
+	r.deltaEventInsert = end.eventInsert - baseline.eventInsert
+	r.deltaLeaseRenewal = end.leaseRenewal - baseline.leaseRenewal
+	r.deltaCallback = end.callback - baseline.callback
+	r.deltaCommand = end.command - baseline.command
+	r.deltaCheckpoint = end.checkpoint - baseline.checkpoint
+	r.deltaDBBusyRetries = end.dbBusyRetries - baseline.dbBusyRetries
+	r.deltaClaimsTotal = end.claimsTotal - baseline.claimsTotal
+
+	// Estimate total tasks: 1 root + fanOut*(depth-1) lanes + 1 join per run.
+	tasksPerRun := 1 + cfg.fanOut*(cfg.depth-1) + 1
+	if cfg.fanOut <= 1 || cfg.depth <= 1 {
+		tasksPerRun = 1
+	}
+	r.totalTasks = cfg.jobCount * tasksPerRun
+	r.taskDuration = cfg.taskDuration
+
+	// Peak per-second rates from adjacent samples.
+	for i := 1; i < len(samples); i++ {
+		dt := samples[i].ts.Sub(samples[i-1].ts).Seconds()
+		if dt <= 0 {
+			continue
+		}
+		if rate := (samples[i].taskRunStatus - samples[i-1].taskRunStatus) / dt; rate > r.peakTaskRunStatusPerSec {
+			r.peakTaskRunStatusPerSec = rate
+		}
+		if rate := (samples[i].eventInsert - samples[i-1].eventInsert) / dt; rate > r.peakEventInsertPerSec {
+			r.peakEventInsertPerSec = rate
+		}
+		if rate := (samples[i].leaseRenewal - samples[i-1].leaseRenewal) / dt; rate > r.peakLeaseRenewalPerSec {
+			r.peakLeaseRenewalPerSec = rate
+		}
+	}
+
+	return r
+}
+
+func (r *report) dominantCategory() (string, float64) {
+	categories := map[string]float64{
+		"task_run_insert": r.deltaTaskRunInsert,
+		"task_run_status": r.deltaTaskRunStatus,
+		"event_insert":    r.deltaEventInsert,
+		"lease_renewal":   r.deltaLeaseRenewal,
+		"callback":        r.deltaCallback,
+		"command":         r.deltaCommand,
+		"checkpoint":      r.deltaCheckpoint,
+	}
+	var topCat string
+	var topVal float64
+	for cat, val := range categories {
+		if val > topVal {
+			topVal = val
+			topCat = cat
+		}
+	}
+	return topCat, topVal
+}
+
+func (r *report) totalWrites() float64 {
+	return r.deltaTaskRunInsert + r.deltaTaskRunStatus + r.deltaEventInsert +
+		r.deltaLeaseRenewal + r.deltaCallback + r.deltaCommand + r.deltaCheckpoint
+}
+
+func (r *report) print(w io.Writer) {
+	domCat, domVal := r.dominantCategory()
+	total := r.totalWrites()
+
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "=== Caesium Load Harness — Baseline Report ===")
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "Server:              %s\n", r.cfg.serverURL)
+	fmt.Fprintf(w, "Jobs:                %d\n", r.cfg.jobCount)
+	fmt.Fprintf(w, "Fan-out width:       %d\n", r.cfg.fanOut)
+	fmt.Fprintf(w, "DAG depth:           %d\n", r.cfg.depth)
+	fmt.Fprintf(w, "Task duration:       %s\n", r.cfg.taskDuration)
+	fmt.Fprintf(w, "Concurrency:         %d\n", r.cfg.concurrency)
+	fmt.Fprintf(w, "Total run time:      %s\n", r.totalDuration.Round(time.Second))
+	fmt.Fprintf(w, "Tasks estimated:     %d\n", r.totalTasks)
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "Runs succeeded:      %d\n", r.runsSucceeded)
+	fmt.Fprintf(w, "Runs failed:         %d\n", r.runsFailed)
+	fmt.Fprintf(w, "Runs timeout:        %d\n", r.runsTimeout)
+	fmt.Fprintf(w, "Runs trigger-failed: %d\n", r.runsTriggerFailed)
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "--- DB Write Breakdown (delta over harness run) ---")
+	fmt.Fprintln(w, "")
+	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
+	fmt.Fprintf(tw, "Category\tCount\tShare\n")
+	fmt.Fprintf(tw, "--------\t-----\t-----\n")
+	cats := []struct {
+		name string
+		val  float64
+	}{
+		{"task_run_insert", r.deltaTaskRunInsert},
+		{"task_run_status", r.deltaTaskRunStatus},
+		{"event_insert", r.deltaEventInsert},
+		{"lease_renewal", r.deltaLeaseRenewal},
+		{"callback", r.deltaCallback},
+		{"command", r.deltaCommand},
+		{"checkpoint", r.deltaCheckpoint},
+	}
+	for _, c := range cats {
+		pct := 0.0
+		if total > 0 {
+			pct = c.val / total * 100
+		}
+		fmt.Fprintf(tw, "%s\t%.0f\t%.1f%%\n", c.name, c.val, pct)
+	}
+	fmt.Fprintf(tw, "TOTAL\t%.0f\t100%%\n", total)
+	tw.Flush()
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "Dominant category:   %s (%.0f writes, %.1f%% of total)\n",
+		domCat, domVal, func() float64 {
+			if total > 0 {
+				return domVal / total * 100
+			}
+			return 0
+		}())
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "--- Peak Write Rates (per second) ---")
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "task_run_status/s:   %.1f\n", r.peakTaskRunStatusPerSec)
+	fmt.Fprintf(w, "event_insert/s:      %.1f\n", r.peakEventInsertPerSec)
+	fmt.Fprintf(w, "lease_renewal/s:     %.1f\n", r.peakLeaseRenewalPerSec)
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "--- Latency ---")
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "End-to-end p50:      %s\n", r.endToEndP50.Round(time.Second))
+	fmt.Fprintf(w, "End-to-end p99:      %s\n", r.endToEndP99.Round(time.Second))
+	fmt.Fprintln(w, "")
+	fmt.Fprintln(w, "--- Contention ---")
+	fmt.Fprintln(w, "")
+	fmt.Fprintf(w, "DB busy retries:     %.0f\n", r.deltaDBBusyRetries)
+	fmt.Fprintf(w, "Claims total:        %.0f\n", r.deltaClaimsTotal)
+	if r.deltaClaimsTotal > 0 {
+		fmt.Fprintf(w, "Writes per claim:    %.2f\n", total/r.deltaClaimsTotal)
+	}
+	fmt.Fprintln(w, "")
+}
+
+func (r *report) markdown() string {
+	var b strings.Builder
+	r.print(&b)
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+func main() {
+	cfg := defaultConfig()
+
+	flag.StringVar(&cfg.serverURL, "server", cfg.serverURL, "Caesium server URL")
+	flag.IntVar(&cfg.jobCount, "jobs", cfg.jobCount, "Number of synthetic jobs to create and run")
+	flag.IntVar(&cfg.fanOut, "fan-out", cfg.fanOut, "DAG fan-out width")
+	flag.IntVar(&cfg.depth, "depth", cfg.depth, "DAG depth (layers)")
+	flag.DurationVar(&cfg.taskDuration, "task-duration", cfg.taskDuration, "How long each task sleeps (container execution time)")
+	flag.IntVar(&cfg.concurrency, "concurrency", cfg.concurrency, "How many runs to trigger concurrently")
+	flag.DurationVar(&cfg.sampleRate, "sample-rate", cfg.sampleRate, "How often to sample Prometheus metrics")
+	flag.StringVar(&cfg.outputFile, "output", cfg.outputFile, "Write report to file (default: stdout only)")
+	flag.StringVar(&cfg.apiKey, "api-key", cfg.apiKey, "API key for authenticated endpoints")
+	flag.Parse()
+
+	h := newHarness(cfg)
+	ctx := context.Background()
+	rep, err := h.run(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load harness failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	rep.print(os.Stdout)
+
+	if cfg.outputFile != "" {
+		content := rep.markdown()
+		if err := os.WriteFile(cfg.outputFile, []byte(content), 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write output file: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Report written to %s\n", cfg.outputFile)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func envOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envIntOrDefault(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		var n int
+		if _, err := fmt.Sscanf(v, "%d", &n); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func envDurOrDefault(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}

--- a/test/load/harness.go
+++ b/test/load/harness.go
@@ -536,60 +536,14 @@ func (h *harness) triggerAndWait(ctx context.Context, alias, triggerPath string)
 	rr := runResult{alias: alias, startedAt: time.Now()}
 
 	// Try HTTP trigger first; fall back to POST /v1/jobs/:alias/run.
-	var runID string
-	var err error
-
-	triggerResp, trigErr := h.client.do(ctx, http.MethodPost, triggerPath, nil)
-	if trigErr == nil && triggerResp.StatusCode < 300 {
-		raw, _ := io.ReadAll(triggerResp.Body)
-		triggerResp.Body.Close()
-		var result struct {
-			ID string `json:"id"`
-		}
-		if jErr := json.Unmarshal(raw, &result); jErr == nil && result.ID != "" {
-			runID = result.ID
-		}
-	} else if triggerResp != nil {
-		triggerResp.Body.Close()
-	}
-
+	var (
+		runID   string
+		err     error
+		trigErr error
+	)
+	runID, trigErr = h.tryHTTPTrigger(ctx, triggerPath)
 	if runID == "" {
-		// Fallback: POST /v1/jobs/:alias/run using alias lookup.
-		// First look up the job to get its ID.
-		jobResp, lookupErr := h.client.do(ctx, http.MethodGet, "/v1/jobs?alias="+alias, nil)
-		if lookupErr == nil && jobResp.StatusCode < 300 {
-			raw, _ := io.ReadAll(jobResp.Body)
-			jobResp.Body.Close()
-			var jobList struct {
-				Jobs []struct {
-					ID string `json:"id"`
-				} `json:"jobs"`
-			}
-			if jErr := json.Unmarshal(raw, &jobList); jErr == nil && len(jobList.Jobs) > 0 {
-				jobID := jobList.Jobs[0].ID
-				runResp, runErr := h.client.do(ctx, http.MethodPost, "/v1/jobs/"+jobID+"/run", nil)
-				if runErr == nil && runResp.StatusCode < 300 {
-					raw, _ := io.ReadAll(runResp.Body)
-					runResp.Body.Close()
-					var runResult struct {
-						ID string `json:"id"`
-					}
-					if jErr := json.Unmarshal(raw, &runResult); jErr == nil {
-						runID = runResult.ID
-					}
-				} else if runResp != nil {
-					runResp.Body.Close()
-					err = fmt.Errorf("fallback trigger %s: HTTP %d", alias, runResp.StatusCode)
-				}
-			}
-			if jobResp != nil {
-				jobResp.Body.Close()
-			}
-		} else {
-			if jobResp != nil {
-				jobResp.Body.Close()
-			}
-		}
+		runID, err = h.tryFallbackRun(ctx, alias)
 	}
 
 	if runID == "" {
@@ -642,6 +596,78 @@ func (h *harness) triggerAndWait(ctx context.Context, alias, triggerPath string)
 	rr.finishedAt = time.Now()
 	rr.status = "timeout"
 	return rr
+}
+
+// tryHTTPTrigger POSTs to the configured trigger path. Returns the runID on
+// success, or ("", err) on transport or HTTP error. Non-2xx responses are
+// reported as an error so callers can decide whether to fall through to the
+// jobs/:id/run fallback path.
+func (h *harness) tryHTTPTrigger(ctx context.Context, triggerPath string) (string, error) {
+	resp, err := h.client.do(ctx, http.MethodPost, triggerPath, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("trigger %s: HTTP %d", triggerPath, resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	var result struct {
+		ID string `json:"id"`
+	}
+	if jErr := json.Unmarshal(raw, &result); jErr != nil {
+		return "", jErr
+	}
+	return result.ID, nil
+}
+
+// tryFallbackRun resolves alias → job ID, then POSTs /v1/jobs/:id/run.
+func (h *harness) tryFallbackRun(ctx context.Context, alias string) (string, error) {
+	jobID, err := h.resolveJobID(ctx, alias)
+	if err != nil {
+		return "", err
+	}
+	resp, err := h.client.do(ctx, http.MethodPost, "/v1/jobs/"+jobID+"/run", nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("fallback trigger %s: HTTP %d", alias, resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	var result struct {
+		ID string `json:"id"`
+	}
+	if jErr := json.Unmarshal(raw, &result); jErr != nil {
+		return "", jErr
+	}
+	return result.ID, nil
+}
+
+// resolveJobID looks up a job by alias via /v1/jobs?alias=.
+func (h *harness) resolveJobID(ctx context.Context, alias string) (string, error) {
+	resp, err := h.client.do(ctx, http.MethodGet, "/v1/jobs?alias="+alias, nil)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		return "", fmt.Errorf("lookup %s: HTTP %d", alias, resp.StatusCode)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	var jobList struct {
+		Jobs []struct {
+			ID string `json:"id"`
+		} `json:"jobs"`
+	}
+	if jErr := json.Unmarshal(raw, &jobList); jErr != nil {
+		return "", jErr
+	}
+	if len(jobList.Jobs) == 0 {
+		return "", fmt.Errorf("lookup %s: no job found", alias)
+	}
+	return jobList.Jobs[0].ID, nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements Phase 0 of the scaling-job-execution design (PR #163) — a measurement-driven foundation for the subsequent write-reduction PRs.

- Adds `test/load/harness.go`, a synthetic-DAG load generator (fan-out width, depth, task duration, concurrent runs).
- Adds `caesium_db_writes_total{category}` Prometheus counter in `internal/metrics/metrics.go` with 7 category constants: `task_run_insert`, `task_run_status`, `event_insert`, `lease_renewal`, `callback`, `command`, `checkpoint`.
- Wires 24 counter increment sites across `internal/run/store.go`, `internal/worker/claimer.go`, `internal/worker/runtime_executor.go`, and `internal/callback/callback.go`. **Read-only observation — no logic changes.**
- Adds `just load-test` recipe.
- Adds baseline measurement report at `docs/load-baseline-2026-05-23.md`.

## What this enables

The Phase 0 → Phase 1 gate in the design doc: re-run the harness after each Phase 1 PR to confirm the per-shard write ceiling has moved as predicted, and to decide whether Phase 2 (run-owner) is needed.

The `command` and `checkpoint` categories are pre-registered but not yet wired (those tables don't exist until Phase 2).

## Limitations

The baseline numbers in the report are **analytical, not empirical** — the agent that produced them couldn't run the harness in its sandbox (no CGO/dqlite, no Docker daemon). The analytical breakdown is grounded in code reading:

- `event_insert` predicted to dominate (~38% at fan-out=4, depth=3)
- `task_run_status` close second (~35%)
- `lease_renewal` ~20% (Phase 1.2 target)

The expectation is that someone will run `just load-test` against a real cluster to validate before Phase 1 sequencing decisions are made.

## Test plan

- [ ] Run `just unit-test` and confirm pass (the agent verified inside the container build but recommends local re-run).
- [ ] Run `just load-test` against a local cluster to produce empirical baseline numbers; update `docs/load-baseline-2026-05-23.md` if reality differs from the analytical prediction.
- [ ] Spot-check counter wiring: trace one task lifecycle and confirm the expected categories increment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)