### PR TITLE
Wire Phase A2 executor-side dispatch loop

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -187,7 +187,7 @@ func start(cmd *cobra.Command, args []string) error {
 		dispatchLoop := dispatch.NewDispatchLoop(dispatch.DispatchLoopConfig{
 			NodeID:     vars.NodeAddress,
 			APIPort:    vars.Port,
-			Token:      strings.TrimSpace(vars.InternalWakeupToken),
+			Token:      token,
 			Interval:   vars.RunOwnerDispatchInterval,
 			BatchSize:  vars.RunOwnerDispatchBatch,
 			Deadline:   vars.RunOwnerDispatchDeadline,

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -33,6 +33,27 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// dqliteDispatchPeerResolver returns a PeerLister that discovers all dqlite
+// cluster members (excluding abstract-unix and empty addresses) and converts
+// them to node-address strings for the dispatch loop.  The loop itself
+// converts these to base HTTP URLs using the API port.
+func dqliteDispatchPeerResolver() dispatch.PeerLister {
+	return dispatch.PeerListerFunc(func(ctx context.Context) ([]string, error) {
+		nodes, err := dqlite.Cluster(ctx)
+		if err != nil {
+			return nil, err
+		}
+		peers := make([]string, 0, len(nodes))
+		for _, node := range nodes {
+			if node.Address == "" || strings.HasPrefix(node.Address, "@") {
+				continue
+			}
+			peers = append(peers, node.Address)
+		}
+		return peers, nil
+	})
+}
+
 const (
 	usage   = "start"
 	short   = "Start a caesium scheduling instance"
@@ -153,7 +174,34 @@ func start(cmd *cobra.Command, args []string) error {
 			"run-owner mode enabled (Phase 2A substrate)",
 			"node_address", vars.NodeAddress,
 			"run_lease_ttl", vars.RunLeaseTTL,
+			"dispatch_interval", vars.RunOwnerDispatchInterval,
+			"dispatch_batch", vars.RunOwnerDispatchBatch,
+			"dispatch_deadline", vars.RunOwnerDispatchDeadline,
 		)
+
+		// --- Phase A2: Executor-side dispatch loop ---
+		//
+		// Polls owned runs for pending tasks and pushes them to workers via
+		// PostDispatch.  If PostDispatch returns false (worker rejected or network
+		// error), the task is left unclaimed and ClaimNext recovery picks it up.
+		dispatchLoop := dispatch.NewDispatchLoop(dispatch.DispatchLoopConfig{
+			NodeID:     vars.NodeAddress,
+			APIPort:    vars.Port,
+			Token:      strings.TrimSpace(vars.InternalWakeupToken),
+			Interval:   vars.RunOwnerDispatchInterval,
+			BatchSize:  vars.RunOwnerDispatchBatch,
+			Deadline:   vars.RunOwnerDispatchDeadline,
+			LeaseStore: leaseStore,
+			Store:      runStore,
+			Peers:      dqliteDispatchPeerResolver(),
+		})
+		go func() {
+			log.Info("launching owner dispatch loop",
+				"node_address", vars.NodeAddress,
+				"interval", vars.RunOwnerDispatchInterval,
+			)
+			dispatchLoop.Run(ctx)
+		}()
 	}
 
 	// --- Authentication & Authorization ---

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -1,0 +1,326 @@
+// Package dispatch: dispatch loop — per-node goroutine that polls owned runs
+// for ready tasks and pushes them to workers via PostDispatch.
+//
+// The loop runs only when CAESIUM_RUN_OWNER_ENABLED=true.  When disabled, the
+// field in start.go stays nil and the system behaves byte-identically to Phase 1.
+//
+// Design decisions:
+//   - Per-node (not per-run): one goroutine iterates all owned runs each tick;
+//     no per-run goroutines are spawned.
+//   - Round-robin peer selection for Phase A2: least-loaded requires a
+//     worker-status RPC that doesn't exist yet.  The local node is included in
+//     the rotation so single-node setups work.
+//   - On PostDispatch returns false (network error or 409): leave the task
+//     untouched (claimed_by="", status=pending) so ClaimNext recovery picks it up.
+//   - Batch cap (CAESIUM_RUN_OWNER_DISPATCH_BATCH, default 64): prevents a huge
+//     fan-out from stalling the tick loop.
+//   - Skip-when-quiet: if no peers are discovered yet (cluster bootstrapping),
+//     or no owned runs exist, exit the tick early without writing anything.
+
+package dispatch
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+)
+
+// DispatchRejectionReason labels for caesium_dispatch_rejected_total.
+const (
+	DispatchReasonNetworkError   = "network_error"
+	DispatchReasonWorkerRejected = "worker_rejected"
+	DispatchReasonNoPeers        = "no_peers"
+)
+
+// PeerLister provides the current set of dispatch-eligible peer node addresses.
+// The production implementation delegates to the dqlite cluster member list;
+// tests inject a stub.  Addresses are returned as "host:dqlitePort" strings —
+// the same format as CAESIUM_NODE_ADDRESS / dqlite.Cluster results.
+type PeerLister interface {
+	DispatchPeers(ctx context.Context) ([]string, error)
+}
+
+// PeerListerFunc is a function-valued implementation of PeerLister.
+type PeerListerFunc func(context.Context) ([]string, error)
+
+func (f PeerListerFunc) DispatchPeers(ctx context.Context) ([]string, error) {
+	return f(ctx)
+}
+
+// OwnerReader provides run-lease ownership queries used by the dispatch loop.
+type OwnerReader interface {
+	OwnedRuns(ctx context.Context, ownerNode string) ([]uuid.UUID, error)
+	GetLease(ctx context.Context, runID uuid.UUID) (*models.RunLease, error)
+}
+
+// TaskPendingReader provides pending-task queries used by the dispatch loop.
+type TaskPendingReader interface {
+	PendingTasksForDispatch(ctx context.Context, runID uuid.UUID, limit int) ([]models.TaskRun, error)
+}
+
+// DispatchLoopConfig holds all parameters for the dispatch loop goroutine.
+type DispatchLoopConfig struct {
+	// NodeID is this node's canonical address (CAESIUM_NODE_ADDRESS).  Used
+	// as the identity for OwnedRuns and included in the round-robin peer list.
+	NodeID string
+	// APIPort is the HTTP API port (CAESIUM_PORT).  Used to build the dispatch
+	// URL from peer node addresses.
+	APIPort int
+	// Token is the CAESIUM_INTERNAL_WAKEUP_TOKEN bearer token.
+	Token string
+	// Interval is the polling tick interval (CAESIUM_RUN_OWNER_DISPATCH_INTERVAL).
+	Interval time.Duration
+	// BatchSize caps the number of tasks dispatched per tick per run
+	// (CAESIUM_RUN_OWNER_DISPATCH_BATCH).
+	BatchSize int
+	// Deadline is added to time.Now() to produce the DispatchRequest.Deadline
+	// (CAESIUM_RUN_OWNER_DISPATCH_DEADLINE).
+	Deadline time.Duration
+	// LeaseStore provides ownership queries.
+	LeaseStore OwnerReader
+	// Store provides pending-task queries.
+	Store TaskPendingReader
+	// Peers resolves the current peer list.
+	Peers PeerLister
+}
+
+// DispatchLoop is the per-node push-dispatch goroutine for Phase A2.
+// Call Run(ctx) in a goroutine; it exits cleanly when ctx is cancelled.
+type DispatchLoop struct {
+	cfg     DispatchLoopConfig
+	counter atomic.Uint64 // round-robin counter; used modulo peer count
+}
+
+// NewDispatchLoop constructs a DispatchLoop from cfg.
+func NewDispatchLoop(cfg DispatchLoopConfig) *DispatchLoop {
+	if cfg.Interval <= 0 {
+		cfg.Interval = time.Second
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 64
+	}
+	if cfg.Deadline <= 0 {
+		cfg.Deadline = 5 * time.Minute
+	}
+	if cfg.APIPort <= 0 {
+		cfg.APIPort = 8080
+	}
+	return &DispatchLoop{cfg: cfg}
+}
+
+// Run starts the polling loop.  It blocks until ctx is cancelled.
+func (l *DispatchLoop) Run(ctx context.Context) {
+	ticker := time.NewTicker(l.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			l.tick(ctx)
+		}
+	}
+}
+
+// tick executes one dispatch sweep: discover peers, find owned runs with ready
+// tasks, and POST a DispatchRequest for each task up to BatchSize.
+func (l *DispatchLoop) tick(ctx context.Context) {
+	// 1. Discover peers (includes self).
+	peers, err := l.cfg.Peers.DispatchPeers(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.Warn("dispatch loop: peer discovery failed", "error", err)
+		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNoPeers).Inc()
+		return
+	}
+	// Normalise peers to dispatch URLs; include self in the rotation.
+	peerURLs := l.buildPeerURLs(peers)
+	if len(peerURLs) == 0 {
+		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNoPeers).Inc()
+		return
+	}
+
+	// 2. Find runs this node owns.
+	ownedRunIDs, err := l.cfg.LeaseStore.OwnedRuns(ctx, l.cfg.NodeID)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.Warn("dispatch loop: OwnedRuns failed", "error", err)
+		return
+	}
+	if len(ownedRunIDs) == 0 {
+		return // nothing to do
+	}
+
+	// 3. For each owned run, find ready tasks and dispatch them.
+	for _, runID := range ownedRunIDs {
+		if ctx.Err() != nil {
+			return
+		}
+		l.dispatchRun(ctx, runID, peerURLs)
+	}
+}
+
+// dispatchRun dispatches up to BatchSize ready tasks for a single owned run.
+func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, peerURLs []string) {
+	tasks, err := l.cfg.Store.PendingTasksForDispatch(ctx, runID, l.cfg.BatchSize)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.Warn("dispatch loop: PendingTasksForDispatch failed",
+			"run_id", runID, "error", err)
+		return
+	}
+	if len(tasks) == 0 {
+		return
+	}
+
+	// Get the current lease generation for this run so we can stamp it into
+	// the DispatchRequest.  A GetLease call per owned run is acceptable: we
+	// only poll runs we own, and the count is bounded by CAESIUM_RUN_OWNER_MAX_RUNS.
+	lease, err := l.cfg.LeaseStore.GetLease(ctx, runID)
+	if err != nil || lease == nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.Warn("dispatch loop: GetLease failed; skipping run",
+			"run_id", runID, "error", err)
+		return
+	}
+
+	for i := range tasks {
+		if ctx.Err() != nil {
+			return
+		}
+		task := &tasks[i]
+
+		// Pick a peer via round-robin (atomic counter so concurrent ticks
+		// from different runs don't drift, even though Phase A2 only runs a
+		// single tick goroutine).
+		idx := l.counter.Add(1) - 1
+		peerURL := peerURLs[idx%uint64(len(peerURLs))]
+
+		req := DispatchRequest{
+			RunID:           runID,
+			TaskID:          task.TaskID,
+			OwnerGeneration: lease.Generation,
+			Attempt:         task.Attempt,
+			WorkerNode:      peerNodeIDFromURL(peerURL, l.cfg.APIPort),
+			Deadline:        time.Now().UTC().Add(l.cfg.Deadline),
+		}
+
+		dispatchURL := peerURL + "/internal/dispatch"
+		accepted, postErr := PostDispatch(ctx, dispatchURL, l.cfg.Token, req)
+		if postErr != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Warn("dispatch loop: PostDispatch network error",
+				"run_id", runID,
+				"task_id", task.TaskID,
+				"peer", peerURL,
+				"error", postErr,
+			)
+			metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNetworkError).Inc()
+			// Leave task unclaimed; ClaimNext recovery will pick it up.
+			continue
+		}
+		if !accepted {
+			log.Warn("dispatch loop: worker rejected dispatch",
+				"run_id", runID,
+				"task_id", task.TaskID,
+				"peer", peerURL,
+			)
+			metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonWorkerRejected).Inc()
+			// Leave task unclaimed; ClaimNext recovery will pick it up.
+			continue
+		}
+
+		metrics.DispatchSentTotal.Inc()
+		log.Debug("dispatch loop: task dispatched",
+			"run_id", runID,
+			"task_id", task.TaskID,
+			"peer", peerURL,
+		)
+	}
+}
+
+// buildPeerURLs converts raw node addresses (host:dqlitePort) to base HTTP
+// URLs (http://host:apiPort) suitable for PostDispatch.  Self is always
+// appended at the end so the round-robin always has at least one target.
+func (l *DispatchLoop) buildPeerURLs(peers []string) []string {
+	seen := make(map[string]struct{}, len(peers)+1)
+	urls := make([]string, 0, len(peers)+1)
+
+	for _, addr := range peers {
+		u := l.nodeAddrToBaseURL(addr)
+		if u == "" {
+			continue
+		}
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		urls = append(urls, u)
+	}
+
+	// Always include self so single-node setups dispatch to themselves.
+	selfURL := l.nodeAddrToBaseURL(l.cfg.NodeID)
+	if selfURL != "" {
+		if _, ok := seen[selfURL]; !ok {
+			seen[selfURL] = struct{}{}
+			urls = append(urls, selfURL)
+		}
+	}
+
+	return urls
+}
+
+// nodeAddrToBaseURL converts "host:dqlitePort" (the dqlite / CAESIUM_NODE_ADDRESS
+// format) to "http://host:apiPort".  Returns "" on parse failure.
+func (l *DispatchLoop) nodeAddrToBaseURL(nodeAddr string) string {
+	host, _, err := net.SplitHostPort(nodeAddr)
+	if err != nil {
+		host = strings.TrimSpace(nodeAddr)
+	}
+	if host == "" || strings.HasPrefix(host, "@") {
+		return ""
+	}
+	return (&url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(host, strconv.Itoa(l.cfg.APIPort)),
+	}).String()
+}
+
+// peerNodeIDFromURL extracts the "host:apiPort" node identity from the base
+// URL that was constructed by buildPeerURLs / nodeAddrToBaseURL.  The returned
+// string is used as WorkerNode in the DispatchRequest so the recipient can
+// validate "dispatch addressed to me".
+func peerNodeIDFromURL(baseURL string, apiPort int) string {
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return baseURL
+	}
+	host, port, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		// No port in URL host — shouldn't happen given buildPeerURLs, but be safe.
+		return fmt.Sprintf("%s:%d", u.Host, apiPort)
+	}
+	_ = port
+	return net.JoinHostPort(host, strconv.Itoa(apiPort))
+}

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -21,11 +21,11 @@ package dispatch
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -37,9 +37,10 @@ import (
 
 // DispatchRejectionReason labels for caesium_dispatch_rejected_total.
 const (
-	DispatchReasonNetworkError   = "network_error"
-	DispatchReasonWorkerRejected = "worker_rejected"
-	DispatchReasonNoPeers        = "no_peers"
+	DispatchReasonNetworkError       = "network_error"
+	DispatchReasonWorkerRejected     = "worker_rejected"
+	DispatchReasonNoPeers            = "no_peers"             // peer discovery returned empty list (bootstrap)
+	DispatchReasonPeerDiscoveryError = "peer_discovery_error" // peer discovery RPC failed
 )
 
 // PeerLister provides the current set of dispatch-eligible peer node addresses.
@@ -58,9 +59,22 @@ func (f PeerListerFunc) DispatchPeers(ctx context.Context) ([]string, error) {
 }
 
 // OwnerReader provides run-lease ownership queries used by the dispatch loop.
+//
+// OwnedRunsWithGenerations returns owned runIDs mapped to their current
+// lease generation in a single query — used per-tick to avoid an N+1
+// GetLease pattern as the owned set grows.
 type OwnerReader interface {
-	OwnedRuns(ctx context.Context, ownerNode string) ([]uuid.UUID, error)
-	GetLease(ctx context.Context, runID uuid.UUID) (*models.RunLease, error)
+	OwnedRunsWithGenerations(ctx context.Context, ownerNode string) (map[uuid.UUID]int64, error)
+}
+
+// peer pairs a peer's canonical node identity (host:dqlitePort — matches the
+// receiving handler's nodeID, derived from CAESIUM_NODE_ADDRESS) with the HTTP
+// base URL the dispatch loop POSTs to (http://host:apiPort). The receiving
+// handler validates `req.WorkerNode == h.nodeID`; using the dqlite-port
+// identity here is what makes that validation pass.
+type peer struct {
+	nodeID  string
+	baseURL string
 }
 
 // TaskPendingReader provides pending-task queries used by the dispatch loop.
@@ -92,6 +106,12 @@ type DispatchLoopConfig struct {
 	Store TaskPendingReader
 	// Peers resolves the current peer list.
 	Peers PeerLister
+	// PeerBaseURL maps a raw peer node address (host:dqlitePort) to the HTTP
+	// base URL the dispatch loop POSTs to (http://host:apiPort). Optional;
+	// tests override it to route multiple distinct peer node IDs to a single
+	// mux server. Production leaves it nil and the loop falls back to the
+	// default (build URL from APIPort).
+	PeerBaseURL func(nodeAddr string) string
 }
 
 // DispatchLoop is the per-node push-dispatch goroutine for Phase A2.
@@ -137,46 +157,51 @@ func (l *DispatchLoop) Run(ctx context.Context) {
 // tasks, and POST a DispatchRequest for each task up to BatchSize.
 func (l *DispatchLoop) tick(ctx context.Context) {
 	// 1. Discover peers (includes self).
-	peers, err := l.cfg.Peers.DispatchPeers(ctx)
+	rawPeers, err := l.cfg.Peers.DispatchPeers(ctx)
 	if err != nil {
 		if ctx.Err() != nil {
 			return
 		}
 		log.Warn("dispatch loop: peer discovery failed", "error", err)
-		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNoPeers).Inc()
+		// Distinct from no_peers (empty list = normal bootstrap) so dashboards
+		// can alert on real RPC failures separately.
+		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonPeerDiscoveryError).Inc()
 		return
 	}
-	// Normalise peers to dispatch URLs; include self in the rotation.
-	peerURLs := l.buildPeerURLs(peers)
-	if len(peerURLs) == 0 {
+	// Normalise peers to {nodeID, baseURL} pairs; include self in the rotation.
+	peers := l.buildPeers(rawPeers)
+	if len(peers) == 0 {
 		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNoPeers).Inc()
 		return
 	}
 
-	// 2. Find runs this node owns.
-	ownedRunIDs, err := l.cfg.LeaseStore.OwnedRuns(ctx, l.cfg.NodeID)
+	// 2. Find runs this node owns AND their current generation in one query
+	//    (avoids the N+1 GetLease pattern as the owned set grows).
+	ownedRuns, err := l.cfg.LeaseStore.OwnedRunsWithGenerations(ctx, l.cfg.NodeID)
 	if err != nil {
 		if ctx.Err() != nil {
 			return
 		}
-		log.Warn("dispatch loop: OwnedRuns failed", "error", err)
+		log.Warn("dispatch loop: OwnedRunsWithGenerations failed", "error", err)
 		return
 	}
-	if len(ownedRunIDs) == 0 {
+	if len(ownedRuns) == 0 {
 		return // nothing to do
 	}
 
-	// 3. For each owned run, find ready tasks and dispatch them.
-	for _, runID := range ownedRunIDs {
+	// 3. For each owned run, find ready tasks and dispatch them concurrently.
+	for runID, generation := range ownedRuns {
 		if ctx.Err() != nil {
 			return
 		}
-		l.dispatchRun(ctx, runID, peerURLs)
+		l.dispatchRun(ctx, runID, generation, peers)
 	}
 }
 
 // dispatchRun dispatches up to BatchSize ready tasks for a single owned run.
-func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, peerURLs []string) {
+// Each task's PostDispatch fires in a worker goroutine bounded by BatchSize/4
+// (capped at 16) so slow or unreachable workers don't serialise the tick.
+func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, generation int64, peers []peer) {
 	tasks, err := l.cfg.Store.PendingTasksForDispatch(ctx, runID, l.cfg.BatchSize)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -190,110 +215,123 @@ func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, peerURL
 		return
 	}
 
-	// Get the current lease generation for this run so we can stamp it into
-	// the DispatchRequest.  A GetLease call per owned run is acceptable: we
-	// only poll runs we own, and the count is bounded by CAESIUM_RUN_OWNER_MAX_RUNS.
-	lease, err := l.cfg.LeaseStore.GetLease(ctx, runID)
-	if err != nil || lease == nil {
-		if ctx.Err() != nil {
-			return
-		}
-		log.Warn("dispatch loop: GetLease failed; skipping run",
-			"run_id", runID, "error", err)
-		return
+	// Bound the per-tick concurrent dispatches so we don't fan out 64 goroutines
+	// for every owned run. 16 is a soft cap that keeps slow workers from
+	// stalling the loop while not requiring a full worker-pool abstraction.
+	const maxConcurrent = 16
+	concurrency := len(tasks)
+	if concurrency > maxConcurrent {
+		concurrency = maxConcurrent
 	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
 
 	for i := range tasks {
 		if ctx.Err() != nil {
-			return
+			break
 		}
 		task := &tasks[i]
 
-		// Pick a peer via round-robin (atomic counter so concurrent ticks
-		// from different runs don't drift, even though Phase A2 only runs a
-		// single tick goroutine).
+		// Pick a peer via round-robin (atomic counter is per-loop, so per-task
+		// dispatch rotation is monotonic across runs and ticks).
 		idx := l.counter.Add(1) - 1
-		peerURL := peerURLs[idx%uint64(len(peerURLs))]
+		p := peers[idx%uint64(len(peers))]
 
 		req := DispatchRequest{
 			RunID:           runID,
 			TaskID:          task.TaskID,
-			OwnerGeneration: lease.Generation,
+			OwnerGeneration: generation,
 			Attempt:         task.Attempt,
-			WorkerNode:      peerNodeIDFromURL(peerURL, l.cfg.APIPort),
-			Deadline:        time.Now().UTC().Add(l.cfg.Deadline),
+			// nodeID matches the recipient's CAESIUM_NODE_ADDRESS so the
+			// handler's `req.WorkerNode == h.nodeID` check passes.
+			WorkerNode: p.nodeID,
+			Deadline:   time.Now().UTC().Add(l.cfg.Deadline),
 		}
 
-		dispatchURL := peerURL + "/internal/dispatch"
-		accepted, postErr := PostDispatch(ctx, dispatchURL, l.cfg.Token, req)
-		if postErr != nil {
-			if ctx.Err() != nil {
-				return
-			}
-			log.Warn("dispatch loop: PostDispatch network error",
-				"run_id", runID,
-				"task_id", task.TaskID,
-				"peer", peerURL,
-				"error", postErr,
-			)
-			metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNetworkError).Inc()
-			// Leave task unclaimed; ClaimNext recovery will pick it up.
-			continue
-		}
-		if !accepted {
-			log.Warn("dispatch loop: worker rejected dispatch",
-				"run_id", runID,
-				"task_id", task.TaskID,
-				"peer", peerURL,
-			)
-			metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonWorkerRejected).Inc()
-			// Leave task unclaimed; ClaimNext recovery will pick it up.
-			continue
-		}
-
-		metrics.DispatchSentTotal.Inc()
-		log.Debug("dispatch loop: task dispatched",
-			"run_id", runID,
-			"task_id", task.TaskID,
-			"peer", peerURL,
-		)
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(p peer, req DispatchRequest) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			l.postOne(ctx, runID, p, req)
+		}(p, req)
 	}
+	wg.Wait()
 }
 
-// buildPeerURLs converts raw node addresses (host:dqlitePort) to base HTTP
-// URLs (http://host:apiPort) suitable for PostDispatch.  Self is always
-// appended at the end so the round-robin always has at least one target.
-func (l *DispatchLoop) buildPeerURLs(peers []string) []string {
-	seen := make(map[string]struct{}, len(peers)+1)
-	urls := make([]string, 0, len(peers)+1)
+// postOne does the actual HTTP call + metric/log accounting for one dispatch.
+func (l *DispatchLoop) postOne(ctx context.Context, runID uuid.UUID, p peer, req DispatchRequest) {
+	dispatchURL := p.baseURL + "/internal/dispatch"
+	accepted, postErr := PostDispatch(ctx, dispatchURL, l.cfg.Token, req)
+	if postErr != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		log.Warn("dispatch loop: PostDispatch network error",
+			"run_id", runID,
+			"task_id", req.TaskID,
+			"peer", p.nodeID,
+			"error", postErr,
+		)
+		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNetworkError).Inc()
+		return
+	}
+	if !accepted {
+		log.Warn("dispatch loop: worker rejected dispatch",
+			"run_id", runID,
+			"task_id", req.TaskID,
+			"peer", p.nodeID,
+		)
+		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonWorkerRejected).Inc()
+		return
+	}
+	metrics.DispatchSentTotal.Inc()
+	log.Debug("dispatch loop: task dispatched",
+		"run_id", runID,
+		"task_id", req.TaskID,
+		"peer", p.nodeID,
+	)
+}
 
-	for _, addr := range peers {
-		u := l.nodeAddrToBaseURL(addr)
-		if u == "" {
-			continue
+// buildPeers normalises raw peer addresses (host:dqlitePort) into peer pairs
+// of {nodeID = host:dqlitePort, baseURL = http://host:apiPort}.  Self is
+// always appended at the end so the round-robin always has at least one target.
+func (l *DispatchLoop) buildPeers(rawPeers []string) []peer {
+	seen := make(map[string]struct{}, len(rawPeers)+1)
+	out := make([]peer, 0, len(rawPeers)+1)
+
+	add := func(addr string) {
+		canonical := strings.TrimSpace(addr)
+		if canonical == "" || strings.HasPrefix(canonical, "@") {
+			return
 		}
-		if _, ok := seen[u]; ok {
-			continue
+		if _, ok := seen[canonical]; ok {
+			return
 		}
-		seen[u] = struct{}{}
-		urls = append(urls, u)
+		baseURL := l.nodeAddrToBaseURL(canonical)
+		if baseURL == "" {
+			return
+		}
+		seen[canonical] = struct{}{}
+		out = append(out, peer{nodeID: canonical, baseURL: baseURL})
 	}
 
+	for _, addr := range rawPeers {
+		add(addr)
+	}
 	// Always include self so single-node setups dispatch to themselves.
-	selfURL := l.nodeAddrToBaseURL(l.cfg.NodeID)
-	if selfURL != "" {
-		if _, ok := seen[selfURL]; !ok {
-			seen[selfURL] = struct{}{}
-			urls = append(urls, selfURL)
-		}
-	}
+	add(l.cfg.NodeID)
 
-	return urls
+	return out
 }
 
 // nodeAddrToBaseURL converts "host:dqlitePort" (the dqlite / CAESIUM_NODE_ADDRESS
-// format) to "http://host:apiPort".  Returns "" on parse failure.
+// format) to "http://host:apiPort".  Returns "" on parse failure. The config's
+// PeerBaseURL override takes precedence when set.
 func (l *DispatchLoop) nodeAddrToBaseURL(nodeAddr string) string {
+	if l.cfg.PeerBaseURL != nil {
+		return l.cfg.PeerBaseURL(nodeAddr)
+	}
 	host, _, err := net.SplitHostPort(nodeAddr)
 	if err != nil {
 		host = strings.TrimSpace(nodeAddr)
@@ -305,22 +343,4 @@ func (l *DispatchLoop) nodeAddrToBaseURL(nodeAddr string) string {
 		Scheme: "http",
 		Host:   net.JoinHostPort(host, strconv.Itoa(l.cfg.APIPort)),
 	}).String()
-}
-
-// peerNodeIDFromURL extracts the "host:apiPort" node identity from the base
-// URL that was constructed by buildPeerURLs / nodeAddrToBaseURL.  The returned
-// string is used as WorkerNode in the DispatchRequest so the recipient can
-// validate "dispatch addressed to me".
-func peerNodeIDFromURL(baseURL string, apiPort int) string {
-	u, err := url.Parse(baseURL)
-	if err != nil || u.Host == "" {
-		return baseURL
-	}
-	host, port, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		// No port in URL host — shouldn't happen given buildPeerURLs, but be safe.
-		return fmt.Sprintf("%s:%d", u.Host, apiPort)
-	}
-	_ = port
-	return net.JoinHostPort(host, strconv.Itoa(apiPort))
 }

--- a/internal/dispatch/loop_test.go
+++ b/internal/dispatch/loop_test.go
@@ -1,0 +1,607 @@
+package dispatch
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+)
+
+// -- Test helpers ------------------------------------------------------------
+
+// testPeerLister is a stub PeerLister that returns a fixed set of addresses.
+type testPeerLister struct {
+	mu    sync.Mutex
+	peers []string
+}
+
+func (p *testPeerLister) DispatchPeers(_ context.Context) ([]string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.peers...), nil
+}
+
+func (p *testPeerLister) setPeers(peers []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.peers = peers
+}
+
+// testOwnerReader wraps run.LeaseStore to satisfy OwnerReader.
+type testOwnerReader struct {
+	ls *run.LeaseStore
+}
+
+func (r *testOwnerReader) OwnedRuns(ctx context.Context, ownerNode string) ([]uuid.UUID, error) {
+	return r.ls.OwnedRuns(ctx, ownerNode)
+}
+
+func (r *testOwnerReader) GetLease(ctx context.Context, runID uuid.UUID) (*models.RunLease, error) {
+	return r.ls.GetLease(ctx, runID)
+}
+
+// testTaskReader wraps run.Store to satisfy TaskPendingReader.
+type testTaskReader struct {
+	s *run.Store
+}
+
+func (r *testTaskReader) PendingTasksForDispatch(ctx context.Context, runID uuid.UUID, limit int) ([]models.TaskRun, error) {
+	return r.s.PendingTasksForDispatch(ctx, runID, limit)
+}
+
+// counterValue reads the current value of a prometheus.Counter.
+func counterValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	var m dto.Metric
+	if err := c.Write(&m); err != nil {
+		t.Fatalf("counter.Write: %v", err)
+	}
+	return m.GetCounter().GetValue()
+}
+
+// counterVecValue reads the current value of a prometheus.CounterVec for the
+// given label values.
+func counterVecValue(t *testing.T, cv *prometheus.CounterVec, lvs ...string) float64 {
+	t.Helper()
+	c, err := cv.GetMetricWithLabelValues(lvs...)
+	if err != nil {
+		t.Fatalf("GetMetricWithLabelValues(%v): %v", lvs, err)
+	}
+	return counterValue(t, c)
+}
+
+// serverPort parses the port from an httptest.Server's listener address string
+// ("127.0.0.1:PORT") and returns it as an int.
+func serverPort(t *testing.T, s *httptest.Server) int {
+	t.Helper()
+	_, portStr, err := net.SplitHostPort(s.Listener.Addr().String())
+	require.NoError(t, err, "parse server listener port")
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err, "convert port to int")
+	return port
+}
+
+// serverNodeID returns a "127.0.0.1:PORT" style node address that the dispatch
+// loop will convert to http://127.0.0.1:PORT using the same port (apiPort ==
+// serverPort(s)).  This lets us route loop dispatches to the test server.
+func serverNodeID(t *testing.T, s *httptest.Server) (nodeID string, apiPort int) {
+	t.Helper()
+	apiPort = serverPort(t, s)
+	nodeID = net.JoinHostPort("127.0.0.1", strconv.Itoa(apiPort))
+	return nodeID, apiPort
+}
+
+// -- Constants ---------------------------------------------------------------
+
+const (
+	loopToken = "loop-test-token"
+)
+
+// -- Test DB helpers ---------------------------------------------------------
+
+// insertPendingTask inserts a minimal pending task_runs row directly using the
+// underlying gorm connection exposed via store.DB().
+func insertPendingTask(t *testing.T, store *run.Store, runID, taskID uuid.UUID) {
+	t.Helper()
+
+	task := &models.TaskRun{
+		ID:                      uuid.New(),
+		JobRunID:                runID,
+		TaskID:                  taskID,
+		AtomID:                  uuid.New(),
+		Engine:                  "docker",
+		Image:                   "busybox:1.36.1", // pinned to pass guardrails check
+		Command:                 "[]",
+		Status:                  string(run.TaskStatusPending),
+		ClaimedBy:               "",
+		OutstandingPredecessors: 0,
+		Attempt:                 1,
+		MaxAttempts:             1,
+	}
+	require.NoError(t, store.DB().Create(task).Error)
+}
+
+// -- Tests -------------------------------------------------------------------
+
+// TestDispatchLoop_HappyPath verifies that the loop finds one ready task on an
+// owned run, dispatches it to a stub worker that returns 202, and increments
+// caesium_dispatch_sent_total.
+func TestDispatchLoop_HappyPath(t *testing.T) {
+	metrics.Register()
+
+	// Track how many dispatch calls arrive at the stub server.
+	var received atomic.Int32
+
+	// Stub worker: accepts dispatches unconditionally.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		var req DispatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		require.Equal(t, 1, req.Attempt)
+		require.NotZero(t, req.OwnerGeneration)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	nodeID, apiPort := serverNodeID(t, server)
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
+
+	runID := uuid.New()
+	_, err := ls.AcquireLease(context.Background(), runID, nodeID, 30*time.Second)
+	require.NoError(t, err)
+	taskID := uuid.New()
+	insertPendingTask(t, store, runID, taskID)
+
+	beforeSent := counterValue(t, metrics.DispatchSentTotal)
+
+	loop := NewDispatchLoop(DispatchLoopConfig{
+		NodeID:     nodeID,
+		APIPort:    apiPort,
+		Token:      loopToken,
+		Interval:   50 * time.Millisecond,
+		BatchSize:  64,
+		Deadline:   5 * time.Minute,
+		LeaseStore: &testOwnerReader{ls},
+		Store:      &testTaskReader{store},
+		Peers:      &testPeerLister{}, // no external peers; self is added automatically
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	t.Cleanup(cancel)
+	loop.Run(ctx)
+
+	require.GreaterOrEqual(t, received.Load(), int32(1), "should have dispatched at least once")
+	afterSent := counterValue(t, metrics.DispatchSentTotal)
+	require.Greater(t, afterSent, beforeSent, "caesium_dispatch_sent_total should have incremented")
+}
+
+// TestDispatchLoop_FallbackOnRejection verifies that when the stub worker
+// returns 409, the task remains pending+unclaimed, the rejection counter
+// increments, and the next tick dispatches again.
+func TestDispatchLoop_FallbackOnRejection(t *testing.T) {
+	metrics.Register()
+
+	var received atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		w.WriteHeader(http.StatusConflict) // 409 — reject
+	}))
+	t.Cleanup(server.Close)
+
+	nodeID, apiPort := serverNodeID(t, server)
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
+
+	runID := uuid.New()
+	_, err := ls.AcquireLease(context.Background(), runID, nodeID, 30*time.Second)
+	require.NoError(t, err)
+	taskID := uuid.New()
+	insertPendingTask(t, store, runID, taskID)
+
+	beforeRejected := counterVecValue(t, metrics.DispatchRejectedTotal, DispatchReasonWorkerRejected)
+
+	loop := NewDispatchLoop(DispatchLoopConfig{
+		NodeID:     nodeID,
+		APIPort:    apiPort,
+		Token:      loopToken,
+		Interval:   50 * time.Millisecond,
+		BatchSize:  64,
+		Deadline:   5 * time.Minute,
+		LeaseStore: &testOwnerReader{ls},
+		Store:      &testTaskReader{store},
+		Peers:      &testPeerLister{},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	t.Cleanup(cancel)
+	loop.Run(ctx)
+
+	afterRejected := counterVecValue(t, metrics.DispatchRejectedTotal, DispatchReasonWorkerRejected)
+	require.Greater(t, afterRejected, beforeRejected,
+		"caesium_dispatch_rejected_total{worker_rejected} should increment")
+
+	// Task must still be pending+unclaimed since dispatch was always rejected.
+	tasks, err := store.PendingTasksForDispatch(context.Background(), runID, 10)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1, "task should remain pending+unclaimed after rejected dispatch")
+
+	require.GreaterOrEqual(t, received.Load(), int32(1), "stub should have received at least one request")
+}
+
+// TestDispatchLoop_NoOwnedRuns verifies that when the node owns no runs, the
+// loop exits early without calling PostDispatch.
+func TestDispatchLoop_NoOwnedRuns(t *testing.T) {
+	metrics.Register()
+
+	var called atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	nodeID, apiPort := serverNodeID(t, server)
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
+	// No leases acquired — OwnedRuns returns empty.
+
+	loop := NewDispatchLoop(DispatchLoopConfig{
+		NodeID:     nodeID,
+		APIPort:    apiPort,
+		Token:      loopToken,
+		Interval:   50 * time.Millisecond,
+		BatchSize:  64,
+		Deadline:   5 * time.Minute,
+		LeaseStore: &testOwnerReader{ls},
+		Store:      &testTaskReader{store},
+		Peers:      &testPeerLister{},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	t.Cleanup(cancel)
+	loop.Run(ctx)
+
+	require.False(t, called.Load(), "PostDispatch should never be called when no runs are owned")
+}
+
+// TestDispatchLoop_NoPeers verifies that when peer discovery returns empty AND
+// the node ID is non-routable, the loop increments
+// caesium_dispatch_rejected_total{reason=no_peers} and exits the tick early.
+func TestDispatchLoop_NoPeers(t *testing.T) {
+	metrics.Register()
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
+
+	// Acquire a lease so OwnedRuns returns a non-empty set.
+	const nodeID = "@abstract-unix" // abstract-unix address; skipped by buildPeerURLs
+	runID := uuid.New()
+	_, err := ls.AcquireLease(context.Background(), runID, nodeID, 30*time.Second)
+	require.NoError(t, err)
+
+	// Peer lister returns empty; NodeID is abstract so self-URL is also empty.
+	peers := &testPeerLister{}
+
+	beforeNoPeers := counterVecValue(t, metrics.DispatchRejectedTotal, DispatchReasonNoPeers)
+
+	loop := NewDispatchLoop(DispatchLoopConfig{
+		NodeID:     nodeID, // abstract unix — skipped by buildPeerURLs; no self URL
+		APIPort:    8080,
+		Token:      loopToken,
+		Interval:   50 * time.Millisecond,
+		BatchSize:  64,
+		Deadline:   5 * time.Minute,
+		LeaseStore: &testOwnerReader{ls},
+		Store:      &testTaskReader{store},
+		Peers:      peers,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	t.Cleanup(cancel)
+	loop.Run(ctx)
+
+	afterNoPeers := counterVecValue(t, metrics.DispatchRejectedTotal, DispatchReasonNoPeers)
+	require.Greater(t, afterNoPeers, beforeNoPeers,
+		"caesium_dispatch_rejected_total{no_peers} should increment when no peer URLs resolve")
+}
+
+// TestDispatchLoop_BatchCap verifies that when an owned run has more ready
+// tasks than the batch limit, only BatchSize tasks are returned per
+// PendingTasksForDispatch call.
+func TestDispatchLoop_BatchCap(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
+
+	runID := uuid.New()
+	const nodeID = "127.0.0.1:9001"
+	_, err := ls.AcquireLease(context.Background(), runID, nodeID, 30*time.Second)
+	require.NoError(t, err)
+
+	const totalTasks = 200
+	const batchSize = 64
+
+	for i := 0; i < totalTasks; i++ {
+		insertPendingTask(t, store, runID, uuid.New())
+	}
+
+	// PendingTasksForDispatch with limit=batchSize should cap the result.
+	tasks, err := store.PendingTasksForDispatch(context.Background(), runID, batchSize)
+	require.NoError(t, err)
+	require.Len(t, tasks, batchSize,
+		"PendingTasksForDispatch with limit=%d should return at most %d tasks from %d",
+		batchSize, batchSize, totalTasks)
+
+	// Verify that with a larger limit we get all tasks.
+	allTasks, err := store.PendingTasksForDispatch(context.Background(), runID, totalTasks+1)
+	require.NoError(t, err)
+	require.Len(t, allTasks, totalTasks,
+		"PendingTasksForDispatch with limit>total should return all %d tasks", totalTasks)
+}
+
+// TestDispatchLoop_SelfDispatch verifies that when there is exactly one peer
+// (self), the dispatch envelope's WorkerNode is populated and dispatches reach
+// the local node.
+func TestDispatchLoop_SelfDispatch(t *testing.T) {
+	metrics.Register()
+
+	var capturedReq DispatchRequest
+	var mu sync.Mutex
+	var received atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.Add(1)
+		var req DispatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+			mu.Lock()
+			capturedReq = req
+			mu.Unlock()
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(server.Close)
+
+	nodeID, apiPort := serverNodeID(t, server)
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
+	runID := uuid.New()
+	_, err := ls.AcquireLease(context.Background(), runID, nodeID, 30*time.Second)
+	require.NoError(t, err)
+	insertPendingTask(t, store, runID, uuid.New())
+
+	loop := NewDispatchLoop(DispatchLoopConfig{
+		NodeID:     nodeID, // single peer: self
+		APIPort:    apiPort,
+		Token:      loopToken,
+		Interval:   50 * time.Millisecond,
+		BatchSize:  64,
+		Deadline:   5 * time.Minute,
+		LeaseStore: &testOwnerReader{ls},
+		Store:      &testTaskReader{store},
+		Peers:      &testPeerLister{}, // no external peers
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	t.Cleanup(cancel)
+	loop.Run(ctx)
+
+	require.GreaterOrEqual(t, received.Load(), int32(1), "should have dispatched to self at least once")
+
+	mu.Lock()
+	wn := capturedReq.WorkerNode
+	mu.Unlock()
+
+	require.NotEmpty(t, wn, "WorkerNode should be set in the DispatchRequest")
+	require.Contains(t, wn, "127.0.0.1",
+		"WorkerNode should reference the local host")
+}
+
+// TestDispatchLoop_RoundRobin verifies that 6 tasks across 3 peers results in
+// 2 dispatches per peer (one synchronous tick with a fresh counter).
+func TestDispatchLoop_RoundRobin(t *testing.T) {
+	metrics.Register()
+
+	type serverState struct {
+		s     *httptest.Server
+		count atomic.Int32
+	}
+
+	const numPeers = 3
+	const numTasks = 6
+
+	states := make([]*serverState, numPeers)
+	peerNodeIDs := make([]string, numPeers)   // "127.0.0.1:PORT" strings
+	peerAPIPorts := make([]int, numPeers)
+
+	for i := range states {
+		st := &serverState{}
+		st.s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			st.count.Add(1)
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		states[i] = st
+		peerNodeIDs[i], peerAPIPorts[i] = serverNodeID(t, st.s)
+		t.Cleanup(st.s.Close)
+	}
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
+	runID := uuid.New()
+
+	// Use the first server as the owning node.
+	ownerNodeID := peerNodeIDs[0]
+	ownerAPIPort := peerAPIPorts[0]
+	_, err := ls.AcquireLease(context.Background(), runID, ownerNodeID, 30*time.Second)
+	require.NoError(t, err)
+
+	for i := 0; i < numTasks; i++ {
+		insertPendingTask(t, store, runID, uuid.New())
+	}
+
+	// Peer lister returns the other nodes (self is appended by the loop).
+	// We give the peer lister the "dqlite node address" style strings (host:port)
+	// for the other servers; the loop builds the http URL using their respective ports.
+	// BUT — the loop uses a single APIPort for ALL peers.  For multi-server tests we
+	// need all servers on the same logical API port, which isn't achievable with
+	// httptest.NewServer on random ports.
+	//
+	// Solution: inject peers as already-constructed base URLs via a custom PeerLister
+	// that bypasses the nodeAddrToBaseURL conversion by pre-building full URLs.
+	// We wrap the PeerLister to return addresses that map through nodeAddrToBaseURL
+	// correctly for each peer's actual port.
+	//
+	// Since each peer has a different actual port, we configure APIPort=0 and
+	// override buildPeerURLs by injecting a PeerLister that returns the peer
+	// node IDs (host:PORT) and setting each peer's API port as its node port.
+	// But the loop only has ONE APIPort.
+	//
+	// Simplest correct approach: use a custom PeerLister that returns full base URLs
+	// as "addresses", and set APIPort=80 so that nodeAddrToBaseURL produces
+	// "http://host:80" — but then we need the test servers on port 80 too.
+	//
+	// The real solution: build a custom PeerLister that bypasses nodeAddrToBaseURL
+	// and returns ready-to-use base URLs.  We can do this by embedding the full URL
+	// in a way that net.SplitHostPort parses correctly.  The cleanest approach is
+	// to use a mock that directly controls the URL.
+	//
+	// For the round-robin test specifically, use a single-port approach: route all
+	// peers through a mux that distributes to the actual backend servers.
+	// Alternatively: use a custom dispatch function.
+	//
+	// PRACTICAL approach: we only need to assert that all 6 tasks are dispatched
+	// and each of 3 URLs receives exactly 2.  We can do this with a custom mux
+	// that acts as the single "server" and routes based on a dispatch counter.
+	// But that doesn't test actual round-robin.
+	//
+	// BEST approach for this codebase: create a PeerLister that returns
+	// "host:PORT" where PORT IS the API port the loop will use.  Since each
+	// server has a unique port, configure APIPort to be the actual server port.
+	// The catch: there's ONE APIPort per loop, not one per peer.
+	//
+	// For a deterministic round-robin test, we use ONE apiPort shared by all
+	// servers (via a reverse proxy / single mux), and verify distribution.
+	//
+	// Simpler: test PendingTasksForDispatch cap + the round-robin counter directly.
+	// We assert round-robin by calling dispatchRun manually and verifying counter
+	// increments, using a single server that records WorkerNode from each request.
+
+	// Use the FIRST server as the sole receiving endpoint; instrument it to
+	// capture WorkerNode values.  The round-robin test verifies that the counter
+	// advances across 6 dispatches even if they all go to the same server.
+	var workerNodes []string
+	var wnMu sync.Mutex
+
+	mux := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req DispatchRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
+			wnMu.Lock()
+			workerNodes = append(workerNodes, req.WorkerNode)
+			wnMu.Unlock()
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	t.Cleanup(mux.Close)
+
+	muxNodeID, muxAPIPort := serverNodeID(t, mux)
+
+	// Build peer list of 3 "nodes" all pointing to the mux but with different
+	// node IDs so round-robin counter advances across them.
+	loopPeers := []string{
+		"node-a:9001",
+		"node-b:9001",
+		"node-c:9001",
+	}
+	peers := &testPeerLister{}
+	peers.setPeers(loopPeers)
+
+	// Use muxNodeID as self so buildPeerURLs always returns the mux URL.
+	// The 3 external "peers" will produce dead URLs (port 8080), but since
+	// the mux is at muxAPIPort and round-robin advances the counter, we can
+	// verify the counter goes through all 3 positions.
+	//
+	// Actually, let's use a simpler direct test: call tick() once and verify
+	// the atomic counter advanced by numTasks positions.
+
+	db2 := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db2) })
+	ls2 := run.NewLeaseStore(db2)
+	store2 := run.NewStore(db2).WithLeaseStore(ls2)
+	runID2 := uuid.New()
+	_, err = ls2.AcquireLease(context.Background(), runID2, muxNodeID, 30*time.Second)
+	require.NoError(t, err)
+	for i := 0; i < numTasks; i++ {
+		insertPendingTask(t, store2, runID2, uuid.New())
+	}
+
+	loop := NewDispatchLoop(DispatchLoopConfig{
+		NodeID:     muxNodeID,
+		APIPort:    muxAPIPort,
+		Token:      loopToken,
+		Interval:   50 * time.Millisecond,
+		BatchSize:  64,
+		Deadline:   5 * time.Minute,
+		LeaseStore: &testOwnerReader{ls2},
+		Store:      &testTaskReader{store2},
+		Peers:      &testPeerLister{}, // only self (mux)
+	})
+
+	// Run a single tick.
+	loop.tick(context.Background())
+
+	wnMu.Lock()
+	wns := append([]string(nil), workerNodes...)
+	wnMu.Unlock()
+
+	require.Len(t, wns, numTasks,
+		"all %d tasks should be dispatched in one tick", numTasks)
+
+	// All WorkerNode values should be the same (the mux) because only self is
+	// in the peer list.  The key assertion is that counter advanced by numTasks.
+	counterAfter := loop.counter.Load()
+	require.Equal(t, uint64(numTasks), counterAfter,
+		"round-robin counter should have advanced by numTasks=%d", numTasks)
+
+	_ = ownerNodeID
+	_ = ownerAPIPort
+	_ = states
+	_ = peerNodeIDs
+	_ = peerAPIPorts
+	_ = store
+	_ = ls
+}

--- a/internal/dispatch/loop_test.go
+++ b/internal/dispatch/loop_test.go
@@ -36,12 +36,6 @@ func (p *testPeerLister) DispatchPeers(_ context.Context) ([]string, error) {
 	return append([]string(nil), p.peers...), nil
 }
 
-func (p *testPeerLister) setPeers(peers []string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.peers = peers
-}
-
 // testOwnerReader wraps run.LeaseStore to satisfy OwnerReader.
 type testOwnerReader struct {
 	ls *run.LeaseStore

--- a/internal/dispatch/loop_test.go
+++ b/internal/dispatch/loop_test.go
@@ -47,12 +47,8 @@ type testOwnerReader struct {
 	ls *run.LeaseStore
 }
 
-func (r *testOwnerReader) OwnedRuns(ctx context.Context, ownerNode string) ([]uuid.UUID, error) {
-	return r.ls.OwnedRuns(ctx, ownerNode)
-}
-
-func (r *testOwnerReader) GetLease(ctx context.Context, runID uuid.UUID) (*models.RunLease, error) {
-	return r.ls.GetLease(ctx, runID)
+func (r *testOwnerReader) OwnedRunsWithGenerations(ctx context.Context, ownerNode string) (map[uuid.UUID]int64, error) {
+	return r.ls.OwnedRunsWithGenerations(ctx, ownerNode)
 }
 
 // testTaskReader wraps run.Store to satisfy TaskPendingReader.
@@ -430,103 +426,22 @@ func TestDispatchLoop_SelfDispatch(t *testing.T) {
 		"WorkerNode should reference the local host")
 }
 
-// TestDispatchLoop_RoundRobin verifies that 6 tasks across 3 peers results in
-// 2 dispatches per peer (one synchronous tick with a fresh counter).
+// TestDispatchLoop_RoundRobin verifies that 6 tasks across 3 peer node IDs
+// are distributed exactly 2 per peer. All dispatches reach a single mux server
+// (so the test doesn't have to engineer 3 servers on the same port); the
+// distribution is observed via the WorkerNode field on each received
+// DispatchRequest. This is enabled by the PeerBaseURL config override, which
+// the test points at the mux for every peer node ID.
 func TestDispatchLoop_RoundRobin(t *testing.T) {
 	metrics.Register()
 
-	type serverState struct {
-		s     *httptest.Server
-		count atomic.Int32
-	}
-
-	const numPeers = 3
 	const numTasks = 6
 
-	states := make([]*serverState, numPeers)
-	peerNodeIDs := make([]string, numPeers)   // "127.0.0.1:PORT" strings
-	peerAPIPorts := make([]int, numPeers)
-
-	for i := range states {
-		st := &serverState{}
-		st.s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			st.count.Add(1)
-			w.WriteHeader(http.StatusAccepted)
-		}))
-		states[i] = st
-		peerNodeIDs[i], peerAPIPorts[i] = serverNodeID(t, st.s)
-		t.Cleanup(st.s.Close)
-	}
-
-	db := testutil.OpenTestDB(t)
-	t.Cleanup(func() { testutil.CloseDB(db) })
-	ls := run.NewLeaseStore(db)
-	store := run.NewStore(db).WithLeaseStore(ls)
-	runID := uuid.New()
-
-	// Use the first server as the owning node.
-	ownerNodeID := peerNodeIDs[0]
-	ownerAPIPort := peerAPIPorts[0]
-	_, err := ls.AcquireLease(context.Background(), runID, ownerNodeID, 30*time.Second)
-	require.NoError(t, err)
-
-	for i := 0; i < numTasks; i++ {
-		insertPendingTask(t, store, runID, uuid.New())
-	}
-
-	// Peer lister returns the other nodes (self is appended by the loop).
-	// We give the peer lister the "dqlite node address" style strings (host:port)
-	// for the other servers; the loop builds the http URL using their respective ports.
-	// BUT — the loop uses a single APIPort for ALL peers.  For multi-server tests we
-	// need all servers on the same logical API port, which isn't achievable with
-	// httptest.NewServer on random ports.
-	//
-	// Solution: inject peers as already-constructed base URLs via a custom PeerLister
-	// that bypasses the nodeAddrToBaseURL conversion by pre-building full URLs.
-	// We wrap the PeerLister to return addresses that map through nodeAddrToBaseURL
-	// correctly for each peer's actual port.
-	//
-	// Since each peer has a different actual port, we configure APIPort=0 and
-	// override buildPeerURLs by injecting a PeerLister that returns the peer
-	// node IDs (host:PORT) and setting each peer's API port as its node port.
-	// But the loop only has ONE APIPort.
-	//
-	// Simplest correct approach: use a custom PeerLister that returns full base URLs
-	// as "addresses", and set APIPort=80 so that nodeAddrToBaseURL produces
-	// "http://host:80" — but then we need the test servers on port 80 too.
-	//
-	// The real solution: build a custom PeerLister that bypasses nodeAddrToBaseURL
-	// and returns ready-to-use base URLs.  We can do this by embedding the full URL
-	// in a way that net.SplitHostPort parses correctly.  The cleanest approach is
-	// to use a mock that directly controls the URL.
-	//
-	// For the round-robin test specifically, use a single-port approach: route all
-	// peers through a mux that distributes to the actual backend servers.
-	// Alternatively: use a custom dispatch function.
-	//
-	// PRACTICAL approach: we only need to assert that all 6 tasks are dispatched
-	// and each of 3 URLs receives exactly 2.  We can do this with a custom mux
-	// that acts as the single "server" and routes based on a dispatch counter.
-	// But that doesn't test actual round-robin.
-	//
-	// BEST approach for this codebase: create a PeerLister that returns
-	// "host:PORT" where PORT IS the API port the loop will use.  Since each
-	// server has a unique port, configure APIPort to be the actual server port.
-	// The catch: there's ONE APIPort per loop, not one per peer.
-	//
-	// For a deterministic round-robin test, we use ONE apiPort shared by all
-	// servers (via a reverse proxy / single mux), and verify distribution.
-	//
-	// Simpler: test PendingTasksForDispatch cap + the round-robin counter directly.
-	// We assert round-robin by calling dispatchRun manually and verifying counter
-	// increments, using a single server that records WorkerNode from each request.
-
-	// Use the FIRST server as the sole receiving endpoint; instrument it to
-	// capture WorkerNode values.  The round-robin test verifies that the counter
-	// advances across 6 dispatches even if they all go to the same server.
-	var workerNodes []string
-	var wnMu sync.Mutex
-
+	// Single mux server captures every dispatch and records its WorkerNode.
+	var (
+		wnMu        sync.Mutex
+		workerNodes []string
+	)
 	mux := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req DispatchRequest
 		if err := json.NewDecoder(r.Body).Decode(&req); err == nil {
@@ -538,70 +453,56 @@ func TestDispatchLoop_RoundRobin(t *testing.T) {
 	}))
 	t.Cleanup(mux.Close)
 
-	muxNodeID, muxAPIPort := serverNodeID(t, mux)
+	// 3 logical peer node IDs (matching the dqlite-port style that
+	// CAESIUM_NODE_ADDRESS uses). Self is omitted so buildPeers gives us
+	// exactly these three plus self (the owner) for 4 total — but the owner's
+	// nodeID is one of these three, so dedup keeps it at 3.
+	const ownerNodeID = "node-a:9001"
+	peerNodeIDs := []string{ownerNodeID, "node-b:9001", "node-c:9001"}
 
-	// Build peer list of 3 "nodes" all pointing to the mux but with different
-	// node IDs so round-robin counter advances across them.
-	loopPeers := []string{
-		"node-a:9001",
-		"node-b:9001",
-		"node-c:9001",
-	}
-	peers := &testPeerLister{}
-	peers.setPeers(loopPeers)
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := run.NewLeaseStore(db)
+	store := run.NewStore(db).WithLeaseStore(ls)
 
-	// Use muxNodeID as self so buildPeerURLs always returns the mux URL.
-	// The 3 external "peers" will produce dead URLs (port 8080), but since
-	// the mux is at muxAPIPort and round-robin advances the counter, we can
-	// verify the counter goes through all 3 positions.
-	//
-	// Actually, let's use a simpler direct test: call tick() once and verify
-	// the atomic counter advanced by numTasks positions.
-
-	db2 := testutil.OpenTestDB(t)
-	t.Cleanup(func() { testutil.CloseDB(db2) })
-	ls2 := run.NewLeaseStore(db2)
-	store2 := run.NewStore(db2).WithLeaseStore(ls2)
-	runID2 := uuid.New()
-	_, err = ls2.AcquireLease(context.Background(), runID2, muxNodeID, 30*time.Second)
+	runID := uuid.New()
+	_, err := ls.AcquireLease(context.Background(), runID, ownerNodeID, 30*time.Second)
 	require.NoError(t, err)
 	for i := 0; i < numTasks; i++ {
-		insertPendingTask(t, store2, runID2, uuid.New())
+		insertPendingTask(t, store, runID, uuid.New())
 	}
 
 	loop := NewDispatchLoop(DispatchLoopConfig{
-		NodeID:     muxNodeID,
-		APIPort:    muxAPIPort,
+		NodeID:     ownerNodeID,
+		APIPort:    8080, // unused because PeerBaseURL overrides
 		Token:      loopToken,
-		Interval:   50 * time.Millisecond,
+		Interval:   time.Hour, // we call tick() directly
 		BatchSize:  64,
 		Deadline:   5 * time.Minute,
-		LeaseStore: &testOwnerReader{ls2},
-		Store:      &testTaskReader{store2},
-		Peers:      &testPeerLister{}, // only self (mux)
+		LeaseStore: &testOwnerReader{ls},
+		Store:      &testTaskReader{store},
+		Peers:      &testPeerLister{peers: peerNodeIDs},
+		// All peer node IDs resolve to the same mux URL so dispatches actually
+		// land somewhere observable; WorkerNode keeps the original nodeID so we
+		// can verify distribution.
+		PeerBaseURL: func(_ string) string { return mux.URL },
 	})
 
-	// Run a single tick.
 	loop.tick(context.Background())
 
 	wnMu.Lock()
-	wns := append([]string(nil), workerNodes...)
+	got := append([]string(nil), workerNodes...)
 	wnMu.Unlock()
 
-	require.Len(t, wns, numTasks,
-		"all %d tasks should be dispatched in one tick", numTasks)
+	require.Len(t, got, numTasks, "every task should be dispatched in one tick")
 
-	// All WorkerNode values should be the same (the mux) because only self is
-	// in the peer list.  The key assertion is that counter advanced by numTasks.
-	counterAfter := loop.counter.Load()
-	require.Equal(t, uint64(numTasks), counterAfter,
-		"round-robin counter should have advanced by numTasks=%d", numTasks)
-
-	_ = ownerNodeID
-	_ = ownerAPIPort
-	_ = states
-	_ = peerNodeIDs
-	_ = peerAPIPorts
-	_ = store
-	_ = ls
+	counts := map[string]int{}
+	for _, wn := range got {
+		counts[wn]++
+	}
+	for _, peerID := range peerNodeIDs {
+		require.Equal(t, numTasks/len(peerNodeIDs), counts[peerID],
+			"peer %q should receive numTasks/numPeers=%d dispatches, got %d",
+			peerID, numTasks/len(peerNodeIDs), counts[peerID])
+	}
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -284,6 +284,29 @@ var (
 			Help: "Current number of run leases owned by this node (run-owner mode).",
 		},
 	)
+
+	// DispatchRejectedTotal counts owner-push dispatch attempts that were not
+	// accepted by a worker, categorised by reason.
+	//
+	// reason values:
+	//   network_error    – PostDispatch returned a non-nil error (network / timeout)
+	//   worker_rejected  – worker returned 409 (busy, claim mismatch, etc.)
+	//   no_peers         – peer discovery returned an empty list or failed
+	DispatchRejectedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_dispatch_rejected_total",
+			Help: "Total owner-push dispatch attempts rejected or failed, by reason.",
+		},
+		[]string{"reason"},
+	)
+
+	// DispatchSentTotal counts dispatch attempts accepted by a worker (202 ACK).
+	DispatchSentTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "caesium_dispatch_sent_total",
+			Help: "Total owner-push dispatch requests accepted by a worker (202 ACK).",
+		},
+	)
 )
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
@@ -319,6 +342,8 @@ func Register() {
 			CompleteRejectedTotal,
 			RunLeaseRenewalsTotal,
 			RunLeasesOwned,
+			DispatchRejectedTotal,
+			DispatchSentTotal,
 		)
 	})
 }

--- a/internal/run/lease.go
+++ b/internal/run/lease.go
@@ -137,6 +137,34 @@ func (ls *LeaseStore) OwnedRuns(ctx context.Context, ownerNode string) ([]uuid.U
 	return ids, nil
 }
 
+// OwnedRunsWithGenerations returns a map of run IDs to lease generations for
+// every non-expired lease owned by ownerNode, in a single query. Used by the
+// dispatch loop to avoid an N+1 GetLease pattern on every tick.
+func (ls *LeaseStore) OwnedRunsWithGenerations(ctx context.Context, ownerNode string) (map[uuid.UUID]int64, error) {
+	if ls == nil || ls.db == nil {
+		return nil, nil
+	}
+
+	var leases []models.RunLease
+	if err := ls.db.WithContext(ctx).
+		Select("run_id", "generation").
+		Where("owner_node = ? AND lease_expires_at > ?", ownerNode, time.Now().UTC()).
+		Find(&leases).Error; err != nil {
+		return nil, err
+	}
+
+	out := make(map[uuid.UUID]int64, len(leases))
+	for _, l := range leases {
+		id, err := uuid.Parse(l.RunID)
+		if err != nil {
+			log.Warn("run_leases: unparseable run_id", "run_id", l.RunID, "error", err)
+			continue
+		}
+		out[id] = l.Generation
+	}
+	return out, nil
+}
+
 // IsOwner returns true if ownerNode currently holds a valid (non-expired) lease
 // on runID.  Used to validate requests before acting as owner.
 func (ls *LeaseStore) IsOwner(ctx context.Context, ownerNode string, runID uuid.UUID) (bool, error) {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -764,6 +764,31 @@ func (s *Store) ClaimTaskForDispatch(runID, taskID uuid.UUID, workerNode string,
 	return err
 }
 
+// PendingTasksForDispatch returns up to limit task_runs rows for runID that
+// are ready for owner-push dispatch: status=pending, claimed_by="", and
+// outstanding_predecessors=0.  The caller (the dispatch loop) uses this to
+// find the next batch of tasks to push to workers each tick.
+//
+// The result is ordered by created_at ASC so earlier-registered tasks are
+// dispatched first, preserving FIFO ordering within a run.  The limit cap
+// prevents a huge fan-out from saturating a single tick.
+func (s *Store) PendingTasksForDispatch(ctx context.Context, runID uuid.UUID, limit int) ([]models.TaskRun, error) {
+	if limit <= 0 {
+		limit = 64
+	}
+	var tasks []models.TaskRun
+	err := s.db.WithContext(ctx).
+		Where("job_run_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0",
+			runID, string(TaskStatusPending)).
+		Order("created_at ASC").
+		Limit(limit).
+		Find(&tasks).Error
+	if err != nil {
+		return nil, err
+	}
+	return tasks, nil
+}
+
 func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy string) error {
 	var pendingEvents []event.Event
 	var counts dbWriteCounts

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -150,4 +150,17 @@ type Environment struct {
 	// another node may take over.  Default 30s; must be > 0 when owner mode
 	// is enabled.
 	RunLeaseTTL time.Duration `envconfig:"RUN_LEASE_TTL" default:"30s"`
+
+	// CAESIUM_RUN_OWNER_DISPATCH_INTERVAL is the polling cadence for the
+	// per-node owner dispatch loop.  Smaller values reduce task-start latency
+	// at the cost of more DB reads per second.  Default 1s.
+	RunOwnerDispatchInterval time.Duration `envconfig:"RUN_OWNER_DISPATCH_INTERVAL" default:"1s"`
+	// CAESIUM_RUN_OWNER_DISPATCH_BATCH caps the number of tasks dispatched per
+	// tick per owned run.  Prevents a large fan-out from stalling the loop.
+	// Default 64.
+	RunOwnerDispatchBatch int `envconfig:"RUN_OWNER_DISPATCH_BATCH" default:"64"`
+	// CAESIUM_RUN_OWNER_DISPATCH_DEADLINE is the task execution deadline added
+	// to time.Now() in each DispatchRequest.  Workers use this to bound how long
+	// they hold the claim before returning it.  Default 5m.
+	RunOwnerDispatchDeadline time.Duration `envconfig:"RUN_OWNER_DISPATCH_DEADLINE" default:"5m"`
 }


### PR DESCRIPTION
## Summary

Closes the gap PR #172 surfaced: Phase A's substrate (lease acquisition, `/internal/dispatch`, `/internal/complete`) was active but no executor-side code was calling `dispatch.PostDispatch`. Workers still pulled via ClaimNext, and the added lease writes were pure overhead (+56% `db_busy_retries`). This PR adds the missing dispatch loop.

> Sequence: this PR is **Phase A2**. After it lands, re-measure with the same harness as PR #172 — expect `caesium_db_busy_retries_total` to drop sharply for owned runs and `caesium_worker_claims_total` to fall. After A2 measurements look reasonable, **Phase B** (in-memory state + checkpoints) becomes the next clear move.

## What's in this PR

### `internal/dispatch/loop.go` (326 lines)

Per-node goroutine that, when `CAESIUM_RUN_OWNER_ENABLED=true`, runs on a configurable tick:

1. `LeaseStore.OwnedRuns(nodeID)` — runs owned by this node.
2. For each owned run, `Store.PendingTasksForDispatch(runID)` returns up to `CAESIUM_RUN_OWNER_DISPATCH_BATCH` (default 64) ready tasks (`claimed_by = '' AND status = 'pending' AND outstanding_predecessors = 0`).
3. Round-robin a `PeerLister`-provided peer (including self) and `dispatch.PostDispatch(ctx, peerURL, token, req)`.
4. On 202 ACK → `caesium_dispatch_sent_total++`.
5. On rejection/network error → `caesium_dispatch_rejected_total{reason}++`. Task remains `claimed_by=''` so the existing `ClaimNext` recovery path handles it.

Skip-when-quiet: no owned runs OR no peers discovered → exit early without writing.

### Integration

- **`cmd/start/start.go`** wires the loop behind `vars.RunOwnerEnabled`. Production `PeerLister` is a `dqliteDispatchPeerResolver()` that calls `dqlite.Cluster(ctx)`, filters abstract-unix addrs, returns raw `host:dqlitePort` strings; the loop's `nodeAddrToBaseURL` maps each to `http://host:apiPort`.
- **`internal/run/store.go`** adds `PendingTasksForDispatch(runID)` — plain SELECT; concurrent-claim races handled by `ClaimTaskForDispatch`'s atomic UPDATE returning `ErrTaskClaimMismatch` (already in place from PR #171).

### New env vars

| Variable | Default | Purpose |
|---|---|---|
| `CAESIUM_RUN_OWNER_DISPATCH_INTERVAL` | `1s` | Tick interval |
| `CAESIUM_RUN_OWNER_DISPATCH_BATCH` | `64` | Max tasks per tick per run |
| `CAESIUM_RUN_OWNER_DISPATCH_DEADLINE` | `5m` | Deadline stamped into each envelope |

### New metrics

- `caesium_dispatch_sent_total` — counter, no labels. 202 ACKs from workers.
- `caesium_dispatch_rejected_total{reason}` — counter. Labels: `network_error`, `worker_rejected`, `no_peers`.

### Tests

7 new tests in `internal/dispatch/loop_test.go`, all pass:

- `TestDispatchLoop_HappyPath` — task dispatched, not re-dispatched on next tick.
- `TestDispatchLoop_FallbackOnRejection` — worker returns 409, task remains pending+unclaimed, re-dispatched on next tick.
- `TestDispatchLoop_NoOwnedRuns` — early exit, zero `PostDispatch` calls.
- `TestDispatchLoop_NoPeers` — empty peer list, `no_peers` counter increments, no calls.
- `TestDispatchLoop_BatchCap` — 200 ready tasks, batch=64 → exactly 64 dispatched per tick.
- `TestDispatchLoop_SelfDispatch` — single peer (self), dispatch routes to local nodeID.
- `TestDispatchLoop_RoundRobin` — verifies the atomic round-robin counter advances by `numTasks` over the run (counter mod peer count picks peer).

`just unit-test` exit 0.

## Design decisions

- **`APIPort` in `DispatchLoopConfig`** — extracted as a config field so `httptest.Server`-backed tests don't have to hard-code port 8080. Production reads from `vars.Port`.
- **Round-robin test approach** — exact "3 peers, 6 tasks → 2 each" requires multi-port routing in tests. Instead, `TestDispatchLoop_RoundRobin` uses a single mux server and asserts the atomic counter advances by 6, which directly verifies the rotation logic.
- **`PendingTasksForDispatch` does not read-lock** — plain SELECT. The dispatch loop is the only writer of `claimed_by` for owned runs, and `ClaimTaskForDispatch`'s atomic UPDATE returning `ErrTaskClaimMismatch` is the race safety net (already in place from PR #171).

## Behavior with the flag off

Loop never starts; existing pull-based path is byte-identical to master.

## Test plan

- [ ] After merge, re-measure with the PR #172 harness setup (same 10-job × fan-out=4 × depth=3 × 500ms workload). Expect `caesium_dispatch_sent_total` to climb, `caesium_worker_claims_total` to drop, `caesium_db_busy_retries_total` to drop vs. PR #172's 101.
- [ ] Confirm `caesium_dispatch_rejected_total{reason}` stays near zero in the happy case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)