### PR TITLE
Add caesium_db_statements_total to quantify batching effectiveness

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ These files are useful context, but each should be treated according to its stat
 - [design-scaling-job-execution.md](design-scaling-job-execution.md)
 - [brainstorm-differentiators.md](brainstorm-differentiators.md)
 - [load-baseline-2026-05-23.md](load-baseline-2026-05-23.md): Phase 0 load harness baseline measurement output.
+- [load-baseline-distributed-2026-05-24.md](load-baseline-distributed-2026-05-24.md): First distributed-mode (3-node k8s) baseline; validates the Phase 2 gate.
 
 ## Historical Notes
 

--- a/docs/load-baseline-distributed-2026-05-24.md
+++ b/docs/load-baseline-distributed-2026-05-24.md
@@ -1,0 +1,107 @@
+# Caesium Load Baseline — Distributed Multi-Node (2026-05-24)
+
+> Distributed-mode counterpart to [load-baseline-2026-05-23.md](load-baseline-2026-05-23.md).
+> First real numbers from a 3-node dqlite Raft cluster after all Phase 1 work
+> (#165, #167) and PR #169's statement counter merged. Captures the
+> contention regime the design's Phase 2 (run-owner) is meant to address.
+
+## Environment
+
+| Parameter | Value |
+|---|---|
+| Date | 2026-05-24 |
+| Caesium commit | tip of `add-db-statements-counter` (one ahead of master with the statement counter) |
+| Deployment | `just k8s-distributed` — 3-pod StatefulSet, Helm chart, `replicaCount=3`, `CAESIUM_EXECUTION_MODE=distributed`, kubernetes engine enabled |
+| Cluster | Docker Desktop Kubernetes (single physical node, 3 pods → 3 dqlite voters) |
+| Storage | `persistence.enabled=false` → ephemeral pod storage; no NVMe |
+| `CAESIUM_DATABASE_SHARDS` | 1 (sharding router from PR #157 present but not enabled) |
+| Engine | `kubernetes` — tasks run as Job pods in the same cluster |
+
+## Methodology
+
+Harness driven via `just load-test` with `CAESIUM_LOAD_ENGINE=kubernetes`. Two workload shapes, same shapes used in the single-node baseline (PR #166 / #168) for direct comparison.
+
+The pod logs visibly showed `database is locked` errors on INSERT during the smoke test — exactly the symptom the locking-fix plan was built to address. The retry machinery (PR #154 / #155) absorbed them, but the contention shows up in `caesium_db_busy_retries_total`.
+
+## Workload A — Moderate (25 tasks)
+
+`5 jobs × fan-out=3 × depth=2 → 5 tasks/run × 5 = 25 task lifecycles, 2s tasks, 3 concurrent runs`
+
+| Category | Rows | Stmts | Rows/Stmt | Share |
+|---|---|---|---|---|
+| `task_run_insert` | 25 | 5 | 5.0 | 13.3% |
+| `task_run_status` | 82 | 72 | 1.1 | **43.6%** (dominant) |
+| `event_insert` | 81 | 62 | 1.3 | 43.1% |
+| `lease_renewal` | 0 | 0 | — | 0.0% |
+| **TOTAL** | **188** | **139** | **1.4** | 100% |
+
+- 5/5 runs succeeded.
+- Wall-clock total: 52s.
+- End-to-end p50/p99: **17s / 31s** per run (single-node local for similar workload: ~4s).
+- `caesium_db_busy_retries_total`: **26** for 25 tasks — roughly one retry per task.
+- `caesium_worker_claims_total`: 19 (3 nodes claiming, some races resolved by retry).
+
+## Workload B — Stress (100 tasks)
+
+`10 jobs × fan-out=4 × depth=3 → 10 tasks/run × 10 = 100 task lifecycles, 500ms tasks, 5 concurrent runs`
+
+| Category | Rows | Stmts | Rows/Stmt | Share |
+|---|---|---|---|---|
+| `task_run_insert` | 100 | 10 | 10.0 | 20.4% |
+| `task_run_status` | 195 | 165 | 1.2 | **39.9%** (dominant) |
+| `event_insert` | 194 | 136 | 1.4 | 39.7% |
+| `lease_renewal` | 0 | 0 | — | 0.0% |
+| **TOTAL** | **489** | **311** | **1.6** | 100% |
+
+- 10/10 runs succeeded.
+- Wall-clock total: 1m7s.
+- End-to-end p50/p99: **31s / 32s** per run.
+- `caesium_db_busy_retries_total`: **65** for 100 tasks — ~0.65 retries per task at the stress workload.
+- Peak write rate: 7.0 `task_run_status`/s, 6.8 `event_insert`/s.
+
+## Single-node vs distributed — same workload, both modes
+
+Workload B (100 tasks, 10 jobs, fan-out=4, depth=3, 500ms tasks) ran on both deployments:
+
+| Metric | Single-node local (PR #169) | Distributed 3-node k8s | Delta |
+|---|---|---|---|
+| Total run time | 18s | 67s | **3.7× slower** |
+| End-to-end p50 | 4s | 31s | **7.8× slower** |
+| End-to-end p99 | 6s | 32s | **5.3× slower** |
+| `db_busy_retries` | 9 | 65 | **7.2× more contention** |
+| Total row writes | 720 | 489 | (-32%, but…) |
+| Total statements | 510 | 311 | (-39%, but…) |
+| Rows/stmt | 1.4 | 1.6 | similar |
+
+The lower row counts in the distributed run reflect tasks completing later in the harness window (the `task_run_status` UPDATEs for some tasks happen after the final metric sample). This is itself a signal — distributed mode is slow enough that completion sweeps fall outside the run window.
+
+## Key findings
+
+1. **Distributed-mode contention is real and measurable.** A 100-task workload on a 3-node Raft cluster triggers ~7× more `db_busy_retries` than the same workload on single-node, and **end-to-end latency is 5–8× worse**. The retry machinery from the locking-fix plan keeps things correct but pays for it in latency.
+
+2. **Phase 1 batching factors hold across deployment modes.** `task_run_insert` batches at 5–10× (RegisterTasks), `event_insert` at 1.3–1.4× (Phase 1.1 coalescing), `task_run_status` at 1.1–1.2× (Phase 1.4 predecessor batching). Same as single-node — confirms the batching is a function of code, not deployment shape.
+
+3. **`lease_renewal` stays at 0 even in distributed mode at these workloads.** Tasks finish faster than the renewal trigger threshold (`lease_ttl/2`), and the skip-when-not-needed path correctly exits. To exercise this column requires tasks longer than 15s.
+
+4. **`task_run_status` is still the dominant write category** (44% on workload A, 40% on workload B). Phase 1.4 reduced it but not enough to change the dominance.
+
+5. **The "database is locked" symptom is what Phase 2 (run-owner) targets directly.** Moving coordination state out of dqlite eliminates most of the per-transition writes that drive the contention. The empirical numbers here argue *for* proceeding with Phase 2, not against.
+
+## Phase 2 gate decision — supported by data
+
+The original Phase 1 → Phase 2 gate in `design-scaling-job-execution.md` said: *"if after Phase 1 the dominant remaining category is `task_run_status` (CompleteTask's predecessor-counter UPDATEs and claim/start transitions), that confirms Phase 2's run-owner design is the right next step."*
+
+Both workloads here confirm that condition. Phase 1 batching reduced statement count by ~30% (rows/stmt = 1.4–1.6 vs 1.0 baseline) but per-completion writes are still O(N) in fan-out width *at the per-task level* — the run-owner pattern collapses that to ~O(1) per run by keeping the DAG state in memory and writing only checkpoints + terminal-state rows.
+
+**Recommendation: proceed with Phase 2 planning.** Specifically:
+
+- Start with **Phase 2 Phase A** from the design doc: the `run_leases` table + owner election + dispatch RPC, *without* the checkpoint/replay machinery yet. Even just push-based dispatch from a single owner per run eliminates the per-claim `task_run_status` UPDATE (the largest current write category) for owned runs.
+- Run this baseline again after Phase 2 Phase A and look for: `task_run_status` rows/stmt rising above 5× (because the owner batches more updates), `db_busy_retries` dropping by an order of magnitude (because the owner serializes its own work).
+
+## Sandbox caveats (still)
+
+- **Single physical node** — 3 dqlite voters live on one machine. Real multi-machine deployments have network RTT between voters that this run doesn't capture. Expect *more* contention there, not less.
+- **In-pod ephemeral storage** — `persistence.enabled=false`. NVMe-backed PVCs in production would change absolute write latency but not the relative contention pattern.
+- **Workload sizes are still modest** — 100 tasks is below the "Medium" deployment shape (low-thousands of concurrent tasks). Larger workloads need to be driven from a multi-node test rig that doesn't share CPU/memory with the cluster under test.
+
+The findings here are directionally clear: distributed contention is the regime Phase 2 was designed for, and the numbers justify the next round of work.

--- a/internal/callback/callback.go
+++ b/internal/callback/callback.go
@@ -295,6 +295,7 @@ func (d *Dispatcher) invokeCallback(ctx context.Context, cb models.Callback, met
 		return fmt.Errorf("record callback run: %w", err)
 	}
 	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryCallback).Inc()
+	metrics.DBStatementsTotal.WithLabelValues(metrics.DBWriteCategoryCallback).Inc()
 
 	handler, ok := lookupHandler(cb.Type)
 	if !ok {
@@ -343,5 +344,6 @@ func (d *Dispatcher) completeCallbackRun(ctx context.Context, id uuid.UUID, stat
 		return err
 	}
 	metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryCallback).Inc()
+	metrics.DBStatementsTotal.WithLabelValues(metrics.DBWriteCategoryCallback).Inc()
 	return nil
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,13 +10,13 @@ var registerOnce sync.Once
 
 // DBWriteCategory constants for use with DBWritesTotal.
 const (
-	DBWriteCategoryTaskRunInsert  = "task_run_insert"
-	DBWriteCategoryTaskRunStatus  = "task_run_status"
-	DBWriteCategoryEventInsert    = "event_insert"
-	DBWriteCategoryLeaseRenewal   = "lease_renewal"
-	DBWriteCategoryCallback       = "callback"
-	DBWriteCategoryCommand        = "command"
-	DBWriteCategoryCheckpoint     = "checkpoint"
+	DBWriteCategoryTaskRunInsert = "task_run_insert"
+	DBWriteCategoryTaskRunStatus = "task_run_status"
+	DBWriteCategoryEventInsert   = "event_insert"
+	DBWriteCategoryLeaseRenewal  = "lease_renewal"
+	DBWriteCategoryCallback      = "callback"
+	DBWriteCategoryCommand       = "command"
+	DBWriteCategoryCheckpoint    = "checkpoint"
 )
 
 var (
@@ -214,7 +214,12 @@ var (
 		[]string{"path", "reason"},
 	)
 
-	// DBWritesTotal counts durable database writes by category. Categories:
+	// DBWritesTotal counts durable database writes by category, measured in
+	// rows touched (so a batched UPDATE/INSERT increments by the row count, not
+	// by one). Use this for capacity-planning and "how much work is the DB
+	// doing." For "how many round-trips" use DBStatementsTotal below.
+	//
+	// Categories:
 	//   task_run_insert   – new task_runs row (RegisterTasks)
 	//   task_run_status   – status UPDATE on task_runs (claim, start, complete, fail, skip, retry)
 	//   event_insert      – new execution_events row
@@ -225,7 +230,20 @@ var (
 	DBWritesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "caesium_db_writes_total",
-			Help: "Total durable database writes by category (task_run_insert, task_run_status, event_insert, lease_renewal, callback, command, checkpoint).",
+			Help: "Total durable database writes by category, measured in rows touched.",
+		},
+		[]string{"category"},
+	)
+
+	// DBStatementsTotal counts distinct SQL statements executed by category —
+	// each batched INSERT or UPDATE increments by 1 regardless of row count.
+	// Pair with DBWritesTotal: rows/statements ratio quantifies batching
+	// effectiveness. Phase 1.1 (event coalescing) and 1.4 (predecessor-counter
+	// UPDATE batching) reduce statement count without changing row count.
+	DBStatementsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_db_statements_total",
+			Help: "Total distinct SQL statements executed by category. A batched UPDATE/INSERT increments by 1 regardless of row count; pair with caesium_db_writes_total to compute rows/statement (batching factor).",
 		},
 		[]string{"category"},
 	)
@@ -260,6 +278,7 @@ func Register() {
 			AuditLogEntriesTotal,
 			WebhookAuthFailuresTotal,
 			DBWritesTotal,
+			DBStatementsTotal,
 		)
 	})
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -549,7 +549,7 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 			if err := tx.Create(&records).Error; err != nil {
 				return err
 			}
-			counts.taskRunInsert += len(records)
+			counts.addTaskRunInsert(len(records))
 			if len(readyEvents) > 0 {
 				eventRecords := make([]models.ExecutionEvent, 0, len(readyEvents))
 				for _, evt := range readyEvents {
@@ -558,7 +558,7 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 				if err := tx.Create(&eventRecords).Error; err != nil {
 					return err
 				}
-				counts.eventInsert += len(eventRecords)
+				counts.addEventInsert(len(eventRecords))
 				for idx := range readyEvents {
 					readyEvents[idx].Sequence = eventRecords[idx].Sequence
 					readyEvents[idx].Timestamp = eventRecords[idx].CreatedAt
@@ -622,7 +622,7 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 				}).Error; err != nil {
 				return err
 			}
-			counts.taskRunStatus++
+			counts.addTaskRunStatus(1)
 			if s.eventStore != nil {
 				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID, &counts)
 				if err != nil {
@@ -664,7 +664,7 @@ func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy s
 			if result.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
-			counts.taskRunStatus++
+			counts.addTaskRunStatus(1)
 			if s.eventStore != nil {
 				evt, err := s.recordTaskEventTx(tx, event.TypeTaskStarted, runID, taskID, &counts)
 				if err != nil {
@@ -802,7 +802,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 			if enforceClaim && resultUpdate.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
-			counts.taskRunStatus++
+			counts.addTaskRunStatus(1)
 
 			// Load the task model for edge traversal and branch detection.
 			var taskModel models.Task
@@ -861,7 +861,7 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 			if err != nil {
 				return err
 			}
-			counts.taskRunStatus += len(toDecrementIDs)
+			counts.addTaskRunStatus(len(toDecrementIDs))
 
 			// Collect all events to emit (task_cached + task_ready for newly-ready successors).
 			var batchEvts []*event.Event
@@ -1056,7 +1056,7 @@ func (s *Store) appendTaskReadyEventTx(tx *gorm.DB, runID, taskID uuid.UUID, pen
 	if err := s.eventStore.AppendTx(tx, &evt); err != nil {
 		return err
 	}
-	counts.eventInsert++
+	counts.addEventInsert(1)
 	*pendingEvents = append(*pendingEvents, evt)
 	return nil
 }
@@ -1092,7 +1092,7 @@ func (s *Store) appendBatchEventsTx(tx *gorm.DB, evts []*event.Event, pendingEve
 	if err := s.eventStore.AppendBatchTx(tx, evts); err != nil {
 		return err
 	}
-	counts.eventInsert += len(evts)
+	counts.addEventInsert(len(evts))
 	for _, e := range evts {
 		*pendingEvents = append(*pendingEvents, *e)
 	}
@@ -1117,7 +1117,7 @@ func (s *Store) markTaskSkippedTx(tx *gorm.DB, runID, taskID uuid.UUID, reason s
 	if result.RowsAffected == 0 {
 		return false, nil
 	}
-	counts.taskRunStatus++
+	counts.addTaskRunStatus(1)
 
 	if s.eventStore != nil {
 		evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID, counts)
@@ -1316,7 +1316,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 			if enforceClaim && resultUpdate.RowsAffected == 0 {
 				return ErrTaskClaimMismatch
 			}
-			counts.taskRunStatus++
+			counts.addTaskRunStatus(1)
 
 			if status == TaskStatusFailed {
 				if s.eventStore != nil {
@@ -1403,7 +1403,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 			if err != nil {
 				return err
 			}
-			counts.taskRunStatus += len(toDecrementIDs)
+			counts.addTaskRunStatus(len(toDecrementIDs))
 
 			// Collect all events to emit (task_succeeded + task_ready for newly-ready successors).
 			var batchEvts []*event.Event
@@ -1539,7 +1539,7 @@ func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, r
 		if err != nil {
 			return skipped, err
 		}
-		counts.taskRunStatus += len(successorIDs)
+		counts.addTaskRunStatus(len(successorIDs))
 
 		// Build a quick lookup map from the updated rows.
 		updatedByTaskID := make(map[uuid.UUID]*models.TaskRun, len(updatedSuccessors))
@@ -1637,7 +1637,7 @@ func (s *Store) failTask(runID, taskID uuid.UUID, failure error, claimedBy strin
 		if enforceClaim && resultUpdate.RowsAffected == 0 {
 			return ErrTaskClaimMismatch
 		}
-		counts.taskRunStatus++
+		counts.addTaskRunStatus(1)
 
 		if s.eventStore != nil {
 			evt, err := s.recordTaskEventTx(tx, event.TypeTaskFailed, runID, taskID, &counts)
@@ -1698,7 +1698,7 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 		if enforceClaim && resultUpdate.RowsAffected == 0 {
 			return ErrTaskClaimMismatch
 		}
-		counts.taskRunStatus++
+		counts.addTaskRunStatus(1)
 
 		if s.eventStore != nil {
 			// Build retrying event payload.
@@ -1773,7 +1773,7 @@ func (s *Store) SkipTask(runID, taskID uuid.UUID, reason string) error {
 			}).Error; err != nil {
 			return err
 		}
-		counts.taskRunStatus++
+		counts.addTaskRunStatus(1)
 		if s.eventStore != nil {
 			evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, taskID, &counts)
 			if err != nil {
@@ -2233,7 +2233,7 @@ func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, task
 		if err := s.eventStore.AppendTx(db, &evt); err != nil {
 			return nil, err
 		}
-		counts.eventInsert++
+		counts.addEventInsert(1)
 	}
 	return &evt, nil
 }
@@ -2250,27 +2250,85 @@ func (s *Store) PublishEvents(events ...event.Event) {
 // attempt. Must be reset() at the start of each retry closure and commit()'d
 // only after the retry returns nil; otherwise transactions retried due to
 // busy/locked errors will over-count.
+//
+// Each category tracks both rows (total work) and stmts (round-trips). A
+// batched UPDATE/INSERT bumps stmts by 1 and rows by N. The two counters
+// together let dashboards compute "rows per statement" to quantify how
+// effective batching is — the headline indicator for Phase 1.1 / 1.4 wins.
 type dbWriteCounts struct {
-	taskRunInsert int
-	taskRunStatus int
-	eventInsert   int
-	callback      int
-	leaseRenewal  int
+	taskRunInsertRows  int
+	taskRunInsertStmts int
+	taskRunStatusRows  int
+	taskRunStatusStmts int
+	eventInsertRows    int
+	eventInsertStmts   int
+	callbackRows       int
+	callbackStmts      int
+	leaseRenewalRows   int
+	leaseRenewalStmts  int
 }
 
 func (c *dbWriteCounts) reset() { *c = dbWriteCounts{} }
 
+// addTaskRunInsert records one batched INSERT touching n rows.
+func (c *dbWriteCounts) addTaskRunInsert(rows int) {
+	if rows <= 0 {
+		return
+	}
+	c.taskRunInsertRows += rows
+	c.taskRunInsertStmts++
+}
+
+// addTaskRunStatus records one batched UPDATE touching n rows.
+func (c *dbWriteCounts) addTaskRunStatus(rows int) {
+	if rows <= 0 {
+		return
+	}
+	c.taskRunStatusRows += rows
+	c.taskRunStatusStmts++
+}
+
+// addEventInsert records one batched INSERT touching n rows.
+func (c *dbWriteCounts) addEventInsert(rows int) {
+	if rows <= 0 {
+		return
+	}
+	c.eventInsertRows += rows
+	c.eventInsertStmts++
+}
+
+// addCallback records one INSERT/UPDATE touching n rows.
+func (c *dbWriteCounts) addCallback(rows int) {
+	if rows <= 0 {
+		return
+	}
+	c.callbackRows += rows
+	c.callbackStmts++
+}
+
+// addLeaseRenewal records one batched UPDATE touching n rows.
+func (c *dbWriteCounts) addLeaseRenewal(rows int) {
+	if rows <= 0 {
+		return
+	}
+	c.leaseRenewalRows += rows
+	c.leaseRenewalStmts++
+}
+
 func (c *dbWriteCounts) commit() {
-	add := func(category string, n int) {
-		if n > 0 {
-			metrics.DBWritesTotal.WithLabelValues(category).Add(float64(n))
+	emit := func(category string, rows, stmts int) {
+		if rows > 0 {
+			metrics.DBWritesTotal.WithLabelValues(category).Add(float64(rows))
+		}
+		if stmts > 0 {
+			metrics.DBStatementsTotal.WithLabelValues(category).Add(float64(stmts))
 		}
 	}
-	add(metrics.DBWriteCategoryTaskRunInsert, c.taskRunInsert)
-	add(metrics.DBWriteCategoryTaskRunStatus, c.taskRunStatus)
-	add(metrics.DBWriteCategoryEventInsert, c.eventInsert)
-	add(metrics.DBWriteCategoryCallback, c.callback)
-	add(metrics.DBWriteCategoryLeaseRenewal, c.leaseRenewal)
+	emit(metrics.DBWriteCategoryTaskRunInsert, c.taskRunInsertRows, c.taskRunInsertStmts)
+	emit(metrics.DBWriteCategoryTaskRunStatus, c.taskRunStatusRows, c.taskRunStatusStmts)
+	emit(metrics.DBWriteCategoryEventInsert, c.eventInsertRows, c.eventInsertStmts)
+	emit(metrics.DBWriteCategoryCallback, c.callbackRows, c.callbackStmts)
+	emit(metrics.DBWriteCategoryLeaseRenewal, c.leaseRenewalRows, c.leaseRenewalStmts)
 }
 
 func withStoreBusyRetry(fn func() error) error {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -2297,23 +2297,11 @@ func (c *dbWriteCounts) addEventInsert(rows int) {
 	c.eventInsertStmts++
 }
 
-// addCallback records one INSERT/UPDATE touching n rows.
-func (c *dbWriteCounts) addCallback(rows int) {
-	if rows <= 0 {
-		return
-	}
-	c.callbackRows += rows
-	c.callbackStmts++
-}
-
-// addLeaseRenewal records one batched UPDATE touching n rows.
-func (c *dbWriteCounts) addLeaseRenewal(rows int) {
-	if rows <= 0 {
-		return
-	}
-	c.leaseRenewalRows += rows
-	c.leaseRenewalStmts++
-}
+// NOTE: addCallback and addLeaseRenewal accessors are intentionally omitted —
+// the callback and lease_renewal categories don't flow through the
+// accumulator-with-retry pattern (callback.go and worker.go emit metrics
+// directly outside retry loops). commit() still emits both counters if the
+// fields are non-zero so future callers can drop the accessors back in.
 
 func (c *dbWriteCounts) commit() {
 	emit := func(category string, rows, stmts int) {

--- a/internal/run/store_metrics_test.go
+++ b/internal/run/store_metrics_test.go
@@ -41,6 +41,7 @@ func (s *StoreMetricsSuite) SetupTest() {
 	metrics.CallbackRunsTotal.Reset()
 	metrics.TriggerFiresTotal.Reset()
 	metrics.DBWritesTotal.Reset()
+	metrics.DBStatementsTotal.Reset()
 }
 
 func (s *StoreMetricsSuite) TearDownTest() {
@@ -305,21 +306,32 @@ func (s *StoreMetricsSuite) TestFanOutCompletionWriteCounts() {
 	s.Require().NoError(s.store.RegisterTask(run.ID, lane4, atom, 1))
 	s.Require().NoError(s.store.StartTask(run.ID, root.ID, "container-root"))
 
-	beforeStatus := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
-	beforeEvent := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	beforeStatusRows := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
+	beforeEventRows := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	beforeStatusStmts := s.dbStatementValue(metrics.DBWriteCategoryTaskRunStatus)
+	beforeEventStmts := s.dbStatementValue(metrics.DBWriteCategoryEventInsert)
 
 	s.Require().NoError(s.store.CompleteTask(run.ID, root.ID, "ok", nil, nil))
 
-	afterStatus := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
-	afterEvent := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	afterStatusRows := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
+	afterEventRows := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	afterStatusStmts := s.dbStatementValue(metrics.DBWriteCategoryTaskRunStatus)
+	afterEventStmts := s.dbStatementValue(metrics.DBWriteCategoryEventInsert)
 
-	// 1 status write for the task itself + 4 for the predecessor decrements = 5 total.
-	s.Equal(float64(5), afterStatus-beforeStatus,
-		"fan-out=4 completion: expected 1 (complete) + 4 (predecessors) = 5 task_run_status writes")
+	// 1 status row for the task itself + 4 for the predecessor decrements = 5 rows total,
+	// produced by 2 statements (1 for the completed task UPDATE + 1 batched UPDATE
+	// for the 4 predecessors). Batching factor: 5/2 = 2.5.
+	s.Equal(float64(5), afterStatusRows-beforeStatusRows,
+		"fan-out=4 completion: expected 5 task_run_status rows (1 complete + 4 predecessors)")
+	s.Equal(float64(2), afterStatusStmts-beforeStatusStmts,
+		"fan-out=4 completion: expected 2 task_run_status statements (1 complete UPDATE + 1 batched predecessor UPDATE)")
 
-	// task_succeeded (1) + task_ready×4 = 5 event rows in one batch INSERT.
-	s.Equal(float64(5), afterEvent-beforeEvent,
-		"fan-out=4 completion: expected 5 event rows (1 task_succeeded + 4 task_ready) in one batch")
+	// task_succeeded (1) + task_ready×4 = 5 event rows in one batched INSERT.
+	// Batching factor: 5/1 = 5.0 — the headline win from Phase 1.1.
+	s.Equal(float64(5), afterEventRows-beforeEventRows,
+		"fan-out=4 completion: expected 5 event rows (1 task_succeeded + 4 task_ready)")
+	s.Equal(float64(1), afterEventStmts-beforeEventStmts,
+		"fan-out=4 completion: expected 1 event_insert statement (5 events in one batched INSERT)")
 }
 
 // TestCacheHitCompletionWriteCounts verifies that CacheHitTask with fan-out=2
@@ -349,8 +361,10 @@ func (s *StoreMetricsSuite) TestCacheHitCompletionWriteCounts() {
 	s.Require().NoError(s.store.RegisterTask(run.ID, lane1, atom, 1))
 	s.Require().NoError(s.store.RegisterTask(run.ID, lane2, atom, 1))
 
-	beforeStatus := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
-	beforeEvent := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	beforeStatusRows := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
+	beforeEventRows := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	beforeStatusStmts := s.dbStatementValue(metrics.DBWriteCategoryTaskRunStatus)
+	beforeEventStmts := s.dbStatementValue(metrics.DBWriteCategoryEventInsert)
 
 	_, err = s.store.CacheHitTask(run.ID, root.ID, CacheHitSource{
 		RunID:     uuid.New(),
@@ -358,21 +372,35 @@ func (s *StoreMetricsSuite) TestCacheHitCompletionWriteCounts() {
 	}, "ok", nil, nil)
 	s.Require().NoError(err)
 
-	afterStatus := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
-	afterEvent := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	afterStatusRows := s.dbWriteValue(metrics.DBWriteCategoryTaskRunStatus)
+	afterEventRows := s.dbWriteValue(metrics.DBWriteCategoryEventInsert)
+	afterStatusStmts := s.dbStatementValue(metrics.DBWriteCategoryTaskRunStatus)
+	afterEventStmts := s.dbStatementValue(metrics.DBWriteCategoryEventInsert)
 
-	// 1 for cache hit status + 2 for predecessor decrements = 3.
-	s.Equal(float64(3), afterStatus-beforeStatus,
-		"fan-out=2 cache hit: expected 1 (cached) + 2 (predecessors) = 3 task_run_status writes")
+	// 1 cache-hit status + 2 predecessor decrements = 3 rows in 2 statements.
+	s.Equal(float64(3), afterStatusRows-beforeStatusRows,
+		"fan-out=2 cache hit: expected 3 task_run_status rows (1 cached + 2 predecessors)")
+	s.Equal(float64(2), afterStatusStmts-beforeStatusStmts,
+		"fan-out=2 cache hit: expected 2 task_run_status statements")
 
-	// task_cached (1) + task_ready×2 = 3 event rows.
-	s.Equal(float64(3), afterEvent-beforeEvent,
-		"fan-out=2 cache hit: expected 3 event rows (1 task_cached + 2 task_ready) in one batch")
+	// task_cached (1) + task_ready×2 = 3 event rows in 1 batched INSERT.
+	s.Equal(float64(3), afterEventRows-beforeEventRows,
+		"fan-out=2 cache hit: expected 3 event rows (1 task_cached + 2 task_ready)")
+	s.Equal(float64(1), afterEventStmts-beforeEventStmts,
+		"fan-out=2 cache hit: expected 1 event_insert statement (3 events in one batched INSERT)")
 }
 
 func (s *StoreMetricsSuite) dbWriteValue(category string) float64 {
 	var m dto.Metric
 	counter, err := metrics.DBWritesTotal.GetMetricWithLabelValues(category)
+	s.Require().NoError(err)
+	s.Require().NoError(counter.(prometheus.Metric).Write(&m))
+	return m.GetCounter().GetValue()
+}
+
+func (s *StoreMetricsSuite) dbStatementValue(category string) float64 {
+	var m dto.Metric
+	counter, err := metrics.DBStatementsTotal.GetMetricWithLabelValues(category)
 	s.Require().NoError(err)
 	s.Require().NoError(counter.(prometheus.Metric).Write(&m))
 	return m.GetCounter().GetValue()

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -23,21 +23,44 @@ const defaultLeaseTTL = 5 * time.Minute
 // dbWriteCounts accumulates per-category DB write counts during a single retry
 // attempt. Must be reset() at the start of each retry closure and commit()'d
 // only after the retry returns nil; otherwise transactions retried due to
-// busy/locked errors will over-count.
+// busy/locked errors will over-count. Each category tracks both rows and
+// stmts; see internal/run/store.go for the equivalent type with full prose.
 type dbWriteCounts struct {
-	taskRunStatus int
-	eventInsert   int
+	taskRunStatusRows  int
+	taskRunStatusStmts int
+	eventInsertRows    int
+	eventInsertStmts   int
 }
 
 func (c *dbWriteCounts) reset() { *c = dbWriteCounts{} }
 
+func (c *dbWriteCounts) addTaskRunStatus(rows int) {
+	if rows <= 0 {
+		return
+	}
+	c.taskRunStatusRows += rows
+	c.taskRunStatusStmts++
+}
+
+func (c *dbWriteCounts) addEventInsert(rows int) {
+	if rows <= 0 {
+		return
+	}
+	c.eventInsertRows += rows
+	c.eventInsertStmts++
+}
+
 func (c *dbWriteCounts) commit() {
-	if c.taskRunStatus > 0 {
-		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Add(float64(c.taskRunStatus))
+	emit := func(category string, rows, stmts int) {
+		if rows > 0 {
+			metrics.DBWritesTotal.WithLabelValues(category).Add(float64(rows))
+		}
+		if stmts > 0 {
+			metrics.DBStatementsTotal.WithLabelValues(category).Add(float64(stmts))
+		}
 	}
-	if c.eventInsert > 0 {
-		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryEventInsert).Add(float64(c.eventInsert))
-	}
+	emit(metrics.DBWriteCategoryTaskRunStatus, c.taskRunStatusRows, c.taskRunStatusStmts)
+	emit(metrics.DBWriteCategoryEventInsert, c.eventInsertRows, c.eventInsertStmts)
 }
 
 type Claimer struct {
@@ -129,6 +152,7 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 	if claimed != nil {
 		metrics.WorkerClaimsTotal.WithLabelValues(c.nodeID).Inc()
 		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+		metrics.DBStatementsTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 		counts.commit()
 	}
 	c.store.PublishEvents(pendingEvents...)
@@ -218,7 +242,7 @@ func (c *Claimer) recordTaskClaimedEventTx(tx *gorm.DB, claimed *models.TaskRun,
 	if err := c.store.RecordEventTx(tx, &evt); err != nil {
 		return nil, err
 	}
-	counts.eventInsert++
+	counts.addEventInsert(1)
 	return &evt, nil
 }
 
@@ -321,7 +345,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 			if result.Error != nil {
 				return result.Error
 			}
-			counts.taskRunStatus += int(result.RowsAffected)
+			counts.addTaskRunStatus(int(result.RowsAffected))
 
 			// Batch all lease-expired + task-ready events into a single INSERT.
 			if len(expired) > 0 {
@@ -367,7 +391,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				if err := tx.Create(&eventRecords).Error; err != nil {
 					return err
 				}
-				counts.eventInsert += len(eventRecords)
+				counts.addEventInsert(len(eventRecords))
 
 				// Build bus-dispatch events from the inserted records.
 				for i := range eventRecords {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -293,6 +293,7 @@ func (w *Worker) renewLeasesNow(ctx context.Context) {
 			continue
 		}
 		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryLeaseRenewal).Add(float64(rowsAffected))
+		metrics.DBStatementsTotal.WithLabelValues(metrics.DBWriteCategoryLeaseRenewal).Inc()
 
 		// Update the in-memory expiry only for the IDs we attempted to renew
 		// AND whose claimedBy is still nodeID (the latter check guards against

--- a/justfile
+++ b/justfile
@@ -362,6 +362,7 @@ load-test:
         -depth "${CAESIUM_LOAD_DEPTH:-3}" \
         -task-duration "${CAESIUM_LOAD_TASK_DURATION:-1s}" \
         -concurrency "${CAESIUM_LOAD_CONCURRENCY:-1}" \
+        -engine "${CAESIUM_LOAD_ENGINE:-docker}" \
         -api-key "${CAESIUM_MANUAL_TRIGGER_API_KEY:-}" \
         -output "${report_file}"
 

--- a/test/load/harness.go
+++ b/test/load/harness.go
@@ -350,7 +350,8 @@ func parseCounter(text, metricName string, labels map[string]string) float64 {
 }
 
 type metricSample struct {
-	ts            time.Time
+	ts time.Time
+	// Row counts (caesium_db_writes_total).
 	taskRunInsert float64
 	taskRunStatus float64
 	eventInsert   float64
@@ -358,8 +359,17 @@ type metricSample struct {
 	callback      float64
 	command       float64
 	checkpoint    float64
-	dbBusyRetries float64
-	claimsTotal   float64
+	// Statement counts (caesium_db_statements_total). Same categories;
+	// rows/statements is the batching factor.
+	taskRunInsertStmts float64
+	taskRunStatusStmts float64
+	eventInsertStmts   float64
+	leaseRenewalStmts  float64
+	callbackStmts      float64
+	commandStmts       float64
+	checkpointStmts    float64
+	dbBusyRetries      float64
+	claimsTotal        float64
 }
 
 func sampleMetrics(ctx context.Context, c *client) (metricSample, error) {
@@ -368,13 +378,23 @@ func sampleMetrics(ctx context.Context, c *client) (metricSample, error) {
 		return metricSample{}, err
 	}
 	s := metricSample{ts: time.Now()}
-	s.taskRunInsert = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "task_run_insert"})
-	s.taskRunStatus = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "task_run_status"})
-	s.eventInsert = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "event_insert"})
-	s.leaseRenewal = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "lease_renewal"})
-	s.callback = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "callback"})
-	s.command = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "command"})
-	s.checkpoint = parseCounter(text, "caesium_db_writes_total", map[string]string{"category": "checkpoint"})
+	cat := func(name, category string) float64 {
+		return parseCounter(text, name, map[string]string{"category": category})
+	}
+	s.taskRunInsert = cat("caesium_db_writes_total", "task_run_insert")
+	s.taskRunStatus = cat("caesium_db_writes_total", "task_run_status")
+	s.eventInsert = cat("caesium_db_writes_total", "event_insert")
+	s.leaseRenewal = cat("caesium_db_writes_total", "lease_renewal")
+	s.callback = cat("caesium_db_writes_total", "callback")
+	s.command = cat("caesium_db_writes_total", "command")
+	s.checkpoint = cat("caesium_db_writes_total", "checkpoint")
+	s.taskRunInsertStmts = cat("caesium_db_statements_total", "task_run_insert")
+	s.taskRunStatusStmts = cat("caesium_db_statements_total", "task_run_status")
+	s.eventInsertStmts = cat("caesium_db_statements_total", "event_insert")
+	s.leaseRenewalStmts = cat("caesium_db_statements_total", "lease_renewal")
+	s.callbackStmts = cat("caesium_db_statements_total", "callback")
+	s.commandStmts = cat("caesium_db_statements_total", "command")
+	s.checkpointStmts = cat("caesium_db_statements_total", "checkpoint")
 	s.dbBusyRetries = parseCounter(text, "caesium_db_busy_retries_total", nil)
 	s.claimsTotal = parseCounter(text, "caesium_worker_claims_total", nil)
 	return s, nil
@@ -660,7 +680,7 @@ type report struct {
 	runsTimeout       int
 	runsTriggerFailed int
 
-	// Delta counts (end - baseline).
+	// Delta row counts (end - baseline).
 	deltaTaskRunInsert float64
 	deltaTaskRunStatus float64
 	deltaEventInsert   float64
@@ -668,8 +688,17 @@ type report struct {
 	deltaCallback      float64
 	deltaCommand       float64
 	deltaCheckpoint    float64
-	deltaDBBusyRetries float64
-	deltaClaimsTotal   float64
+	// Delta statement counts (end - baseline). Rows / statements is the
+	// batching factor: > 1 means each statement touches multiple rows.
+	deltaTaskRunInsertStmts float64
+	deltaTaskRunStatusStmts float64
+	deltaEventInsertStmts   float64
+	deltaLeaseRenewalStmts  float64
+	deltaCallbackStmts      float64
+	deltaCommandStmts       float64
+	deltaCheckpointStmts    float64
+	deltaDBBusyRetries      float64
+	deltaClaimsTotal        float64
 
 	// Per-second rates during the run.
 	peakTaskRunStatusPerSec float64
@@ -724,7 +753,7 @@ func buildReport(
 		r.endToEndP99 = durations[int(float64(len(durations))*0.99)]
 	}
 
-	// Delta counters.
+	// Delta row counts.
 	r.deltaTaskRunInsert = end.taskRunInsert - baseline.taskRunInsert
 	r.deltaTaskRunStatus = end.taskRunStatus - baseline.taskRunStatus
 	r.deltaEventInsert = end.eventInsert - baseline.eventInsert
@@ -732,6 +761,14 @@ func buildReport(
 	r.deltaCallback = end.callback - baseline.callback
 	r.deltaCommand = end.command - baseline.command
 	r.deltaCheckpoint = end.checkpoint - baseline.checkpoint
+	// Delta statement counts.
+	r.deltaTaskRunInsertStmts = end.taskRunInsertStmts - baseline.taskRunInsertStmts
+	r.deltaTaskRunStatusStmts = end.taskRunStatusStmts - baseline.taskRunStatusStmts
+	r.deltaEventInsertStmts = end.eventInsertStmts - baseline.eventInsertStmts
+	r.deltaLeaseRenewalStmts = end.leaseRenewalStmts - baseline.leaseRenewalStmts
+	r.deltaCallbackStmts = end.callbackStmts - baseline.callbackStmts
+	r.deltaCommandStmts = end.commandStmts - baseline.commandStmts
+	r.deltaCheckpointStmts = end.checkpointStmts - baseline.checkpointStmts
 	r.deltaDBBusyRetries = end.dbBusyRetries - baseline.dbBusyRetries
 	r.deltaClaimsTotal = end.claimsTotal - baseline.claimsTotal
 
@@ -813,28 +850,39 @@ func (r *report) print(w io.Writer) {
 	fmt.Fprintln(w, "--- DB Write Breakdown (delta over harness run) ---")
 	fmt.Fprintln(w, "")
 	tw := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
-	fmt.Fprintf(tw, "Category\tCount\tShare\n")
-	fmt.Fprintf(tw, "--------\t-----\t-----\n")
+	fmt.Fprintf(tw, "Category\tRows\tStmts\tRows/Stmt\tShare\n")
+	fmt.Fprintf(tw, "--------\t----\t-----\t---------\t-----\n")
 	cats := []struct {
-		name string
-		val  float64
+		name  string
+		rows  float64
+		stmts float64
 	}{
-		{"task_run_insert", r.deltaTaskRunInsert},
-		{"task_run_status", r.deltaTaskRunStatus},
-		{"event_insert", r.deltaEventInsert},
-		{"lease_renewal", r.deltaLeaseRenewal},
-		{"callback", r.deltaCallback},
-		{"command", r.deltaCommand},
-		{"checkpoint", r.deltaCheckpoint},
+		{"task_run_insert", r.deltaTaskRunInsert, r.deltaTaskRunInsertStmts},
+		{"task_run_status", r.deltaTaskRunStatus, r.deltaTaskRunStatusStmts},
+		{"event_insert", r.deltaEventInsert, r.deltaEventInsertStmts},
+		{"lease_renewal", r.deltaLeaseRenewal, r.deltaLeaseRenewalStmts},
+		{"callback", r.deltaCallback, r.deltaCallbackStmts},
+		{"command", r.deltaCommand, r.deltaCommandStmts},
+		{"checkpoint", r.deltaCheckpoint, r.deltaCheckpointStmts},
 	}
+	var totalStmts float64
 	for _, c := range cats {
+		totalStmts += c.stmts
 		pct := 0.0
 		if total > 0 {
-			pct = c.val / total * 100
+			pct = c.rows / total * 100
 		}
-		fmt.Fprintf(tw, "%s\t%.0f\t%.1f%%\n", c.name, c.val, pct)
+		batching := "—"
+		if c.stmts > 0 {
+			batching = fmt.Sprintf("%.1f", c.rows/c.stmts)
+		}
+		fmt.Fprintf(tw, "%s\t%.0f\t%.0f\t%s\t%.1f%%\n", c.name, c.rows, c.stmts, batching, pct)
 	}
-	fmt.Fprintf(tw, "TOTAL\t%.0f\t100%%\n", total)
+	overallBatching := "—"
+	if totalStmts > 0 {
+		overallBatching = fmt.Sprintf("%.1f", total/totalStmts)
+	}
+	fmt.Fprintf(tw, "TOTAL\t%.0f\t%.0f\t%s\t100%%\n", total, totalStmts, overallBatching)
 	tw.Flush()
 	fmt.Fprintln(w, "")
 	fmt.Fprintf(w, "Dominant category:   %s (%.0f writes, %.1f%% of total)\n",

--- a/test/load/harness.go
+++ b/test/load/harness.go
@@ -45,6 +45,7 @@ type config struct {
 	sampleRate   time.Duration
 	outputFile   string
 	apiKey       string
+	engine       string // docker | kubernetes | podman; default docker
 }
 
 func defaultConfig() config {
@@ -58,6 +59,7 @@ func defaultConfig() config {
 		sampleRate:   envDurOrDefault("CAESIUM_LOAD_SAMPLE_RATE", 5*time.Second),
 		outputFile:   envOrDefault("CAESIUM_LOAD_OUTPUT", ""),
 		apiKey:       envOrDefault("CAESIUM_MANUAL_TRIGGER_API_KEY", ""),
+		engine:       envOrDefault("CAESIUM_LOAD_ENGINE", "docker"),
 	}
 }
 
@@ -85,6 +87,7 @@ type triggerDef struct {
 
 type stepDef struct {
 	Name      string   `json:"name"`
+	Engine    string   `json:"engine,omitempty"`
 	Image     string   `json:"image"`
 	Command   []string `json:"command,omitempty"`
 	Next      []string `json:"next,omitempty"`
@@ -96,7 +99,7 @@ type stepDef struct {
 // Layers 1..depth-1: fanOut tasks each.
 // Final layer: one join task that depends on all layer depth-1 tasks.
 // All tasks sleep for taskDuration seconds and emit one caesium::output line.
-func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
+func buildDAGSteps(fanOut, depth int, taskDuration time.Duration, engine string) []stepDef {
 	// Use floating-point seconds so sub-second durations are honored;
 	// busybox:1.36.1 sleep accepts decimal values. Floor at 1ms so we never
 	// emit "sleep 0".
@@ -110,6 +113,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 		return []stepDef{
 			{
 				Name:    "task-root",
+				Engine:  engine,
 				Image:   "busybox:1.36.1",
 				Command: []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
 			},
@@ -126,6 +130,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 	}
 	steps = append(steps, stepDef{
 		Name:    rootName,
+		Engine:  engine,
 		Image:   "busybox:1.36.1",
 		Command: []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"step\":\"root\"}'", sleepSec)},
 		Next:    rootNexts,
@@ -144,6 +149,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 			}
 			steps = append(steps, stepDef{
 				Name:      name,
+				Engine:    engine,
 				Image:     "busybox:1.36.1",
 				Command:   []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
 				DependsOn: dependsOn,
@@ -166,6 +172,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 		}
 		steps = append(steps, stepDef{
 			Name:      name,
+			Engine:    engine,
 			Image:     "busybox:1.36.1",
 			Command:   []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"step\":\"%s\"}'", sleepSec, name)},
 			DependsOn: dependsOn,
@@ -176,6 +183,7 @@ func buildDAGSteps(fanOut, depth int, taskDuration time.Duration) []stepDef {
 	// Join task.
 	steps = append(steps, stepDef{
 		Name:      "task-join",
+		Engine:    engine,
 		Image:     "busybox:1.36.1",
 		Command:   []string{"sh", "-c", fmt.Sprintf("sleep %g && echo '##caesium::output {\"done\":\"1\"}'", sleepSec)},
 		DependsOn: joinDeps,
@@ -462,7 +470,7 @@ type appliedJob struct {
 // definition, which keeps harness setup time bounded for large workloads.
 func (h *harness) applyJobs(ctx context.Context) ([]appliedJob, error) {
 	cfg := h.cfg
-	steps := buildDAGSteps(cfg.fanOut, cfg.depth, cfg.taskDuration)
+	steps := buildDAGSteps(cfg.fanOut, cfg.depth, cfg.taskDuration, cfg.engine)
 
 	defs := make([]jobDef, 0, cfg.jobCount)
 	aliases := make([]string, 0, cfg.jobCount)
@@ -936,6 +944,7 @@ func main() {
 	flag.DurationVar(&cfg.sampleRate, "sample-rate", cfg.sampleRate, "How often to sample Prometheus metrics")
 	flag.StringVar(&cfg.outputFile, "output", cfg.outputFile, "Write report to file (default: stdout only)")
 	flag.StringVar(&cfg.apiKey, "api-key", cfg.apiKey, "API key for authenticated endpoints")
+	flag.StringVar(&cfg.engine, "engine", cfg.engine, "Task engine: docker (default), kubernetes, or podman. Must match what the target Caesium deployment supports.")
 	flag.Parse()
 
 	h := newHarness(cfg)


### PR DESCRIPTION
## Summary

Adds a parallel **statement-count** counter (`caesium_db_statements_total{category}`) alongside the existing row-count counter (`caesium_db_writes_total{category}`). Each batched UPDATE/INSERT bumps statements by 1 regardless of row count, so **rows/statements becomes the headline indicator for batching effectiveness**.

## Why this matters

PR #168's re-baseline showed local-mode row counts were byte-identical before and after Phase 1 (#165, #167) — by design, since the counter measures rows. The actual Phase 1 wins (fewer roundtrips, lower contention) were invisible. This PR makes them measurable.

## Example output (the same workload as PR #168 / #166)

```
Category          Rows   Stmts   Rows/Stmt   Share
--------          ----   -----   ---------   -----
task_run_insert   100    10      10.0        13.9%
task_run_status   320    290     1.1         44.4%
event_insert      300    210     1.4         41.7%
TOTAL             720    510     1.4         100%
```

The new "Rows/Stmt" column shows:
- **`task_run_insert`: 10.0×** — RegisterTasks batches all DAG tasks into one INSERT.
- **`event_insert`: 1.4×** — Phase 1.1 event coalescing saves ~90 statements per 300 event rows.
- **`task_run_status`: 1.1×** — Phase 1.4 predecessor batching saves ~30 statements per 320 rows (most status writes are still single-row claim/start/complete).

## Implementation

- **`internal/metrics/metrics.go`**: new `DBStatementsTotal` counter, registered alongside `DBWritesTotal`. Same category labels.
- **`internal/run/store.go` + `internal/worker/claimer.go`**: `dbWriteCounts` accumulator gains paired `xxxRows`/`xxxStmts` fields and `add{Category}(n)` helper methods so each batched call increments both atomically. `commit()` emits both counters.
- **`internal/callback/callback.go`, `internal/worker/worker.go`**: direct emission sites also bump the new counter (one stmt each for the lease-renewal batch and the per-callback INSERT/UPDATE).
- **`test/load/harness.go`**: report now displays Rows, Stmts, Rows/Stmt, and Share per category, plus a TOTAL row with overall batching factor.

## Tests

- **`internal/run/store_metrics_test.go`**: `TestFanOutCompletionWriteCounts` and `TestCacheHitCompletionWriteCounts` extended to assert statement counts. Fan-out=4 completion now locks in: 5 status rows in **2 statements** (1 complete UPDATE + 1 batched predecessor UPDATE), 5 event rows in **1 statement** (batched INSERT). These assertions would have caught any regression that un-batched the work.
- `just unit-test` passes locally.

## Test plan

- [ ] Watch the new counter on a real cluster — the rows/stmts ratio is the headline indicator for Phase 1 efficacy.
- [ ] Consider adding a Grafana panel for `rate(caesium_db_writes_total[5m]) / rate(caesium_db_statements_total[5m])` per category to monitor batching efficiency over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)