### PR TITLE
Add global dqlite busy-retry at the connection-pool layer

### DIFF
--- a/internal/backfill/store.go
+++ b/internal/backfill/store.go
@@ -4,15 +4,14 @@ import (
 	"encoding/json"
 	"errors"
 	"math/rand/v2"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/google/uuid"
-	"github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
 )
 
@@ -59,6 +58,8 @@ func (s *Store) Create(b *models.Backfill) error {
 }
 
 func (s *Store) Get(id uuid.UUID) (*models.Backfill, error) {
+	// Single autocommit read: contention retry is handled globally by the
+	// connection-pool busy-retry in pkg/db, so no per-call-site wrap is needed.
 	var b models.Backfill
 	if err := s.db.First(&b, "id = ?", id).Error; err != nil {
 		return nil, err
@@ -232,17 +233,9 @@ func (s *Store) withBusyRetry(fn func() error) error {
 // isPoisonedConnErr matches the narrow case where a pooled connection has
 // been left with a stale active transaction. Distinct from isContentionErr,
 // which also covers transient busy/locked errors that don't require active
-// recovery.
+// recovery. Delegates to the shared classifier in pkg/dqlite.
 func isPoisonedConnErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	for ; err != nil; err = errors.Unwrap(err) {
-		if strings.Contains(strings.ToLower(err.Error()), "cannot start a transaction within a transaction") {
-			return true
-		}
-	}
-	return false
+	return dqlite.IsConnPoolPoisonedError(err)
 }
 
 func jitterBackoff(base time.Duration) time.Duration {
@@ -272,23 +265,8 @@ func jitterBackoff(base time.Duration) time.Duration {
 //     are likely to draw a clean one. Without retry the poisoned connection
 //     persists for the lifetime of the process and breaks every caller that
 //     happens to receive it — exactly the cascade observed in #155 / #156.
+//
+// Delegates to the single shared classifier in pkg/dqlite.
 func isContentionErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var sqliteErr sqlite3.Error
-	if errors.As(err, &sqliteErr) {
-		return sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked
-	}
-
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "database is locked") ||
-		strings.Contains(msg, "database table is locked") ||
-		strings.Contains(msg, "database schema is locked") ||
-		strings.Contains(msg, "database is busy") ||
-		strings.Contains(msg, "checkpoint in progress") ||
-		strings.Contains(msg, "sqlite_busy") ||
-		strings.Contains(msg, "sqlite_locked") ||
-		strings.Contains(msg, "cannot start a transaction within a transaction")
+	return dqlite.IsContentionError(err)
 }

--- a/internal/jobdef/importer.go
+++ b/internal/jobdef/importer.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/jsonmap"
 	"github.com/caesium-cloud/caesium/pkg/jsonutil"
 	"github.com/google/uuid"
-	"github.com/mattn/go-sqlite3"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
@@ -235,27 +235,9 @@ func jitterImporterBusyRetryBackoff(base time.Duration) time.Duration {
 }
 
 func isImporterContentionErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var sqliteErr sqlite3.Error
-	if errors.As(err, &sqliteErr) {
-		return sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked
-	}
-
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "database is locked") ||
-		strings.Contains(msg, "database table is locked") ||
-		strings.Contains(msg, "database schema is locked") ||
-		strings.Contains(msg, "database is busy") ||
-		strings.Contains(msg, "checkpoint in progress") ||
-		strings.Contains(msg, "sqlite_busy") ||
-		strings.Contains(msg, "sqlite_locked") ||
-		// Connection-state poisoning following an earlier failed rollback —
-		// retry on a fresh pooled connection usually succeeds. See
-		// internal/backfill/store.go::isContentionErr for the full rationale.
-		strings.Contains(msg, "cannot start a transaction within a transaction")
+	// Delegate to the single shared classifier so the matched error strings
+	// live in exactly one place (pkg/dqlite).
+	return dqlite.IsContentionError(err)
 }
 
 func (i *Importer) findJobByAliasTx(tx *gorm.DB, alias string) (*models.Job, error) {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1943,33 +1943,25 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 		errMsg = result.Error()
 	}
 
-	// Look up the run to get jobID and startedAt for metrics. This is a
-	// best-effort read whose failure must not abort completion, but it can
-	// still hit transient dqlite contention (e.g. "checkpoint in progress"),
-	// so wrap it in the same bounded busy-retry used for the write below.
-	var (
-		run      models.JobRun
-		haveRun  bool
-		duration float64
-	)
-	_ = withStoreBusyRetry(func() error {
-		if err := s.db.First(&run, "id = ?", runID).Error; err != nil {
-			return err
-		}
-		haveRun = true
-		duration = now.Sub(run.StartedAt).Seconds()
-		return nil
-	})
-
 	// The completion write is on the run-completion path taken by every job
 	// run; an unretried transient "database is locked" / "checkpoint in
-	// progress" here marks an otherwise-successful run as failed. Retry it
-	// with the same bounded backoff as the other write paths in this file.
-	// pendingEvents is captured per attempt and only promoted on success so a
-	// retried transaction never double-publishes events.
-	var pendingEvents []event.Event
+	// progress" here marks an otherwise-successful run as failed. Retry the
+	// whole transaction with bounded backoff. jobID + startedAt (for metrics)
+	// and pendingEvents are captured per attempt and promoted only on success,
+	// so a retried transaction never double-counts or double-publishes — and
+	// the gauge bookkeeping below never depends on a separate best-effort read
+	// that could fail and leak the active-runs gauge.
+	var (
+		pendingEvents []event.Event
+		jobID         uuid.UUID
+		startedAt     time.Time
+	)
 	err := withStoreBusyRetry(func() error {
 		attemptEvents := make([]event.Event, 0, 2)
+		var (
+			attemptJobID     uuid.UUID
+			attemptStartedAt time.Time
+		)
 		txErr := s.db.Transaction(func(tx *gorm.DB) error {
 			if err := tx.Model(&models.JobRun{}).
 				Where("id = ?", runID).
@@ -1981,8 +1973,17 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 				return err
 			}
 
+			// Read jobID + startedAt inside the same retried transaction so the
+			// post-commit metrics/gauge bookkeeping always has them.
+			var jr models.JobRun
+			if err := tx.Select("job_id", "started_at").First(&jr, "id = ?", runID).Error; err != nil {
+				return err
+			}
+			attemptJobID = jr.JobID
+			attemptStartedAt = jr.StartedAt
+
 			if s.eventStore != nil {
-				run, loadErr := s.loadRunWithDB(tx, runID)
+				loaded, loadErr := s.loadRunWithDB(tx, runID)
 				if loadErr != nil {
 					return loadErr
 				}
@@ -1991,16 +1992,16 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 				if status == StatusFailed {
 					eventType = event.TypeRunFailed
 				}
-				payload, marshalErr := json.Marshal(run)
+				payload, marshalErr := json.Marshal(loaded)
 				if marshalErr != nil {
 					return marshalErr
 				}
 
 				completionEvent := event.Event{
 					Type:      eventType,
-					JobID:     run.JobID,
+					JobID:     loaded.JobID,
 					RunID:     runID,
-					Timestamp: time.Now().UTC(),
+					Timestamp: now,
 					Payload:   payload,
 				}
 				if err := s.eventStore.AppendTx(tx, &completionEvent); err != nil {
@@ -2010,9 +2011,9 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 
 				terminalEvent := event.Event{
 					Type:      event.TypeRunTerminal,
-					JobID:     run.JobID,
+					JobID:     loaded.JobID,
 					RunID:     runID,
-					Timestamp: time.Now().UTC(),
+					Timestamp: now,
 					Payload:   payload,
 				}
 				if err := s.eventStore.AppendTx(tx, &terminalEvent); err != nil {
@@ -2025,6 +2026,8 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 		})
 		if txErr == nil {
 			pendingEvents = attemptEvents
+			jobID = attemptJobID
+			startedAt = attemptStartedAt
 		}
 		return txErr
 	})
@@ -2033,22 +2036,21 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 	}
 
 	// Emit metrics and clear active-run bookkeeping exactly once, after the
-	// completion write has committed, so retries don't double-count.
-	if haveRun {
-		jobID := run.JobID.String()
-		metrics.JobRunsTotal.WithLabelValues(jobID, string(status)).Inc()
-		// Only decrement the active gauge if this process incremented it.
-		s.startedMu.Lock()
-		_, started := s.startedRuns[runID]
-		if started {
-			delete(s.startedRuns, runID)
-		}
-		s.startedMu.Unlock()
-		if started {
-			metrics.JobsActive.WithLabelValues(jobID).Dec()
-		}
-		metrics.JobRunDurationSeconds.WithLabelValues(jobID, string(status)).Observe(duration)
+	// completion write has committed, so retries don't double-count. jobID and
+	// startedAt are guaranteed populated because the transaction succeeded.
+	jobIDStr := jobID.String()
+	metrics.JobRunsTotal.WithLabelValues(jobIDStr, string(status)).Inc()
+	// Only decrement the active gauge if this process incremented it.
+	s.startedMu.Lock()
+	_, started := s.startedRuns[runID]
+	if started {
+		delete(s.startedRuns, runID)
 	}
+	s.startedMu.Unlock()
+	if started {
+		metrics.JobsActive.WithLabelValues(jobIDStr).Dec()
+	}
+	metrics.JobRunDurationSeconds.WithLabelValues(jobIDStr, string(status)).Observe(now.Sub(startedAt).Seconds())
 
 	s.publishEvents(pendingEvents...)
 	return nil

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -8,7 +8,6 @@ import (
 	"maps"
 	"math/rand/v2"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -17,13 +16,13 @@ import (
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/jsonmap"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	pkgtask "github.com/caesium-cloud/caesium/pkg/task"
 	"github.com/google/uuid"
-	"github.com/mattn/go-sqlite3"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
@@ -1944,9 +1943,98 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 		errMsg = result.Error()
 	}
 
-	// Look up the run to get jobID and startedAt for metrics.
-	var run models.JobRun
-	if err := s.db.First(&run, "id = ?", runID).Error; err == nil {
+	// Look up the run to get jobID and startedAt for metrics. This is a
+	// best-effort read whose failure must not abort completion, but it can
+	// still hit transient dqlite contention (e.g. "checkpoint in progress"),
+	// so wrap it in the same bounded busy-retry used for the write below.
+	var (
+		run      models.JobRun
+		haveRun  bool
+		duration float64
+	)
+	_ = withStoreBusyRetry(func() error {
+		if err := s.db.First(&run, "id = ?", runID).Error; err != nil {
+			return err
+		}
+		haveRun = true
+		duration = now.Sub(run.StartedAt).Seconds()
+		return nil
+	})
+
+	// The completion write is on the run-completion path taken by every job
+	// run; an unretried transient "database is locked" / "checkpoint in
+	// progress" here marks an otherwise-successful run as failed. Retry it
+	// with the same bounded backoff as the other write paths in this file.
+	// pendingEvents is captured per attempt and only promoted on success so a
+	// retried transaction never double-publishes events.
+	var pendingEvents []event.Event
+	err := withStoreBusyRetry(func() error {
+		attemptEvents := make([]event.Event, 0, 2)
+		txErr := s.db.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Model(&models.JobRun{}).
+				Where("id = ?", runID).
+				Updates(map[string]interface{}{
+					"status":       string(status),
+					"completed_at": now,
+					"error":        errMsg,
+				}).Error; err != nil {
+				return err
+			}
+
+			if s.eventStore != nil {
+				run, loadErr := s.loadRunWithDB(tx, runID)
+				if loadErr != nil {
+					return loadErr
+				}
+
+				eventType := event.TypeRunCompleted
+				if status == StatusFailed {
+					eventType = event.TypeRunFailed
+				}
+				payload, marshalErr := json.Marshal(run)
+				if marshalErr != nil {
+					return marshalErr
+				}
+
+				completionEvent := event.Event{
+					Type:      eventType,
+					JobID:     run.JobID,
+					RunID:     runID,
+					Timestamp: time.Now().UTC(),
+					Payload:   payload,
+				}
+				if err := s.eventStore.AppendTx(tx, &completionEvent); err != nil {
+					return err
+				}
+				attemptEvents = append(attemptEvents, completionEvent)
+
+				terminalEvent := event.Event{
+					Type:      event.TypeRunTerminal,
+					JobID:     run.JobID,
+					RunID:     runID,
+					Timestamp: time.Now().UTC(),
+					Payload:   payload,
+				}
+				if err := s.eventStore.AppendTx(tx, &terminalEvent); err != nil {
+					return err
+				}
+				attemptEvents = append(attemptEvents, terminalEvent)
+			}
+
+			return nil
+		})
+		if txErr == nil {
+			pendingEvents = attemptEvents
+		}
+		return txErr
+	})
+	if err != nil {
+		return err
+	}
+
+	// Emit metrics and clear active-run bookkeeping exactly once, after the
+	// completion write has committed, so retries don't double-count.
+	if haveRun {
 		jobID := run.JobID.String()
 		metrics.JobRunsTotal.WithLabelValues(jobID, string(status)).Inc()
 		// Only decrement the active gauge if this process incremented it.
@@ -1959,68 +2047,11 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 		if started {
 			metrics.JobsActive.WithLabelValues(jobID).Dec()
 		}
-		duration := now.Sub(run.StartedAt).Seconds()
 		metrics.JobRunDurationSeconds.WithLabelValues(jobID, string(status)).Observe(duration)
 	}
 
-	pendingEvents := make([]event.Event, 0, 2)
-	err := s.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(&models.JobRun{}).
-			Where("id = ?", runID).
-			Updates(map[string]interface{}{
-				"status":       string(status),
-				"completed_at": now,
-				"error":        errMsg,
-			}).Error; err != nil {
-			return err
-		}
-
-		if s.eventStore != nil {
-			run, loadErr := s.loadRunWithDB(tx, runID)
-			if loadErr != nil {
-				return loadErr
-			}
-
-			eventType := event.TypeRunCompleted
-			if status == StatusFailed {
-				eventType = event.TypeRunFailed
-			}
-			payload, marshalErr := json.Marshal(run)
-			if marshalErr != nil {
-				return marshalErr
-			}
-
-			completionEvent := event.Event{
-				Type:      eventType,
-				JobID:     run.JobID,
-				RunID:     runID,
-				Timestamp: time.Now().UTC(),
-				Payload:   payload,
-			}
-			if err := s.eventStore.AppendTx(tx, &completionEvent); err != nil {
-				return err
-			}
-			pendingEvents = append(pendingEvents, completionEvent)
-
-			terminalEvent := event.Event{
-				Type:      event.TypeRunTerminal,
-				JobID:     run.JobID,
-				RunID:     runID,
-				Timestamp: time.Now().UTC(),
-				Payload:   payload,
-			}
-			if err := s.eventStore.AppendTx(tx, &terminalEvent); err != nil {
-				return err
-			}
-			pendingEvents = append(pendingEvents, terminalEvent)
-		}
-
-		return nil
-	})
-	if err == nil {
-		s.publishEvents(pendingEvents...)
-	}
-	return err
+	s.publishEvents(pendingEvents...)
+	return nil
 }
 
 func (s *Store) ResetInFlightTasks(runID uuid.UUID) error {
@@ -2493,27 +2524,11 @@ func jitterStoreBusyRetryBackoff(base time.Duration) time.Duration {
 }
 
 func isStoreContentionErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var sqliteErr sqlite3.Error
-	if errors.As(err, &sqliteErr) {
-		return sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked
-	}
-
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "database is locked") ||
-		strings.Contains(msg, "database table is locked") ||
-		strings.Contains(msg, "database schema is locked") ||
-		strings.Contains(msg, "database is busy") ||
-		strings.Contains(msg, "checkpoint in progress") ||
-		strings.Contains(msg, "sqlite_busy") ||
-		strings.Contains(msg, "sqlite_locked") ||
-		// Connection-state poisoning following an earlier failed rollback —
-		// retry on a fresh pooled connection usually succeeds. See
-		// internal/backfill/store.go::isContentionErr for the full rationale.
-		strings.Contains(msg, "cannot start a transaction within a transaction")
+	// Delegate to the single shared classifier so the matched error strings
+	// live in exactly one place (pkg/dqlite). This helper retries whole
+	// transaction closures; the pkg/db connection-pool retry covers single
+	// autocommit statements.
+	return dqlite.IsContentionError(err)
 }
 
 // PredecessorOutputs returns a map of step-name → output key-values for all

--- a/internal/run/store_test.go
+++ b/internal/run/store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 func TestStorePersistsRunState(t *testing.T) {
@@ -110,6 +111,46 @@ func TestStorePersistsRunState(t *testing.T) {
 
 	finalStore := NewStore(db)
 	finalRun, err := finalStore.Get(runRecord.ID)
+	require.NoError(t, err)
+	require.Equal(t, StatusSucceeded, finalRun.Status)
+}
+
+// TestCompleteRetriesTransientContention pins that Store.Complete routes
+// through withStoreBusyRetry. Complete runs on the run-completion path taken by
+// every job run; before this guard a transient "checkpoint in progress" /
+// "database is locked" on the completion write (or its bookkeeping SELECT)
+// propagated to the caller and marked an otherwise-successful run as failed —
+// the exact integration flake in TestBackfillBasicHappyPath. Here we inject a
+// one-shot contention error on the job_runs UPDATE and assert the run still
+// commits as succeeded and Complete returns nil.
+func TestCompleteRetriesTransientContention(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		testutil.CloseDB(db)
+	})
+
+	store := NewStore(db)
+
+	jobID := uuid.New()
+	runRecord, err := store.Start(jobID, nil)
+	require.NoError(t, err)
+
+	fired := false
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register("test:one_shot_contention", func(tx *gorm.DB) {
+		if fired || tx.Statement.Table != "job_runs" {
+			return
+		}
+		fired = true
+		_ = tx.AddError(errors.New("checkpoint in progress"))
+	}))
+	t.Cleanup(func() {
+		_ = db.Callback().Update().Remove("test:one_shot_contention")
+	})
+
+	require.NoError(t, store.Complete(runRecord.ID, nil))
+	require.True(t, fired, "expected the injected contention error to fire at least once")
+
+	finalRun, err := store.Get(runRecord.ID)
 	require.NoError(t, err)
 	require.Equal(t, StatusSucceeded, finalRun.Status)
 }

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -14,8 +14,8 @@ import (
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/google/uuid"
-	"github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
 )
 
@@ -544,27 +544,11 @@ func jitterBusyRetryBackoff(base time.Duration) time.Duration {
 }
 
 func isClaimContentionErr(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var sqliteErr sqlite3.Error
-	if errors.As(err, &sqliteErr) {
-		return sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked
-	}
-
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "database is locked") ||
-		strings.Contains(msg, "database table is locked") ||
-		strings.Contains(msg, "database schema is locked") ||
-		strings.Contains(msg, "database is busy") ||
-		strings.Contains(msg, "checkpoint in progress") ||
-		strings.Contains(msg, "sqlite_busy") ||
-		strings.Contains(msg, "sqlite_locked") ||
-		// Connection-state poisoning following an earlier failed rollback —
-		// retry on a fresh pooled connection usually succeeds. See
-		// internal/backfill/store.go::isContentionErr for the full rationale.
-		strings.Contains(msg, "cannot start a transaction within a transaction")
+	// Delegate to the single shared classifier so the matched error strings
+	// live in exactly one place (pkg/dqlite). This helper retries whole
+	// transaction closures; the pkg/db connection-pool retry covers single
+	// autocommit statements.
+	return dqlite.IsContentionError(err)
 }
 
 func derefUUID(id *uuid.UUID) uuid.UUID {

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -117,6 +117,14 @@ func openConnection(databaseName string, enforceForeignKeys bool) (*gorm.DB, err
 
 	cfg := &gorm.Config{
 		Logger: NewLogger().LogMode(gormLogLevel()),
+		// Execute top-level single-row Create/Update/Delete as one autocommit
+		// statement instead of wrapping each in an implicit BEGIN/COMMIT. A
+		// single INSERT/UPDATE/DELETE is atomic in SQLite/dqlite regardless, so
+		// this is safe, and it lets the connection-pool busy-retry (see
+		// retryPlugin) cover single writes — the implicit transaction would
+		// otherwise route the write onto a *sql.Tx that bypasses pool retry.
+		// Explicit db.Transaction(fn) closures are unaffected by this flag.
+		SkipDefaultTransaction: true,
 	}
 	if !enforceForeignKeys {
 		cfg.DisableForeignKeyConstraintWhenMigrating = true
@@ -143,6 +151,16 @@ func openConnection(databaseName string, enforceForeignKeys bool) (*gorm.DB, err
 		)
 	}
 	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the connection pool with transparent busy-retry for single
+	// autocommit statements (reads and single-row writes outside an explicit
+	// transaction). This is the global backstop that covers every call site
+	// uniformly, including bare reads in the DAG-execution path that no
+	// per-call-site wrapper guards. In-transaction statements bypass it by
+	// construction; see retryConnPool for the safety rationale.
+	if err := conn.Use(retryPlugin{}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/db/retry.go
+++ b/pkg/db/retry.go
@@ -1,0 +1,200 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"math/rand/v2"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
+	"gorm.io/gorm"
+)
+
+// retryBusyBackoffs schedules retries for transient dqlite/SQLite contention on
+// single autocommit statements. Total max wait ~310ms across 5 retries, the
+// same schedule the per-transaction busy-retry helpers use so the layers
+// compose predictably under load.
+var retryBusyBackoffs = []time.Duration{
+	10 * time.Millisecond,
+	20 * time.Millisecond,
+	40 * time.Millisecond,
+	80 * time.Millisecond,
+	160 * time.Millisecond,
+}
+
+// retryConnPool is a gorm.ConnPool decorator that transparently retries a
+// single autocommit statement when it fails with a transient contention error
+// (e.g. "database is locked", "checkpoint in progress").
+//
+// SAFETY: this only ever wraps the connection POOL, never a transaction. GORM
+// runs an explicit transaction (db.Transaction(fn) / db.Begin()) by calling
+// BeginTx and then issuing every statement against the returned *sql.Tx. This
+// decorator's BeginTx delegates to the underlying *sql.DB and returns the raw
+// *sql.Tx unwrapped, so statements executed inside a transaction bypass this
+// decorator entirely and are NEVER retried individually — re-running one
+// statement against a transaction the DB may have already rolled back would
+// corrupt state. Whole-transaction retry remains owned by the existing
+// withStoreBusyRetry / withBusyRetry closures, which re-run the entire
+// BEGIN..COMMIT unit.
+//
+// Because the catalog/dqlite connections are opened with
+// SkipDefaultTransaction=true, top-level single-row Create/Update/Delete also
+// execute as one autocommit ExecContext through this decorator (a single
+// INSERT/UPDATE/DELETE is atomic in SQLite/dqlite regardless of an enclosing
+// BEGIN/COMMIT), so they are retried safely too.
+type retryConnPool struct {
+	pool     gorm.ConnPool
+	backoffs []time.Duration
+}
+
+// Compile-time assertions that the decorator satisfies the interfaces GORM
+// type-asserts on the connection pool.
+var (
+	_ gorm.ConnPool       = (*retryConnPool)(nil)
+	_ gorm.TxBeginner     = (*retryConnPool)(nil)
+	_ gorm.GetDBConnector = (*retryConnPool)(nil)
+)
+
+func newRetryConnPool(pool gorm.ConnPool) *retryConnPool {
+	return &retryConnPool{pool: pool, backoffs: retryBusyBackoffs}
+}
+
+// retry runs fn, retrying on transient contention with bounded backoff+jitter.
+// Non-contention errors (including sql.ErrNoRows / gorm.ErrRecordNotFound,
+// which are not contention) return immediately.
+func (p *retryConnPool) retry(ctx context.Context, fn func() error) error {
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = fn()
+		if err == nil || !dqlite.IsContentionError(err) {
+			return err
+		}
+		if attempt >= len(p.backoffs) {
+			return err
+		}
+
+		metrics.DBBusyRetriesTotal.Inc()
+		if sleepErr := sleepRetry(ctx, p.backoffs[attempt]); sleepErr != nil {
+			return err
+		}
+	}
+}
+
+func (p *retryConnPool) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	// Prepared statements are not used on the contention-prone hot paths;
+	// delegate without retry to avoid double-preparing on a retry.
+	return p.pool.PrepareContext(ctx, query)
+}
+
+func (p *retryConnPool) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	var (
+		res sql.Result
+		err error
+	)
+	err = p.retry(ctx, func() error {
+		res, err = p.pool.ExecContext(ctx, query, args...)
+		return err
+	})
+	return res, err
+}
+
+func (p *retryConnPool) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	var (
+		rows *sql.Rows
+		err  error
+	)
+	err = p.retry(ctx, func() error {
+		rows, err = p.pool.QueryContext(ctx, query, args...)
+		return err
+	})
+	return rows, err
+}
+
+func (p *retryConnPool) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	// (*sql.Row).Err() is not populated until Scan, and sql.Row has no
+	// exported constructor, so we surface contention by probing with a
+	// QueryContext retry first, then returning a fresh QueryRowContext. The
+	// extra read happens only on the rare contention path.
+	var row *sql.Row
+	_ = p.retry(ctx, func() error {
+		rows, err := p.pool.QueryContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		_ = rows.Close()
+		return nil
+	})
+	row = p.pool.QueryRowContext(ctx, query, args...)
+	return row
+}
+
+// BeginTx delegates to the underlying pool and returns the raw transaction so
+// that statements executed inside the transaction bypass this decorator. See
+// the type doc for the safety rationale.
+func (p *retryConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	if beginner, ok := p.pool.(gorm.TxBeginner); ok {
+		return beginner.BeginTx(ctx, opts)
+	}
+	return nil, gorm.ErrInvalidTransaction
+}
+
+// GetDBConn lets gorm's db.DB() reach the underlying *sql.DB for pool
+// configuration (SetMaxOpenConns, etc.).
+func (p *retryConnPool) GetDBConn() (*sql.DB, error) {
+	if sqlDB, ok := p.pool.(*sql.DB); ok {
+		return sqlDB, nil
+	}
+	if connector, ok := p.pool.(gorm.GetDBConnector); ok {
+		return connector.GetDBConn()
+	}
+	return nil, gorm.ErrInvalidDB
+}
+
+// Ping is consulted by gorm.Open via an interface assertion on the pool.
+func (p *retryConnPool) Ping() error {
+	if pinger, ok := p.pool.(interface{ Ping() error }); ok {
+		return pinger.Ping()
+	}
+	return nil
+}
+
+func sleepRetry(ctx context.Context, base time.Duration) error {
+	timer := time.NewTimer(jitterRetryBackoff(base))
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func jitterRetryBackoff(base time.Duration) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	maxJitter := int64(base / 5)
+	if maxJitter <= 0 {
+		return base
+	}
+	return base - time.Duration(rand.Int64N(maxJitter+1))
+}
+
+// retryPlugin is a gorm.Plugin that wraps the connection pool with
+// retryConnPool so every autocommit statement issued through the *gorm.DB is
+// covered by contention retry, regardless of which call site issues it.
+type retryPlugin struct{}
+
+func (retryPlugin) Name() string { return "caesium:busy_retry" }
+
+func (retryPlugin) Initialize(db *gorm.DB) error {
+	if db.ConnPool == nil {
+		return nil
+	}
+	if _, already := db.ConnPool.(*retryConnPool); already {
+		return nil
+	}
+	db.ConnPool = newRetryConnPool(db.ConnPool)
+	return nil
+}

--- a/pkg/db/retry.go
+++ b/pkg/db/retry.go
@@ -112,21 +112,19 @@ func (p *retryConnPool) QueryContext(ctx context.Context, query string, args ...
 }
 
 func (p *retryConnPool) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
-	// (*sql.Row).Err() is not populated until Scan, and sql.Row has no
-	// exported constructor, so we surface contention by probing with a
-	// QueryContext retry first, then returning a fresh QueryRowContext. The
-	// extra read happens only on the rare contention path.
-	var row *sql.Row
-	_ = p.retry(ctx, func() error {
-		rows, err := p.pool.QueryContext(ctx, query, args...)
-		if err != nil {
-			return err
-		}
-		_ = rows.Close()
-		return nil
-	})
-	row = p.pool.QueryRowContext(ctx, query, args...)
-	return row
+	// database/sql defers all errors from QueryRowContext to (*sql.Row).Scan,
+	// and *sql.Row has no exported constructor, so the decorator cannot inspect
+	// the result or re-run across the caller's Scan boundary. We therefore
+	// delegate plainly rather than probe-then-call (the previous approach issued
+	// two round-trips on every call and still left the real call unretried).
+	//
+	// This is an acceptable gap: GORM only routes through QueryRowContext for
+	// the explicit `.Row()` API, whose sole users in this codebase are the
+	// schema migrator's sqlite_master / PRAGMA reads in pkg/dqlite/migrator.go.
+	// Those run at startup against low-contention metadata, before the server
+	// takes traffic. Every hot-path read goes through QueryContext (First/Take/
+	// Find/Scan all use it), which IS retried above.
+	return p.pool.QueryRowContext(ctx, query, args...)
 }
 
 // BeginTx delegates to the underlying pool and returns the raw transaction so

--- a/pkg/db/retry_test.go
+++ b/pkg/db/retry_test.go
@@ -1,0 +1,154 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// countingConnPool is a gorm.ConnPool that fails the first failBefore calls to
+// Exec/Query with a contention error, then succeeds, counting total attempts.
+// It embeds a real *sql.DB so BeginTx returns a genuine *sql.Tx.
+type countingConnPool struct {
+	db          *sql.DB
+	execAttempt int32
+	failBefore  int32
+	failErr     error
+}
+
+func (c *countingConnPool) PrepareContext(ctx context.Context, query string) (*sql.Stmt, error) {
+	return c.db.PrepareContext(ctx, query)
+}
+
+func (c *countingConnPool) ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error) {
+	if n := atomic.AddInt32(&c.execAttempt, 1); n <= c.failBefore {
+		return nil, c.failErr
+	}
+	return c.db.ExecContext(ctx, query, args...)
+}
+
+func (c *countingConnPool) QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error) {
+	if n := atomic.AddInt32(&c.execAttempt, 1); n <= c.failBefore {
+		return nil, c.failErr
+	}
+	return c.db.QueryContext(ctx, query, args...)
+}
+
+func (c *countingConnPool) QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row {
+	return c.db.QueryRowContext(ctx, query, args...)
+}
+
+func (c *countingConnPool) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	return c.db.BeginTx(ctx, opts)
+}
+
+func newCountingPool(t *testing.T, failBefore int, failErr error) *countingConnPool {
+	t.Helper()
+	sqlDB, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return &countingConnPool{db: sqlDB, failBefore: int32(failBefore), failErr: failErr}
+}
+
+// TestRetryConnPoolRetriesAutocommitContention proves a single autocommit
+// statement is retried on a transient contention error and then succeeds.
+func TestRetryConnPoolRetriesAutocommitContention(t *testing.T) {
+	pool := newCountingPool(t, 2, errors.New("checkpoint in progress"))
+	rp := newRetryConnPool(pool)
+
+	_, err := rp.ExecContext(context.Background(), "SELECT 1")
+	require.NoError(t, err)
+	require.Equal(t, int32(3), atomic.LoadInt32(&pool.execAttempt),
+		"expected 2 contention failures to be retried, succeeding on attempt 3")
+}
+
+// TestRetryConnPoolDoesNotRetryNonContention proves non-contention errors are
+// returned immediately without retry.
+func TestRetryConnPoolDoesNotRetryNonContention(t *testing.T) {
+	pool := newCountingPool(t, 1, errors.New("syntax error"))
+	rp := newRetryConnPool(pool)
+
+	_, err := rp.QueryContext(context.Background(), "SELECT 1")
+	require.Error(t, err)
+	require.Equal(t, int32(1), atomic.LoadInt32(&pool.execAttempt),
+		"non-contention errors must not be retried")
+}
+
+// TestRetryConnPoolBeginTxReturnsRawTx is the critical safety guard: BeginTx
+// must return a raw *sql.Tx, NOT a *retryConnPool. This is what guarantees that
+// statements executed inside an explicit transaction bypass the per-statement
+// retry — re-running one statement of a transaction the DB may have rolled back
+// would corrupt state.
+func TestRetryConnPoolBeginTxReturnsRawTx(t *testing.T) {
+	pool := newCountingPool(t, 0, nil)
+	rp := newRetryConnPool(pool)
+
+	tx, err := rp.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	// The returned value is a *sql.Tx, which does not carry the retry wrapper.
+	require.IsType(t, &sql.Tx{}, tx)
+	_, isRetry := interface{}(tx).(*retryConnPool)
+	require.False(t, isRetry, "BeginTx must not return a retry-wrapped pool")
+}
+
+// TestPluginInstallsRetryPool proves the plugin wraps the gorm connection pool
+// exactly once and that the wrapped DB still works end-to-end.
+func TestPluginInstallsRetryPool(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{SkipDefaultTransaction: true})
+	require.NoError(t, err)
+
+	require.NoError(t, gdb.Use(retryPlugin{}))
+	_, ok := gdb.ConnPool.(*retryConnPool)
+	require.True(t, ok, "plugin should wrap ConnPool in retryConnPool")
+
+	// Idempotent: re-running Initialize on an already-wrapped DB must not
+	// double-wrap (gorm itself rejects a second Use of the same plugin name,
+	// but the Initialize guard protects against any direct re-invocation).
+	require.NoError(t, retryPlugin{}.Initialize(gdb))
+	rp := gdb.ConnPool.(*retryConnPool)
+	_, doubleWrapped := rp.pool.(*retryConnPool)
+	require.False(t, doubleWrapped, "plugin must not double-wrap the pool")
+
+	// db.DB() must still resolve through the decorator's GetDBConn.
+	sqlDB, err := gdb.DB()
+	require.NoError(t, err)
+	require.NoError(t, sqlDB.PingContext(context.Background()))
+}
+
+// TestInTransactionStatementNotIndividuallyRetried proves that when a statement
+// runs inside an explicit gorm transaction, the per-statement retry is bypassed
+// (the tx statements never touch retryConnPool). We assert this structurally:
+// inside db.Transaction the statement's ConnPool is a *sql.Tx, not the
+// retryConnPool, so a contention error there is owned by the surrounding
+// closure-level retry, not silently re-run mid-transaction.
+func TestInTransactionStatementNotIndividuallyRetried(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{SkipDefaultTransaction: true})
+	require.NoError(t, err)
+	require.NoError(t, gdb.Use(retryPlugin{}))
+
+	// Outside a transaction the active ConnPool is the retry decorator.
+	_, autocommitWrapped := gdb.ConnPool.(*retryConnPool)
+	require.True(t, autocommitWrapped)
+
+	var connPoolInsideTx interface{}
+	require.NoError(t, gdb.Transaction(func(tx *gorm.DB) error {
+		connPoolInsideTx = tx.Statement.ConnPool
+		return nil
+	}))
+
+	// Inside the transaction the statement runs against a committer (*sql.Tx),
+	// never the retry decorator — so individual in-tx statements are not
+	// retried by the global mechanism.
+	_, isRetryInsideTx := connPoolInsideTx.(*retryConnPool)
+	require.False(t, isRetryInsideTx, "in-transaction statements must not run through the retry pool")
+	_, isCommitter := connPoolInsideTx.(gorm.TxCommitter)
+	require.True(t, isCommitter, "in-transaction ConnPool should be a TxCommitter (*sql.Tx)")
+}

--- a/pkg/dqlite/contention.go
+++ b/pkg/dqlite/contention.go
@@ -1,0 +1,65 @@
+package dqlite
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// IsContentionError reports whether err is a transient dqlite/SQLite contention
+// or connection-state error worth retrying.
+//
+// This is the single source of truth for contention classification across the
+// codebase. The bounded busy-retry helpers (internal/run, internal/worker,
+// internal/backfill) and the global connection-pool retry in pkg/db all
+// delegate here so the matched error strings live in exactly one place.
+//
+// Two distinct classes are recognised:
+//
+//   - Direct contention (`database is locked`, `checkpoint in progress`, etc.):
+//     a simple retry is likely to find the database in a non-busy state. dqlite
+//     surfaces a WAL checkpoint in progress as a discrete "checkpoint in
+//     progress" error rather than SQLITE_BUSY, so it must be matched by string.
+//   - Connection-state poisoning (`cannot start a transaction within a
+//     transaction`): a previous transaction on the same pooled connection
+//     failed mid-flight (typically because the implicit ROLLBACK after a
+//     `checkpoint in progress` itself failed) and left the connection with a
+//     still-active SQLite transaction handle. The next caller's BEGIN on that
+//     connection then fails. With multiple pooled connections, retries are
+//     likely to draw a clean one.
+func IsContentionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		if sqliteErr.Code == sqlite3.ErrBusy || sqliteErr.Code == sqlite3.ErrLocked {
+			return true
+		}
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "database is locked") ||
+		strings.Contains(msg, "database table is locked") ||
+		strings.Contains(msg, "database schema is locked") ||
+		strings.Contains(msg, "database is busy") ||
+		strings.Contains(msg, "checkpoint in progress") ||
+		strings.Contains(msg, "sqlite_busy") ||
+		strings.Contains(msg, "sqlite_locked") ||
+		strings.Contains(msg, "cannot start a transaction within a transaction")
+}
+
+// IsConnPoolPoisonedError matches the narrow case where a pooled connection has
+// been left with a stale active transaction. Distinct from IsContentionError,
+// which also covers transient busy/locked errors that don't require active
+// recovery (an explicit ROLLBACK on the pool to clear the leftover BEGIN).
+func IsConnPoolPoisonedError(err error) bool {
+	for ; err != nil; err = errors.Unwrap(err) {
+		if strings.Contains(strings.ToLower(err.Error()), "cannot start a transaction within a transaction") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/dqlite/contention_test.go
+++ b/pkg/dqlite/contention_test.go
@@ -1,0 +1,56 @@
+package dqlite
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsContentionError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("syntax error near SELECT"), false},
+		{"record not found is not contention", errors.New("record not found"), false},
+		{"database is locked", errors.New("database is locked"), true},
+		{"database table is locked", errors.New("database table is locked"), true},
+		{"database is busy", errors.New("database is busy"), true},
+		{"checkpoint in progress", errors.New("checkpoint in progress"), true},
+		{"sqlite_busy text", errors.New("SQLITE_BUSY: database is locked"), true},
+		{"transaction within a transaction", errors.New("cannot start a transaction within a transaction"), true},
+		{"wrapped checkpoint", fmt.Errorf("exec failed: %w", errors.New("checkpoint in progress")), true},
+		{"sqlite3 busy code", sqlite3.Error{Code: sqlite3.ErrBusy}, true},
+		{"sqlite3 locked code", sqlite3.Error{Code: sqlite3.ErrLocked}, true},
+		{"sqlite3 other code", sqlite3.Error{Code: sqlite3.ErrConstraint}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, IsContentionError(tc.err))
+		})
+	}
+}
+
+func TestIsConnPoolPoisonedError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"locked is not poisoned", errors.New("database is locked"), false},
+		{"direct", errors.New("cannot start a transaction within a transaction"), true},
+		{"wrapped", fmt.Errorf("begin: %w", errors.New("cannot start a transaction within a transaction")), true},
+		{"case-insensitive", errors.New("CANNOT start a Transaction WITHIN a transaction"), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, IsConnPoolPoisonedError(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
## Why the pivot from call-site wrapping

The diagnosis in the first revision was correct (unretried transient dqlite contention marks successful runs as failed), but **wrapping individual call sites is whack-a-mole** — each PR's CI exposes the next bare query. This PR's *own* `build-and-integration-test` run failed on `TestBackfillBasicHappyPath` through paths the call-site wraps never touched:

```
22:18:35.778 ERROR db "database error" sql:"SELECT * FROM `task_edges` WHERE job_id = ..."          error:"checkpoint in progress"
22:18:35.778 ERROR db "database error" sql:"SELECT * FROM `job_runs` WHERE id = ... LIMIT 1"         error:"checkpoint in progress"
22:18:35.789 db  UPDATE `job_runs` SET ... `error`="checkpoint in progress",`status`="failed" ...
22:18:35.795 ERROR job/backfill.go:221 "backfill: run failed" error:"checkpoint in progress"
```

`SELECT * FROM task_edges` is a bare autocommit read in the DAG-execution path (the executor reading edges), not a surface the previous revision wrapped. The same run also shows autocommit `INSERT INTO task_runs` / `UPDATE task_runs` failing with `database is locked`. All are **single atomic statements** — safe to re-run on transient contention.

## The global approach

Replace per-call-site wrapping with a single retry at the GORM connection-pool layer so every autocommit statement is covered uniformly.

- **`pkg/dqlite/contention.go`** — one shared classifier `IsContentionError` / `IsConnPoolPoisonedError`. The four duplicated classifiers (`internal/run`, `internal/worker`, `internal/backfill`, `internal/jobdef`) now delegate here, so the matched error strings live in exactly one place.
- **`pkg/db/retry.go`** — `retryConnPool`, a `gorm.ConnPool` decorator that retries a single autocommit statement on contention (bounded 5× backoff + jitter, ~310ms), installed via a `gorm.Plugin` over both the dqlite and postgres pools in `pkg/db`.
- **`pkg/db/db.go`** — `SkipDefaultTransaction = true` so top-level single-row `Create`/`Update`/`Delete` execute as one autocommit statement through the decorator (a single INSERT/UPDATE/DELETE is atomic in SQLite/dqlite regardless of an implicit BEGIN/COMMIT) rather than on a `*sql.Tx` that bypasses pool retry. Explicit `db.Transaction(fn)` closures are unaffected by this flag.

## The critical safety constraint: never retry a statement inside a transaction

Re-running one statement of a multi-statement transaction the DB may have rolled back corrupts state. The detection here is **structural, not a runtime flag**:

> The decorator only ever wraps the connection **pool**. GORM runs an explicit transaction by calling `BeginTx` and issuing every statement against the returned `*sql.Tx`. `retryConnPool.BeginTx` delegates to the underlying `*sql.DB` and returns the **raw `*sql.Tx` unwrapped**, so in-transaction statements never touch the decorator and are never individually retried.

Whole-transaction retry remains owned by the existing `withStoreBusyRetry` / `withBusyRetry` closures, which re-run the entire `BEGIN..COMMIT` unit. Two unit tests pin the boundary:
- `TestRetryConnPoolBeginTxReturnsRawTx` — `BeginTx` returns a `*sql.Tx`, not a retry-wrapped pool.
- `TestInTransactionStatementNotIndividuallyRetried` — inside `db.Transaction`, `Statement.ConnPool` is a `gorm.TxCommitter` (`*sql.Tx`), not `retryConnPool`.

## What was kept / removed from the call-site revision

- **Kept** `Store.Complete`'s transaction-closure wrap — it's a multi-statement `db.Transaction(...)`, correct to retry at the whole-transaction level, and the pool retry deliberately does not cover in-tx statements.
- **Removed** the backfill *read*-method wraps — now redundant under the global pool retry (they're single autocommit reads).
- **Kept** the backfill *write*-method wraps (`withBusyRetry` from #162) — they carry the poisoned-connection `ROLLBACK` recovery that the pool retry intentionally does not replicate.

## Production-relevant, not test-infra-only

The flake reproduces real production behavior: a checkpoint blip on any autocommit statement (DAG reads, single writes, completion bookkeeping) flips a successful run to `failed`. The global pool retry hardens every such statement in production.

## Test plan

- [x] `pkg/db/retry_test.go`: autocommit statement retries on injected contention; non-contention returns immediately; `BeginTx` returns raw `*sql.Tx`; plugin wraps pool once; in-tx statements bypass the decorator.
- [x] `pkg/dqlite/contention_test.go`: classifier table (locked / checkpoint / busy / poisoned / sqlite3 codes / not-found-is-not-contention / wrapped).
- [x] `internal/run/store_test.go::TestCompleteRetriesTransientContention`: whole-transaction retry on injected `checkpoint in progress`.
- [x] Full `go test -race ./...` green in the builder (64 packages, 0 failures) — confirms `SkipDefaultTransaction=true` + global retry cause no regressions.
- [x] `go vet ./...`, `gofmt`, `golangci-lint` clean on edited packages.
- [x] Rebased onto `origin/master` (PR #175 / Phase B0+B1) — no conflicts.
- [ ] CI integration jobs — the real signal.

**Caveat:** intermittent flake; green CI is necessary but not sufficient. Confidence now comes from coverage being *uniform* rather than path-by-path: every autocommit statement (the class that was flaking) is retried at one chokepoint, and the in-transaction safety boundary is structurally enforced and unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)