### PR TITLE
Phase B0+B1: token guard and ClaimNext deferral for owned runs

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -164,6 +164,10 @@ func start(cmd *cobra.Command, args []string) error {
 		// We check for the Phase B env vars to future-proof the warning.
 		dispatch.WarnIfNoMTLS()
 
+		// Warn if the bearer token is missing — dispatch endpoints reject every
+		// request without it, making run-owner mode silently inert.
+		dispatch.WarnIfNoToken(vars.InternalWakeupToken)
+
 		leaseStore := run.NewLeaseStore(db.Connection())
 		runStore.WithLeaseStore(leaseStore)
 

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -425,3 +425,21 @@ func WarnIfNoMTLS() {
 			"CAESIUM_INTERNAL_MTLS_CERT, and CAESIUM_INTERNAL_MTLS_KEY.",
 	)
 }
+
+// WarnIfNoToken emits a startup warning when owner mode is on but the
+// internal wakeup token is not set.  Without the token, the dispatch and
+// complete endpoints reject every request (bearer-token check fails closed),
+// so run-owner dispatch is silently inert — adding lease overhead with zero
+// benefit.  Mirrors WarnIfNoMTLS in tone and intent; warn-only for now.
+func WarnIfNoToken(token string) {
+	if strings.TrimSpace(token) != "" {
+		return
+	}
+	log.Warn(
+		"run-owner mode is enabled but CAESIUM_INTERNAL_WAKEUP_TOKEN is not set; " +
+			"the /internal/dispatch and /internal/complete endpoints require a " +
+			"Bearer token and will reject every request without one — " +
+			"run-owner dispatch will be silently inert. " +
+			"Set CAESIUM_INTERNAL_WAKEUP_TOKEN on every node to enable dispatch.",
+	)
+}

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -177,6 +177,18 @@ func (c *Claimer) claimNextSingleStatementTx(tx *gorm.DB, now, leaseExpiry time.
 	if err != nil {
 		return nil, uuid.Nil, err
 	}
+
+	// liveLeaseGuard returns SQL that is true only when the candidate task's run
+	// does NOT have a live (non-expired) run_leases row.  When no row exists
+	// (owner mode off, pre-owner runs) NOT EXISTS is always true, so ClaimNext
+	// behaves byte-identically to the no-owner-mode path.
+	//
+	// The job_run_id column is stored as UUID on Postgres but as TEXT on
+	// SQLite/dqlite.  run_leases.run_id is always TEXT.  On Postgres we must
+	// cast to avoid a type-mismatch error; on SQLite the comparison works
+	// without any cast.
+	liveLeaseGuard := c.liveLeaseGuardSQL(tx.Name(), "tr")
+
 	sql := `
 UPDATE task_runs
 SET claimed_by = ?, claim_expires_at = ?, claim_attempt = claim_attempt + 1, status = ?, updated_at = ?
@@ -189,6 +201,7 @@ WHERE id = (
 		AND tr.outstanding_predecessors = ?
 		AND (tr.claimed_by = '' OR tr.claim_expires_at IS NULL OR tr.claim_expires_at < ?)
 		AND ` + selectorSQL + `
+		AND ` + liveLeaseGuard + `
 	ORDER BY tr.created_at ASC
 	LIMIT 1
 )
@@ -209,6 +222,8 @@ RETURNING *, (SELECT job_id FROM job_runs WHERE id = task_runs.job_run_id) AS cl
 		now,
 	}
 	args = append(args, selectorArgs...)
+	// liveLeaseGuard binds one parameter: now (the live-lease expiry cutoff).
+	args = append(args, now)
 	args = append(args, string(run.TaskStatusPending), 0, now, string(run.StatusRunning))
 
 	var claimed claimedTaskRunRow
@@ -220,6 +235,32 @@ RETURNING *, (SELECT job_id FROM job_runs WHERE id = task_runs.job_run_id) AS cl
 		return nil, uuid.Nil, nil
 	}
 	return &claimed.TaskRun, claimed.ClaimJobID, nil
+}
+
+// liveLeaseGuardSQL returns a NOT EXISTS predicate that is true when the
+// candidate task's run does NOT have a live (non-expired) run_leases row.
+// The single bound parameter is now (UTC), which must be appended to the args
+// slice immediately after the selector args and before any post-subquery args.
+//
+// Semantics:
+//   - No run_leases row           → NOT EXISTS true → claimable (owner mode off).
+//   - Live lease (expires_at > ?) → NOT EXISTS false → defer to owner's dispatch loop.
+//   - Expired lease               → NOT EXISTS true → claimable (recovery path).
+func (c *Claimer) liveLeaseGuardSQL(dialect, tableAlias string) string {
+	// job_run_id is a native UUID column on Postgres; a text column on
+	// SQLite/dqlite.  run_leases.run_id is always TEXT.  Cast only on Postgres.
+	var jobRunIDExpr string
+	switch dialect {
+	case "postgres":
+		jobRunIDExpr = "CAST(" + tableAlias + ".job_run_id AS TEXT)"
+	default: // dqlite, sqlite
+		jobRunIDExpr = tableAlias + ".job_run_id"
+	}
+	return "NOT EXISTS (" +
+		"SELECT 1 FROM run_leases rl " +
+		"WHERE rl.run_id = " + jobRunIDExpr + " " +
+		"AND rl.lease_expires_at > ?" +
+		")"
 }
 
 type claimedTaskRunRow struct {
@@ -326,15 +367,29 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				Select("id").
 				Where("status = ?", string(run.StatusRunning))
 
+			// liveLeaseGuard skips tasks belonging to a live-owned run — the
+			// owner's dispatch loop is responsible for re-dispatching them after a
+			// worker crash.  Resetting such a task here would race the owner,
+			// risking double-execution.
+			//
+			// liveLeaseGuardSQL generates "NOT EXISTS (SELECT 1 FROM run_leases rl
+			// WHERE rl.run_id = <job_run_id_expr> AND rl.lease_expires_at > ?)"
+			// and handles the Postgres UUID→TEXT cast internally via tableAlias.
+			// One bound parameter (now) is appended via liveLeaseArgs.
+			liveLeaseGuard := c.liveLeaseGuardSQL(tx.Name(), "task_runs")
+			liveLeaseArgs := []interface{}{now}
+
 			var expired []models.TaskRun
 			if err := tx.
-				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ?", runningRunIDs, string(run.TaskStatusRunning), now).
+				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ? AND "+liveLeaseGuard,
+					append([]interface{}{runningRunIDs, string(run.TaskStatusRunning), now}, liveLeaseArgs...)...).
 				Find(&expired).Error; err != nil {
 				return err
 			}
 
 			result := tx.Model(&models.TaskRun{}).
-				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ?", runningRunIDs, string(run.TaskStatusRunning), now).
+				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ? AND "+liveLeaseGuard,
+					append([]interface{}{runningRunIDs, string(run.TaskStatusRunning), now}, liveLeaseArgs...)...).
 				Updates(map[string]interface{}{
 					"status":           string(run.TaskStatusPending),
 					"claimed_by":       "",

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"errors"
+	"fmt"
 	"maps"
 	"math/rand/v2"
 	"sort"
@@ -187,7 +188,10 @@ func (c *Claimer) claimNextSingleStatementTx(tx *gorm.DB, now, leaseExpiry time.
 	// SQLite/dqlite.  run_leases.run_id is always TEXT.  On Postgres we must
 	// cast to avoid a type-mismatch error; on SQLite the comparison works
 	// without any cast.
-	liveLeaseGuard := c.liveLeaseGuardSQL(tx.Name(), "tr")
+	liveLeaseGuard, err := c.liveLeaseGuardSQL(tx.Name(), "tr")
+	if err != nil {
+		return nil, uuid.Nil, err
+	}
 
 	sql := `
 UPDATE task_runs
@@ -246,21 +250,26 @@ RETURNING *, (SELECT job_id FROM job_runs WHERE id = task_runs.job_run_id) AS cl
 //   - No run_leases row           → NOT EXISTS true → claimable (owner mode off).
 //   - Live lease (expires_at > ?) → NOT EXISTS false → defer to owner's dispatch loop.
 //   - Expired lease               → NOT EXISTS true → claimable (recovery path).
-func (c *Claimer) liveLeaseGuardSQL(dialect, tableAlias string) string {
+func (c *Claimer) liveLeaseGuardSQL(dialect, tableAlias string) (string, error) {
 	// job_run_id is a native UUID column on Postgres; a text column on
 	// SQLite/dqlite.  run_leases.run_id is always TEXT.  Cast only on Postgres.
+	// Mirror nodeSelectorPredicateSQL: reject unknown dialects rather than
+	// silently defaulting, so a future backend that needs different casting
+	// surfaces the misconfiguration at claim time instead of producing wrong SQL.
 	var jobRunIDExpr string
 	switch dialect {
+	case "dqlite", "sqlite":
+		jobRunIDExpr = tableAlias + ".job_run_id"
 	case "postgres":
 		jobRunIDExpr = "CAST(" + tableAlias + ".job_run_id AS TEXT)"
-	default: // dqlite, sqlite
-		jobRunIDExpr = tableAlias + ".job_run_id"
+	default:
+		return "", fmt.Errorf("worker claimer: unsupported dialect %q for live-lease guard", dialect)
 	}
 	return "NOT EXISTS (" +
 		"SELECT 1 FROM run_leases rl " +
 		"WHERE rl.run_id = " + jobRunIDExpr + " " +
 		"AND rl.lease_expires_at > ?" +
-		")"
+		")", nil
 }
 
 type claimedTaskRunRow struct {
@@ -376,20 +385,25 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 			// WHERE rl.run_id = <job_run_id_expr> AND rl.lease_expires_at > ?)"
 			// and handles the Postgres UUID→TEXT cast internally via tableAlias.
 			// One bound parameter (now) is appended via liveLeaseArgs.
-			liveLeaseGuard := c.liveLeaseGuardSQL(tx.Name(), "task_runs")
-			liveLeaseArgs := []interface{}{now}
+			liveLeaseGuard, err := c.liveLeaseGuardSQL(tx.Name(), "task_runs")
+			if err != nil {
+				return err
+			}
+
+			// Shared between the Find (to collect events) and the Updates (to
+			// reset claims) so the expiry criteria can't drift between them.
+			// liveLeaseGuard binds one parameter (now); it trails the three
+			// static args.
+			expiredWhere := "job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ? AND " + liveLeaseGuard
+			expiredArgs := []interface{}{runningRunIDs, string(run.TaskStatusRunning), now, now}
 
 			var expired []models.TaskRun
-			if err := tx.
-				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ? AND "+liveLeaseGuard,
-					append([]interface{}{runningRunIDs, string(run.TaskStatusRunning), now}, liveLeaseArgs...)...).
-				Find(&expired).Error; err != nil {
+			if err := tx.Where(expiredWhere, expiredArgs...).Find(&expired).Error; err != nil {
 				return err
 			}
 
 			result := tx.Model(&models.TaskRun{}).
-				Where("job_run_id IN (?) AND status = ? AND claim_expires_at IS NOT NULL AND claim_expires_at < ? AND "+liveLeaseGuard,
-					append([]interface{}{runningRunIDs, string(run.TaskStatusRunning), now}, liveLeaseArgs...)...).
+				Where(expiredWhere, expiredArgs...).
 				Updates(map[string]interface{}{
 					"status":           string(run.TaskStatusPending),
 					"claimed_by":       "",

--- a/internal/worker/claimer_test.go
+++ b/internal/worker/claimer_test.go
@@ -322,6 +322,9 @@ type seedTaskRunInput struct {
 	claimAttempt            int
 	jobRunStatus            string
 	createdAt               time.Time
+	// jobRunID, when non-nil, reuses the given job_run_id instead of creating a
+	// fresh one.  The caller is responsible for ensuring the job_run already exists.
+	jobRunID *uuid.UUID
 }
 
 func seedTaskRun(t *testing.T, db *gorm.DB, in seedTaskRunInput) *models.TaskRun {
@@ -334,16 +337,21 @@ func seedTaskRun(t *testing.T, db *gorm.DB, in seedTaskRunInput) *models.TaskRun
 		in.jobRunStatus = string(run.StatusRunning)
 	}
 
-	jobRunID := uuid.New()
-	jobID := uuid.New()
-	require.NoError(t, db.Create(&models.JobRun{
-		ID:        jobRunID,
-		JobID:     jobID,
-		Status:    in.jobRunStatus,
-		StartedAt: in.createdAt,
-		CreatedAt: in.createdAt,
-		UpdatedAt: in.createdAt,
-	}).Error)
+	var jobRunID uuid.UUID
+	if in.jobRunID != nil {
+		jobRunID = *in.jobRunID
+	} else {
+		jobRunID = uuid.New()
+		jobID := uuid.New()
+		require.NoError(t, db.Create(&models.JobRun{
+			ID:        jobRunID,
+			JobID:     jobID,
+			Status:    in.jobRunStatus,
+			StartedAt: in.createdAt,
+			CreatedAt: in.createdAt,
+			UpdatedAt: in.createdAt,
+		}).Error)
+	}
 
 	record := &models.TaskRun{
 		ID:                      uuid.New(),
@@ -367,6 +375,237 @@ func seedTaskRun(t *testing.T, db *gorm.DB, in seedTaskRunInput) *models.TaskRun
 	return record
 }
 
+// seedJobRun creates a job_run row and returns its ID.  Used by tests that need
+// to share a job_run across multiple task_run seeds or insert a run_leases row
+// for the same run.
+func seedJobRun(t *testing.T, db *gorm.DB, status string) uuid.UUID {
+	t.Helper()
+	if strings.TrimSpace(status) == "" {
+		status = string(run.StatusRunning)
+	}
+	runID := uuid.New()
+	jobID := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:        runID,
+		JobID:     jobID,
+		Status:    status,
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	return runID
+}
+
+// seedRunLease inserts a run_leases row directly.  leaseExpiresAt controls
+// whether the lease is live (future) or expired (past).
+func seedRunLease(t *testing.T, db *gorm.DB, runID uuid.UUID, ownerNode string, leaseExpiresAt time.Time) {
+	t.Helper()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.RunLease{
+		RunID:          runID.String(),
+		OwnerNode:      ownerNode,
+		AcquiredAt:     now,
+		LeaseExpiresAt: leaseExpiresAt,
+		Generation:     1,
+	}).Error)
+}
+
 func ptrTime(v time.Time) *time.Time {
 	return &v
+}
+
+// --- B0/B1 deferral tests ---
+
+// TestClaimerClaimNextBackwardCompatNoLeases verifies that ClaimNext claims a
+// ready task exactly as before when no run_leases rows exist (owner mode off).
+// This is the critical backward-compat property.
+func TestClaimerClaimNextBackwardCompatNoLeases(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+	ready := seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusPending),
+		outstandingPredecessors: 0,
+		createdAt:               now.Add(-time.Minute),
+	})
+
+	claimer := NewClaimer("node-a", run.NewStore(db), 2*time.Minute)
+	claimed, err := claimer.ClaimNext(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, ready.ID, claimed.ID)
+}
+
+// TestClaimerClaimNextDefersLiveLease verifies that a ready task whose run has
+// a live (non-expired) lease is NOT claimed by ClaimNext — it should be
+// dispatched by the owner's loop instead.
+func TestClaimerClaimNextDefersLiveLease(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+	runID := seedJobRun(t, db, string(run.StatusRunning))
+	// Insert a live lease (expires in the future).
+	seedRunLease(t, db, runID, "owner-node", now.Add(30*time.Second))
+
+	_ = seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusPending),
+		outstandingPredecessors: 0,
+		createdAt:               now.Add(-time.Minute),
+		jobRunID:                &runID,
+	})
+
+	claimer := NewClaimer("node-a", run.NewStore(db), 2*time.Minute)
+	claimed, err := claimer.ClaimNext(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, claimed, "ClaimNext must not claim tasks owned by a live lease")
+}
+
+// TestClaimerClaimNextRecoveryExpiredLease verifies that a ready task whose run
+// has an *expired* lease IS claimed by ClaimNext (recovery path: owner is dead).
+func TestClaimerClaimNextRecoveryExpiredLease(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+	runID := seedJobRun(t, db, string(run.StatusRunning))
+	// Insert an expired lease.
+	seedRunLease(t, db, runID, "dead-owner", now.Add(-5*time.Second))
+
+	ready := seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusPending),
+		outstandingPredecessors: 0,
+		createdAt:               now.Add(-time.Minute),
+		jobRunID:                &runID,
+	})
+
+	claimer := NewClaimer("node-a", run.NewStore(db), 2*time.Minute)
+	claimed, err := claimer.ClaimNext(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, claimed, "ClaimNext must claim tasks from runs with expired leases")
+	require.Equal(t, ready.ID, claimed.ID)
+}
+
+// TestClaimerClaimNextOwnerNodeAlsoDefers verifies that even the owner node
+// itself does not claim tasks via ClaimNext when a live lease is present.
+// The owner's dispatch loop — not ClaimNext — is the correct path for owned runs.
+func TestClaimerClaimNextOwnerNodeAlsoDefers(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+	runID := seedJobRun(t, db, string(run.StatusRunning))
+	const ownerNode = "owner-node"
+	// The same node as the claimer holds the live lease.
+	seedRunLease(t, db, runID, ownerNode, now.Add(30*time.Second))
+
+	_ = seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusPending),
+		outstandingPredecessors: 0,
+		createdAt:               now.Add(-time.Minute),
+		jobRunID:                &runID,
+	})
+
+	// Even the owner node must not use ClaimNext for its own owned runs.
+	claimer := NewClaimer(ownerNode, run.NewStore(db), 2*time.Minute)
+	claimed, err := claimer.ClaimNext(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, claimed, "owner node must use dispatch loop, not ClaimNext, for live-lease runs")
+}
+
+// TestClaimerClaimNextMixedLeasesPicksUnowned verifies that ClaimNext skips
+// tasks with live leases and picks the first unowned ready task.
+func TestClaimerClaimNextMixedLeasesPicksUnowned(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+
+	// Run with live lease — ClaimNext must skip.
+	ownedRunID := seedJobRun(t, db, string(run.StatusRunning))
+	seedRunLease(t, db, ownedRunID, "owner-node", now.Add(30*time.Second))
+	_ = seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusPending),
+		outstandingPredecessors: 0,
+		createdAt:               now.Add(-2 * time.Minute),
+		jobRunID:                &ownedRunID,
+	})
+
+	// Unowned run (no run_leases row) — ClaimNext may claim this.
+	freeTask := seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusPending),
+		outstandingPredecessors: 0,
+		createdAt:               now.Add(-time.Minute),
+	})
+
+	claimer := NewClaimer("node-a", run.NewStore(db), 2*time.Minute)
+	claimed, err := claimer.ClaimNext(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, claimed)
+	require.Equal(t, freeTask.ID, claimed.ID, "must claim the unowned task, not the owned one")
+}
+
+// TestClaimerReclaimExpiredSkipsLiveLeasedRun verifies that ReclaimExpired does
+// not reset a task whose run has a live lease (the owner handles re-dispatch).
+func TestClaimerReclaimExpiredSkipsLiveLeasedRun(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+	runID := seedJobRun(t, db, string(run.StatusRunning))
+	seedRunLease(t, db, runID, "owner-node", now.Add(30*time.Second))
+
+	// A task with an expired task-claim (worker crashed) but whose run is live-leased.
+	owned := seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusRunning),
+		outstandingPredecessors: 0,
+		claimedBy:               "worker-old",
+		claimExpiresAt:          ptrTime(now.Add(-time.Minute)),
+		claimAttempt:            1,
+		createdAt:               now.Add(-2 * time.Minute),
+		jobRunID:                &runID,
+	})
+
+	claimer := NewClaimer("node-a", run.NewStore(db), time.Minute)
+	require.NoError(t, claimer.ReclaimExpired(context.Background()))
+
+	var persisted models.TaskRun
+	require.NoError(t, db.First(&persisted, "id = ?", owned.ID).Error)
+	// The owner's dispatch loop is responsible — ReclaimExpired must not touch this.
+	require.Equal(t, string(run.TaskStatusRunning), persisted.Status,
+		"ReclaimExpired must not reset tasks in live-leased runs")
+	require.Equal(t, "worker-old", persisted.ClaimedBy)
+}
+
+// TestClaimerReclaimExpiredReclaimsExpiredLeaseRun verifies that ReclaimExpired
+// DOES reset a task whose run has an *expired* run-lease (owner is dead — recovery path).
+func TestClaimerReclaimExpiredReclaimsExpiredLeaseRun(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+	runID := seedJobRun(t, db, string(run.StatusRunning))
+	// Run-level lease is expired (owner crashed).
+	seedRunLease(t, db, runID, "dead-owner", now.Add(-5*time.Second))
+
+	expired := seedTaskRun(t, db, seedTaskRunInput{
+		status:                  string(run.TaskStatusRunning),
+		outstandingPredecessors: 0,
+		claimedBy:               "worker-old",
+		claimExpiresAt:          ptrTime(now.Add(-time.Minute)),
+		claimAttempt:            1,
+		createdAt:               now.Add(-2 * time.Minute),
+		jobRunID:                &runID,
+	})
+
+	claimer := NewClaimer("node-a", run.NewStore(db), time.Minute)
+	require.NoError(t, claimer.ReclaimExpired(context.Background()))
+
+	var persisted models.TaskRun
+	require.NoError(t, db.First(&persisted, "id = ?", expired.ID).Error)
+	require.Equal(t, string(run.TaskStatusPending), persisted.Status,
+		"ReclaimExpired must reset tasks in runs with expired leases (recovery)")
+	require.Equal(t, "", persisted.ClaimedBy)
 }


### PR DESCRIPTION
## Summary

First increment of Phase 2 Phase B. Two small changes that, together, make the dispatch loop actually take over for owned runs — directly addressing the structural finding from PR #174 (dispatch races ClaimNext and loses).

This PR does NOT touch the in-memory-state rewrite (B2) or checkpointing (B3).

## B0 — Startup token guard

PR #174 Finding 0: run-owner dispatch is silently inert when `CAESIUM_INTERNAL_WAKEUP_TOKEN` is unset, because the dispatch/complete endpoints fail the bearer-token check closed (every dispatch 401s). Added `dispatch.WarnIfNoToken(token)` next to `WarnIfNoMTLS()`; `start.go` calls it in the `RunOwnerEnabled` block. Warn-only (does not refuse to start), consistent with the Phase A mTLS warning.

## B1 — ClaimNext deferral for owned runs

The fix for PR #174 Finding 1. The worker's claim query now skips tasks whose run has a **live** lease, leaving them for the owner's dispatch loop. ClaimNext remains the recovery path for unowned runs and dead-owner (expired-lease) runs.

New helper `liveLeaseGuardSQL(dialect, tableAlias)` generates:

```sql
NOT EXISTS (
    SELECT 1 FROM run_leases rl
    WHERE rl.run_id = <job_run_id_expr>
      AND rl.lease_expires_at > ?   -- now
)
```

- **dqlite/sqlite:** `rl.run_id = tr.job_run_id` (both TEXT).
- **postgres:** `rl.run_id = CAST(tr.job_run_id AS TEXT)` (`task_runs.job_run_id` is native UUID; `run_leases.run_id` is TEXT — cast avoids the type mismatch).

Injected into the candidate `SELECT` in `claimNextSingleStatementTx` (both dialect paths).

**Semantics:**
| run_leases state | NOT EXISTS | ClaimNext behavior |
|---|---|---|
| no row (owner mode off, or pre-owner run) | true | claims — byte-identical to today |
| live lease (`expires > now`), any owner | false | defers to owner's dispatch loop |
| expired lease (`expires <= now`) | true | claims — recovery for dead owner |

This is what makes dispatch *win* instead of race: for any live-owned run, ClaimNext steps aside entirely — including on the owner node itself, so the owner's own ClaimNext doesn't double-claim what its dispatch loop is handling.

## ReclaimExpired also guarded

The same `NOT EXISTS (live run_leases)` predicate was added to `ReclaimExpired`'s `Find` and `Updates` queries. Without it, a worker's task-claim expiry while the run's owner is still alive would reset the task to `pending`, racing the owner's re-dispatch — a double-execution window. Guarding it closes that race; expired-lease (dead-owner) runs are still reclaimed normally.

## Backward compatibility

When owner mode is off, no `run_leases` rows exist, so `NOT EXISTS` is always true and both ClaimNext and ReclaimExpired are byte-identical to today. Verified by `TestClaimerClaimNextBackwardCompatNoLeases`.

## Tests (7 new, all pass)

- `TestClaimerClaimNextBackwardCompatNoLeases` — no leases → normal claim.
- `TestClaimerClaimNextDefersLiveLease` — live lease → returns nil.
- `TestClaimerClaimNextRecoveryExpiredLease` — expired lease → claims (recovery).
- `TestClaimerClaimNextOwnerNodeAlsoDefers` — owner's own ClaimNext defers when a live lease is present.
- `TestClaimerClaimNextMixedLeasesPicksUnowned` — skips owned run, claims unowned task.
- `TestClaimerReclaimExpiredSkipsLiveLeasedRun` — ReclaimExpired leaves live-owned tasks alone.
- `TestClaimerReclaimExpiredReclaimsExpiredLeaseRun` — ReclaimExpired reclaims dead-owner tasks.

`just unit-test` passes.

## Test plan

- [ ] Re-measure against the PR #174 k8s setup (token set this time). With ClaimNext deferring, expect `caesium_dispatch_sent_total` to climb meaningfully (dispatch now wins) and `caesium_worker_claims_total` to drop toward zero for owned runs. The dispatch loop's 1s poll still adds some read pressure — B2 (in-memory state) removes that — but this measurement tells us how much of the win comes from deferral alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)