### PR TITLE
Phase 2 B2: close run-owner dispatch/execute/complete cycle

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -325,6 +325,73 @@ func start(cmd *cobra.Command, args []string) error {
 		}()
 	}
 
+	// Construct the distributed worker synchronously (cheap, no I/O) so that,
+	// when run-owner mode is on, its dispatched-task submit seam can be wired
+	// into the dispatch handler BEFORE the API starts serving /internal/dispatch.
+	// Wiring it before api.Start avoids a data race on the handler's submitter
+	// field and guarantees a dispatch can never arrive at a handler with no
+	// worker attached.
+	var distributedWorker *worker.Worker
+	if vars.WorkerEnabled && distributedMode {
+		poolSize := vars.WorkerPoolSize
+		if poolSize < 1 {
+			poolSize = 1
+		}
+
+		log.Info(
+			"launching distributed worker",
+			"node_address",
+			vars.NodeAddress,
+			"node_labels",
+			vars.NodeLabels,
+			"pool_size",
+			poolSize,
+			"poll_interval",
+			vars.WorkerPollInterval,
+			"reclaim_interval",
+			vars.WorkerReclaimInterval,
+			"lease_ttl",
+			vars.WorkerLeaseTTL,
+		)
+
+		claimer := worker.NewClaimer(vars.NodeAddress, runStore, vars.WorkerLeaseTTL, worker.ParseNodeLabels(vars.NodeLabels))
+		executorFn := worker.NewRuntimeExecutor(runStore, vars.TaskTimeout, vars.TaskFailurePolicy)
+		wakeups := worker.SubscribeWakeups(ctx, bus, wakeupSignaler.C())
+		distributedWorker = worker.NewWorker(claimer, worker.NewPool(poolSize), vars.WorkerPollInterval, executorFn).
+			WithReclaimInterval(vars.WorkerReclaimInterval).
+			WithWakeups(wakeups).
+			WithLeaseRenewal(runStore, vars.WorkerLeaseTTL, vars.WorkerLeaseRenewInterval)
+
+		// Phase 2: piggyback run-lease renewal on the same worker goroutine
+		// when owner mode is enabled, and enable the inbound dispatch path so
+		// dispatched tasks flow onto this worker's shared pool.
+		if vars.RunOwnerEnabled && runStore.LeaseStore() != nil {
+			distributedWorker = distributedWorker.
+				WithRunLeaseRenewal(runStore.LeaseStore(), vars.RunLeaseTTL, vars.NodeAddress).
+				WithInboundDispatch(strings.TrimSpace(vars.InternalWakeupToken))
+
+			// Hand the dispatch handler the worker's submit seam so accepted
+			// dispatches flow onto the worker's pool (the dispatch→execute step).
+			if ownerDispatchHandler != nil {
+				ownerDispatchHandler = ownerDispatchHandler.WithWorkerSubmitter(distributedWorker)
+			}
+		}
+
+		if usesInternalDqlite(vars.DatabaseType) {
+			distributedWorker = distributedWorker.WithReclaimGate(worker.ReclaimGateFunc(func(ctx context.Context) (bool, error) {
+				return dqlite.IsLocalLeader(ctx)
+			}))
+		}
+	} else {
+		log.Info(
+			"distributed worker disabled",
+			"worker_enabled",
+			vars.WorkerEnabled,
+			"execution_mode",
+			vars.ExecutionMode,
+		)
+	}
+
 	go func() {
 		log.Info("spinning up api")
 		errs <- api.Start(ctx, bus, authSvc, auditor, limiter, internalWakeupHandler, ownerDispatchHandler)
@@ -335,58 +402,10 @@ func start(cmd *cobra.Command, args []string) error {
 		errs <- executor.Start(ctx)
 	}()
 
-	if vars.WorkerEnabled && distributedMode {
+	if distributedWorker != nil {
 		go func() {
-			poolSize := vars.WorkerPoolSize
-			if poolSize < 1 {
-				poolSize = 1
-			}
-
-			log.Info(
-				"launching distributed worker",
-				"node_address",
-				vars.NodeAddress,
-				"node_labels",
-				vars.NodeLabels,
-				"pool_size",
-				poolSize,
-				"poll_interval",
-				vars.WorkerPollInterval,
-				"reclaim_interval",
-				vars.WorkerReclaimInterval,
-				"lease_ttl",
-				vars.WorkerLeaseTTL,
-			)
-
-			claimer := worker.NewClaimer(vars.NodeAddress, runStore, vars.WorkerLeaseTTL, worker.ParseNodeLabels(vars.NodeLabels))
-			executorFn := worker.NewRuntimeExecutor(runStore, vars.TaskTimeout, vars.TaskFailurePolicy)
-			wakeups := worker.SubscribeWakeups(ctx, bus, wakeupSignaler.C())
-			w := worker.NewWorker(claimer, worker.NewPool(poolSize), vars.WorkerPollInterval, executorFn).
-				WithReclaimInterval(vars.WorkerReclaimInterval).
-				WithWakeups(wakeups).
-				WithLeaseRenewal(runStore, vars.WorkerLeaseTTL, vars.WorkerLeaseRenewInterval)
-
-			// Phase 2: piggyback run-lease renewal on the same worker goroutine
-			// when owner mode is enabled.
-			if vars.RunOwnerEnabled && runStore.LeaseStore() != nil {
-				w = w.WithRunLeaseRenewal(runStore.LeaseStore(), vars.RunLeaseTTL, vars.NodeAddress)
-			}
-
-			if usesInternalDqlite(vars.DatabaseType) {
-				w = w.WithReclaimGate(worker.ReclaimGateFunc(func(ctx context.Context) (bool, error) {
-					return dqlite.IsLocalLeader(ctx)
-				}))
-			}
-			errs <- w.Run(ctx)
+			errs <- distributedWorker.Run(ctx)
 		}()
-	} else {
-		log.Info(
-			"distributed worker disabled",
-			"worker_enabled",
-			vars.WorkerEnabled,
-			"execution_mode",
-			vars.ExecutionMode,
-		)
 	}
 
 	defer shutdown()

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@ These files are useful context, but each should be treated according to its stat
 - [load-baseline-distributed-2026-05-24.md](load-baseline-distributed-2026-05-24.md): First distributed-mode (3-node k8s) baseline; validates the Phase 2 gate.
 - [load-baseline-phase2a-2026-05-24.md](load-baseline-phase2a-2026-05-24.md): First measurement of Phase 2 Phase A; surfaces the missing executor-side dispatch loop.
 - [load-baseline-phase2a2-2026-05-24.md](load-baseline-phase2a2-2026-05-24.md): Phase A2 dispatch loop measured; finds it races ClaimNext and loses — redirects strategy to Phase B.
+- [load-baseline-b2-2026-05-24.md](load-baseline-b2-2026-05-24.md): Phase B2 dispatch→execute→complete cycle; 0/10 → stable 10/10 after hardening the completion and run-start paths against transient dqlite contention.
 
 ## Historical Notes
 

--- a/docs/load-baseline-b2-2026-05-24.md
+++ b/docs/load-baseline-b2-2026-05-24.md
@@ -1,0 +1,114 @@
+# Caesium Load Baseline — Phase 2 Phase B2 Measurement (2026-05-24)
+
+> Measurement of Phase B2 (the dispatch→execute→complete cycle) on the 3-node
+> k8s deployment. **Headline finding: B2 closes the run-owner execution loop —
+> the 100-task stress workload went from B1's 0/10 to a stable 10/10 across
+> three consecutive runs. Reaching 10/10 required hardening two run-owner paths
+> against transient dqlite contention; both fixes are validated firing under
+> real load.**
+
+## Environment
+
+Same 3-pod StatefulSet on Docker Desktop k8s as the prior phase docs:
+`CAESIUM_EXECUTION_MODE=distributed`, `CAESIUM_RUN_OWNER_ENABLED=true`,
+`CAESIUM_INTERNAL_WAKEUP_TOKEN` set, kubernetes engine, ephemeral storage.
+Branch `phase2-b2-dispatch-execute-complete` (base commit `b00c869` plus the two
+contention fixes below). Standard workload: 10 jobs × fan-out=4 × depth=3 ×
+500ms task duration × concurrency=5 = 100 tasks per run.
+
+## Finding 0 — B2's cycle works; first stress run was 8/10
+
+The B2 commit (`b00c869`) wired the cycle: the owner pushes tasks via
+`/internal/dispatch`, the worker executes on its existing pool, and reports the
+outcome back via `/internal/complete` (the `CompletionSink` routing
+ClaimNext'd tasks to the local store and dispatched tasks to the owner). A
+2-job smoke test passed 2/2, and the first 100-task stress run scored **8/10** —
+already a step change from B1's **0/10** (B1 deferred ClaimNext to the owner but
+the owner executed nothing; B2 supplies the missing execution).
+
+## Finding 1 — lost completions on owner-side contention (fixed)
+
+The 2 failures in the 8/10 run traced to the owner's completion apply
+(`CompleteTaskClaimed`) hitting `"database is locked"` under the burst of
+concurrent completions. That error is not `ErrTaskClaimMismatch`, so
+`HandleComplete` fell through to a generic **409**, and the worker treated 409
+as a terminal fence rejection — dropping a completion for a task that had
+actually succeeded. The run then stalled and failed.
+
+**Fix:** distinguish transient contention from a real fence violation.
+- Owner: on a `dqlite.IsContentionError` apply failure, `HandleComplete` now
+  returns **503** (retryable) via `rejectRetryable`, not 409, and records
+  `caesium_complete_retryable_total{reason="contention"}`.
+- `PostComplete` surfaces 503 as the `ErrOwnerBusy` sentinel.
+- Worker `ownerSink.send` retries on `ErrOwnerBusy` with bounded backoff
+  (~1.55s across 6 tries) before giving up; an exhausted retry is recorded as
+  `caesium_complete_report_failed_total{reason="owner_busy"}`.
+
+## Finding 2 — run-start fails the whole run on a contention blip (fixed)
+
+After Finding 1's fix, a re-run scored **7/10** with **zero** completion-failure
+metrics — a *different* cause. All 3 failures were runs that died ~30ms after
+start with `total_tasks=0` and `error: "checkpoint in progress"`, clustered in a
+~45ms window at the start of the workload (a WAL checkpoint was in progress when
+the first concurrent batch fired).
+
+Root cause: the run-start / DAG-materialization reads (`atomService.Get`,
+`taskEdgeService.List`, `taskService.List`, `store.Get`) fail the *entire run*
+on a transient contention error. The global connection-pool retry (PR #176)
+misses it because dqlite can surface `"checkpoint in progress"` during **row
+iteration**, after `QueryContext` has already returned cleanly — so the
+pool-layer wrapper never sees it. The 30ms-to-failure timing confirmed no retry
+layer engaged.
+
+**Fix:** `retryOnContention` (internal/job) wraps the five idempotent run-start
+reads with a bounded backoff (~630ms across 6 tries) keyed on
+`dqlite.IsContentionError`. These reads have no side effects, so re-running them
+is safe. (Also fixed a latent `err`-scoping reference at job.go:1071 that was
+always `nil` in practice.)
+
+## Finding 3 — duplicate execution was a symptom of Finding 1, not a separate bug
+
+The 7/10 run showed tasks executing 2–6×, which looked like duplicate dispatch.
+With both fixes in place, `caesium_dispatch_sent_total` is **exactly** 100 per
+run (300 across three runs) — every task dispatched once, no re-dispatch. The
+earlier duplication was downstream of lost completions: a dropped completion
+left a task looking un-terminal, its claim lease expired, and recovery
+re-executed it. Fixing the completion path (Finding 1) removed the churn.
+
+## Results
+
+| Config | Runs OK | dispatch_sent | complete_retryable | complete_report_failed |
+|---|---|---|---|---|
+| B1 (#175) | 0/10 | n/a (owner executed nothing) | — | — |
+| B2 base (`b00c869`) | 8/10 | ~104 | n/a (metric not yet added) | post_error (lost) |
+| B2 + completion fix | 7/10 | 70 | 0 | 0 (ran-start failures instead) |
+| **B2 + both fixes** | **10/10 ×3** | **100/run (300 total)** | **8 (all recovered)** | **0** |
+
+End-to-end p50 ≈ 17s, p99 ≈ 31s (unchanged from the healthy baselines). The 8
+`complete_retryable` events across the three 10/10 runs are direct evidence the
+completion-503 path fires under real contention and the worker retry recovers
+every one — zero lost completions, zero fence rejections.
+
+## Conclusions
+
+1. **B2 delivers run-owner execution.** 0/10 → a stable 10/10. The owner is the
+   single writer for its run's coordination rows, and dispatched tasks report
+   back over `/internal/complete` with the owner-generation fence intact.
+
+2. **Contention hardening was the gating work, not the cycle itself.** Both
+   failure modes were transient dqlite contention escaping a retry layer (one on
+   the completion apply, one on run-start reads surfacing at iteration time).
+   The cycle mechanism was correct from `b00c869`.
+
+3. **`CAESIUM_RUN_OWNER_ENABLED` stays default-off.** B2 is verified in the
+   sandbox but mTLS for the internal endpoints is still warn-only; owner mode
+   should not be enabled in a real deployment until that lands.
+
+## Sandbox caveats
+
+Single physical node, 3 dqlite voters, ephemeral storage. The checkpoint
+contention is more frequent here than on dedicated hardware would be — which
+makes it a useful stress test for the retry hardening, but the absolute failure
+rates of the intermediate (8/10, 7/10) configs are partly sandbox-amplified. The
+fixes are correctness improvements (no lost completions, no run killed by a
+transient blip) that hold regardless of cluster size.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
@@ -68,7 +69,13 @@ type DispatchRequest struct {
 	OwnerGeneration int64     `json:"owner_generation"`
 	Attempt         int       `json:"attempt"`
 	WorkerNode      string    `json:"worker_node"`
-	Deadline        time.Time `json:"deadline"`
+	// OwnerBaseURL is the owner's own HTTP API base URL
+	// (http://<owner-host>:<apiPort>).  The receiving worker POSTs its task
+	// completion back to OwnerBaseURL + "/internal/complete" so the owner
+	// remains the single writer for its run's hot rows.  Set by the dispatch
+	// loop from the owner's node address + API port.
+	OwnerBaseURL string    `json:"owner_base_url"`
+	Deadline     time.Time `json:"deadline"`
 }
 
 // CompleteRequest is the envelope sent by a worker back to the owner when a
@@ -102,6 +109,35 @@ type ErrorResponse struct {
 	Message string `json:"message"`
 }
 
+// InboundDispatch is a task accepted by this node for execution plus the owner
+// metadata it needs to report completion back to the owner.  HandleDispatch
+// builds one of these and hands it to the worker via the WorkerSubmitter.
+type InboundDispatch struct {
+	// Task is the full task_runs row to execute (image/command/engine/etc.).
+	Task *models.TaskRun
+	// OwnerBaseURL is the owner's API base URL; the worker POSTs its completion
+	// to OwnerBaseURL + "/internal/complete".
+	OwnerBaseURL string
+	// OwnerGeneration / Attempt / WorkerNode are the fencing fields the owner
+	// validates on the completion envelope.
+	OwnerGeneration int64
+	Attempt         int
+	WorkerNode      string
+}
+
+// WorkerSubmitter is the seam the dispatch handler uses to hand an accepted
+// task to the local worker's execution pool.  The worker implementation
+// (worker.Worker.SubmitDispatched) enqueues the task onto its inbound channel
+// for the Run loop to drain onto the shared pool.  It returns an error when the
+// worker cannot accept the task (inbound buffer full or worker not running) so
+// HandleDispatch can roll back the claim and let the owner re-dispatch.
+//
+// It is an interface so dispatch tests can inject a fake without standing up a
+// real worker + pool.
+type WorkerSubmitter interface {
+	SubmitDispatched(d InboundDispatch) error
+}
+
 // Handler holds the dependencies needed to serve the dispatch and complete
 // endpoints.
 type Handler struct {
@@ -109,6 +145,10 @@ type Handler struct {
 	leaseStore *run.LeaseStore
 	nodeID     string
 	token      string
+	// submitter hands accepted dispatches to the local worker pool.  When nil
+	// (worker disabled on this node), HandleDispatch cannot execute the task and
+	// rolls back the claim so the owner re-dispatches elsewhere.
+	submitter WorkerSubmitter
 }
 
 // NewHandler constructs a Handler.  store is the run.Store; leaseStore is the
@@ -121,6 +161,14 @@ func NewHandler(store *run.Store, leaseStore *run.LeaseStore, nodeID, token stri
 		nodeID:     nodeID,
 		token:      token,
 	}
+}
+
+// WithWorkerSubmitter wires the local worker's submit seam into the handler so
+// accepted dispatches flow onto the worker's shared execution pool.  Returns
+// the handler for chaining at construction time.
+func (h *Handler) WithWorkerSubmitter(s WorkerSubmitter) *Handler {
+	h.submitter = s
+	return h
 }
 
 // authorized checks the Bearer token in the request's Authorization header.
@@ -182,6 +230,17 @@ func (h *Handler) HandleDispatch(w http.ResponseWriter, r *http.Request) {
 		ttl = 5 * time.Minute
 	}
 
+	// A worker must be wired up to execute the task.  Without one, accepting the
+	// dispatch would claim the task with nobody to run it (the exact orphaning
+	// B1 measured).  Reject before claiming so the owner re-dispatches elsewhere.
+	if h.submitter == nil {
+		writeJSON(w, http.StatusConflict, ErrorResponse{
+			Code:    ReasonTaskNotRunning,
+			Message: "no worker available on this node to execute dispatched tasks",
+		})
+		return
+	}
+
 	// Accept the dispatch: atomically claim the task and mark it as running.
 	// ClaimTaskForDispatch transitions pending→running with claimed_by=nodeID
 	// in one UPDATE (equivalent to ClaimNext but targeting a specific task),
@@ -206,7 +265,59 @@ func (h *Handler) HandleDispatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Load the full task row to execute (image/command/engine/etc.).  If the
+	// row vanished between claim and load (reclaimed by another node in the
+	// race window), roll back and reject.
+	taskRun, err := h.store.LoadDispatchedTaskRun(req.RunID, req.TaskID, h.nodeID)
+	if err != nil {
+		h.rollbackClaim(req)
+		writeJSON(w, http.StatusConflict, ErrorResponse{
+			Code:    ReasonTaskNotRunning,
+			Message: "claimed task row not found",
+		})
+		return
+	}
+
+	// Hand the claimed task to the local worker pool.  SubmitDispatched is
+	// non-blocking: it returns an error if the inbound buffer is full or the
+	// worker is not running.  On failure we MUST NOT leave the task
+	// claimed-but-orphaned — roll the claim back to pending so the owner's next
+	// dispatch tick re-dispatches it (here or to a peer), and reject with 409.
+	if submitErr := h.submitter.SubmitDispatched(InboundDispatch{
+		Task:            taskRun,
+		OwnerBaseURL:    req.OwnerBaseURL,
+		OwnerGeneration: req.OwnerGeneration,
+		Attempt:         req.Attempt,
+		WorkerNode:      h.nodeID,
+	}); submitErr != nil {
+		h.rollbackClaim(req)
+		log.Warn("dispatch: worker could not accept task; rolled back claim",
+			"run_id", req.RunID,
+			"task_id", req.TaskID,
+			"error", submitErr,
+		)
+		writeJSON(w, http.StatusConflict, ErrorResponse{
+			Code:    ReasonTaskNotRunning,
+			Message: "worker busy; task returned to dispatch pool",
+		})
+		return
+	}
+
 	w.WriteHeader(http.StatusAccepted)
+}
+
+// rollbackClaim reverts a just-claimed task back to the dispatchable pending
+// state so the owner re-dispatches it.  Logged but not surfaced to the caller
+// beyond the 409 the caller already returns; a failed rollback is rare (the
+// claim lease still expires and ClaimNext recovery covers it).
+func (h *Handler) rollbackClaim(req DispatchRequest) {
+	if err := h.store.ReleaseTaskClaim(req.RunID, req.TaskID, h.nodeID, req.OwnerGeneration); err != nil {
+		log.Error("dispatch: failed to roll back claim after worker rejected task",
+			"run_id", req.RunID,
+			"task_id", req.TaskID,
+			"error", err,
+		)
+	}
 }
 
 // HandleComplete handles POST /internal/complete.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -284,6 +284,14 @@ func (h *Handler) HandleDispatch(w http.ResponseWriter, r *http.Request) {
 	taskRun, err := h.store.LoadDispatchedTaskRun(req.RunID, req.TaskID, h.nodeID)
 	if err != nil {
 		h.rollbackClaim(req)
+		// Surface the underlying error rather than dropping it: a missing row is
+		// the expected reclaim race, but a transient DB/connection failure here
+		// looks identical from the fixed 409 body otherwise.
+		log.Warn("dispatch: could not load claimed task row; rolled back claim",
+			"run_id", req.RunID,
+			"task_id", req.TaskID,
+			"error", err,
+		)
 		writeJSON(w, http.StatusConflict, ErrorResponse{
 			Code:    ReasonTaskNotRunning,
 			Message: "claimed task row not found",

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
 )
@@ -40,7 +42,18 @@ const (
 	ReasonNotOwner        = "not_owner"
 	ReasonMissingRun      = "missing_run"
 	ReasonMalformed       = "malformed"
+	// ReasonContention labels caesium_complete_retryable_total when the owner
+	// could not apply a completion because of transient dqlite contention and
+	// answered 503 so the worker retries.  It is NOT a fence violation.
+	ReasonContention = "contention"
 )
+
+// ErrOwnerBusy is returned by PostComplete when the owner answered 503 Service
+// Unavailable: it could not apply the completion because of transient dqlite
+// contention and is asking the worker to retry the identical request.  This is
+// distinct from a fence rejection (409), which is terminal — callers should
+// retry on ErrOwnerBusy and give up on any other error.
+var ErrOwnerBusy = errors.New("owner busy: retryable")
 
 // internalClient is the shared HTTP client used for both PostDispatch and
 // PostComplete. Sharing keeps the underlying TCP/keep-alive pool warm
@@ -416,6 +429,10 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if applyErr != nil {
+			if dqlite.IsContentionError(applyErr) {
+				h.rejectRetryable(w, req, applyErr)
+				return
+			}
 			log.Error("complete: apply failed",
 				"run_id", req.RunID,
 				"task_id", req.TaskID,
@@ -441,6 +458,10 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if applyErr != nil {
+			if dqlite.IsContentionError(applyErr) {
+				h.rejectRetryable(w, req, applyErr)
+				return
+			}
 			log.Error("complete: CacheHitTaskClaimed failed",
 				"run_id", req.RunID,
 				"task_id", req.TaskID,
@@ -455,6 +476,25 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, CompleteResponse{Accepted: true})
+}
+
+// rejectRetryable answers a completion the owner could not apply because of
+// transient dqlite contention.  It returns 503 (not 409) so the worker knows
+// the request is safe to re-send once the leader's contention clears, and logs
+// at warn rather than error because this is expected under burst load and is
+// not a lost completion unless the worker exhausts its own retries.
+func (h *Handler) rejectRetryable(w http.ResponseWriter, req CompleteRequest, applyErr error) {
+	metrics.CompleteRetryableTotal.WithLabelValues(ReasonContention).Inc()
+	log.Warn("complete: transient contention, asking worker to retry",
+		"run_id", req.RunID,
+		"task_id", req.TaskID,
+		"status", req.Status,
+		"error", applyErr,
+	)
+	writeJSON(w, http.StatusServiceUnavailable, ErrorResponse{
+		Code:    ReasonContention,
+		Message: "owner busy applying completion; retry",
+	})
 }
 
 func writeJSON(w http.ResponseWriter, code int, v interface{}) {
@@ -520,6 +560,12 @@ func PostComplete(ctx context.Context, ownerURL, token string, req CompleteReque
 	if resp.StatusCode == http.StatusOK {
 		_ = json.Unmarshal(respBody, &result)
 		return &result, nil
+	}
+	// 503: the owner hit transient contention applying the completion and wants
+	// the worker to retry the same request.  Wrap ErrOwnerBusy so the caller can
+	// distinguish it from a terminal fence rejection (409) via errors.Is.
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		return nil, fmt.Errorf("complete: owner returned status %d: %w", resp.StatusCode, ErrOwnerBusy)
 	}
 	return nil, fmt.Errorf("complete: owner returned status %d", resp.StatusCode)
 }

--- a/internal/dispatch/dispatch_test.go
+++ b/internal/dispatch/dispatch_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -337,3 +338,171 @@ func TestHandleComplete_ExpiredLease(t *testing.T) {
 	// Skipped status is checked first, before ownership.
 	require.Equal(t, http.StatusConflict, w.Code)
 }
+
+// --- Phase 2 B2: HandleDispatch accept/reject + worker submit seam ---
+
+// fakeSubmitter is a test WorkerSubmitter that records accepted dispatches and
+// can be told to reject (simulating a full inbound buffer).
+type fakeSubmitter struct {
+	accepted []InboundDispatch
+	err      error
+}
+
+func (f *fakeSubmitter) SubmitDispatched(d InboundDispatch) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.accepted = append(f.accepted, d)
+	return nil
+}
+
+// seedPendingTaskRun inserts a dispatchable (pending, unclaimed, no outstanding
+// predecessors) task_runs row, plus the trigger/job/atom/task/job_run chain it
+// needs so the event-recording path inside ClaimTaskForDispatch can resolve the
+// owning job_run.  Returns the job-run ID (== run ID) and the task ID.
+func seedPendingTaskRun(t *testing.T, store *run.Store) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	db := store.DB()
+	now := time.Now().UTC()
+
+	trigger := &models.Trigger{ID: uuid.New(), Alias: "disp-trigger", Type: models.TriggerTypeCron, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(trigger).Error)
+
+	job := &models.Job{ID: uuid.New(), Alias: "disp-job", TriggerID: trigger.ID, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(job).Error)
+
+	atom := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "busybox:1.36.1", Command: `["sh","-c","echo hi"]`, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(atom).Error)
+
+	task := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "step1", CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(task).Error)
+
+	jobRun := &models.JobRun{ID: uuid.New(), JobID: job.ID, TriggerID: trigger.ID, TriggerType: string(trigger.Type), Status: string(run.StatusRunning), StartedAt: now, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(jobRun).Error)
+
+	tr := &models.TaskRun{
+		ID:                      uuid.New(),
+		JobRunID:                jobRun.ID,
+		TaskID:                  task.ID,
+		AtomID:                  atom.ID,
+		Engine:                  models.AtomEngineDocker,
+		Image:                   "busybox:1.36.1",
+		Command:                 `["sh","-c","echo hi"]`,
+		Status:                  string(run.TaskStatusPending),
+		ClaimedBy:               "",
+		Attempt:                 1,
+		MaxAttempts:             1,
+		OutstandingPredecessors: 0,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+	require.NoError(t, db.Create(tr).Error)
+	return jobRun.ID, task.ID
+}
+
+// taskStatus reads back the current status + claimed_by for assertions.
+func taskStatus(t *testing.T, store *run.Store, runID, taskID uuid.UUID) (string, string) {
+	t.Helper()
+	var tr models.TaskRun
+	require.NoError(t, store.DB().Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&tr).Error)
+	return tr.Status, tr.ClaimedBy
+}
+
+// TestHandleDispatch_AcceptsAndSubmits verifies the happy path: a dispatch
+// addressed to this node claims the task, hands it to the worker, and returns
+// 202 with the owner metadata threaded into the InboundDispatch.
+func TestHandleDispatch_AcceptsAndSubmits(t *testing.T) {
+	store, _, h := setupHandler(t)
+	sub := &fakeSubmitter{}
+	h = h.WithWorkerSubmitter(sub)
+
+	runID, taskID := seedPendingTaskRun(t, store)
+
+	req := DispatchRequest{
+		RunID:           runID,
+		TaskID:          taskID,
+		OwnerGeneration: 1,
+		Attempt:         1,
+		WorkerNode:      ownerNodeAddr,
+		OwnerBaseURL:    "http://10.0.0.1:8080",
+		Deadline:        time.Now().Add(5 * time.Minute),
+	}
+	w := postJSON(t, h.HandleDispatch, req)
+	require.Equal(t, http.StatusAccepted, w.Code, "dispatch should be accepted")
+
+	require.Len(t, sub.accepted, 1, "task should be handed to the worker")
+	got := sub.accepted[0]
+	require.Equal(t, runID, got.Task.JobRunID)
+	require.Equal(t, taskID, got.Task.TaskID)
+	require.Equal(t, "http://10.0.0.1:8080", got.OwnerBaseURL)
+	require.Equal(t, int64(1), got.OwnerGeneration)
+	require.Equal(t, ownerNodeAddr, got.WorkerNode)
+
+	// Task is now claimed/running on this node.
+	status, claimedBy := taskStatus(t, store, runID, taskID)
+	require.Equal(t, string(run.TaskStatusRunning), status)
+	require.Equal(t, ownerNodeAddr, claimedBy)
+}
+
+// TestHandleDispatch_RejectsAndRollsBackWhenWorkerFull verifies that when the
+// worker cannot accept (buffer full), the handler rolls the claim back to
+// pending/unclaimed so the owner re-dispatches, and returns 409.
+func TestHandleDispatch_RejectsAndRollsBackWhenWorkerFull(t *testing.T) {
+	store, _, h := setupHandler(t)
+	sub := &fakeSubmitter{err: ErrInboundFullSentinel}
+	h = h.WithWorkerSubmitter(sub)
+
+	runID, taskID := seedPendingTaskRun(t, store)
+
+	req := DispatchRequest{
+		RunID:           runID,
+		TaskID:          taskID,
+		OwnerGeneration: 1,
+		Attempt:         1,
+		WorkerNode:      ownerNodeAddr,
+		OwnerBaseURL:    "http://10.0.0.1:8080",
+		Deadline:        time.Now().Add(5 * time.Minute),
+	}
+	w := postJSON(t, h.HandleDispatch, req)
+	require.Equal(t, http.StatusConflict, w.Code, "a full worker must reject the dispatch")
+
+	// Claim must have been rolled back so the next dispatch tick picks it up.
+	status, claimedBy := taskStatus(t, store, runID, taskID)
+	require.Equal(t, string(run.TaskStatusPending), status, "task must be returned to pending")
+	require.Equal(t, "", claimedBy, "claim must be released on rollback")
+}
+
+// TestHandleDispatch_RejectsWhenNoWorker verifies that a node without a worker
+// submitter rejects the dispatch (and does NOT claim the task) so the owner
+// re-dispatches to a node that can actually run it.
+func TestHandleDispatch_RejectsWhenNoWorker(t *testing.T) {
+	store, _, h := setupHandler(t) // no WithWorkerSubmitter
+
+	runID, taskID := seedPendingTaskRun(t, store)
+
+	req := DispatchRequest{
+		RunID:           runID,
+		TaskID:          taskID,
+		OwnerGeneration: 1,
+		Attempt:         1,
+		WorkerNode:      ownerNodeAddr,
+		Deadline:        time.Now().Add(5 * time.Minute),
+	}
+	w := postJSON(t, h.HandleDispatch, req)
+	require.Equal(t, http.StatusConflict, w.Code)
+
+	// Task must remain pending and unclaimed (never claimed in the first place).
+	status, claimedBy := taskStatus(t, store, runID, taskID)
+	require.Equal(t, string(run.TaskStatusPending), status)
+	require.Equal(t, "", claimedBy)
+}
+
+// ErrInboundFullSentinel mirrors the worker's full-buffer error for the
+// dispatch-package test without importing the worker package (which would
+// create an import cycle). Its identity is irrelevant to the handler — any
+// non-nil error triggers the rollback path.
+var ErrInboundFullSentinel = &sentinelError{"inbound buffer full"}
+
+type sentinelError struct{ msg string }
+
+func (e *sentinelError) Error() string { return e.msg }

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -119,6 +119,10 @@ type DispatchLoopConfig struct {
 type DispatchLoop struct {
 	cfg     DispatchLoopConfig
 	counter atomic.Uint64 // round-robin counter; used modulo peer count
+	// ownerBaseURL is this node's own API base URL, stamped onto every
+	// DispatchRequest.OwnerBaseURL so the receiving worker knows where to POST
+	// its completion.  Computed once from NodeID + APIPort.
+	ownerBaseURL string
 }
 
 // NewDispatchLoop constructs a DispatchLoop from cfg.
@@ -135,7 +139,11 @@ func NewDispatchLoop(cfg DispatchLoopConfig) *DispatchLoop {
 	if cfg.APIPort <= 0 {
 		cfg.APIPort = 8080
 	}
-	return &DispatchLoop{cfg: cfg}
+	l := &DispatchLoop{cfg: cfg}
+	// Reuse the same nodeAddr→baseURL logic the peer list uses so the owner's
+	// own base URL is built identically (and honors the PeerBaseURL test hook).
+	l.ownerBaseURL = l.nodeAddrToBaseURL(cfg.NodeID)
+	return l
 }
 
 // Run starts the polling loop.  It blocks until ctx is cancelled.
@@ -245,7 +253,11 @@ func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, generat
 			// nodeID matches the recipient's CAESIUM_NODE_ADDRESS so the
 			// handler's `req.WorkerNode == h.nodeID` check passes.
 			WorkerNode: p.nodeID,
-			Deadline:   time.Now().UTC().Add(l.cfg.Deadline),
+			// OwnerBaseURL is this node's (the owner's) own API base URL; the
+			// receiving worker POSTs its completion back here so the owner stays
+			// the single writer for its run's hot rows.
+			OwnerBaseURL: l.ownerBaseURL,
+			Deadline:     time.Now().UTC().Add(l.cfg.Deadline),
 		}
 
 		wg.Add(1)

--- a/internal/job/contention_retry_test.go
+++ b/internal/job/contention_retry_test.go
@@ -1,0 +1,104 @@
+package job
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// withFastRunStartBackoffs shrinks the run-start retry schedule to n×1ms for
+// the duration of a test so exhaustion cases don't sleep the real ~630ms
+// budget. Tests using it must not run in parallel while the package var is
+// swapped.
+func withFastRunStartBackoffs(t *testing.T, n int) {
+	t.Helper()
+	orig := runStartReadBackoffs
+	fast := make([]time.Duration, n)
+	for i := range fast {
+		fast[i] = time.Millisecond
+	}
+	runStartReadBackoffs = fast
+	t.Cleanup(func() { runStartReadBackoffs = orig })
+}
+
+func TestRetryOnContention_SucceedsFirstTry(t *testing.T) {
+	withFastRunStartBackoffs(t, 5)
+	calls := 0
+	err := retryOnContention(context.Background(), func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryOnContention_RetriesThenSucceeds(t *testing.T) {
+	withFastRunStartBackoffs(t, 5)
+	calls := 0
+	err := retryOnContention(context.Background(), func() error {
+		calls++
+		if calls <= 2 {
+			return errors.New("checkpoint in progress")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil error after retries, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls (two contention then success), got %d", calls)
+	}
+}
+
+func TestRetryOnContention_NonContentionNotRetried(t *testing.T) {
+	withFastRunStartBackoffs(t, 5)
+	sentinel := errors.New("record not found")
+	calls := 0
+	err := retryOnContention(context.Background(), func() error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("a non-contention error must not be retried; got %d calls", calls)
+	}
+}
+
+func TestRetryOnContention_ExhaustsAndReturnsError(t *testing.T) {
+	withFastRunStartBackoffs(t, 3)
+	calls := 0
+	err := retryOnContention(context.Background(), func() error {
+		calls++
+		return errors.New("checkpoint in progress")
+	})
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if want := len(runStartReadBackoffs) + 1; calls != want {
+		t.Fatalf("expected %d calls (initial + one per backoff), got %d", want, calls)
+	}
+}
+
+func TestRetryOnContention_ContextCancelStops(t *testing.T) {
+	withFastRunStartBackoffs(t, 5)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	err := retryOnContention(ctx, func() error {
+		calls++
+		return errors.New("database is locked")
+	})
+	if err == nil {
+		t.Fatal("expected error when context is cancelled")
+	}
+	if calls != 1 {
+		t.Fatalf("a pre-cancelled context must stop after the first attempt; got %d calls", calls)
+	}
+}

--- a/internal/job/contention_retry_test.go
+++ b/internal/job/contention_retry_test.go
@@ -95,8 +95,8 @@ func TestRetryOnContention_ContextCancelStops(t *testing.T) {
 		calls++
 		return errors.New("database is locked")
 	})
-	if err == nil {
-		t.Fatal("expected error when context is cancelled")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled on cancellation, got %v", err)
 	}
 	if calls != 1 {
 		t.Fatalf("a pre-cancelled context must stop after the first attempt; got %d calls", calls)

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/rand/v2"
 	"runtime"
 	"slices"
 	"strconv"
@@ -27,6 +28,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/internal/worker"
 	"github.com/caesium-cloud/caesium/pkg/container"
+	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/log"
@@ -34,6 +36,52 @@ import (
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
+
+// runStartReadBackoffs bounds retries for transient dqlite contention (e.g.
+// "checkpoint in progress") on the idempotent reads the run-start /
+// DAG-materialization path issues. A contention blip on any of these reads
+// would otherwise fail the entire run before a single task row is created.
+// ~630ms total across 6 retries — deliberately longer than the per-statement
+// connection-pool retry because a WAL checkpoint can outlast a single
+// statement's budget, and a stalled run start is far worse than a brief wait.
+var runStartReadBackoffs = []time.Duration{
+	10 * time.Millisecond,
+	20 * time.Millisecond,
+	40 * time.Millisecond,
+	80 * time.Millisecond,
+	160 * time.Millisecond,
+	320 * time.Millisecond,
+}
+
+// retryOnContention runs fn, retrying only on transient dqlite contention.
+//
+// The global connection-pool retry (pkg/db) covers a contended statement at
+// call time, but dqlite can surface a "checkpoint in progress" error during
+// row iteration — after QueryContext has already returned cleanly — which
+// escapes that layer and would propagate up as a fatal run-start error. The
+// run-start reads guarded here are side-effect-free (or abort without
+// committing on contention), so re-running the whole call is safe. A cancelled
+// context stops the loop and returns the last error.
+func retryOnContention(ctx context.Context, fn func() error) error {
+	for attempt := 0; ; attempt++ {
+		err := fn()
+		if err == nil || !dqlite.IsContentionError(err) || attempt >= len(runStartReadBackoffs) {
+			return err
+		}
+		base := runStartReadBackoffs[attempt]
+		d := base
+		if maxJitter := int64(base / 5); maxJitter > 0 {
+			d = base - time.Duration(rand.Int64N(maxJitter+1))
+		}
+		timer := time.NewTimer(d)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return err
+		case <-timer.C:
+		}
+	}
+}
 
 // Job
 type Job interface {
@@ -311,8 +359,12 @@ func (j *job) Run(ctx context.Context) error {
 		return store.Start(j.id, j.triggerID, j.params)
 	}
 
-	snapshot, err := resolveRun()
-	if err != nil {
+	var snapshot *run.JobRun
+	if err := retryOnContention(ctx, func() error {
+		var e error
+		snapshot, e = resolveRun()
+		return e
+	}); err != nil {
 		return err
 	}
 
@@ -330,11 +382,15 @@ func (j *job) Run(ctx context.Context) error {
 		}
 	}()
 
-	tasks, err := j.taskServiceFactory(ctx).List(&task.ListRequest{
-		JobID:   j.id.String(),
-		OrderBy: []string{"position", "created_at"},
-	})
-	if err != nil {
+	var tasks models.Tasks
+	if err := retryOnContention(ctx, func() error {
+		var e error
+		tasks, e = j.taskServiceFactory(ctx).List(&task.ListRequest{
+			JobID:   j.id.String(),
+			OrderBy: []string{"position", "created_at"},
+		})
+		return e
+	}); err != nil {
 		runErr = err
 		return err
 	}
@@ -364,8 +420,12 @@ func (j *job) Run(ctx context.Context) error {
 		}
 		triggerRuleByTask[t.ID] = rule
 
-		modelAtom, err := svc.Get(t.AtomID)
-		if err != nil {
+		var modelAtom *models.Atom
+		if err := retryOnContention(ctx, func() error {
+			var e error
+			modelAtom, e = svc.Get(t.AtomID)
+			return e
+		}); err != nil {
 			runErr = err
 			return err
 		}
@@ -399,11 +459,15 @@ func (j *job) Run(ctx context.Context) error {
 		runners[t.ID] = runner
 	}
 
-	edges, err := j.taskEdgeServiceFactory(ctx).List(&taskedge.ListRequest{
-		JobID:   j.id.String(),
-		OrderBy: []string{"created_at"},
-	})
-	if err != nil {
+	var edges models.TaskEdges
+	if err := retryOnContention(ctx, func() error {
+		var e error
+		edges, e = j.taskEdgeServiceFactory(ctx).List(&taskedge.ListRequest{
+			JobID:   j.id.String(),
+			OrderBy: []string{"created_at"},
+		})
+		return e
+	}); err != nil {
 		runErr = err
 		return err
 	}
@@ -467,8 +531,12 @@ func (j *job) Run(ctx context.Context) error {
 		return err
 	}
 
-	currentRun, err := store.Get(runID)
-	if err != nil {
+	var currentRun *run.JobRun
+	if err := retryOnContention(ctx, func() error {
+		var e error
+		currentRun, e = store.Get(runID)
+		return e
+	}); err != nil {
 		runErr = err
 		return err
 	}
@@ -1000,7 +1068,7 @@ func (j *job) Run(ctx context.Context) error {
 					processed[id] = true
 					terminalTasks++
 					delete(inQueue, id)
-					if err == nil && !halt {
+					if !halt {
 						if propErr := propagateSkipped(id); propErr != nil {
 							log.Error("failed to propagate skipped task", "run_id", runID, "task_id", id, "error", propErr)
 							if runErr == nil {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -77,7 +77,10 @@ func retryOnContention(ctx context.Context, fn func() error) error {
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return err
+			// Return the cancellation, not the dqlite error, so the run's
+			// failure reason is a clear cancellation rather than a misleading
+			// "checkpoint in progress".
+			return ctx.Err()
 		case <-timer.C:
 		}
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -327,6 +327,24 @@ var (
 		},
 		[]string{"reason"},
 	)
+
+	// CompleteRetryableTotal counts /internal/complete requests the owner could
+	// not apply because of transient dqlite contention and answered with 503 so
+	// the worker retries the same request.  Unlike CompleteRejectedTotal (a
+	// terminal fence violation), a retryable answer is expected under burst load
+	// and is not itself a lost completion — it only becomes one if the worker
+	// exhausts its retries, which is tracked by
+	// caesium_complete_report_failed_total{reason="owner_busy"}.
+	//
+	// reason values:
+	//   contention – the apply (CompleteTaskClaimed/etc) returned a dqlite contention error
+	CompleteRetryableTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_complete_retryable_total",
+			Help: "Total /internal/complete requests answered 503 (retryable) due to transient contention, by reason.",
+		},
+		[]string{"reason"},
+	)
 )
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
@@ -365,6 +383,7 @@ func Register() {
 			DispatchRejectedTotal,
 			DispatchSentTotal,
 			CompleteReportFailedTotal,
+			CompleteRetryableTotal,
 		)
 	})
 }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -307,6 +307,26 @@ var (
 			Help: "Total owner-push dispatch requests accepted by a worker (202 ACK).",
 		},
 	)
+
+	// CompleteReportFailedTotal counts the worker-side failures to report a
+	// dispatched task's completion back to the owner via /internal/complete.
+	// This is the run-owner counterpart to a lost completion: the task ran but
+	// the owner never heard about it, so the claim lease will expire and either
+	// ClaimNext recovery (for an un-owned/expired run) or a re-dispatch picks it
+	// up.  The reason label distinguishes a transport failure from an explicit
+	// owner-side fence rejection so operators can tell a partition apart from a
+	// stale-owner reject.
+	//
+	// reason values:
+	//   post_error      – PostComplete returned a non-nil error (network/timeout)
+	//   owner_rejected  – the owner returned {"accepted": false} (fence violation)
+	CompleteReportFailedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_complete_report_failed_total",
+			Help: "Total worker-side failures to report a dispatched task's completion to the owner, by reason.",
+		},
+		[]string{"reason"},
+	)
 )
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
@@ -344,6 +364,7 @@ func Register() {
 			RunLeasesOwned,
 			DispatchRejectedTotal,
 			DispatchSentTotal,
+			CompleteReportFailedTotal,
 		)
 	})
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -788,6 +788,62 @@ func (s *Store) PendingTasksForDispatch(ctx context.Context, runID uuid.UUID, li
 	return tasks, nil
 }
 
+// LoadDispatchedTaskRun loads the full task_runs row for a task that was just
+// claimed for dispatch.  The (claimedBy, status=running) predicate ensures the
+// row really is the one this node claimed via ClaimTaskForDispatch and not a
+// row another node has since reclaimed.  Returns ErrTaskClaimMismatch if no
+// matching running row exists.  The dispatch handler uses this to obtain the
+// full execution spec (image/command/engine/etc.) to hand to the worker pool.
+func (s *Store) LoadDispatchedTaskRun(runID, taskID uuid.UUID, claimedBy string) (*models.TaskRun, error) {
+	var taskRun models.TaskRun
+	err := s.db.
+		Where("job_run_id = ? AND task_id = ? AND claimed_by = ? AND status = ?",
+			runID, taskID, claimedBy, string(TaskStatusRunning)).
+		First(&taskRun).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrTaskClaimMismatch
+		}
+		return nil, err
+	}
+	return &taskRun, nil
+}
+
+// ReleaseTaskClaim reverts a task this node claimed for dispatch back to the
+// dispatchable pending state (status=running → pending, claimed_by="",
+// claim_expires_at=nil, runtime_id="", started_at=nil).  It is the rollback
+// used by HandleDispatch when the local worker cannot accept a just-claimed
+// task (buffer full / worker not running): rather than leave the task
+// claimed-but-orphaned, the owner returns it to the pool so the next dispatch
+// tick re-dispatches it (to this or another peer).
+//
+// The owner_generation predicate keeps the release fenced: only the owner that
+// stamped the row (or a legacy generation-0 row) can release it.  The status
+// and claimed_by predicates make the release a no-op (zero rows, no error) if
+// the task already advanced — e.g. a completion landed in the race window.
+func (s *Store) ReleaseTaskClaim(runID, taskID uuid.UUID, claimedBy string, ownerGeneration int64) error {
+	return withStoreBusyRetry(func() error {
+		result := s.db.Model(&models.TaskRun{}).
+			Where("job_run_id = ? AND task_id = ? AND claimed_by = ? AND status = ? AND (owner_generation = ? OR owner_generation = 0)",
+				runID, taskID, claimedBy, string(TaskStatusRunning), ownerGeneration).
+			Updates(map[string]interface{}{
+				"status":           string(TaskStatusPending),
+				"claimed_by":       "",
+				"claim_expires_at": nil,
+				"runtime_id":       "",
+				"started_at":       nil,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected > 0 {
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Add(float64(result.RowsAffected))
+			metrics.DBStatementsTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+		}
+		return nil
+	})
+}
+
 func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy string) error {
 	var pendingEvents []event.Event
 	var counts dbWriteCounts

--- a/internal/worker/completion_sink.go
+++ b/internal/worker/completion_sink.go
@@ -2,7 +2,10 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"math/rand/v2"
+	"time"
 
 	"github.com/caesium-cloud/caesium/internal/dispatch"
 	"github.com/caesium-cloud/caesium/internal/metrics"
@@ -10,6 +13,21 @@ import (
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/log"
 )
+
+// ownerBusyBackoffs schedules the worker's retries when the owner answers a
+// completion with 503 (dispatch.ErrOwnerBusy) because of transient dqlite
+// contention.  It is intentionally a touch longer than the owner's own
+// in-handler busy-retry budget so a burst of simultaneous completions spreads
+// out across workers rather than re-colliding on the leader on every retry.
+// ~1.55s total across 6 retries.
+var ownerBusyBackoffs = []time.Duration{
+	25 * time.Millisecond,
+	50 * time.Millisecond,
+	100 * time.Millisecond,
+	200 * time.Millisecond,
+	400 * time.Millisecond,
+	800 * time.Millisecond,
+}
 
 // CompletionSink is the abstraction the runtime executor calls to finalize a
 // task's terminal outcome.  It exists so a single execution path can route its
@@ -135,9 +153,12 @@ func (s *ownerSink) Cached(ctx context.Context, taskRun *models.TaskRun, source 
 }
 
 // send fills the fencing fields common to every completion and POSTs the
-// envelope to the owner.  A failure to report is logged and surfaced as a
-// dispatch-side metric (the task's claim lease eventually expires and recovery
-// re-dispatches) — the error is never swallowed silently.
+// envelope to the owner.  When the owner answers 503 (dispatch.ErrOwnerBusy)
+// because of transient contention, send retries the same request with bounded
+// backoff before giving up; a true fence rejection (409) or a network failure
+// is terminal.  A failure to report is logged and surfaced as a dispatch-side
+// metric (the task's claim lease eventually expires and recovery re-dispatches)
+// — the error is never swallowed silently.
 func (s *ownerSink) send(ctx context.Context, taskRun *models.TaskRun, req dispatch.CompleteRequest) error {
 	req.RunID = taskRun.JobRunID
 	req.TaskID = taskRun.TaskID
@@ -146,31 +167,71 @@ func (s *ownerSink) send(ctx context.Context, taskRun *models.TaskRun, req dispa
 	req.WorkerNode = s.workerNode
 
 	url := s.ownerBaseURL + "/internal/complete"
-	resp, err := s.post(ctx, url, s.token, req)
-	if err != nil {
-		metrics.CompleteReportFailedTotal.WithLabelValues("post_error").Inc()
+
+	for attempt := 0; ; attempt++ {
+		resp, err := s.post(ctx, url, s.token, req)
+		if err == nil {
+			if resp != nil && !resp.Accepted {
+				// The owner fenced the completion (stale generation, wrong
+				// worker, etc.).  This is not a transport error; the owner
+				// deliberately rejected it.
+				metrics.CompleteReportFailedTotal.WithLabelValues("owner_rejected").Inc()
+				log.Warn("dispatched task: owner rejected completion",
+					"run_id", req.RunID,
+					"task_id", req.TaskID,
+					"status", req.Status,
+					"reason", resp.Reason,
+				)
+				return fmt.Errorf("owner sink: owner rejected completion: %s", resp.Reason)
+			}
+			return nil
+		}
+
+		// Transient owner-side contention: the owner asked us to re-send the
+		// identical request once its leader frees up.  Back off and retry until
+		// the schedule (or the context) is exhausted.
+		if errors.Is(err, dispatch.ErrOwnerBusy) && attempt < len(ownerBusyBackoffs) {
+			if sleepErr := sleepOwnerBusy(ctx, ownerBusyBackoffs[attempt]); sleepErr == nil {
+				continue
+			}
+			// ctx cancelled while waiting — fall through and treat as terminal.
+		}
+
+		reason := "post_error"
+		if errors.Is(err, dispatch.ErrOwnerBusy) {
+			reason = "owner_busy"
+		}
+		metrics.CompleteReportFailedTotal.WithLabelValues(reason).Inc()
 		log.Error("dispatched task: failed to report completion to owner",
 			"run_id", req.RunID,
 			"task_id", req.TaskID,
 			"owner_url", s.ownerBaseURL,
 			"status", req.Status,
+			"attempts", attempt+1,
 			"error", err,
 		)
 		return fmt.Errorf("owner sink: report completion: %w", err)
 	}
-	if resp != nil && !resp.Accepted {
-		// The owner fenced the completion (stale generation, wrong worker, etc.).
-		// This is not a transport error; the owner deliberately rejected it.
-		metrics.CompleteReportFailedTotal.WithLabelValues("owner_rejected").Inc()
-		log.Warn("dispatched task: owner rejected completion",
-			"run_id", req.RunID,
-			"task_id", req.TaskID,
-			"status", req.Status,
-			"reason", resp.Reason,
-		)
-		return fmt.Errorf("owner sink: owner rejected completion: %s", resp.Reason)
+}
+
+// sleepOwnerBusy waits base (minus up to 20% jitter) or returns early if ctx is
+// cancelled.  The jitter de-synchronises a thundering herd of workers all
+// retrying a contended owner at the same instant.
+func sleepOwnerBusy(ctx context.Context, base time.Duration) error {
+	d := base
+	if base > 0 {
+		if maxJitter := int64(base / 5); maxJitter > 0 {
+			d = base - time.Duration(rand.Int64N(maxJitter+1))
+		}
 	}
-	return nil
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 // dispatchMeta is the owner-routing metadata a dispatched task carries from the

--- a/internal/worker/completion_sink.go
+++ b/internal/worker/completion_sink.go
@@ -191,10 +191,14 @@ func (s *ownerSink) send(ctx context.Context, taskRun *models.TaskRun, req dispa
 		// identical request once its leader frees up.  Back off and retry until
 		// the schedule (or the context) is exhausted.
 		if errors.Is(err, dispatch.ErrOwnerBusy) && attempt < len(ownerBusyBackoffs) {
-			if sleepErr := sleepOwnerBusy(ctx, ownerBusyBackoffs[attempt]); sleepErr == nil {
-				continue
+			if sleepErr := sleepOwnerBusy(ctx, ownerBusyBackoffs[attempt]); sleepErr != nil {
+				// Context cancelled/expired while backing off. Surface the
+				// cancellation — not ErrOwnerBusy — so the executor's
+				// context.Canceled branch fires: the container already ran to
+				// completion, so it must not be marked failed or re-executed.
+				return fmt.Errorf("owner sink: report completion aborted: %w", sleepErr)
 			}
-			// ctx cancelled while waiting — fall through and treat as terminal.
+			continue
 		}
 
 		reason := "post_error"

--- a/internal/worker/completion_sink.go
+++ b/internal/worker/completion_sink.go
@@ -1,0 +1,205 @@
+package worker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/caesium-cloud/caesium/internal/dispatch"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/pkg/log"
+)
+
+// CompletionSink is the abstraction the runtime executor calls to finalize a
+// task's terminal outcome.  It exists so a single execution path can route its
+// completion either to the local DB (the ClaimNext pull path, unchanged from
+// Phase 1) or back to the owning node over /internal/complete (the run-owner
+// push-dispatch path).
+//
+// The three methods mirror the three store finalization calls the executor
+// made directly before this abstraction was introduced:
+//
+//	Succeeded → run.Store.CompleteTaskClaimed
+//	Failed    → run.Store.FailTaskClaimed
+//	Cached    → run.Store.CacheHitTaskClaimed
+//
+// The owner re-derives the real terminal status from the result string in
+// CompleteTaskClaimed, so a "failure" result routed through Succeeded still
+// lands as TaskStatusFailed on the owner — byte-identical to the local path.
+type CompletionSink interface {
+	// Succeeded finalizes a task that ran to a normal completion (whatever the
+	// underlying container result was — the result string carries it).
+	Succeeded(ctx context.Context, taskRun *models.TaskRun, result string, outputs map[string]string, branchSelections []string) error
+	// Failed finalizes a task whose attempts were exhausted with an error.
+	Failed(ctx context.Context, taskRun *models.TaskRun, failure error) error
+	// Cached finalizes a task satisfied from the result cache.
+	Cached(ctx context.Context, taskRun *models.TaskRun, source run.CacheHitSource, result string, outputs map[string]string, branchSelections []string) error
+}
+
+// localSink is the default sink used by ClaimNext'd tasks.  It calls the same
+// run.Store.*Claimed methods the executor called inline before the sink
+// abstraction existed, so the pull path is byte-identical to Phase 1.
+type localSink struct {
+	store *run.Store
+}
+
+// NewLocalSink returns the default DB-backed completion sink.
+func NewLocalSink(store *run.Store) CompletionSink {
+	return &localSink{store: store}
+}
+
+func (s *localSink) Succeeded(_ context.Context, taskRun *models.TaskRun, result string, outputs map[string]string, branchSelections []string) error {
+	return s.store.CompleteTaskClaimed(taskRun.JobRunID, taskRun.TaskID, result, taskRun.ClaimedBy, outputs, branchSelections)
+}
+
+func (s *localSink) Failed(_ context.Context, taskRun *models.TaskRun, failure error) error {
+	return s.store.FailTaskClaimed(taskRun.JobRunID, taskRun.TaskID, failure, taskRun.ClaimedBy)
+}
+
+func (s *localSink) Cached(_ context.Context, taskRun *models.TaskRun, source run.CacheHitSource, result string, outputs map[string]string, branchSelections []string) error {
+	return s.store.CacheHitTaskClaimed(taskRun.JobRunID, taskRun.TaskID, source, result, taskRun.ClaimedBy, outputs, branchSelections)
+}
+
+// completePoster is the seam the owner sink uses to reach the owner's
+// /internal/complete endpoint.  Production wires it to dispatch.PostComplete;
+// tests inject a fake that records the CompleteRequest.
+type completePoster func(ctx context.Context, ownerURL, token string, req dispatch.CompleteRequest) (*dispatch.CompleteResponse, error)
+
+// ownerSink routes a dispatched task's terminal outcome back to the run owner
+// via POST /internal/complete instead of writing the hot rows locally.  This
+// keeps the owner the single writer for its run's coordination rows (preserving
+// the owner_generation fence) and sets up cleanly for the later in-memory-state
+// layer where authoritative state lives in the owner's memory.
+//
+// A dispatched task carries the owner_generation, attempt, owner base URL, and
+// worker_node identity it arrived with; those are threaded onto the sink so the
+// CompleteRequest envelope matches what the owner expects to fence against.
+type ownerSink struct {
+	ownerBaseURL string
+	token        string
+	workerNode   string
+	generation   int64
+	attempt      int
+	post         completePoster
+}
+
+// newOwnerSink builds an owner-routed completion sink from a dispatch envelope's
+// fields.  post is the function used to POST to the owner (dispatch.PostComplete
+// in production, a fake in tests).
+func newOwnerSink(meta dispatchMeta, post completePoster) *ownerSink {
+	if post == nil {
+		post = dispatch.PostComplete
+	}
+	return &ownerSink{
+		ownerBaseURL: meta.OwnerBaseURL,
+		token:        meta.Token,
+		workerNode:   meta.WorkerNode,
+		generation:   meta.OwnerGeneration,
+		attempt:      meta.Attempt,
+		post:         post,
+	}
+}
+
+func (s *ownerSink) Succeeded(ctx context.Context, taskRun *models.TaskRun, result string, outputs map[string]string, branchSelections []string) error {
+	return s.send(ctx, taskRun, dispatch.CompleteRequest{
+		Status:           string(run.TaskStatusSucceeded),
+		Result:           result,
+		Outputs:          outputs,
+		BranchSelections: branchSelections,
+	})
+}
+
+func (s *ownerSink) Failed(ctx context.Context, taskRun *models.TaskRun, failure error) error {
+	errMsg := ""
+	if failure != nil {
+		errMsg = failure.Error()
+	}
+	return s.send(ctx, taskRun, dispatch.CompleteRequest{
+		Status: string(run.TaskStatusFailed),
+		Error:  errMsg,
+	})
+}
+
+func (s *ownerSink) Cached(ctx context.Context, taskRun *models.TaskRun, source run.CacheHitSource, result string, outputs map[string]string, branchSelections []string) error {
+	// The owner reconstructs CacheHitSource on its side; the worker only needs
+	// to report result + outputs + branch selections.  (Phase A's owner handler
+	// builds a CacheHitSource{RunID: req.RunID}; the richer origin metadata is a
+	// Phase B concern and not load-bearing for DAG advancement.)
+	return s.send(ctx, taskRun, dispatch.CompleteRequest{
+		Status:           string(run.TaskStatusCached),
+		Result:           result,
+		Outputs:          outputs,
+		BranchSelections: branchSelections,
+	})
+}
+
+// send fills the fencing fields common to every completion and POSTs the
+// envelope to the owner.  A failure to report is logged and surfaced as a
+// dispatch-side metric (the task's claim lease eventually expires and recovery
+// re-dispatches) — the error is never swallowed silently.
+func (s *ownerSink) send(ctx context.Context, taskRun *models.TaskRun, req dispatch.CompleteRequest) error {
+	req.RunID = taskRun.JobRunID
+	req.TaskID = taskRun.TaskID
+	req.OwnerGeneration = s.generation
+	req.Attempt = s.attempt
+	req.WorkerNode = s.workerNode
+
+	url := s.ownerBaseURL + "/internal/complete"
+	resp, err := s.post(ctx, url, s.token, req)
+	if err != nil {
+		metrics.CompleteReportFailedTotal.WithLabelValues("post_error").Inc()
+		log.Error("dispatched task: failed to report completion to owner",
+			"run_id", req.RunID,
+			"task_id", req.TaskID,
+			"owner_url", s.ownerBaseURL,
+			"status", req.Status,
+			"error", err,
+		)
+		return fmt.Errorf("owner sink: report completion: %w", err)
+	}
+	if resp != nil && !resp.Accepted {
+		// The owner fenced the completion (stale generation, wrong worker, etc.).
+		// This is not a transport error; the owner deliberately rejected it.
+		metrics.CompleteReportFailedTotal.WithLabelValues("owner_rejected").Inc()
+		log.Warn("dispatched task: owner rejected completion",
+			"run_id", req.RunID,
+			"task_id", req.TaskID,
+			"status", req.Status,
+			"reason", resp.Reason,
+		)
+		return fmt.Errorf("owner sink: owner rejected completion: %s", resp.Reason)
+	}
+	return nil
+}
+
+// dispatchMeta is the owner-routing metadata a dispatched task carries from the
+// /internal/dispatch envelope through to its completion sink.  ClaimNext'd
+// (pull-path) tasks have no dispatchMeta and use the local sink.
+type dispatchMeta struct {
+	OwnerBaseURL    string
+	Token           string
+	WorkerNode      string
+	OwnerGeneration int64
+	Attempt         int
+}
+
+// dispatchMetaKey is the context key under which a dispatched task's owner
+// metadata is threaded from the worker to the runtime executor.  Using the
+// context (rather than a field on TaskRun or a shared map) keeps the
+// TaskExecutor signature unchanged and avoids any shared mutable state.
+type dispatchMetaKeyType struct{}
+
+var dispatchMetaKey = dispatchMetaKeyType{}
+
+// withDispatchMeta returns a context carrying the dispatched-task owner metadata.
+func withDispatchMeta(ctx context.Context, meta dispatchMeta) context.Context {
+	return context.WithValue(ctx, dispatchMetaKey, meta)
+}
+
+// dispatchMetaFrom extracts the owner metadata from ctx, if present.  ok is
+// false for ClaimNext'd tasks, which select the local sink.
+func dispatchMetaFrom(ctx context.Context) (dispatchMeta, bool) {
+	meta, ok := ctx.Value(dispatchMetaKey).(dispatchMeta)
+	return meta, ok
+}

--- a/internal/worker/completion_sink_test.go
+++ b/internal/worker/completion_sink_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/caesium-cloud/caesium/internal/dispatch"
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -141,6 +142,93 @@ func TestOwnerSink_OwnerRejectionSurfaces(t *testing.T) {
 	err := sink.Succeeded(context.Background(), sampleTaskRun(), "success", nil, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "stale_generation")
+}
+
+// busyPoster returns dispatch.ErrOwnerBusy (the owner's retryable 503) for the
+// first failFor calls — or every call when alwaysBusy — then accepts.  It lets
+// the retry tests assert exactly how many times the sink re-posted.
+type busyPoster struct {
+	calls      int
+	failFor    int
+	alwaysBusy bool
+}
+
+func (p *busyPoster) post(_ context.Context, _, _ string, _ dispatch.CompleteRequest) (*dispatch.CompleteResponse, error) {
+	p.calls++
+	if p.alwaysBusy || p.calls <= p.failFor {
+		return nil, dispatch.ErrOwnerBusy
+	}
+	return &dispatch.CompleteResponse{Accepted: true}, nil
+}
+
+// withFastOwnerBusyBackoffs shrinks the retry schedule to n×1ms for the
+// duration of the test so the retry tests don't sleep the real ~1.55s budget.
+// Tests using it must not run in parallel while the package var is swapped.
+func withFastOwnerBusyBackoffs(t *testing.T, n int) {
+	t.Helper()
+	orig := ownerBusyBackoffs
+	fast := make([]time.Duration, n)
+	for i := range fast {
+		fast[i] = time.Millisecond
+	}
+	ownerBusyBackoffs = fast
+	t.Cleanup(func() { ownerBusyBackoffs = orig })
+}
+
+// TestOwnerSink_RetriesOnOwnerBusyThenSucceeds asserts the sink re-posts the
+// identical completion when the owner answers 503 (ErrOwnerBusy) and reports
+// success once the owner's contention clears.
+func TestOwnerSink_RetriesOnOwnerBusyThenSucceeds(t *testing.T) {
+	withFastOwnerBusyBackoffs(t, 5)
+	p := &busyPoster{failFor: 2}
+	sink := newOwnerSink(ownerMeta(), p.post)
+
+	err := sink.Succeeded(context.Background(), sampleTaskRun(), "success", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, 3, p.calls, "two 503s then a success = 3 posts")
+}
+
+// TestOwnerSink_OwnerBusyExhaustedSurfaces asserts a sustained 503 is retried
+// across the whole schedule and then surfaced as ErrOwnerBusy (not swallowed),
+// so lease-expiry recovery can re-dispatch the task.
+func TestOwnerSink_OwnerBusyExhaustedSurfaces(t *testing.T) {
+	withFastOwnerBusyBackoffs(t, 3)
+	p := &busyPoster{alwaysBusy: true}
+	sink := newOwnerSink(ownerMeta(), p.post)
+
+	err := sink.Succeeded(context.Background(), sampleTaskRun(), "success", nil, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, dispatch.ErrOwnerBusy)
+	require.Equal(t, len(ownerBusyBackoffs)+1, p.calls, "initial attempt + one retry per backoff entry")
+}
+
+// TestOwnerSink_TerminalErrorNotRetried asserts a non-busy error (a true fence
+// rejection or a network failure) is returned immediately without retrying, so
+// the worker never spins on a permanent rejection.
+func TestOwnerSink_TerminalErrorNotRetried(t *testing.T) {
+	withFastOwnerBusyBackoffs(t, 5)
+	p := &recordingPoster{err: errors.New("connection refused")}
+	sink := newOwnerSink(ownerMeta(), p.post)
+
+	err := sink.Succeeded(context.Background(), sampleTaskRun(), "success", nil, nil)
+	require.Error(t, err)
+	require.Len(t, p.calls, 1, "a terminal (non-busy) error must not be retried")
+}
+
+// TestOwnerSink_OwnerBusyContextCancelStops asserts a cancelled context aborts
+// the retry loop promptly and surfaces the busy error rather than spinning.
+func TestOwnerSink_OwnerBusyContextCancelStops(t *testing.T) {
+	withFastOwnerBusyBackoffs(t, 5)
+	p := &busyPoster{alwaysBusy: true}
+	sink := newOwnerSink(ownerMeta(), p.post)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sink.Succeeded(ctx, sampleTaskRun(), "success", nil, nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, dispatch.ErrOwnerBusy)
+	require.Equal(t, 1, p.calls, "a pre-cancelled context must stop after the first attempt")
 }
 
 // fakeSink is an injectable CompletionSink for executor tests; it records which

--- a/internal/worker/completion_sink_test.go
+++ b/internal/worker/completion_sink_test.go
@@ -216,7 +216,9 @@ func TestOwnerSink_TerminalErrorNotRetried(t *testing.T) {
 }
 
 // TestOwnerSink_OwnerBusyContextCancelStops asserts a cancelled context aborts
-// the retry loop promptly and surfaces the busy error rather than spinning.
+// the retry loop promptly and surfaces the cancellation (not ErrOwnerBusy), so
+// the executor's context.Canceled branch fires and a succeeded task is neither
+// marked failed nor re-executed.
 func TestOwnerSink_OwnerBusyContextCancelStops(t *testing.T) {
 	withFastOwnerBusyBackoffs(t, 5)
 	p := &busyPoster{alwaysBusy: true}
@@ -227,7 +229,8 @@ func TestOwnerSink_OwnerBusyContextCancelStops(t *testing.T) {
 
 	err := sink.Succeeded(ctx, sampleTaskRun(), "success", nil, nil)
 	require.Error(t, err)
-	require.ErrorIs(t, err, dispatch.ErrOwnerBusy)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, dispatch.ErrOwnerBusy)
 	require.Equal(t, 1, p.calls, "a pre-cancelled context must stop after the first attempt")
 }
 

--- a/internal/worker/completion_sink_test.go
+++ b/internal/worker/completion_sink_test.go
@@ -1,0 +1,210 @@
+package worker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/dispatch"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingPoster captures the CompleteRequest the owner sink POSTs so tests
+// can assert the envelope fields without standing up an HTTP server.
+type recordingPoster struct {
+	calls []dispatch.CompleteRequest
+	url   string
+	token string
+	resp  *dispatch.CompleteResponse
+	err   error
+}
+
+func (p *recordingPoster) post(_ context.Context, url, token string, req dispatch.CompleteRequest) (*dispatch.CompleteResponse, error) {
+	p.url = url
+	p.token = token
+	p.calls = append(p.calls, req)
+	if p.err != nil {
+		return nil, p.err
+	}
+	if p.resp != nil {
+		return p.resp, nil
+	}
+	return &dispatch.CompleteResponse{Accepted: true}, nil
+}
+
+func sampleTaskRun() *models.TaskRun {
+	return &models.TaskRun{
+		ID:        uuid.New(),
+		JobRunID:  uuid.New(),
+		TaskID:    uuid.New(),
+		ClaimedBy: "10.0.0.5:9001",
+	}
+}
+
+func ownerMeta() dispatchMeta {
+	return dispatchMeta{
+		OwnerBaseURL:    "http://10.0.0.1:8080",
+		Token:           "tok",
+		WorkerNode:      "10.0.0.5:9001",
+		OwnerGeneration: 7,
+		Attempt:         3,
+	}
+}
+
+// TestOwnerSink_Succeeded asserts the owner sink POSTs a CompleteRequest with
+// all fencing fields and the succeeded status/result/outputs/branches.
+func TestOwnerSink_Succeeded(t *testing.T) {
+	p := &recordingPoster{}
+	meta := ownerMeta()
+	sink := newOwnerSink(meta, p.post)
+	task := sampleTaskRun()
+
+	outputs := map[string]string{"rows": "42"}
+	branches := []string{"left"}
+	err := sink.Succeeded(context.Background(), task, "success", outputs, branches)
+	require.NoError(t, err)
+
+	require.Len(t, p.calls, 1)
+	got := p.calls[0]
+	require.Equal(t, task.JobRunID, got.RunID)
+	require.Equal(t, task.TaskID, got.TaskID)
+	require.Equal(t, int64(7), got.OwnerGeneration)
+	require.Equal(t, 3, got.Attempt)
+	require.Equal(t, "10.0.0.5:9001", got.WorkerNode)
+	require.Equal(t, string(run.TaskStatusSucceeded), got.Status)
+	require.Equal(t, "success", got.Result)
+	require.Equal(t, outputs, got.Outputs)
+	require.Equal(t, branches, got.BranchSelections)
+	require.Empty(t, got.Error)
+
+	// URL and token plumbed correctly.
+	require.Equal(t, "http://10.0.0.1:8080/internal/complete", p.url)
+	require.Equal(t, "tok", p.token)
+}
+
+// TestOwnerSink_Failed asserts the failed status and error string are sent.
+func TestOwnerSink_Failed(t *testing.T) {
+	p := &recordingPoster{}
+	sink := newOwnerSink(ownerMeta(), p.post)
+	task := sampleTaskRun()
+
+	err := sink.Failed(context.Background(), task, errors.New("boom"))
+	require.NoError(t, err)
+
+	require.Len(t, p.calls, 1)
+	got := p.calls[0]
+	require.Equal(t, string(run.TaskStatusFailed), got.Status)
+	require.Equal(t, "boom", got.Error)
+	require.Empty(t, got.Result)
+}
+
+// TestOwnerSink_Cached asserts the cached status, result, outputs and branch
+// selections are sent.
+func TestOwnerSink_Cached(t *testing.T) {
+	p := &recordingPoster{}
+	sink := newOwnerSink(ownerMeta(), p.post)
+	task := sampleTaskRun()
+
+	outputs := map[string]string{"k": "v"}
+	branches := []string{"b1", "b2"}
+	err := sink.Cached(context.Background(), task, run.CacheHitSource{RunID: uuid.New()}, "success", outputs, branches)
+	require.NoError(t, err)
+
+	require.Len(t, p.calls, 1)
+	got := p.calls[0]
+	require.Equal(t, string(run.TaskStatusCached), got.Status)
+	require.Equal(t, "success", got.Result)
+	require.Equal(t, outputs, got.Outputs)
+	require.Equal(t, branches, got.BranchSelections)
+}
+
+// TestOwnerSink_PostErrorSurfaces asserts a transport error is returned (not
+// swallowed) so the caller logs it and the lease-expiry recovery kicks in.
+func TestOwnerSink_PostErrorSurfaces(t *testing.T) {
+	p := &recordingPoster{err: errors.New("connection refused")}
+	sink := newOwnerSink(ownerMeta(), p.post)
+
+	err := sink.Succeeded(context.Background(), sampleTaskRun(), "success", nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "connection refused")
+}
+
+// TestOwnerSink_OwnerRejectionSurfaces asserts an owner fence rejection
+// (accepted=false) is returned as an error so it isn't silently lost.
+func TestOwnerSink_OwnerRejectionSurfaces(t *testing.T) {
+	p := &recordingPoster{resp: &dispatch.CompleteResponse{Accepted: false, Reason: "stale_generation"}}
+	sink := newOwnerSink(ownerMeta(), p.post)
+
+	err := sink.Succeeded(context.Background(), sampleTaskRun(), "success", nil, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "stale_generation")
+}
+
+// fakeSink is an injectable CompletionSink for executor tests; it records which
+// terminal method the executor invoked.
+type fakeSink struct {
+	succeeded int
+	failed    int
+	cached    int
+	lastErr   error
+}
+
+func (f *fakeSink) Succeeded(context.Context, *models.TaskRun, string, map[string]string, []string) error {
+	f.succeeded++
+	return nil
+}
+
+func (f *fakeSink) Failed(_ context.Context, _ *models.TaskRun, err error) error {
+	f.failed++
+	f.lastErr = err
+	return nil
+}
+
+func (f *fakeSink) Cached(context.Context, *models.TaskRun, run.CacheHitSource, string, map[string]string, []string) error {
+	f.cached++
+	return nil
+}
+
+// TestSinkFor_SelectsLocalWithoutMeta asserts the executor picks its configured
+// local sink for a context with no dispatch metadata (the ClaimNext pull path).
+// Uses a fake sink so the test pins the selection wiring, not store behavior.
+func TestSinkFor_SelectsLocalWithoutMeta(t *testing.T) {
+	local := &fakeSink{}
+	e := &runtimeExecutor{localSink: local}
+
+	got := e.sinkFor(context.Background())
+	require.Same(t, local, got, "ClaimNext'd tasks must use the configured local sink")
+}
+
+// TestSinkFor_SelectsOwnerWithMeta asserts the executor builds an owner sink
+// when the context carries dispatch metadata (the push path).
+func TestSinkFor_SelectsOwnerWithMeta(t *testing.T) {
+	local := &fakeSink{}
+	e := &runtimeExecutor{localSink: local}
+
+	ctx := withDispatchMeta(context.Background(), ownerMeta())
+	got := e.sinkFor(ctx)
+	owner, isOwner := got.(*ownerSink)
+	require.True(t, isOwner, "dispatched tasks must use the owner sink")
+	require.NotSame(t, CompletionSink(local), got)
+	// The owner sink carries the envelope fields from the metadata.
+	require.Equal(t, "http://10.0.0.1:8080", owner.ownerBaseURL)
+	require.Equal(t, int64(7), owner.generation)
+	require.Equal(t, 3, owner.attempt)
+}
+
+// TestDispatchMetaRoundTrip asserts metadata threaded through the context is
+// recovered intact.
+func TestDispatchMetaRoundTrip(t *testing.T) {
+	meta := ownerMeta()
+	ctx := withDispatchMeta(context.Background(), meta)
+	got, ok := dispatchMetaFrom(ctx)
+	require.True(t, ok)
+	require.Equal(t, meta, got)
+
+	_, ok = dispatchMetaFrom(context.Background())
+	require.False(t, ok, "a bare context must not report dispatch metadata")
+}

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -34,6 +34,13 @@ type runtimeExecutor struct {
 	store             *run.Store
 	taskTimeout       time.Duration
 	continueOnFailure bool
+
+	// localSink finalizes ClaimNext'd tasks against the local DB (unchanged from
+	// Phase 1).  Dispatched tasks build an owner-routed sink per task instead.
+	localSink CompletionSink
+	// completePost is the seam the owner sink uses to POST to /internal/complete.
+	// nil in production → defaults to dispatch.PostComplete; tests inject a fake.
+	completePost completePoster
 }
 
 func NewRuntimeExecutor(store *run.Store, taskTimeout time.Duration, failurePolicy string) TaskExecutor {
@@ -45,13 +52,30 @@ func NewRuntimeExecutor(store *run.Store, taskTimeout time.Duration, failurePoli
 		store:             store,
 		taskTimeout:       taskTimeout,
 		continueOnFailure: normalizeTaskFailurePolicy(failurePolicy) == taskFailurePolicyContinue,
+		localSink:         NewLocalSink(store),
 	}).Execute
+}
+
+// sinkFor selects the completion sink for a task.  Dispatched tasks (carrying
+// owner metadata in their context) route their terminal outcome back to the
+// owner via /internal/complete; ClaimNext'd tasks complete locally exactly as
+// in Phase 1.  When run-owner mode is off there is never any dispatchMeta, so
+// the local sink is always selected and behavior is byte-identical.
+func (e *runtimeExecutor) sinkFor(ctx context.Context) CompletionSink {
+	if meta, ok := dispatchMetaFrom(ctx); ok {
+		return newOwnerSink(meta, e.completePost)
+	}
+	return e.localSink
 }
 
 func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) {
 	if taskRun == nil {
 		return
 	}
+
+	// Select the completion sink once per task: owner-routed for dispatched
+	// tasks, local DB writes for ClaimNext'd tasks.
+	sink := e.sinkFor(ctx)
 
 	jobAlias := ""
 	resolveJobAlias := func() string {
@@ -157,11 +181,11 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 				log.Warn("cache: lookup failed", "task_id", taskRun.TaskID, "hash", cacheHash, "error", getErr)
 			} else if found {
 				log.Info("cache hit for worker task", "task_id", taskRun.TaskID, "hash", cacheHash, "cached_run_id", entry.RunID)
-				if err := e.store.CacheHitTaskClaimed(taskRun.JobRunID, taskRun.TaskID, run.CacheHitSource{
+				if err := sink.Cached(ctx, taskRun, run.CacheHitSource{
 					RunID:     entry.RunID,
 					CreatedAt: entry.CreatedAt,
 					ExpiresAt: entry.ExpiresAt,
-				}, entry.Result, taskRun.ClaimedBy, entry.Output, entry.BranchSelections); err != nil {
+				}, entry.Result, entry.Output, entry.BranchSelections); err != nil {
 					if errors.Is(err, run.ErrTaskClaimMismatch) {
 						log.Info("worker task claim changed during cache hit", "task_id", taskRun.TaskID, "run_id", taskRun.JobRunID)
 						return
@@ -187,7 +211,7 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 
 	var lastErr error
 	for attempt := currentAttempt; attempt <= maxAttempts; attempt++ {
-		execErr := e.executeTask(ctx, taskRun)
+		execErr := e.executeTask(ctx, taskRun, sink)
 		if execErr == nil {
 			// Store successful result in cache.
 			if cacheStore != nil && cacheHash != "" {
@@ -247,7 +271,7 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		}
 	}
 
-	if persistErr := e.store.FailTaskClaimed(taskRun.JobRunID, taskRun.TaskID, lastErr, taskRun.ClaimedBy); persistErr != nil {
+	if persistErr := sink.Failed(ctx, taskRun, lastErr); persistErr != nil {
 		if errors.Is(persistErr, run.ErrTaskClaimMismatch) {
 			log.Info("worker task claim changed before failure persistence", "task_id", taskRun.TaskID, "run_id", taskRun.JobRunID)
 			return
@@ -285,7 +309,7 @@ func (e *runtimeExecutor) sleepRetryDelay(ctx context.Context, delay time.Durati
 	}
 }
 
-func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskRun) error {
+func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskRun, sink CompletionSink) error {
 	taskCtx := ctx
 	cancel := func() {}
 	if e.taskTimeout > 0 {
@@ -375,7 +399,7 @@ func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskR
 		return err
 	}
 
-	if err := e.store.CompleteTaskClaimed(taskRun.JobRunID, taskRun.TaskID, string(a.Result()), taskRun.ClaimedBy, taskOutput, branchSelections); err != nil {
+	if err := sink.Succeeded(ctx, taskRun, string(a.Result()), taskOutput, branchSelections); err != nil {
 		return err
 	}
 	if err := e.store.SaveTaskLogSnapshot(taskRun.JobRunID, taskRun.TaskID, logSnapshot); err != nil {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -2,10 +2,12 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"math/rand/v2"
 	"sync"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/dispatch"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/log"
@@ -87,6 +89,28 @@ type Worker struct {
 	runLeaseRenewer RunLeaseRenewer
 	runLeaseTTL     time.Duration
 	runLeaseNodeID  string
+
+	// Inbound dispatched tasks (Phase 2 run-owner push path).  HandleDispatch
+	// hands accepted tasks here via SubmitDispatched; the Run loop drains them
+	// alongside ClaimNext'd tasks and submits each onto the SAME w.pool so the
+	// pool size and backpressure are unified across both paths.  nil until
+	// WithInboundDispatch is called (i.e. owner mode off → byte-identical Phase 1).
+	inbound chan inboundTask
+	// inboundNotify is a wake-only signal poked by SubmitDispatched so the Run
+	// loop's idle wait returns promptly when a dispatched task arrives, instead
+	// of waiting a full poll interval.  Buffered size 1; a missed poke (buffer
+	// already full) is fine because the loop re-checks inbound on every pass.
+	inboundNotify chan struct{}
+	// completionToken is the bearer token the owner sink uses when POSTing a
+	// dispatched task's completion back to the owner's /internal/complete.
+	completionToken string
+}
+
+// inboundTask pairs a dispatched task with the owner metadata the executor
+// needs to route its completion back to the owner.
+type inboundTask struct {
+	task *models.TaskRun
+	meta dispatchMeta
 }
 
 func NewWorker(claimer TaskClaimer, pool *Pool, pollInterval time.Duration, executor TaskExecutor) *Worker {
@@ -157,6 +181,78 @@ func (w *Worker) WithRunLeaseRenewal(renewer RunLeaseRenewer, leaseTTL time.Dura
 	return w
 }
 
+// WithInboundDispatch enables the Phase 2 run-owner push path: the worker
+// accepts dispatched tasks via SubmitDispatched and drains them onto the same
+// execution pool as ClaimNext'd tasks.  completionToken is the bearer token the
+// worker presents when reporting a dispatched task's completion back to the
+// owner's /internal/complete (the CAESIUM_INTERNAL_WAKEUP_TOKEN).
+//
+// The buffer is sized to the pool size (floored at 1): it holds at most one
+// pool's worth of tasks waiting for a slot, which lets the worker absorb a
+// dispatch burst without blocking the Run loop's drain, while bounding memory
+// and keeping backpressure unified with the pool — when the buffer fills,
+// SubmitDispatched rejects and the owner re-dispatches.  Without an explicit
+// call this stays nil and the worker behaves byte-identically to Phase 1.
+func (w *Worker) WithInboundDispatch(completionToken string) *Worker {
+	size := 1
+	if w.pool != nil && cap(w.pool.sem) > size {
+		size = cap(w.pool.sem)
+	}
+	w.inbound = make(chan inboundTask, size)
+	w.inboundNotify = make(chan struct{}, 1)
+	w.completionToken = completionToken
+	return w
+}
+
+// ErrInboundFull is returned by SubmitDispatched when the inbound buffer is at
+// capacity (the worker is saturated).  The dispatch handler treats this as a
+// rejectable condition and rolls the claim back so the owner re-dispatches.
+var ErrInboundFull = errors.New("worker: inbound dispatch buffer full")
+
+// ErrWorkerNotAccepting is returned by SubmitDispatched when the worker is not
+// configured to accept dispatched tasks (WithInboundDispatch was never called).
+var ErrWorkerNotAccepting = errors.New("worker: not accepting dispatched tasks")
+
+// SubmitDispatched enqueues a dispatched task for execution on the worker's
+// shared pool.  It is non-blocking: it returns ErrInboundFull when the inbound
+// buffer is full and ErrWorkerNotAccepting when the inbound path is disabled.
+// *Worker implements dispatch.WorkerSubmitter via this method, so the dispatch
+// handler can hand it accepted tasks directly (no adapter needed).
+//
+// The non-blocking contract is deliberate: HandleDispatch runs on an HTTP
+// request goroutine and must not block on a full pool.  A full buffer surfaces
+// as a 409 the owner retries, rather than holding the dispatch RPC open.
+func (w *Worker) SubmitDispatched(d dispatch.InboundDispatch) error {
+	if w.inbound == nil {
+		return ErrWorkerNotAccepting
+	}
+	if d.Task == nil {
+		return errors.New("worker: dispatched task is nil")
+	}
+	// The completion bearer token is the internal wakeup token the worker holds
+	// (from WithInboundDispatch); it is NOT carried in the dispatch envelope so
+	// it never travels owner→worker on the wire needlessly.
+	meta := dispatchMeta{
+		OwnerBaseURL:    d.OwnerBaseURL,
+		Token:           w.completionToken,
+		WorkerNode:      d.WorkerNode,
+		OwnerGeneration: d.OwnerGeneration,
+		Attempt:         d.Attempt,
+	}
+	select {
+	case w.inbound <- inboundTask{task: d.Task, meta: meta}:
+		// Poke the wake signal (non-blocking; a full notify buffer means the
+		// loop is already about to drain).
+		select {
+		case w.inboundNotify <- struct{}{}:
+		default:
+		}
+		return nil
+	default:
+		return ErrInboundFull
+	}
+}
+
 // batchLeaseRenewInterval derives the per-node batched renewal interval.
 // If override > 0 it is used directly; otherwise leaseTTL/4 is used (minimum 1s).
 func batchLeaseRenewInterval(leaseTTL, override time.Duration) time.Duration {
@@ -195,6 +291,13 @@ func (w *Worker) Run(ctx context.Context) error {
 		default:
 		}
 
+		// Drain any dispatched (push-path) tasks first so the run-owner path
+		// shares the same pool and backpressure as ClaimNext'd (pull-path) tasks.
+		if err := w.drainInbound(ctx); err != nil {
+			w.pool.Wait()
+			return nil
+		}
+
 		w.reclaimIfDue(ctx)
 
 		task, err := w.claimer.ClaimNext(ctx)
@@ -207,23 +310,19 @@ func (w *Worker) Run(ctx context.Context) error {
 		}
 
 		if err != nil || task == nil {
-			if sleepErr := waitForWork(ctx, w.wakeups, w.pollInterval); sleepErr != nil {
+			// No pull-path work: wait for a wakeup, a dispatched-task arrival, or
+			// the poll interval — whichever comes first.  The inboundNotify wake
+			// means a dispatched task is picked up promptly instead of after a
+			// full poll interval.
+			if sleepErr := waitForWork(ctx, w.wakeups, w.inboundNotify, w.pollInterval); sleepErr != nil {
 				w.pool.Wait()
 				return nil
 			}
 			continue
 		}
 
-		// Register the claim before submitting so the renewal ticker can see it
-		// as soon as the goroutine is alive, even before execution starts.
-		w.trackInFlight(task)
-
-		if err := w.pool.Submit(ctx, func() {
-			defer w.untrackInFlight(task.ID)
-			w.executor(ctx, task)
-		}); err != nil {
-			// Submit failed (context cancelled); undo the registration.
-			w.untrackInFlight(task.ID)
+		// ClaimNext'd task: execute with the plain context (local sink path).
+		if err := w.submitToPool(ctx, ctx, task); err != nil {
 			if ctx.Err() != nil {
 				w.pool.Wait()
 				return nil
@@ -231,6 +330,52 @@ func (w *Worker) Run(ctx context.Context) error {
 			return err
 		}
 	}
+}
+
+// drainInbound submits every currently-buffered dispatched task onto the shared
+// pool.  It pulls non-blocking until the channel is momentarily empty so a
+// burst of dispatches is absorbed in one pass.  Each dispatched task executes
+// with a context carrying its owner metadata so the executor selects the
+// owner-routed completion sink.  Returns a non-nil error only when the context
+// was cancelled mid-submit (pool.Submit blocks on a full pool until a slot
+// frees or ctx is done).
+func (w *Worker) drainInbound(ctx context.Context) error {
+	if w.inbound == nil {
+		return nil
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case in := <-w.inbound:
+			execCtx := withDispatchMeta(ctx, in.meta)
+			if err := w.submitToPool(execCtx, ctx, in.task); err != nil {
+				return err
+			}
+		default:
+			return nil
+		}
+	}
+}
+
+// submitToPool registers a task as in-flight and submits its execution onto the
+// pool.  execCtx is the context passed to the executor (carries dispatch
+// metadata for push-path tasks); submitCtx governs the pool.Submit blocking
+// (the worker's lifecycle context).  On a failed submit the in-flight
+// registration is undone so the lease-renewal ticker doesn't track a task that
+// never ran.
+func (w *Worker) submitToPool(execCtx, submitCtx context.Context, task *models.TaskRun) error {
+	// Register the claim before submitting so the renewal ticker can see it as
+	// soon as the goroutine is alive, even before execution starts.
+	w.trackInFlight(task)
+	if err := w.pool.Submit(submitCtx, func() {
+		defer w.untrackInFlight(task.ID)
+		w.executor(execCtx, task)
+	}); err != nil {
+		w.untrackInFlight(task.ID)
+		return err
+	}
+	return nil
 }
 
 // trackInFlight registers a task run as in-flight for lease renewal purposes.
@@ -426,8 +571,15 @@ func randomReclaimOffset(interval time.Duration) time.Duration {
 	return time.Duration(rand.Int64N(int64(interval)))
 }
 
-func waitForWork(ctx context.Context, wakeups <-chan struct{}, d time.Duration) error {
-	if wakeups == nil {
+// waitForWork blocks until there is plausibly work to do: a pull-path wakeup
+// signal, a dispatched-task arrival notification, or the poll interval
+// elapsing.  notify is a wake-only signal (buffered size 1, poked by
+// SubmitDispatched); consuming it is harmless because the actual task sits
+// safely in the inbound buffer and is drained by the next loop iteration.  A
+// nil wakeups and nil notify (owner mode off, no wakeups) collapses to the
+// pre-Phase-2 sleep behavior.
+func waitForWork(ctx context.Context, wakeups <-chan struct{}, notify <-chan struct{}, d time.Duration) error {
+	if wakeups == nil && notify == nil {
 		return sleepWithContext(ctx, d)
 	}
 
@@ -438,6 +590,8 @@ func waitForWork(ctx context.Context, wakeups <-chan struct{}, d time.Duration) 
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-wakeups:
+		return nil
+	case <-notify:
 		return nil
 	case <-timer.C:
 		return nil

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/dispatch"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 )
@@ -381,5 +382,129 @@ func TestBatchedRenewal_ZeroRowsAffectedNoLocalUpdate(t *testing.T) {
 	w.inFlightMu.Unlock()
 	if !claim.claimExpiresAt.Equal(imminent) {
 		t.Fatalf("expected in-memory expiry unchanged when rows_affected=0, got %v want %v", claim.claimExpiresAt, imminent)
+	}
+}
+
+// --- Phase 2 B2: inbound dispatched-task channel ---
+
+// TestSubmitDispatched_NotAccepting verifies that a worker without the inbound
+// path enabled rejects dispatched tasks (owner mode off → byte-identical Phase 1).
+func TestSubmitDispatched_NotAccepting(t *testing.T) {
+	w := NewWorker(&sequenceClaimer{}, NewPool(1), time.Millisecond, nil)
+	err := w.SubmitDispatched(dispatch.InboundDispatch{Task: &models.TaskRun{ID: uuid.New()}})
+	if !errors.Is(err, ErrWorkerNotAccepting) {
+		t.Fatalf("expected ErrWorkerNotAccepting, got %v", err)
+	}
+}
+
+// TestSubmitDispatched_NilTask guards against a nil task panicking downstream.
+func TestSubmitDispatched_NilTask(t *testing.T) {
+	w := NewWorker(&sequenceClaimer{}, NewPool(1), time.Millisecond, nil).
+		WithInboundDispatch("tok")
+	if err := w.SubmitDispatched(dispatch.InboundDispatch{Task: nil}); err == nil {
+		t.Fatal("expected error for nil dispatched task")
+	}
+}
+
+// TestSubmitDispatched_BufferFull verifies that once the inbound buffer is full
+// (pool-size-bounded), further submits are rejected with ErrInboundFull so the
+// owner can re-dispatch — backpressure is unified with the pool.
+func TestSubmitDispatched_BufferFull(t *testing.T) {
+	// Pool size 2 → inbound buffer cap 2. Don't run the worker so nothing drains.
+	w := NewWorker(&sequenceClaimer{}, NewPool(2), time.Millisecond, nil).
+		WithInboundDispatch("tok")
+
+	for i := 0; i < 2; i++ {
+		if err := w.SubmitDispatched(dispatch.InboundDispatch{Task: &models.TaskRun{ID: uuid.New()}}); err != nil {
+			t.Fatalf("submit %d should succeed (buffer not full yet), got %v", i, err)
+		}
+	}
+	// Third submit overflows the size-2 buffer.
+	err := w.SubmitDispatched(dispatch.InboundDispatch{Task: &models.TaskRun{ID: uuid.New()}})
+	if !errors.Is(err, ErrInboundFull) {
+		t.Fatalf("expected ErrInboundFull on overflow, got %v", err)
+	}
+}
+
+// TestWorkerRunDrainsInboundDispatch verifies the Run loop drains a dispatched
+// task onto the shared pool and executes it with the owner metadata threaded
+// through the execution context (so the executor would select the owner sink).
+func TestWorkerRunDrainsInboundDispatch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var gotMeta dispatchMeta
+	var sawMeta bool
+	executed := make(chan struct{}, 1)
+
+	// Claimer returns no pull-path work, so the only execution is the dispatched
+	// task drained from the inbound channel.
+	w := NewWorker(&sequenceClaimer{}, NewPool(2), 50*time.Millisecond,
+		func(ec context.Context, task *models.TaskRun) {
+			gotMeta, sawMeta = dispatchMetaFrom(ec)
+			executed <- struct{}{}
+			cancel()
+		}).WithInboundDispatch("tok")
+
+	meta := dispatch.InboundDispatch{
+		Task:            &models.TaskRun{ID: uuid.New(), TaskID: uuid.New(), JobRunID: uuid.New()},
+		OwnerBaseURL:    "http://10.0.0.1:8080",
+		OwnerGeneration: 9,
+		Attempt:         2,
+		WorkerNode:      "10.0.0.5:9001",
+	}
+	if err := w.SubmitDispatched(meta); err != nil {
+		t.Fatalf("SubmitDispatched failed: %v", err)
+	}
+
+	if err := w.Run(ctx); err != nil {
+		t.Fatalf("worker run failed: %v", err)
+	}
+
+	select {
+	case <-executed:
+	default:
+		t.Fatal("dispatched task was never executed")
+	}
+	if !sawMeta {
+		t.Fatal("executor did not receive dispatch metadata via context")
+	}
+	if gotMeta.OwnerBaseURL != "http://10.0.0.1:8080" || gotMeta.OwnerGeneration != 9 || gotMeta.Attempt != 2 || gotMeta.WorkerNode != "10.0.0.5:9001" {
+		t.Fatalf("dispatch metadata mismatch in executor context: %+v", gotMeta)
+	}
+	if gotMeta.Token != "tok" {
+		t.Fatalf("expected completion token 'tok' threaded onto meta, got %q", gotMeta.Token)
+	}
+}
+
+// TestWorkerRunDrainsInboundAndClaimNext verifies both paths share the pool:
+// a dispatched task and a ClaimNext'd task both execute.
+func TestWorkerRunDrainsInboundAndClaimNext(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var executed int32
+	claimer := &sequenceClaimer{
+		responses: []claimerResponse{
+			{task: &models.TaskRun{ID: uuid.New()}}, // pull-path task
+		},
+	}
+	w := NewWorker(claimer, NewPool(2), 50*time.Millisecond,
+		func(_ context.Context, _ *models.TaskRun) {
+			if atomic.AddInt32(&executed, 1) == 2 {
+				cancel()
+			}
+		}).WithInboundDispatch("tok")
+
+	// Enqueue one dispatched task; ClaimNext yields one pull-path task.
+	if err := w.SubmitDispatched(dispatch.InboundDispatch{Task: &models.TaskRun{ID: uuid.New()}}); err != nil {
+		t.Fatalf("SubmitDispatched failed: %v", err)
+	}
+
+	if err := w.Run(ctx); err != nil {
+		t.Fatalf("worker run failed: %v", err)
+	}
+	if got := atomic.LoadInt32(&executed); got != 2 {
+		t.Fatalf("expected 2 executed tasks (1 dispatched + 1 ClaimNext'd), got %d", got)
 	}
 }


### PR DESCRIPTION
## Summary

Phase B2 makes run-owner mode actually execute a DAG. Before this, the owner
dispatched tasks but nothing ran them (`HandleDispatch` claimed a task and
returned 202 with no executor; `PostComplete` had no callers), so owned-run
DAGs stalled — B1 measured **0/10** on the stress workload.

**The cycle** (`b00c869`):
- `DispatchRequest` carries `OwnerBaseURL`; the worker reports completion back to
  the owner's `/internal/complete`, keeping the owner the single writer for its
  run's coordination rows (owner-generation fence intact).
- A pool-sized inbound channel + `SubmitDispatched` feed dispatched tasks onto the
  **same** worker pool as ClaimNext'd tasks (unified backpressure). If the worker
  can't accept, `HandleDispatch` rolls the claim back to pending and returns 409
  so the owner re-dispatches rather than orphaning the task.
- A `CompletionSink` selects per task: local sink (ClaimNext path, byte-identical
  to Phase 1) vs. owner sink (dispatched path → `PostComplete`).

**Contention hardening** (the work that gated 10/10):
- **Completion path** (`d6e4dfd`): a transient `database is locked` on the owner's
  apply was mis-mapped to a terminal **409** and the worker dropped a *succeeded*
  task. Now the owner answers retryable **503** (`ErrOwnerBusy`) and the worker
  retries with bounded backoff; genuine fence violations stay 409.
- **Run-start path** (`c8013b1`): a `checkpoint in progress` blip failed the whole
  run before any task was created (the error surfaces at row-iteration, escaping
  the pool-layer retry). `retryOnContention` now wraps the 5 idempotent run-start
  reads.

Behavior is unchanged when `CAESIUM_RUN_OWNER_ENABLED=false` (default). Owner mode
stays default-off until internal-endpoint mTLS lands (currently warn-only).

## Verification (3-node k8s, 100-task workload: 10 jobs × fan-out 4 × depth 3)

| Config | Runs OK |
|---|---|
| B1 (prior) | 0/10 |
| B2 cycle only | 8/10 |
| B2 + completion fix | 7/10 (run-start failures surfaced) |
| **B2 + both fixes** | **10/10 ×3 (30/30)** |

Across the three 10/10 runs: `dispatch_sent_total = 300` (exactly 1×/task — no
duplicate dispatch), `complete_retryable_total{contention} = 8` (all recovered by
worker retry), `complete_report_failed_total = 0` (zero lost completions),
`complete_rejected_total = 0`. Duplicate execution seen at intermediate stages was
a symptom of lost completions and disappeared once the completion path was fixed.
Full writeup: `docs/load-baseline-b2-2026-05-24.md`.

## Test plan

- [x] `just unit-test` green (race + coverage), including new tests:
  `completion_sink_test.go` (owner-busy retry/exhaust/terminal/ctx-cancel) and
  `contention_retry_test.go` (run-start retry classification).
- [x] 3-node k8s: stable 10/10 across 3 consecutive stress runs.
- [x] Both retry paths observed firing under real contention (metrics above).
- [ ] Reviewer: confirm `CAESIUM_RUN_OWNER_ENABLED` stays default-off pending mTLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)