### PR TITLE
Enforce mutual TLS on run-owner internal endpoints

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -14,7 +14,6 @@ import (
 	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	"github.com/caesium-cloud/caesium/api/rest/bind"
 	"github.com/caesium-cloud/caesium/internal/auth"
-	"github.com/caesium-cloud/caesium/internal/dispatch"
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/pkg/env"
@@ -26,7 +25,12 @@ import (
 type InternalWakeupHandler func(ctx context.Context, id string, ttl int)
 
 // Start launches Caesium's API.
-func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, wakeupHandler InternalWakeupHandler, dispatchHandler ...*dispatch.Handler) error {
+//
+// The run-owner coordination endpoints (/internal/dispatch, /internal/complete)
+// are deliberately NOT served here — they live on a dedicated mutually
+// authenticated TLS listener (see dispatch.InternalServer) so the public API
+// can remain plain HTTP behind the operator's proxy.
+func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, wakeupHandler InternalWakeupHandler) error {
 	e := echo.New()
 	vars := env.Variables()
 	configureIPExtractor(e, vars)
@@ -35,21 +39,6 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 	e.GET("/health", Health)
 	e.GET("/auth/status", authStatus(vars))
 	registerInternalWakeup(e, vars, wakeupHandler)
-
-	// Phase 2: run-owner dispatch and complete endpoints.
-	// These are registered only when a dispatch.Handler is provided
-	// (i.e., CAESIUM_RUN_OWNER_ENABLED=true).
-	if len(dispatchHandler) > 0 && dispatchHandler[0] != nil {
-		dh := dispatchHandler[0]
-		e.POST("/internal/dispatch", func(c *echo.Context) error {
-			dh.HandleDispatch(c.Response(), c.Request())
-			return nil
-		})
-		e.POST("/internal/complete", func(c *echo.Context) error {
-			dh.HandleComplete(c.Response(), c.Request())
-			return nil
-		})
-	}
 
 	// metrics
 	e.Use(echoprometheus.NewMiddleware("caesium"))

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -229,6 +229,7 @@ func start(cmd *cobra.Command, args []string) error {
 			Interval:     vars.RunOwnerDispatchInterval,
 			BatchSize:    vars.RunOwnerDispatchBatch,
 			Deadline:     vars.RunOwnerDispatchDeadline,
+			LeaseTTL:     vars.RunLeaseTTL,
 			LeaseStore:   leaseStore,
 			Store:        runStore,
 			Peers:        dqliteDispatchPeerResolver(),

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -2,6 +2,7 @@ package start
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"os"
 	"os/signal"
@@ -159,10 +160,29 @@ func start(cmd *cobra.Command, args []string) error {
 	// When the flag is false (default), this block is a no-op and the system
 	// behaves byte-identically to Phase 1.
 	var ownerDispatchHandler *dispatch.Handler
+	var ownerInternalServerTLS *tls.Config
 	if vars.RunOwnerEnabled {
-		// Warn if mTLS is not configured — Phase B will make this a hard error.
-		// We check for the Phase B env vars to future-proof the warning.
-		dispatch.WarnIfNoMTLS()
+		// Run-owner mode requires mutual TLS on the internal endpoints.  Fail
+		// fast (rather than the earlier Phase-A warning) when any material is
+		// missing, so a misconfigured cluster never silently runs unauthenticated
+		// node-to-node dispatch.
+		mtls := dispatch.MTLSConfig{
+			CAFile:   vars.InternalMTLSCA,
+			CertFile: vars.InternalMTLSCert,
+			KeyFile:  vars.InternalMTLSKey,
+		}
+		if !mtls.Configured() {
+			return fmt.Errorf("run-owner mode (CAESIUM_RUN_OWNER_ENABLED=true) requires mutual TLS: set CAESIUM_INTERNAL_MTLS_CA, CAESIUM_INTERNAL_MTLS_CERT, and CAESIUM_INTERNAL_MTLS_KEY")
+		}
+		clientTLS, err := dispatch.ClientTLSConfig(mtls)
+		if err != nil {
+			return fmt.Errorf("run-owner mode: build internal client TLS: %w", err)
+		}
+		dispatch.ConfigureInternalMTLS(clientTLS)
+		ownerInternalServerTLS, err = dispatch.ServerTLSConfig(mtls)
+		if err != nil {
+			return fmt.Errorf("run-owner mode: build internal server TLS: %w", err)
+		}
 
 		// Warn if the bearer token is missing — dispatch endpoints reject every
 		// request without it, making run-owner mode silently inert.
@@ -189,15 +209,16 @@ func start(cmd *cobra.Command, args []string) error {
 		// PostDispatch.  If PostDispatch returns false (worker rejected or network
 		// error), the task is left unclaimed and ClaimNext recovery picks it up.
 		dispatchLoop := dispatch.NewDispatchLoop(dispatch.DispatchLoopConfig{
-			NodeID:     vars.NodeAddress,
-			APIPort:    vars.Port,
-			Token:      token,
-			Interval:   vars.RunOwnerDispatchInterval,
-			BatchSize:  vars.RunOwnerDispatchBatch,
-			Deadline:   vars.RunOwnerDispatchDeadline,
-			LeaseStore: leaseStore,
-			Store:      runStore,
-			Peers:      dqliteDispatchPeerResolver(),
+			NodeID:       vars.NodeAddress,
+			APIPort:      vars.Port,
+			InternalPort: vars.InternalPort,
+			Token:        token,
+			Interval:     vars.RunOwnerDispatchInterval,
+			BatchSize:    vars.RunOwnerDispatchBatch,
+			Deadline:     vars.RunOwnerDispatchDeadline,
+			LeaseStore:   leaseStore,
+			Store:        runStore,
+			Peers:        dqliteDispatchPeerResolver(),
 		})
 		go func() {
 			log.Info("launching owner dispatch loop",
@@ -392,9 +413,24 @@ func start(cmd *cobra.Command, args []string) error {
 		)
 	}
 
+	// Run-owner coordination endpoints live on a dedicated mutually
+	// authenticated TLS listener, separate from the public API.  Start it after
+	// the worker submitter is wired into the handler (above) so a dispatch can
+	// never arrive at a handler with no worker attached.
+	if ownerDispatchHandler != nil && ownerInternalServerTLS != nil {
+		internalAddr := fmt.Sprintf(":%d", vars.InternalPort)
+		internalSrv := dispatch.NewInternalServer(ownerDispatchHandler, internalAddr, ownerInternalServerTLS)
+		go func() {
+			log.Info("spinning up internal mTLS listener", "addr", internalAddr)
+			if err := internalSrv.Run(ctx); err != nil && ctx.Err() == nil {
+				errs <- err
+			}
+		}()
+	}
+
 	go func() {
 		log.Info("spinning up api")
-		errs <- api.Start(ctx, bus, authSvc, auditor, limiter, internalWakeupHandler, ownerDispatchHandler)
+		errs <- api.Start(ctx, bus, authSvc, auditor, limiter, internalWakeupHandler)
 	}()
 
 	go func() {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -194,9 +194,22 @@ func start(cmd *cobra.Command, args []string) error {
 		token := strings.TrimSpace(vars.InternalWakeupToken)
 		ownerDispatchHandler = dispatch.NewHandler(runStore, leaseStore, vars.NodeAddress, token)
 
+		// B3: when the in-memory advancement flag is on, build the OwnerManager
+		// and route both completion application (handler) and dispatch (loop)
+		// through it.  Off by default — completions take the proven SQL path.
+		var ownerManager *run.OwnerManager
+		if vars.RunOwnerInMemory {
+			ownerManager = run.NewOwnerManager(runStore, run.CheckpointConfig{
+				Events:   vars.RunCheckpointEvents,
+				Interval: vars.RunCheckpointInterval,
+			})
+			ownerDispatchHandler = ownerDispatchHandler.WithOwnerManager(ownerManager)
+		}
+
 		log.Info(
-			"run-owner mode enabled (Phase 2A substrate)",
+			"run-owner mode enabled",
 			"node_address", vars.NodeAddress,
+			"in_memory", vars.RunOwnerInMemory,
 			"run_lease_ttl", vars.RunLeaseTTL,
 			"dispatch_interval", vars.RunOwnerDispatchInterval,
 			"dispatch_batch", vars.RunOwnerDispatchBatch,
@@ -219,6 +232,7 @@ func start(cmd *cobra.Command, args []string) error {
 			LeaseStore:   leaseStore,
 			Store:        runStore,
 			Peers:        dqliteDispatchPeerResolver(),
+			OwnerManager: ownerManager,
 		})
 		go func() {
 			log.Info("launching owner dispatch loop",

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ These files are useful context, but each should be treated according to its stat
 - [load-baseline-phase2a2-2026-05-24.md](load-baseline-phase2a2-2026-05-24.md): Phase A2 dispatch loop measured; finds it races ClaimNext and loses — redirects strategy to Phase B.
 - [load-baseline-b1-2026-05-25.md](load-baseline-b1-2026-05-25.md): B0+B1 measured; deferral works but exposes the push path never executes dispatched tasks — reshapes Phase B around the execution cycle.
 - [load-baseline-b2-2026-05-24.md](load-baseline-b2-2026-05-24.md): Phase B2 dispatch→execute→complete cycle; 0/10 → stable 10/10 after hardening the completion and run-start paths against transient dqlite contention.
+- [load-baseline-b3-2026-05-25.md](load-baseline-b3-2026-05-25.md): Phase B3 in-memory owner state + checkpoint/replay + internal mTLS; in-memory advancement verified 10/10 (single + 3-node) after fixing the claim/predecessor stall; failover mechanism proven, owner-crash end-to-end still flaky under sandbox voter loss.
 
 ## Historical Notes
 

--- a/docs/load-baseline-b3-2026-05-25.md
+++ b/docs/load-baseline-b3-2026-05-25.md
@@ -1,0 +1,82 @@
+# Caesium Load Baseline — Phase 2 B3 Measurement (2026-05-25)
+
+> Measurement of Phase B3 (in-memory owner run-state + checkpoint/replay) plus
+> the internal-endpoint mTLS work, on the 3-node k8s deployment with
+> `CAESIUM_RUN_OWNER_IN_MEMORY=true`. **Headline: the in-memory advancement path
+> is verified — the 100-task stress workload completes 10/10 on both single-node
+> and 3-node. Failover takeover + checkpoint replay are mechanically proven;
+> end-to-end completion through a force-killed dqlite voter is sandbox-flaky and
+> is the remaining hardening item.**
+
+## Environment
+
+3-pod StatefulSet on Docker Desktop k8s, `CAESIUM_EXECUTION_MODE=distributed`,
+`CAESIUM_RUN_OWNER_ENABLED=true`, `CAESIUM_RUN_OWNER_IN_MEMORY=true`, internal
+mTLS configured (CA + shared node cert as a Secret, dedicated `:8443` listener),
+kubernetes engine, ephemeral storage. Branch
+`phase2-b3-checkpoint-replay-and-internal-mtls`.
+
+## mTLS — verified
+
+The dedicated internal mTLS listener came up on every node, and owner→worker
+dispatches reached `HandleDispatch` over mutual TLS (handshakes succeed
+pod-to-pod, using the dynamic-IP chain-verify-but-skip-hostname client config).
+Run-owner mode hard-fails at startup without all three `CAESIUM_INTERNAL_MTLS_*`
+files.
+
+## The stall bug (found + fixed)
+
+First in-memory runs stalled: roots dispatched and succeeded, but successors were
+never dispatched. The owner's terminal write stamped `terminal_sequence` and the
+DAG advanced **in memory** — but `ClaimTaskForDispatch` (run by the worker on
+receipt of a dispatch) required `outstanding_predecessors = 0` in the DB. Because
+the owner advances in memory and deliberately does *not* decrement the DB
+counter, an in-memory-ready successor still showed `outstanding > 0` in the DB,
+so its claim was rejected (409) and the loop spun re-dispatching it.
+
+**Fix:** the owner is authoritative for readiness, so `ClaimTaskForDispatch`
+takes a `trustOwnerReadiness` flag (set in in-memory mode) that drops the
+`outstanding_predecessors = 0` predicate. In SQL mode the check is unchanged
+(the owner only dispatches `outstanding = 0` tasks there anyway).
+
+## Result — in-memory advancement verified
+
+| Config | Runs OK |
+|---|---|
+| single-node, in-memory | 10/10 |
+| 3-node, in-memory | 10/10 |
+
+Per-run logs confirm correct DAG advancement: a completion advances the
+in-memory state, stamps a monotonic `terminal_sequence`, readies successors, and
+finalizes the run when the DAG completes — with terminal-only DB writes (no
+per-transition predecessor UPDATEs) and periodic `run_checkpoints`.
+
+## Failover — mechanism proven, end-to-end flaky in sandbox
+
+Killing the run owner mid-run, a surviving node's dispatch loop took over the
+expired leases (`AcquireExpiredLeases`, generation incremented to 2) and
+reconstructed each run's state from the latest checkpoint + post-checkpoint
+terminal rows (`recovered run … ready=N`). Two real bugs were fixed here: a
+dead peer in the round-robin hung dispatches for the 30s client timeout (added a
+4s per-dispatch timeout to fail fast), and `ResetInFlightTasks` did not clear
+`claimed_by`, so a new owner could not re-claim the rows (now cleared).
+
+However, **force-killing a dqlite voter disrupts catalog quorum briefly**, which
+sometimes prevents the takeover sweep from acquiring the expired leases at all —
+so end-to-end completion through an owner crash did not reproduce reliably in
+this single-machine sandbox. The takeover + replay machinery is correct (proven
+on the runs where takeover did fire); making owner-crash failover robust under
+voter loss is the remaining item.
+
+## Recommendation
+
+Ship the in-memory path **default-off** (`CAESIUM_RUN_OWNER_IN_MEMORY=false`):
+steady-state advancement is verified (10/10), but owner-crash failover needs more
+hardening before it is on by default. mTLS and the B2 path are unaffected by the
+flag.
+
+## Sandbox caveats
+
+Single physical node, 3 dqlite voters, ephemeral storage. The voter-kill quorum
+disruption is largely a sandbox artifact; real multi-node hardware tolerates a
+single voter loss far better.

--- a/helm/caesium/templates/statefulset.yaml
+++ b/helm/caesium/templates/statefulset.yaml
@@ -159,11 +159,17 @@ spec:
               mountPath: /etc/caesium
             - name: data
               mountPath: /var/lib/caesium/dqlite
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
       volumes:
         - name: tmp
           emptyDir: {}
         - name: peer-config
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: peer-discovery-script
           configMap:
             name: {{ include "caesium.peerConfigName" . }}

--- a/helm/caesium/values.yaml
+++ b/helm/caesium/values.yaml
@@ -59,6 +59,19 @@ ingress:
           pathType: Prefix
   tls: []
 
+# Extra volumes / mounts on the caesium container. Used, for example, to mount
+# the internal mTLS material (CA/cert/key) from a Secret for run-owner mode:
+#   extraVolumes:
+#     - name: internal-mtls
+#       secret:
+#         secretName: caesium-internal-mtls
+#   extraVolumeMounts:
+#     - name: internal-mtls
+#       mountPath: /etc/caesium/mtls
+#       readOnly: true
+extraVolumes: []
+extraVolumeMounts: []
+
 resources: {}
   # requests:
   #   cpu: 100m

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -177,6 +177,10 @@ type Handler struct {
 	// (worker disabled on this node), HandleDispatch cannot execute the task and
 	// rolls back the claim so the owner re-dispatches elsewhere.
 	submitter WorkerSubmitter
+	// ownerManager, when set (CAESIUM_RUN_OWNER_IN_MEMORY=true), routes
+	// completions through the in-memory DAG state instead of the SQL-advancement
+	// path.  Nil keeps the proven B2 path.
+	ownerManager *run.OwnerManager
 }
 
 // NewHandler constructs a Handler.  store is the run.Store; leaseStore is the
@@ -196,6 +200,14 @@ func NewHandler(store *run.Store, leaseStore *run.LeaseStore, nodeID, token stri
 // the handler for chaining at construction time.
 func (h *Handler) WithWorkerSubmitter(s WorkerSubmitter) *Handler {
 	h.submitter = s
+	return h
+}
+
+// WithOwnerManager enables the in-memory advancement path: completions are
+// applied to the owner's RunState and persisted as terminal-only rows, instead
+// of the SQL-advancement path.  Returns the handler for chaining.
+func (h *Handler) WithOwnerManager(m *run.OwnerManager) *Handler {
+	h.ownerManager = m
 	return h
 }
 
@@ -429,6 +441,43 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 			Message: fmt.Sprintf("owner generation mismatch: expected %d, got %d", lease.Generation, req.OwnerGeneration),
 		})
 		return
+	}
+
+	// Run-owner in-memory path: when enabled and this node holds the run's
+	// in-memory state, advance the DAG in memory and persist terminal-only rows
+	// (no per-transition SQL advancement).  A run not tracked here (Owned=false)
+	// falls through to the SQL path below as a safety net.
+	if h.ownerManager != nil {
+		res, omErr := h.ownerManager.Complete(
+			req.RunID, req.TaskID, run.TaskStatus(req.Status),
+			req.Result, req.Error, req.WorkerNode, req.Outputs, req.BranchSelections,
+		)
+		if omErr != nil {
+			if dqlite.IsContentionError(omErr) {
+				h.rejectRetryable(w, req, omErr)
+				return
+			}
+			if errors.Is(omErr, run.ErrTaskClaimMismatch) {
+				metrics.CompleteRejectedTotal.WithLabelValues(ReasonWrongWorker).Inc()
+				writeJSON(w, http.StatusConflict, ErrorResponse{
+					Code:    ReasonWrongWorker,
+					Message: "task claimed_by mismatch or task not in running state",
+				})
+				return
+			}
+			log.Error("complete: owner-manager apply failed",
+				"run_id", req.RunID, "task_id", req.TaskID, "status", req.Status, "error", omErr)
+			writeJSON(w, http.StatusConflict, ErrorResponse{
+				Code:    ReasonTaskNotRunning,
+				Message: "failed to apply task completion",
+			})
+			return
+		}
+		if res.Owned {
+			writeJSON(w, http.StatusOK, CompleteResponse{Accepted: true})
+			return
+		}
+		// Not tracked in memory here — fall through to the SQL path.
 	}
 
 	// Rules 3 & 4 are enforced by the ClaimNext-path functions via

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -67,6 +67,11 @@ var internalClient = &http.Client{
 	Timeout: 30 * time.Second,
 }
 
+// dispatchPostTimeout bounds a single /internal/dispatch POST so an unreachable
+// peer fails fast instead of stalling the dispatch loop (the task is simply
+// retried next tick against another peer).
+const dispatchPostTimeout = 4 * time.Second
+
 // ConfigureInternalMTLS replaces the shared internal client with one that
 // presents this node's client certificate and verifies peers against the
 // configured CA.  Called once at startup when run-owner mode is enabled, before
@@ -285,7 +290,11 @@ func (h *Handler) HandleDispatch(w http.ResponseWriter, r *http.Request) {
 	// ClaimTaskForDispatch transitions pending→running with claimed_by=nodeID
 	// in one UPDATE (equivalent to ClaimNext but targeting a specific task),
 	// stamping owner_generation so subsequent writes fence against takeover.
-	if err := h.store.ClaimTaskForDispatch(req.RunID, req.TaskID, h.nodeID, req.OwnerGeneration, ttl); err != nil {
+	// In in-memory mode the owner advanced the DAG in memory (the DB's
+	// outstanding_predecessors counter is intentionally stale), so trust the
+	// owner's readiness decision rather than re-checking it here.
+	trustOwnerReadiness := h.ownerManager != nil
+	if err := h.store.ClaimTaskForDispatch(req.RunID, req.TaskID, h.nodeID, req.OwnerGeneration, ttl, trustOwnerReadiness); err != nil {
 		if err == run.ErrTaskClaimMismatch {
 			writeJSON(w, http.StatusConflict, ErrorResponse{
 				Code:    ReasonTaskNotRunning,
@@ -586,7 +595,14 @@ func PostDispatch(ctx context.Context, targetURL, token string, req DispatchRequ
 		return false, fmt.Errorf("dispatch: marshal: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, targetURL, bytes.NewReader(body))
+	// Fail fast on an unreachable peer: a dispatch is cheap to retry on the next
+	// tick (to a different peer), so a dead node in the round-robin must not hang
+	// the loop for the client's full 30s timeout — critical during failover, when
+	// the just-crashed owner can still be in the peer list.
+	dialCtx, cancel := context.WithTimeout(ctx, dispatchPostTimeout)
+	defer cancel()
+
+	httpReq, err := http.NewRequestWithContext(dialCtx, http.MethodPost, targetURL, bytes.NewReader(body))
 	if err != nil {
 		return false, fmt.Errorf("dispatch: new request: %w", err)
 	}

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -17,6 +17,7 @@ package dispatch
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,10 +61,24 @@ var ErrOwnerBusy = errors.New("owner busy: retryable")
 // across requests so we don't pay connection setup on every dispatch.
 // The per-call timeout is enforced via context.WithTimeout, not on the
 // client itself, so callers can extend it if their workload needs it.
-// Phase B will swap the Transport for one configured with mTLS material
-// (CAESIUM_INTERNAL_MTLS_*); the rest of the call sites stay the same.
+// ConfigureInternalMTLS swaps in a TLS-enabled transport at startup when
+// run-owner mode is on; the call sites stay the same.
 var internalClient = &http.Client{
 	Timeout: 30 * time.Second,
+}
+
+// ConfigureInternalMTLS replaces the shared internal client with one that
+// presents this node's client certificate and verifies peers against the
+// configured CA.  Called once at startup when run-owner mode is enabled, before
+// any dispatch or completion POST is issued.  Peer internal endpoints are
+// reached over https on the internal port (see DispatchLoopConfig.InternalPort).
+func ConfigureInternalMTLS(clientTLS *tls.Config) {
+	internalClient = &http.Client{
+		Timeout: 30 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: clientTLS,
+		},
+	}
 }
 
 // ValidCompleteStatuses are the only task statuses workers may report.
@@ -578,24 +593,12 @@ func PostComplete(ctx context.Context, ownerURL, token string, req CompleteReque
 	return nil, fmt.Errorf("complete: owner returned status %d", resp.StatusCode)
 }
 
-// WarnIfNoMTLS emits a startup warning when owner mode is on but no mTLS
-// material is configured.  Phase B will turn this into a hard error.
-func WarnIfNoMTLS() {
-	// Phase A: mTLS is recommended, not required.  Log a warning so operators
-	// know they should configure it before Phase B ships.
-	log.Warn(
-		"run-owner mode is enabled without mTLS material configured; " +
-			"this is not a supported configuration for production use. " +
-			"Phase B will require CAESIUM_INTERNAL_MTLS_CA, " +
-			"CAESIUM_INTERNAL_MTLS_CERT, and CAESIUM_INTERNAL_MTLS_KEY.",
-	)
-}
-
 // WarnIfNoToken emits a startup warning when owner mode is on but the
 // internal wakeup token is not set.  Without the token, the dispatch and
 // complete endpoints reject every request (bearer-token check fails closed),
 // so run-owner dispatch is silently inert — adding lease overhead with zero
-// benefit.  Mirrors WarnIfNoMTLS in tone and intent; warn-only for now.
+// benefit.  Warn-only: unlike the mTLS material (a hard startup error), a
+// missing token is recoverable by setting it without regenerating certs.
 func WarnIfNoToken(token string) {
 	if strings.TrimSpace(token) != "" {
 		return

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/metrics"
@@ -72,18 +73,27 @@ var internalClient = &http.Client{
 // retried next tick against another peer).
 const dispatchPostTimeout = 4 * time.Second
 
+// configureMTLSOnce ensures the shared internal client is swapped for its
+// TLS-enabled form exactly once, even if ConfigureInternalMTLS is called from
+// multiple goroutines (e.g. concurrent tests) — avoiding a data race on the
+// package-level internalClient.
+var configureMTLSOnce sync.Once
+
 // ConfigureInternalMTLS replaces the shared internal client with one that
 // presents this node's client certificate and verifies peers against the
 // configured CA.  Called once at startup when run-owner mode is enabled, before
-// any dispatch or completion POST is issued.  Peer internal endpoints are
-// reached over https on the internal port (see DispatchLoopConfig.InternalPort).
+// any dispatch or completion POST is issued.  Subsequent calls are no-ops.  Peer
+// internal endpoints are reached over https on the internal port (see
+// DispatchLoopConfig.InternalPort).
 func ConfigureInternalMTLS(clientTLS *tls.Config) {
-	internalClient = &http.Client{
-		Timeout: 30 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: clientTLS,
-		},
-	}
+	configureMTLSOnce.Do(func() {
+		internalClient = &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: clientTLS,
+			},
+		}
+	})
 }
 
 // ValidCompleteStatuses are the only task statuses workers may report.

--- a/internal/dispatch/internal_server.go
+++ b/internal/dispatch/internal_server.go
@@ -1,0 +1,60 @@
+package dispatch
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/caesium-cloud/caesium/pkg/log"
+)
+
+// InternalServer hosts the run-owner coordination endpoints
+// (/internal/dispatch, /internal/complete) on a dedicated, mutually
+// authenticated TLS listener — separate from the public API server, which stays
+// plain HTTP behind the operator's own proxy.  Node-to-node coordination
+// traffic therefore never touches the public surface and every peer is
+// authenticated by client certificate at the TLS layer.
+type InternalServer struct {
+	srv *http.Server
+}
+
+// NewInternalServer builds the internal mTLS server for handler, bound to addr
+// (e.g. ":8443") with the supplied server TLS config (from ServerTLSConfig).
+func NewInternalServer(handler *Handler, addr string, tlsConfig *tls.Config) *InternalServer {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/internal/dispatch", handler.HandleDispatch)
+	mux.HandleFunc("/internal/complete", handler.HandleComplete)
+	return &InternalServer{
+		srv: &http.Server{
+			Addr:              addr,
+			Handler:           mux,
+			TLSConfig:         tlsConfig,
+			ReadHeaderTimeout: 10 * time.Second,
+		},
+	}
+}
+
+// Run serves until ctx is cancelled, then shuts down gracefully.  It blocks; run
+// it in a goroutine.  The certificate comes from srv.TLSConfig.Certificates, so
+// ServeTLS is called with empty file arguments.
+func (s *InternalServer) Run(ctx context.Context) error {
+	ln, err := net.Listen("tcp", s.srv.Addr)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = s.srv.Shutdown(shutdownCtx)
+	}()
+
+	log.Info("internal mTLS listener started", "addr", s.srv.Addr)
+	if err := s.srv.ServeTLS(ln, "", ""); err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}

--- a/internal/dispatch/internal_server.go
+++ b/internal/dispatch/internal_server.go
@@ -40,7 +40,8 @@ func NewInternalServer(handler *Handler, addr string, tlsConfig *tls.Config) *In
 // it in a goroutine.  The certificate comes from srv.TLSConfig.Certificates, so
 // ServeTLS is called with empty file arguments.
 func (s *InternalServer) Run(ctx context.Context) error {
-	ln, err := net.Listen("tcp", s.srv.Addr)
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", s.srv.Addr)
 	if err != nil {
 		return err
 	}

--- a/internal/dispatch/internal_server.go
+++ b/internal/dispatch/internal_server.go
@@ -28,10 +28,15 @@ func NewInternalServer(handler *Handler, addr string, tlsConfig *tls.Config) *In
 	mux.HandleFunc("/internal/complete", handler.HandleComplete)
 	return &InternalServer{
 		srv: &http.Server{
-			Addr:              addr,
-			Handler:           mux,
-			TLSConfig:         tlsConfig,
+			Addr:      addr,
+			Handler:   mux,
+			TLSConfig: tlsConfig,
+			// Bound every phase of a connection so a slow or stuck peer can't
+			// tie up the internal listener (slowloris-style resource exhaustion).
 			ReadHeaderTimeout: 10 * time.Second,
+			ReadTimeout:       15 * time.Second,
+			WriteTimeout:      15 * time.Second,
+			IdleTimeout:       120 * time.Second,
 		},
 	}
 }

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -88,8 +88,13 @@ type DispatchLoopConfig struct {
 	// as the identity for OwnedRuns and included in the round-robin peer list.
 	NodeID string
 	// APIPort is the HTTP API port (CAESIUM_PORT).  Used to build the dispatch
-	// URL from peer node addresses.
+	// URL from peer node addresses when InternalPort is unset (tests / non-mTLS).
 	APIPort int
+	// InternalPort is the dedicated internal mTLS listener port
+	// (CAESIUM_INTERNAL_PORT).  When > 0, peer and owner base URLs are built as
+	// https://host:InternalPort so dispatch/complete traffic flows over the
+	// mutually-authenticated internal listener instead of the public API port.
+	InternalPort int
 	// Token is the CAESIUM_INTERNAL_WAKEUP_TOKEN bearer token.
 	Token string
 	// Interval is the polling tick interval (CAESIUM_RUN_OWNER_DISPATCH_INTERVAL).
@@ -351,8 +356,12 @@ func (l *DispatchLoop) nodeAddrToBaseURL(nodeAddr string) string {
 	if host == "" || strings.HasPrefix(host, "@") {
 		return ""
 	}
+	scheme, port := "http", l.cfg.APIPort
+	if l.cfg.InternalPort > 0 {
+		scheme, port = "https", l.cfg.InternalPort
+	}
 	return (&url.URL{
-		Scheme: "http",
-		Host:   net.JoinHostPort(host, strconv.Itoa(l.cfg.APIPort)),
+		Scheme: scheme,
+		Host:   net.JoinHostPort(host, strconv.Itoa(port)),
 	}).String()
 }

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -66,6 +66,10 @@ func (f PeerListerFunc) DispatchPeers(ctx context.Context) ([]string, error) {
 // GetLease pattern as the owned set grows.
 type OwnerReader interface {
 	OwnedRunsWithGenerations(ctx context.Context, ownerNode string) (map[uuid.UUID]int64, error)
+	// AcquireExpiredLeases takes over leases whose owner let them expire,
+	// reassigning them to ownerNode with an incremented generation.  Used by the
+	// in-memory failover sweep so a peer recovers a dead owner's runs.
+	AcquireExpiredLeases(ctx context.Context, newOwner string, ttl time.Duration) (int64, error)
 }
 
 // peer pairs a peer's canonical node identity (host:dqlitePort — matches the
@@ -106,6 +110,9 @@ type DispatchLoopConfig struct {
 	// Deadline is added to time.Now() to produce the DispatchRequest.Deadline
 	// (CAESIUM_RUN_OWNER_DISPATCH_DEADLINE).
 	Deadline time.Duration
+	// LeaseTTL is the run-lease TTL (CAESIUM_RUN_LEASE_TTL), used as the new
+	// expiry when this node takes over an expired lease in the failover sweep.
+	LeaseTTL time.Duration
 	// LeaseStore provides ownership queries.
 	LeaseStore OwnerReader
 	// Store provides pending-task queries.
@@ -192,6 +199,19 @@ func (l *DispatchLoop) tick(ctx context.Context) {
 	if len(peers) == 0 {
 		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNoPeers).Inc()
 		return
+	}
+
+	// 1b. Failover sweep (in-memory mode only): take over any lease whose owner
+	//     let it expire, so a dead owner's runs get a live owner that recovers
+	//     and resumes them.  In SQL mode, ClaimNext recovery handles this instead.
+	if l.cfg.OwnerManager != nil {
+		if n, takeErr := l.cfg.LeaseStore.AcquireExpiredLeases(ctx, l.cfg.NodeID, l.cfg.LeaseTTL); takeErr != nil {
+			if ctx.Err() == nil {
+				log.Warn("dispatch loop: expired-lease takeover failed", "error", takeErr)
+			}
+		} else if n > 0 {
+			log.Info("dispatch loop: took over expired run leases", "count", n, "new_owner", l.cfg.NodeID)
+		}
 	}
 
 	// 2. Find runs this node owns AND their current generation in one query

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
 )
@@ -117,6 +118,11 @@ type DispatchLoopConfig struct {
 	// mux server. Production leaves it nil and the loop falls back to the
 	// default (build URL from APIPort).
 	PeerBaseURL func(nodeAddr string) string
+	// OwnerManager, when set (CAESIUM_RUN_OWNER_IN_MEMORY=true), is the source of
+	// truth for ready tasks: the loop dispatches from the in-memory ready queue
+	// and records dispatches/recoveries on it, instead of polling the DB for
+	// pending tasks.  Nil keeps the proven B2 DB-poll path.
+	OwnerManager *run.OwnerManager
 }
 
 // DispatchLoop is the per-node push-dispatch goroutine for Phase A2.
@@ -215,6 +221,13 @@ func (l *DispatchLoop) tick(ctx context.Context) {
 // Each task's PostDispatch fires in a worker goroutine bounded by BatchSize/4
 // (capped at 16) so slow or unreachable workers don't serialise the tick.
 func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, generation int64, peers []peer) {
+	// In-memory mode: dispatch from the owner's RunState ready queue rather than
+	// polling the DB.  Adopt-or-recover the run lazily on first sight.
+	if l.cfg.OwnerManager != nil {
+		l.dispatchRunInMemory(ctx, runID, generation, peers)
+		return
+	}
+
 	tasks, err := l.cfg.Store.PendingTasksForDispatch(ctx, runID, l.cfg.BatchSize)
 	if err != nil {
 		if ctx.Err() != nil {
@@ -276,6 +289,64 @@ func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, generat
 	wg.Wait()
 }
 
+// dispatchRunInMemory dispatches a run's ready tasks from the owner's in-memory
+// RunState.  It lazily adopts/recovers the run on first sight (Recover handles
+// both a freshly-created run — no checkpoint, fresh state — and a takeover —
+// replay from checkpoint + terminal tail, re-queuing lost in-flight work).
+func (l *DispatchLoop) dispatchRunInMemory(ctx context.Context, runID uuid.UUID, generation int64, peers []peer) {
+	mgr := l.cfg.OwnerManager
+	if !mgr.Owns(runID) {
+		if _, err := mgr.Recover(runID, generation); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			log.Warn("dispatch loop: owner recover failed", "run_id", runID, "error", err)
+			return
+		}
+	}
+
+	ready := mgr.ReadyForDispatch(runID)
+	if len(ready) == 0 {
+		return
+	}
+	if len(ready) > l.cfg.BatchSize {
+		ready = ready[:l.cfg.BatchSize]
+	}
+
+	const maxConcurrent = 16
+	concurrency := len(ready)
+	if concurrency > maxConcurrent {
+		concurrency = maxConcurrent
+	}
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for _, dt := range ready {
+		if ctx.Err() != nil {
+			break
+		}
+		idx := l.counter.Add(1) - 1
+		p := peers[idx%uint64(len(peers))]
+		req := DispatchRequest{
+			RunID:           runID,
+			TaskID:          dt.TaskID,
+			OwnerGeneration: generation,
+			Attempt:         dt.Attempt,
+			WorkerNode:      p.nodeID,
+			OwnerBaseURL:    l.ownerBaseURL,
+			Deadline:        time.Now().UTC().Add(l.cfg.Deadline),
+		}
+		wg.Add(1)
+		sem <- struct{}{}
+		go func(p peer, req DispatchRequest) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			l.postOne(ctx, runID, p, req)
+		}(p, req)
+	}
+	wg.Wait()
+}
+
 // postOne does the actual HTTP call + metric/log accounting for one dispatch.
 func (l *DispatchLoop) postOne(ctx context.Context, runID uuid.UUID, p peer, req DispatchRequest) {
 	dispatchURL := p.baseURL + "/internal/dispatch"
@@ -303,6 +374,12 @@ func (l *DispatchLoop) postOne(ctx context.Context, runID uuid.UUID, p peer, req
 		return
 	}
 	metrics.DispatchSentTotal.Inc()
+	// In-memory mode: record the dispatch in the owner's RunState so the task
+	// leaves the ready queue and becomes running (re-dispatched on lease expiry).
+	if l.cfg.OwnerManager != nil {
+		leaseMs := time.Now().Add(l.cfg.Deadline).UnixMilli()
+		l.cfg.OwnerManager.MarkDispatched(runID, req.TaskID, p.nodeID, req.Attempt, leaseMs)
+	}
 	log.Debug("dispatch loop: task dispatched",
 		"run_id", runID,
 		"task_id", req.TaskID,

--- a/internal/dispatch/loop_test.go
+++ b/internal/dispatch/loop_test.go
@@ -45,6 +45,10 @@ func (r *testOwnerReader) OwnedRunsWithGenerations(ctx context.Context, ownerNod
 	return r.ls.OwnedRunsWithGenerations(ctx, ownerNode)
 }
 
+func (r *testOwnerReader) AcquireExpiredLeases(ctx context.Context, newOwner string, ttl time.Duration) (int64, error) {
+	return r.ls.AcquireExpiredLeases(ctx, newOwner, ttl)
+}
+
 // testTaskReader wraps run.Store to satisfy TaskPendingReader.
 type testTaskReader struct {
 	s *run.Store

--- a/internal/dispatch/mtls.go
+++ b/internal/dispatch/mtls.go
@@ -59,7 +59,16 @@ func ServerTLSConfig(c MTLSConfig) (*tls.Config, error) {
 
 // ClientTLSConfig builds the *tls.Config used when this node POSTs to a peer's
 // internal endpoints (PostDispatch / PostComplete): it presents this node's
-// certificate and verifies the peer's server certificate against the CA.
+// certificate and verifies the peer's server certificate was signed by the CA.
+//
+// Hostname verification is deliberately disabled: cluster peers are reached by
+// dynamic pod IPs / node addresses that a long-lived certificate can't enumerate
+// in its SANs, so the built-in name check would reject valid peers.  Peer
+// identity instead rests on (a) the certificate being signed by the shared
+// internal CA, verified here against the chain, and (b) the application-layer
+// owner-generation + worker-node fence on every dispatch/complete.  We therefore
+// set InsecureSkipVerify (which only disables the name/standard verification)
+// and re-implement chain verification in VerifyPeerCertificate.
 func ClientTLSConfig(c MTLSConfig) (*tls.Config, error) {
 	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
 	if err != nil {
@@ -70,8 +79,38 @@ func ClientTLSConfig(c MTLSConfig) (*tls.Config, error) {
 		return nil, err
 	}
 	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      pool,
-		MinVersion:   tls.VersionTLS12,
+		Certificates:          []tls.Certificate{cert},
+		RootCAs:               pool,
+		MinVersion:            tls.VersionTLS12,
+		InsecureSkipVerify:    true, //nolint:gosec // chain verified below; hostname intentionally skipped for dynamic pod IPs
+		VerifyPeerCertificate: verifyChainAgainst(pool),
 	}, nil
+}
+
+// verifyChainAgainst returns a VerifyPeerCertificate callback that validates the
+// peer's presented certificate chains to the trusted CA pool, without any
+// hostname/DNS check.  Used by ClientTLSConfig in place of the default
+// verification that InsecureSkipVerify disables.
+func verifyChainAgainst(pool *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return fmt.Errorf("mtls: peer presented no certificate")
+		}
+		certs := make([]*x509.Certificate, 0, len(rawCerts))
+		for _, raw := range rawCerts {
+			crt, err := x509.ParseCertificate(raw)
+			if err != nil {
+				return fmt.Errorf("mtls: parse peer certificate: %w", err)
+			}
+			certs = append(certs, crt)
+		}
+		intermediates := x509.NewCertPool()
+		for _, crt := range certs[1:] {
+			intermediates.AddCert(crt)
+		}
+		if _, err := certs[0].Verify(x509.VerifyOptions{Roots: pool, Intermediates: intermediates}); err != nil {
+			return fmt.Errorf("mtls: peer certificate not signed by trusted CA: %w", err)
+		}
+		return nil
+	}
 }

--- a/internal/dispatch/mtls.go
+++ b/internal/dispatch/mtls.go
@@ -108,8 +108,16 @@ func verifyChainAgainst(pool *x509.CertPool) func([][]byte, [][]*x509.Certificat
 		for _, crt := range certs[1:] {
 			intermediates.AddCert(crt)
 		}
-		if _, err := certs[0].Verify(x509.VerifyOptions{Roots: pool, Intermediates: intermediates}); err != nil {
-			return fmt.Errorf("mtls: peer certificate not signed by trusted CA: %w", err)
+		if _, err := certs[0].Verify(x509.VerifyOptions{
+			Roots:         pool,
+			Intermediates: intermediates,
+			// We are verifying the peer as a SERVER (this is the client side):
+			// require serverAuth so a client-only certificate can't be presented
+			// as a server.  Without this, VerifyOptions defaults to
+			// ExtKeyUsageAny and would accept it.
+			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		}); err != nil {
+			return fmt.Errorf("mtls: peer certificate not signed by trusted CA or not valid for server auth: %w", err)
 		}
 		return nil
 	}

--- a/internal/dispatch/mtls.go
+++ b/internal/dispatch/mtls.go
@@ -1,0 +1,77 @@
+package dispatch
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+)
+
+// MTLSConfig holds the file paths for the internal mutual-TLS material
+// (CAESIUM_INTERNAL_MTLS_CA/CERT/KEY).  The same key pair is this node's
+// identity in both directions: the server certificate on its internal listener
+// and the client certificate it presents when POSTing to a peer.
+type MTLSConfig struct {
+	CAFile   string
+	CertFile string
+	KeyFile  string
+}
+
+// Configured reports whether all three material paths are set.  Run-owner mode
+// requires this to be true (enforced at startup).
+func (c MTLSConfig) Configured() bool {
+	return c.CAFile != "" && c.CertFile != "" && c.KeyFile != ""
+}
+
+// loadCertPool reads a PEM CA bundle into an x509 pool.
+func loadCertPool(caFile string) (*x509.CertPool, error) {
+	pem, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("mtls: read CA %q: %w", caFile, err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(pem) {
+		return nil, fmt.Errorf("mtls: no certificates found in CA %q", caFile)
+	}
+	return pool, nil
+}
+
+// ServerTLSConfig builds the *tls.Config for the internal listener: it presents
+// this node's certificate and requires + verifies a client certificate signed
+// by the configured CA on every connection.  A peer with no certificate, or one
+// signed by an unknown CA, fails the TLS handshake before reaching a handler.
+func ServerTLSConfig(c MTLSConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("mtls: load server keypair: %w", err)
+	}
+	pool, err := loadCertPool(c.CAFile)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientCAs:    pool,
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+// ClientTLSConfig builds the *tls.Config used when this node POSTs to a peer's
+// internal endpoints (PostDispatch / PostComplete): it presents this node's
+// certificate and verifies the peer's server certificate against the CA.
+func ClientTLSConfig(c MTLSConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("mtls: load client keypair: %w", err)
+	}
+	pool, err := loadCertPool(c.CAFile)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		RootCAs:      pool,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}

--- a/internal/dispatch/mtls_test.go
+++ b/internal/dispatch/mtls_test.go
@@ -95,6 +95,70 @@ func materialFromCA(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey,
 	}
 }
 
+// leafDER signs a leaf certificate with the given CA and returns its DER bytes.
+func leafDER(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	certPEM, _ := genLeaf(t, ca, caKey, "leaf", nil)
+	block, _ := pem.Decode(certPEM)
+	require.NotNil(t, block)
+	return block.Bytes
+}
+
+// TestVerifyChainAgainst checks the client's CA-chain verification (used in place
+// of the default verification that InsecureSkipVerify disables): a CA-signed
+// cert is accepted, an untrusted-CA cert and an empty chain are rejected.
+func TestVerifyChainAgainst(t *testing.T) {
+	ca1, ca1Key, _ := genCA(t)
+	ca2, ca2Key, _ := genCA(t)
+	pool := x509.NewCertPool()
+	pool.AddCert(ca1)
+	verify := verifyChainAgainst(pool)
+
+	require.NoError(t, verify([][]byte{leafDER(t, ca1, ca1Key)}, nil),
+		"a cert signed by the trusted CA must verify")
+	require.Error(t, verify([][]byte{leafDER(t, ca2, ca2Key)}, nil),
+		"a cert signed by an untrusted CA must be rejected")
+	require.Error(t, verify(nil, nil), "an empty chain must be rejected")
+}
+
+// TestClientTLSConfig_SkipsHostname proves the client accepts a CA-signed server
+// certificate even when the dialed address is absent from the cert's SANs — the
+// behavior dynamic pod IPs require.
+func TestClientTLSConfig_SkipsHostname(t *testing.T) {
+	ca, caKey, _ := genCA(t)
+	// Server cert deliberately has NO 127.0.0.1 SAN (loopback=false).
+	serverMat := materialFromCA(t, ca, caKey, "server-no-san", false)
+	clientMat := materialFromCA(t, ca, caKey, "client", false)
+	clientMat.CAFile = serverMat.CAFile
+
+	serverTLS, err := ServerTLSConfig(serverMat)
+	require.NoError(t, err)
+	clientTLS, err := ClientTLSConfig(clientMat)
+	require.NoError(t, err)
+	clientTLS.MaxVersion = tls.VersionTLS12
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			if tc, ok := c.(*tls.Conn); ok {
+				_ = tc.HandshakeContext(context.Background())
+			}
+			_ = c.Close()
+		}
+	}()
+
+	d := tls.Dialer{NetDialer: &net.Dialer{Timeout: 3 * time.Second}, Config: clientTLS}
+	conn, err := d.DialContext(context.Background(), "tcp", ln.Addr().String())
+	require.NoError(t, err, "client must accept a CA-signed server cert despite the dialed host being absent from its SANs")
+	_ = conn.Close()
+}
+
 func TestServerTLSConfig_MissingFiles(t *testing.T) {
 	_, err := ServerTLSConfig(MTLSConfig{CAFile: "/nope/ca", CertFile: "/nope/c", KeyFile: "/nope/k"})
 	require.Error(t, err)

--- a/internal/dispatch/mtls_test.go
+++ b/internal/dispatch/mtls_test.go
@@ -1,0 +1,168 @@
+package dispatch
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMTLSConfig_Configured(t *testing.T) {
+	require.True(t, MTLSConfig{CAFile: "ca", CertFile: "c", KeyFile: "k"}.Configured())
+	require.False(t, MTLSConfig{CertFile: "c", KeyFile: "k"}.Configured(), "missing CA")
+	require.False(t, MTLSConfig{CAFile: "ca", KeyFile: "k"}.Configured(), "missing cert")
+	require.False(t, MTLSConfig{CAFile: "ca", CertFile: "c"}.Configured(), "missing key")
+	require.False(t, MTLSConfig{}.Configured())
+}
+
+// genCA returns a self-signed CA certificate + key and its PEM encoding.
+func genCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+// genLeaf signs a leaf certificate (server or client) with the given CA.
+func genLeaf(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, cn string, ips []net.IP) (certPEM, keyPEM []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(time.Now().UnixNano()),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		IPAddresses:  ips,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+func writeFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, data, 0o600))
+	return p
+}
+
+// materialFromCA writes a CA + a CA-signed leaf to temp files and returns an
+// MTLSConfig pointing at them.  loopback adds 127.0.0.1 as a SAN for server use.
+func materialFromCA(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, name string, loopback bool) MTLSConfig {
+	t.Helper()
+	dir := t.TempDir()
+	var ips []net.IP
+	if loopback {
+		ips = []net.IP{net.ParseIP("127.0.0.1")}
+	}
+	certPEM, keyPEM := genLeaf(t, ca, caKey, name, ips)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.Raw})
+	return MTLSConfig{
+		CAFile:   writeFile(t, dir, "ca.pem", caPEM),
+		CertFile: writeFile(t, dir, name+".pem", certPEM),
+		KeyFile:  writeFile(t, dir, name+"-key.pem", keyPEM),
+	}
+}
+
+func TestServerTLSConfig_MissingFiles(t *testing.T) {
+	_, err := ServerTLSConfig(MTLSConfig{CAFile: "/nope/ca", CertFile: "/nope/c", KeyFile: "/nope/k"})
+	require.Error(t, err)
+	_, err = ClientTLSConfig(MTLSConfig{CAFile: "/nope/ca", CertFile: "/nope/c", KeyFile: "/nope/k"})
+	require.Error(t, err)
+}
+
+// TestInternalMTLS_Handshake stands up a TLS listener with ServerTLSConfig and
+// asserts the handshake accepts a client cert from the trusted CA, and rejects
+// both a client presenting no certificate and one signed by a different CA.
+func TestInternalMTLS_Handshake(t *testing.T) {
+	ca, caKey, caPEM := genCA(t)
+	serverMat := materialFromCA(t, ca, caKey, "server", true)
+	clientMat := materialFromCA(t, ca, caKey, "client", false)
+	// Point the client's CA file at the same CA so it trusts the server cert.
+	clientMat.CAFile = serverMat.CAFile
+
+	serverTLS, err := ServerTLSConfig(serverMat)
+	require.NoError(t, err)
+	clientTLS, err := ClientTLSConfig(clientMat)
+	require.NoError(t, err)
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	require.NoError(t, err)
+	defer ln.Close()
+
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Force the handshake so client-cert verification runs, then close.
+			if tc, ok := c.(*tls.Conn); ok {
+				_ = tc.Handshake()
+			}
+			_ = c.Close()
+		}
+	}()
+
+	addr := ln.Addr().String()
+	dialer := &net.Dialer{Timeout: 3 * time.Second}
+
+	// Pin TLS 1.2 on the dialing side: under TLS 1.3 a client-cert rejection is
+	// delivered as a post-handshake alert (surfacing on first I/O, not at Dial),
+	// which makes the negative assertions racy.  The enforcement mechanism
+	// (RequireAndVerifyClientCert) is version-independent; 1.2 just makes the
+	// rejection synchronous at handshake so the test can assert it directly.
+	clientTLS.MaxVersion = tls.VersionTLS12
+
+	// Valid client certificate → handshake succeeds.
+	conn, err := tls.DialWithDialer(dialer, "tcp", addr, clientTLS)
+	require.NoError(t, err, "valid client cert should be accepted")
+	_ = conn.Close()
+
+	// No client certificate → server requires one, handshake fails.
+	noCert := &tls.Config{RootCAs: clientTLS.RootCAs, MinVersion: tls.VersionTLS12, MaxVersion: tls.VersionTLS12}
+	_, err = tls.DialWithDialer(dialer, "tcp", addr, noCert)
+	require.Error(t, err, "absent client cert must be rejected")
+
+	// Client certificate signed by a DIFFERENT CA → verification fails.
+	otherCA, otherKey, _ := genCA(t)
+	otherMat := materialFromCA(t, otherCA, otherKey, "intruder", false)
+	otherMat.CAFile = serverMat.CAFile // still trust the real server
+	intruderTLS, err := ClientTLSConfig(otherMat)
+	require.NoError(t, err)
+	intruderTLS.MaxVersion = tls.VersionTLS12
+	_, err = tls.DialWithDialer(dialer, "tcp", addr, intruderTLS)
+	require.Error(t, err, "client cert from an untrusted CA must be rejected")
+
+	_ = caPEM // (CA PEM is written via materialFromCA; retained for clarity)
+}

--- a/internal/dispatch/mtls_test.go
+++ b/internal/dispatch/mtls_test.go
@@ -1,6 +1,7 @@
 package dispatch
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -128,14 +129,18 @@ func TestInternalMTLS_Handshake(t *testing.T) {
 			}
 			// Force the handshake so client-cert verification runs, then close.
 			if tc, ok := c.(*tls.Conn); ok {
-				_ = tc.Handshake()
+				_ = tc.HandshakeContext(context.Background())
 			}
 			_ = c.Close()
 		}
 	}()
 
 	addr := ln.Addr().String()
-	dialer := &net.Dialer{Timeout: 3 * time.Second}
+	ctx := context.Background()
+	dial := func(cfg *tls.Config) (net.Conn, error) {
+		d := tls.Dialer{NetDialer: &net.Dialer{Timeout: 3 * time.Second}, Config: cfg}
+		return d.DialContext(ctx, "tcp", addr)
+	}
 
 	// Pin TLS 1.2 on the dialing side: under TLS 1.3 a client-cert rejection is
 	// delivered as a post-handshake alert (surfacing on first I/O, not at Dial),
@@ -145,13 +150,13 @@ func TestInternalMTLS_Handshake(t *testing.T) {
 	clientTLS.MaxVersion = tls.VersionTLS12
 
 	// Valid client certificate → handshake succeeds.
-	conn, err := tls.DialWithDialer(dialer, "tcp", addr, clientTLS)
+	conn, err := dial(clientTLS)
 	require.NoError(t, err, "valid client cert should be accepted")
 	_ = conn.Close()
 
 	// No client certificate → server requires one, handshake fails.
 	noCert := &tls.Config{RootCAs: clientTLS.RootCAs, MinVersion: tls.VersionTLS12, MaxVersion: tls.VersionTLS12}
-	_, err = tls.DialWithDialer(dialer, "tcp", addr, noCert)
+	_, err = dial(noCert)
 	require.Error(t, err, "absent client cert must be rejected")
 
 	// Client certificate signed by a DIFFERENT CA → verification fails.
@@ -161,7 +166,7 @@ func TestInternalMTLS_Handshake(t *testing.T) {
 	intruderTLS, err := ClientTLSConfig(otherMat)
 	require.NoError(t, err)
 	intruderTLS.MaxVersion = tls.VersionTLS12
-	_, err = tls.DialWithDialer(dialer, "tcp", addr, intruderTLS)
+	_, err = dial(intruderTLS)
 	require.Error(t, err, "client cert from an untrusted CA must be rejected")
 
 	_ = caPEM // (CA PEM is written via materialFromCA; retained for clarity)

--- a/internal/job/failure_policy.go
+++ b/internal/job/failure_policy.go
@@ -114,75 +114,14 @@ func skipDescendantsFiltered(
 	}
 }
 
-// collectPredecessorStatuses returns the known statuses for the given set of
-// predecessor task IDs using the in-memory outcomes map.
+// collectPredecessorStatuses and satisfiesTriggerRule are thin wrappers over the
+// canonical implementations in internal/run, kept so the local executor's call
+// sites stay unchanged while the run-owner in-memory state machine shares the
+// exact same trigger-rule semantics (single source of truth in internal/run).
 func collectPredecessorStatuses(predIDs []uuid.UUID, taskOutcomes map[uuid.UUID]run.TaskStatus) []run.TaskStatus {
-	statuses := make([]run.TaskStatus, 0, len(predIDs))
-	for _, id := range predIDs {
-		if status, ok := taskOutcomes[id]; ok {
-			statuses = append(statuses, status)
-		}
-	}
-	return statuses
+	return run.CollectPredecessorStatuses(predIDs, taskOutcomes)
 }
 
-// satisfiesTriggerRule evaluates the trigger rule against the provided
-// predecessor statuses. It returns true when the task should run, false
-// when it should be skipped. An empty rule defaults to all_success.
 func satisfiesTriggerRule(rule string, predStatuses []run.TaskStatus) bool {
-	if rule == "" {
-		rule = jobdefschema.TriggerRuleAllSuccess
-	}
-
-	// A task with no predecessors always runs regardless of rule.
-	if len(predStatuses) == 0 {
-		return true
-	}
-
-	isTerminal := func(s run.TaskStatus) bool {
-		return s == run.TaskStatusSucceeded || s == run.TaskStatusCached || s == run.TaskStatusFailed || s == run.TaskStatusSkipped
-	}
-
-	switch rule {
-	case jobdefschema.TriggerRuleAllSuccess:
-		for _, s := range predStatuses {
-			if !run.IsTerminalSuccess(s) {
-				return false
-			}
-		}
-		return true
-
-	case jobdefschema.TriggerRuleAllDone, jobdefschema.TriggerRuleAlways:
-		for _, s := range predStatuses {
-			if !isTerminal(s) {
-				return false
-			}
-		}
-		return true
-
-	case jobdefschema.TriggerRuleAllFailed:
-		for _, s := range predStatuses {
-			if s != run.TaskStatusFailed {
-				return false
-			}
-		}
-		return true
-
-	case jobdefschema.TriggerRuleOneSuccess:
-		for _, s := range predStatuses {
-			if run.IsTerminalSuccess(s) {
-				return true
-			}
-		}
-		return false
-
-	default:
-		// Unknown rule: default to all_success behaviour.
-		for _, s := range predStatuses {
-			if !run.IsTerminalSuccess(s) {
-				return false
-			}
-		}
-		return true
-	}
+	return run.SatisfiesTriggerRule(rule, predStatuses)
 }

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -22,4 +22,8 @@ var All = []interface{}{
 	&NotificationPolicy{},
 	// Phase 2 run-owner coordination tables (catalog DB, cross-run, low-volume).
 	&RunLease{},
+	// run_checkpoints is per-run and lives with task_runs (catalog when
+	// unsharded, hot shard when sharded — see hotPathModels), so it is listed
+	// here for the unsharded case and in hotPathModels for the sharded case.
+	&RunCheckpoint{},
 }

--- a/internal/models/run.go
+++ b/internal/models/run.go
@@ -31,7 +31,7 @@ type JobRun struct {
 
 type TaskRun struct {
 	ID               uuid.UUID         `gorm:"type:uuid;primaryKey" json:"id"`
-	JobRunID         uuid.UUID         `gorm:"type:uuid;index:idx_taskrun_jobrun_task;index;not null" json:"job_run_id"`
+	JobRunID         uuid.UUID         `gorm:"type:uuid;index:idx_taskrun_jobrun_task;index;index:idx_taskrun_terminal_seq,priority:1;not null" json:"job_run_id"`
 	JobRun           JobRun            `gorm:"constraint:OnDelete:CASCADE" json:"-"`
 	TaskID           uuid.UUID         `gorm:"type:uuid;index:idx_taskrun_jobrun_task;index;not null" json:"task_id"`
 	Task             Task              `gorm:"constraint:OnDelete:CASCADE" json:"-"`
@@ -73,8 +73,16 @@ type TaskRun struct {
 	// includes AND (owner_generation = ? OR owner_generation = 0) in its WHERE
 	// clause — the OR = 0 keeps legacy rows (and flag-off rows) mutable by any
 	// node so the migration path stays gradual.  Defaults to 0.
-	OwnerGeneration int64      `gorm:"not null;default:0" json:"owner_generation,omitempty"`
-	StartedAt       *time.Time `json:"started_at,omitempty"`
+	OwnerGeneration int64 `gorm:"not null;default:0" json:"owner_generation,omitempty"`
+	// TerminalSequence is the per-run monotonic, dense sequence number stamped on
+	// a task_runs row when it reaches a terminal status under run-owner mode.  It
+	// shares a number space with run_checkpoints.sequence_high so failure
+	// recovery can replay "terminal rows since the last checkpoint" in a
+	// deterministic order (NOT wall-clock, which is skew-prone).  0 means
+	// "never stamped" (non-owner mode, or not yet terminal).  The composite index
+	// (job_run_id, terminal_sequence) makes the post-checkpoint tail scan cheap.
+	TerminalSequence int64      `gorm:"not null;default:0;index:idx_taskrun_terminal_seq,priority:2" json:"terminal_sequence,omitempty"`
+	StartedAt        *time.Time `json:"started_at,omitempty"`
 	CompletedAt     *time.Time `json:"completed_at,omitempty"`
 	CreatedAt       time.Time  `gorm:"not null" json:"created_at"`
 	UpdatedAt       time.Time  `gorm:"not null" json:"updated_at"`

--- a/internal/models/run_checkpoint.go
+++ b/internal/models/run_checkpoint.go
@@ -1,0 +1,45 @@
+package models
+
+import "time"
+
+// RunCheckpoint persists a point-in-time snapshot of an owner's in-memory DAG
+// state for a run (run-owner mode, CAESIUM_RUN_OWNER_ENABLED=true).  Combined
+// with the terminal task_runs rows written after the checkpoint
+// (terminal_sequence > sequence_high), it lets a new owner reconstruct exact
+// run state after the previous owner crashes — recovery bounded by the
+// checkpoint interval.
+//
+// Like task_runs, a checkpoint is per-run and transactionally local to its
+// run's other rows: it lives in the catalog DB when unsharded, and in the run's
+// hot shard when sharding is enabled (so it appears in both models.All and
+// hotPathModels).
+type RunCheckpoint struct {
+	// RunID identifies the job run.  Stored as text per existing GORM
+	// convention for run-owner tables.
+	RunID string `gorm:"type:text;primaryKey;index:idx_run_checkpoint_run_seq,priority:1" json:"run_id"`
+
+	// SequenceHigh is the highest terminal_sequence covered by this checkpoint.
+	// Recovery applies the checkpoint, then layers task_runs rows with a strictly
+	// greater terminal_sequence.  Part of the primary key so each run keeps a
+	// history of checkpoints (pruned on archival).
+	SequenceHigh int64 `gorm:"primaryKey;autoIncrement:false;index:idx_run_checkpoint_run_seq,priority:2" json:"sequence_high"`
+
+	// OwnerGeneration is the RunLease.Generation of the writing owner — a fence
+	// column so a stale owner's checkpoint can be distinguished from the current
+	// owner's during a takeover race.
+	OwnerGeneration int64 `gorm:"not null" json:"owner_generation"`
+
+	// StateBlob is the serialized RunState snapshot (or delta).  Encoding is an
+	// internal detail owned by the checkpoint writer/reader (JSON in v1); the
+	// column is opaque bytes.
+	StateBlob []byte `gorm:"type:blob;not null" json:"-"`
+
+	// IsIncremental is false for a full snapshot and true for a delta containing
+	// only the task states that changed since the prior checkpoint.  Recovery
+	// walks back to the most recent full snapshot and applies deltas forward.
+	IsIncremental bool `gorm:"not null;default:false" json:"is_incremental"`
+
+	// CreatedAt is the wall-clock write time (diagnostics only; ordering uses
+	// SequenceHigh, never timestamps).
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+}

--- a/internal/run/checkpoint_store.go
+++ b/internal/run/checkpoint_store.go
@@ -1,0 +1,99 @@
+package run
+
+import (
+	"errors"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// WriteCheckpoint persists a run_checkpoints row for runID.  sequenceHigh is the
+// highest terminal_sequence the snapshot covers; ownerGeneration fences the
+// write against a stale owner; blob is the serialized state (RunState.Snapshot);
+// incremental marks a delta vs a full snapshot.  Re-writing the same
+// (run_id, sequence_high) overwrites — checkpoints are idempotent at a sequence.
+func (s *Store) WriteCheckpoint(runID uuid.UUID, sequenceHigh, ownerGeneration int64, blob []byte, incremental bool) error {
+	cp := &models.RunCheckpoint{
+		RunID:           runID.String(),
+		SequenceHigh:    sequenceHigh,
+		OwnerGeneration: ownerGeneration,
+		StateBlob:       blob,
+		IsIncremental:   incremental,
+		CreatedAt:       time.Now().UTC(),
+	}
+	return withStoreBusyRetry(func() error {
+		return s.db.Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "run_id"}, {Name: "sequence_high"}},
+			UpdateAll: true,
+		}).Create(cp).Error
+	})
+}
+
+// LatestFullCheckpoint returns the highest-sequence full (non-incremental)
+// snapshot for runID, or (nil, nil) when the run has no checkpoint yet.
+func (s *Store) LatestFullCheckpoint(runID uuid.UUID) (*models.RunCheckpoint, error) {
+	var cp models.RunCheckpoint
+	err := s.db.
+		Where("run_id = ? AND is_incremental = ?", runID.String(), false).
+		Order("sequence_high DESC").
+		First(&cp).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &cp, nil
+}
+
+// CheckpointDeltasSince returns the incremental checkpoints with sequence_high
+// strictly greater than fromSeq, ascending, so recovery can apply them in order
+// after the most recent full snapshot.  (v1 writes only full snapshots, so this
+// normally returns empty; it exists so the recovery path is delta-ready.)
+func (s *Store) CheckpointDeltasSince(runID uuid.UUID, fromSeq int64) ([]models.RunCheckpoint, error) {
+	var deltas []models.RunCheckpoint
+	err := s.db.
+		Where("run_id = ? AND is_incremental = ? AND sequence_high > ?", runID.String(), true, fromSeq).
+		Order("sequence_high ASC").
+		Find(&deltas).Error
+	return deltas, err
+}
+
+// PruneCheckpoints retains the most recent keepFulls full snapshots for runID
+// (and every checkpoint at or after the oldest retained full's sequence),
+// deleting anything older.  A no-op until more than keepFulls fulls exist.
+func (s *Store) PruneCheckpoints(runID uuid.UUID, keepFulls int) error {
+	if keepFulls < 1 {
+		keepFulls = 1
+	}
+	var fullSeqs []int64
+	if err := s.db.Model(&models.RunCheckpoint{}).
+		Where("run_id = ? AND is_incremental = ?", runID.String(), false).
+		Order("sequence_high DESC").
+		Limit(keepFulls).
+		Pluck("sequence_high", &fullSeqs).Error; err != nil {
+		return err
+	}
+	if len(fullSeqs) < keepFulls {
+		return nil
+	}
+	threshold := fullSeqs[len(fullSeqs)-1] // oldest full we are keeping
+	return withStoreBusyRetry(func() error {
+		return s.db.
+			Where("run_id = ? AND sequence_high < ?", runID.String(), threshold).
+			Delete(&models.RunCheckpoint{}).Error
+	})
+}
+
+// DeleteCheckpoints removes all checkpoints for a run, called when a terminal
+// run is archived (the durable task_runs rows remain the system of record).
+func (s *Store) DeleteCheckpoints(runID uuid.UUID) error {
+	return withStoreBusyRetry(func() error {
+		return s.db.
+			Where("run_id = ?", runID.String()).
+			Delete(&models.RunCheckpoint{}).Error
+	})
+}

--- a/internal/run/checkpoint_store.go
+++ b/internal/run/checkpoint_store.go
@@ -88,6 +88,25 @@ func (s *Store) PruneCheckpoints(runID uuid.UUID, keepFulls int) error {
 	})
 }
 
+// TerminalTaskRunsSince returns the run's terminal task_runs rows with a
+// terminal_sequence strictly greater than afterSeq, ordered by terminal_sequence
+// ascending — the "post-checkpoint tail" a recovering owner replays on top of
+// the latest checkpoint.  Uses the (job_run_id, terminal_sequence) index.
+func (s *Store) TerminalTaskRunsSince(runID uuid.UUID, afterSeq int64) ([]models.TaskRun, error) {
+	var rows []models.TaskRun
+	err := s.db.
+		Where("job_run_id = ? AND terminal_sequence > ? AND status IN ?",
+			runID, afterSeq, []string{
+				string(TaskStatusSucceeded),
+				string(TaskStatusFailed),
+				string(TaskStatusSkipped),
+				string(TaskStatusCached),
+			}).
+		Order("terminal_sequence ASC").
+		Find(&rows).Error
+	return rows, err
+}
+
 // DeleteCheckpoints removes all checkpoints for a run, called when a terminal
 // run is archived (the durable task_runs rows remain the system of record).
 func (s *Store) DeleteCheckpoints(runID uuid.UUID) error {

--- a/internal/run/checkpoint_test.go
+++ b/internal/run/checkpoint_test.go
@@ -1,0 +1,190 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+func TestCheckpointStore_WriteLoadLatest(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	runID := uuid.New()
+
+	if cp, err := store.LatestFullCheckpoint(runID); err != nil || cp != nil {
+		t.Fatalf("expected no checkpoint yet, got cp=%v err=%v", cp, err)
+	}
+
+	if err := store.WriteCheckpoint(runID, 5, 1, []byte(`{"sequence":5}`), false); err != nil {
+		t.Fatalf("write checkpoint 5: %v", err)
+	}
+	if err := store.WriteCheckpoint(runID, 12, 1, []byte(`{"sequence":12}`), false); err != nil {
+		t.Fatalf("write checkpoint 12: %v", err)
+	}
+
+	cp, err := store.LatestFullCheckpoint(runID)
+	if err != nil || cp == nil {
+		t.Fatalf("expected a checkpoint, got cp=%v err=%v", cp, err)
+	}
+	if cp.SequenceHigh != 12 {
+		t.Fatalf("latest full should be seq 12, got %d", cp.SequenceHigh)
+	}
+	if string(cp.StateBlob) != `{"sequence":12}` {
+		t.Fatalf("blob mismatch: %s", cp.StateBlob)
+	}
+}
+
+func TestCheckpointStore_RewriteSameSequence(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	runID := uuid.New()
+
+	if err := store.WriteCheckpoint(runID, 7, 1, []byte("v1"), false); err != nil {
+		t.Fatal(err)
+	}
+	// Re-writing the same (run_id, sequence_high) overwrites, not errors.
+	if err := store.WriteCheckpoint(runID, 7, 2, []byte("v2"), false); err != nil {
+		t.Fatalf("rewrite at same sequence should upsert: %v", err)
+	}
+	cp, _ := store.LatestFullCheckpoint(runID)
+	if cp == nil || string(cp.StateBlob) != "v2" || cp.OwnerGeneration != 2 {
+		t.Fatalf("expected overwritten checkpoint v2/gen2, got %+v", cp)
+	}
+}
+
+func TestCheckpointStore_Prune(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	runID := uuid.New()
+
+	for _, seq := range []int64{1, 2, 3, 4, 5} {
+		if err := store.WriteCheckpoint(runID, seq, 1, []byte("x"), false); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := store.PruneCheckpoints(runID, 2); err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	// Only the 2 most recent fulls (4, 5) should remain.
+	var remaining []int64
+	if err := db.Model(&models.RunCheckpoint{}).
+		Where("run_id = ?", runID.String()).
+		Order("sequence_high ASC").
+		Pluck("sequence_high", &remaining).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(remaining) != 2 || remaining[0] != 4 || remaining[1] != 5 {
+		t.Fatalf("expected [4 5] after prune keep=2, got %v", remaining)
+	}
+
+	if err := store.DeleteCheckpoints(runID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if cp, _ := store.LatestFullCheckpoint(runID); cp != nil {
+		t.Fatal("expected no checkpoints after delete")
+	}
+}
+
+// fakePersister records WriteCheckpoint/PruneCheckpoints calls for writer tests.
+type fakePersister struct {
+	writes  int
+	prunes  int
+	lastSeq int64
+}
+
+func (f *fakePersister) WriteCheckpoint(_ uuid.UUID, seq, _ int64, _ []byte, _ bool) error {
+	f.writes++
+	f.lastSeq = seq
+	return nil
+}
+func (f *fakePersister) PruneCheckpoints(_ uuid.UUID, _ int) error {
+	f.prunes++
+	return nil
+}
+
+func singleTaskState(t *testing.T) *RunState {
+	t.Helper()
+	b := newTopoBuilder()
+	b.task("")
+	b.task("")
+	rs := NewRunState(b.build(), 0)
+	return rs
+}
+
+func TestCheckpointWriter_DueByEvents(t *testing.T) {
+	f := &fakePersister{}
+	w := NewCheckpointWriter(f, uuid.New(), CheckpointConfig{Events: 2, Interval: time.Hour, KeepFulls: 3})
+
+	rs := singleTaskState(t)
+	ids := rs.ReadyTasks()
+
+	// 1 terminal transition: below the events threshold (2), not due.
+	rs.ApplyCompletion(ids[0], TaskStatusSucceeded, nil)
+	if err := w.Maybe(rs, 1); err != nil {
+		t.Fatal(err)
+	}
+	if f.writes != 0 {
+		t.Fatalf("should not checkpoint after 1 event (threshold 2), writes=%d", f.writes)
+	}
+
+	// 2nd terminal transition reaches the threshold → checkpoint.
+	rs.ApplyCompletion(ids[1], TaskStatusSucceeded, nil)
+	if err := w.Maybe(rs, 1); err != nil {
+		t.Fatal(err)
+	}
+	if f.writes != 1 || f.prunes != 1 {
+		t.Fatalf("should checkpoint+prune at the events threshold, writes=%d prunes=%d", f.writes, f.prunes)
+	}
+	if f.lastSeq != 2 {
+		t.Fatalf("checkpoint should cover sequence 2, got %d", f.lastSeq)
+	}
+}
+
+func TestCheckpointWriter_DueByInterval(t *testing.T) {
+	f := &fakePersister{}
+	w := NewCheckpointWriter(f, uuid.New(), CheckpointConfig{Events: 1000, Interval: time.Second, KeepFulls: 3})
+
+	clock := time.Now()
+	w.now = func() time.Time { return clock }
+	w.lastAt = clock
+
+	rs := singleTaskState(t)
+	ids := rs.ReadyTasks()
+	rs.ApplyCompletion(ids[0], TaskStatusSucceeded, nil)
+
+	// Below the events threshold; no time elapsed → not due.
+	if err := w.Maybe(rs, 1); err != nil {
+		t.Fatal(err)
+	}
+	if f.writes != 0 {
+		t.Fatalf("not due before interval elapses, writes=%d", f.writes)
+	}
+
+	// Advance the clock past the interval → due by time.
+	clock = clock.Add(2 * time.Second)
+	if err := w.Maybe(rs, 1); err != nil {
+		t.Fatal(err)
+	}
+	if f.writes != 1 {
+		t.Fatalf("should checkpoint once the interval elapses, writes=%d", f.writes)
+	}
+}
+
+func TestCheckpointWriter_ForceAlwaysWrites(t *testing.T) {
+	f := &fakePersister{}
+	w := NewCheckpointWriter(f, uuid.New(), CheckpointConfig{Events: 1000, Interval: time.Hour, KeepFulls: 3})
+	rs := singleTaskState(t)
+
+	if err := w.Force(rs, 1); err != nil {
+		t.Fatal(err)
+	}
+	if f.writes != 1 {
+		t.Fatalf("Force should always write, writes=%d", f.writes)
+	}
+}

--- a/internal/run/checkpoint_writer.go
+++ b/internal/run/checkpoint_writer.go
@@ -1,0 +1,87 @@
+package run
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// checkpointPersister is the slice of *Store the writer depends on, named as an
+// interface so tests can substitute a fake.
+type checkpointPersister interface {
+	WriteCheckpoint(runID uuid.UUID, sequenceHigh, ownerGeneration int64, blob []byte, incremental bool) error
+	PruneCheckpoints(runID uuid.UUID, keepFulls int) error
+}
+
+// CheckpointConfig controls checkpoint cadence and retention.
+type CheckpointConfig struct {
+	Events    int           // checkpoint after this many new terminal transitions
+	Interval  time.Duration // ...or this much elapsed since the last checkpoint, whichever first
+	KeepFulls int           // full snapshots to retain when pruning
+}
+
+// CheckpointWriter persists a RunState snapshot on a cadence — whichever comes
+// first of Events new terminal transitions or Interval elapsed — and prunes old
+// checkpoints afterward.  One per owned run; the owner calls Maybe after
+// applying completions and Force on graceful handoff/shutdown.  v1 always writes
+// full snapshots (is_incremental=false); delta checkpoints are a later
+// optimization.  Not safe for concurrent use.
+type CheckpointWriter struct {
+	store   checkpointPersister
+	runID   uuid.UUID
+	cfg     CheckpointConfig
+	lastSeq int64
+	lastAt  time.Time
+	now     func() time.Time // injectable for tests
+}
+
+// NewCheckpointWriter builds a writer for runID; zero/negative config values
+// fall back to the design defaults (100 events, 2s, keep 3 fulls).
+func NewCheckpointWriter(store checkpointPersister, runID uuid.UUID, cfg CheckpointConfig) *CheckpointWriter {
+	if cfg.Events <= 0 {
+		cfg.Events = 100
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = 2 * time.Second
+	}
+	if cfg.KeepFulls <= 0 {
+		cfg.KeepFulls = 3
+	}
+	w := &CheckpointWriter{store: store, runID: runID, cfg: cfg, now: time.Now}
+	w.lastAt = w.now()
+	return w
+}
+
+// due reports whether a checkpoint should be written at the current sequence.
+func (w *CheckpointWriter) due(seq int64) bool {
+	if seq <= w.lastSeq {
+		return false // nothing new since the last checkpoint
+	}
+	if seq-w.lastSeq >= int64(w.cfg.Events) {
+		return true
+	}
+	return w.now().Sub(w.lastAt) >= w.cfg.Interval
+}
+
+// Maybe writes a checkpoint when the cadence threshold is met, else no-ops.
+func (w *CheckpointWriter) Maybe(rs *RunState, ownerGeneration int64) error {
+	if !w.due(rs.Sequence()) {
+		return nil
+	}
+	return w.Force(rs, ownerGeneration)
+}
+
+// Force writes a full checkpoint and prunes, regardless of cadence.
+func (w *CheckpointWriter) Force(rs *RunState, ownerGeneration int64) error {
+	blob, err := rs.Snapshot()
+	if err != nil {
+		return err
+	}
+	seq := rs.Sequence()
+	if err := w.store.WriteCheckpoint(w.runID, seq, ownerGeneration, blob, false); err != nil {
+		return err
+	}
+	w.lastSeq = seq
+	w.lastAt = w.now()
+	return w.store.PruneCheckpoints(w.runID, w.cfg.KeepFulls)
+}

--- a/internal/run/lease.go
+++ b/internal/run/lease.go
@@ -63,6 +63,39 @@ func (ls *LeaseStore) AcquireLease(ctx context.Context, runID uuid.UUID, ownerNo
 	return lease.Generation, nil
 }
 
+// AcquireExpiredLeases takes over every run lease whose holder let it expire
+// (lease_expires_at <= now), reassigning it to newOwner with an incremented
+// generation and a fresh expiry — in a single atomic UPDATE.  The expiry
+// predicate is the compare-and-swap: if two nodes sweep concurrently, the first
+// commit moves those rows out of the expired set, so the second updates nothing
+// (no double takeover).  Returns the number of leases taken over; the caller's
+// dispatch loop then sees them via OwnedRunsWithGenerations and recovers their
+// in-memory state from the latest checkpoint + terminal tail.
+//
+// This is the run-owner failover mechanism: in in-memory mode the DB's
+// per-task predecessor counters are stale (the owner advanced the DAG in
+// memory), so ClaimNext recovery does not apply — a peer must take ownership
+// and replay.
+func (ls *LeaseStore) AcquireExpiredLeases(ctx context.Context, newOwner string, ttl time.Duration) (int64, error) {
+	if ls == nil || ls.db == nil {
+		return 0, nil
+	}
+	now := time.Now().UTC()
+	result := ls.db.WithContext(ctx).
+		Model(&models.RunLease{}).
+		Where("lease_expires_at <= ? AND owner_node <> ?", now, newOwner).
+		Updates(map[string]interface{}{
+			"owner_node":       newOwner,
+			"acquired_at":      now,
+			"lease_expires_at": now.Add(ttl),
+			"generation":       gorm.Expr("generation + 1"),
+		})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
+}
+
 // RenewRunLeases performs a single batched UPDATE extending lease_expires_at
 // for every run in runIDs that is still owned by ownerNode.  The WHERE
 // clause on owner_node is the safety net that prevents renewing a lease that

--- a/internal/run/owner_complete_test.go
+++ b/internal/run/owner_complete_test.go
@@ -50,7 +50,7 @@ func TestCompleteTaskOwner_WritesTerminalRowsWithoutAdvancing(t *testing.T) {
 		runRecord.ID, taskA.ID, TaskStatusSucceeded, "success", "", "node-1",
 		map[string]string{"k": "v"}, nil,
 		5, 7,
-		[]OwnerSkip{{TaskID: taskB.ID, TerminalSequence: 6, Reason: "branch not selected"}},
+		[]SkippedTask{{TaskID: taskB.ID, TerminalSequence: 6, Reason: "branch not selected"}},
 	)
 	require.NoError(t, err)
 

--- a/internal/run/owner_complete_test.go
+++ b/internal/run/owner_complete_test.go
@@ -47,7 +47,7 @@ func TestCompleteTaskOwner_WritesTerminalRowsWithoutAdvancing(t *testing.T) {
 	mkRun(taskC, string(TaskStatusPending), "", 1)       // successor; must NOT be decremented
 
 	err = store.CompleteTaskOwner(
-		runRecord.ID, taskA.ID, TaskStatusSucceeded, "success", "node-1",
+		runRecord.ID, taskA.ID, TaskStatusSucceeded, "success", "", "node-1",
 		map[string]string{"k": "v"}, nil,
 		5, 7,
 		[]OwnerSkip{{TaskID: taskB.ID, TerminalSequence: 6, Reason: "branch not selected"}},
@@ -100,6 +100,6 @@ func TestCompleteTaskOwner_ClaimMismatch(t *testing.T) {
 	}).Error)
 
 	// A completion from a node that does not hold the claim is rejected.
-	err = store.CompleteTaskOwner(runRecord.ID, task.ID, TaskStatusSucceeded, "success", "wrong-node", nil, nil, 1, 1, nil)
+	err = store.CompleteTaskOwner(runRecord.ID, task.ID, TaskStatusSucceeded, "success", "", "wrong-node", nil, nil, 1, 1, nil)
 	require.ErrorIs(t, err, ErrTaskClaimMismatch)
 }

--- a/internal/run/owner_complete_test.go
+++ b/internal/run/owner_complete_test.go
@@ -103,3 +103,79 @@ func TestCompleteTaskOwner_ClaimMismatch(t *testing.T) {
 	err = store.CompleteTaskOwner(runRecord.ID, task.ID, TaskStatusSucceeded, "success", "", "wrong-node", nil, nil, 1, 1, nil)
 	require.ErrorIs(t, err, ErrTaskClaimMismatch)
 }
+
+// TestClaimTaskForDispatch_TrustOwnerReadiness covers the in-memory-mode claim:
+// the owner advanced the DAG in memory without decrementing the DB's
+// outstanding_predecessors, so a dispatched successor still shows outstanding>0
+// here.  trustOwnerReadiness=false (SQL mode) must reject it; true (in-memory
+// mode) must claim it.  This is the fix for the in-memory dispatch stall.
+func TestClaimTaskForDispatch_TrustOwnerReadiness(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	now := time.Now().UTC()
+
+	trigger := &models.Trigger{ID: uuid.New(), Alias: "claim-trig", Type: models.TriggerTypeCron, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(trigger).Error)
+	job := &models.Job{ID: uuid.New(), Alias: "claim-job", TriggerID: trigger.ID, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(job).Error)
+	runRecord, err := store.Start(job.ID, &trigger.ID)
+	require.NoError(t, err)
+	atom := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo"]`, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(atom).Error)
+	task := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "succ", CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(task).Error)
+
+	mk := func() {
+		require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runRecord.ID, task.ID).Delete(&models.TaskRun{}).Error)
+		require.NoError(t, db.Create(&models.TaskRun{
+			ID: uuid.New(), JobRunID: runRecord.ID, TaskID: task.ID, AtomID: atom.ID,
+			Engine: atom.Engine, Image: atom.Image, Command: atom.Command,
+			Status: string(TaskStatusPending), Attempt: 1, MaxAttempts: 1,
+			OutstandingPredecessors: 1, // not yet zero in the DB
+			CreatedAt: now, UpdatedAt: now,
+		}).Error)
+	}
+
+	// SQL mode: the predecessor check rejects a not-yet-ready successor.
+	mk()
+	err = store.ClaimTaskForDispatch(runRecord.ID, task.ID, "n1", 1, time.Minute, false)
+	require.ErrorIs(t, err, ErrTaskClaimMismatch, "SQL-mode claim must respect outstanding_predecessors")
+
+	// In-memory mode: trust the owner's readiness decision and claim anyway.
+	mk()
+	require.NoError(t, store.ClaimTaskForDispatch(runRecord.ID, task.ID, "n1", 1, time.Minute, true),
+		"in-memory-mode claim must succeed despite outstanding_predecessors>0")
+	var tr models.TaskRun
+	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runRecord.ID, task.ID).First(&tr).Error)
+	require.Equal(t, string(TaskStatusRunning), tr.Status)
+	require.Equal(t, "n1", tr.ClaimedBy)
+}
+
+// TestResetInFlightTasks_ClearsClaim verifies the recovery reset clears claimed_by
+// (not just status), so a new owner taking over a run can re-claim the rows the
+// dead owner held.
+func TestResetInFlightTasks_ClearsClaim(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	now := time.Now().UTC()
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{ID: runID, JobID: uuid.New(), Status: string(StatusRunning), CreatedAt: now, UpdatedAt: now}).Error)
+
+	expiry := now.Add(time.Minute)
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: runID, TaskID: uuid.New(), AtomID: uuid.New(),
+		Engine: models.AtomEngineDocker, Image: "x", Command: "x",
+		Status: string(TaskStatusRunning), ClaimedBy: "dead-worker:9001", ClaimExpiresAt: &expiry,
+		Attempt: 1, MaxAttempts: 1, CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	require.NoError(t, store.ResetInFlightTasks(runID))
+
+	var tr models.TaskRun
+	require.NoError(t, db.Where("job_run_id = ?", runID).First(&tr).Error)
+	require.Equal(t, string(TaskStatusPending), tr.Status, "running task must reset to pending")
+	require.Equal(t, "", tr.ClaimedBy, "claim must be cleared so a new owner can re-claim")
+	require.Nil(t, tr.ClaimExpiresAt, "claim expiry must be cleared")
+}

--- a/internal/run/owner_complete_test.go
+++ b/internal/run/owner_complete_test.go
@@ -47,7 +47,7 @@ func TestCompleteTaskOwner_WritesTerminalRowsWithoutAdvancing(t *testing.T) {
 	mkRun(taskC, string(TaskStatusPending), "", 1)       // successor; must NOT be decremented
 
 	err = store.CompleteTaskOwner(
-		runRecord.ID, taskA.ID, "success", "node-1",
+		runRecord.ID, taskA.ID, TaskStatusSucceeded, "success", "node-1",
 		map[string]string{"k": "v"}, nil,
 		5, 7,
 		[]OwnerSkip{{TaskID: taskB.ID, TerminalSequence: 6, Reason: "branch not selected"}},
@@ -100,6 +100,6 @@ func TestCompleteTaskOwner_ClaimMismatch(t *testing.T) {
 	}).Error)
 
 	// A completion from a node that does not hold the claim is rejected.
-	err = store.CompleteTaskOwner(runRecord.ID, task.ID, "success", "wrong-node", nil, nil, 1, 1, nil)
+	err = store.CompleteTaskOwner(runRecord.ID, task.ID, TaskStatusSucceeded, "success", "wrong-node", nil, nil, 1, 1, nil)
 	require.ErrorIs(t, err, ErrTaskClaimMismatch)
 }

--- a/internal/run/owner_complete_test.go
+++ b/internal/run/owner_complete_test.go
@@ -1,0 +1,105 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompleteTaskOwner_WritesTerminalRowsWithoutAdvancing verifies the owner
+// durable-write path: it stamps terminal_sequence + owner_generation on the
+// completed task and on owner-decided skips, but does NOT decrement a
+// successor's predecessor count (advancement is the owner's in-memory job).
+func TestCompleteTaskOwner_WritesTerminalRowsWithoutAdvancing(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	now := time.Now().UTC()
+
+	trigger := &models.Trigger{ID: uuid.New(), Alias: "own-trig", Type: models.TriggerTypeCron, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(trigger).Error)
+	job := &models.Job{ID: uuid.New(), Alias: "own-job", TriggerID: trigger.ID, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(job).Error)
+	runRecord, err := store.Start(job.ID, &trigger.ID)
+	require.NoError(t, err)
+	atom := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo","x"]`, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(atom).Error)
+
+	taskA := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "a", CreatedAt: now, UpdatedAt: now}
+	taskB := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "b", CreatedAt: now, UpdatedAt: now}
+	taskC := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "c", CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create([]*models.Task{taskA, taskB, taskC}).Error)
+
+	mkRun := func(task *models.Task, status string, claimedBy string, outstanding int) {
+		require.NoError(t, db.Create(&models.TaskRun{
+			ID: uuid.New(), JobRunID: runRecord.ID, TaskID: task.ID, AtomID: atom.ID,
+			Engine: atom.Engine, Image: atom.Image, Command: atom.Command,
+			Status: status, ClaimedBy: claimedBy, Attempt: 1, MaxAttempts: 1,
+			OutstandingPredecessors: outstanding, CreatedAt: now, UpdatedAt: now,
+		}).Error)
+	}
+	mkRun(taskA, string(TaskStatusRunning), "node-1", 0) // claimed + running
+	mkRun(taskB, string(TaskStatusPending), "", 1)       // will be owner-skipped
+	mkRun(taskC, string(TaskStatusPending), "", 1)       // successor; must NOT be decremented
+
+	err = store.CompleteTaskOwner(
+		runRecord.ID, taskA.ID, "success", "node-1",
+		map[string]string{"k": "v"}, nil,
+		5, 7,
+		[]OwnerSkip{{TaskID: taskB.ID, TerminalSequence: 6, Reason: "branch not selected"}},
+	)
+	require.NoError(t, err)
+
+	get := func(taskID uuid.UUID) models.TaskRun {
+		var tr models.TaskRun
+		require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runRecord.ID, taskID).First(&tr).Error)
+		return tr
+	}
+
+	a := get(taskA.ID)
+	require.Equal(t, string(TaskStatusSucceeded), a.Status)
+	require.Equal(t, int64(5), a.TerminalSequence)
+	require.Equal(t, int64(7), a.OwnerGeneration)
+
+	b := get(taskB.ID)
+	require.Equal(t, string(TaskStatusSkipped), b.Status)
+	require.Equal(t, int64(6), b.TerminalSequence)
+	require.Equal(t, int64(7), b.OwnerGeneration)
+
+	// The crucial assertion: C was NOT advanced — no SQL predecessor decrement.
+	c := get(taskC.ID)
+	require.Equal(t, 1, c.OutstandingPredecessors, "owner path must not decrement successors in SQL")
+	require.Equal(t, string(TaskStatusPending), c.Status)
+}
+
+func TestCompleteTaskOwner_ClaimMismatch(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	now := time.Now().UTC()
+
+	trigger := &models.Trigger{ID: uuid.New(), Alias: "own-trig2", Type: models.TriggerTypeCron, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(trigger).Error)
+	job := &models.Job{ID: uuid.New(), Alias: "own-job2", TriggerID: trigger.ID, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(job).Error)
+	runRecord, err := store.Start(job.ID, &trigger.ID)
+	require.NoError(t, err)
+	atom := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo","x"]`, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(atom).Error)
+	task := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "a", CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(task).Error)
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: runRecord.ID, TaskID: task.ID, AtomID: atom.ID,
+		Engine: atom.Engine, Image: atom.Image, Command: atom.Command,
+		Status: string(TaskStatusRunning), ClaimedBy: "node-1", Attempt: 1, MaxAttempts: 1,
+		CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	// A completion from a node that does not hold the claim is rejected.
+	err = store.CompleteTaskOwner(runRecord.ID, task.ID, "success", "wrong-node", nil, nil, 1, 1, nil)
+	require.ErrorIs(t, err, ErrTaskClaimMismatch)
+}

--- a/internal/run/owner_manager.go
+++ b/internal/run/owner_manager.go
@@ -97,13 +97,14 @@ func (m *OwnerManager) Recover(runID uuid.UUID, generation int64) (RecoveryResul
 	if err != nil {
 		return RecoveryResult{}, err
 	}
-	// Reset the DB rows of tasks left in-flight by the dead owner to pending so
-	// the re-dispatch (RecoveryResult.ReDispatch, already re-queued in RunState)
-	// can re-claim them.  Best-effort: a failure just delays the re-claim.
-	if len(res.ReDispatch) > 0 {
-		if rErr := m.store.ResetInFlightTasks(runID); rErr != nil {
-			log.Warn("owner manager: reset in-flight tasks failed", "run_id", runID, "error", rErr)
-		}
+	// Reset every DB row the dead owner left running back to pending (clearing
+	// the stale claim) so the new owner can re-dispatch+claim them.  Always run
+	// this, not just when RunState re-queued tasks: the checkpoint can lag the
+	// DB (the dead owner dispatched a task after its last checkpoint), so a row
+	// may be "running" in the DB while the recovered in-memory state shows it
+	// "ready".  Best-effort: a failure just delays the re-claim.
+	if rErr := m.store.ResetInFlightTasks(runID); rErr != nil {
+		log.Warn("owner manager: reset in-flight tasks failed", "run_id", runID, "error", rErr)
 	}
 	or := &ownedRun{
 		state:  rs,
@@ -113,6 +114,8 @@ func (m *OwnerManager) Recover(runID uuid.UUID, generation int64) (RecoveryResul
 	m.runs[runID] = or
 	// Persist a checkpoint stamped with the new generation immediately.
 	_ = or.writer.Force(rs, generation)
+	log.Info("run owner: recovered run on takeover", "run_id", runID, "generation", generation,
+		"ready", len(res.Ready), "redispatch", len(res.ReDispatch), "complete", res.Complete)
 	return res, nil
 }
 

--- a/internal/run/owner_manager.go
+++ b/internal/run/owner_manager.go
@@ -206,12 +206,7 @@ func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, resu
 
 	res := or.state.ApplyCompletion(taskID, status, branchSkips)
 
-	ownerSkips := make([]OwnerSkip, len(res.Skipped))
-	for i, sk := range res.Skipped {
-		ownerSkips[i] = OwnerSkip{TaskID: sk.TaskID, TerminalSequence: sk.TerminalSequence, Reason: sk.Reason}
-	}
-
-	if err := m.store.CompleteTaskOwner(runID, taskID, status, result, errMsg, claimedBy, output, branchSelections, res.TerminalSequence, or.gen, ownerSkips); err != nil {
+	if err := m.store.CompleteTaskOwner(runID, taskID, status, result, errMsg, claimedBy, output, branchSelections, res.TerminalSequence, or.gen, res.Skipped); err != nil {
 		return CompleteResult{Owned: true}, err
 	}
 

--- a/internal/run/owner_manager.go
+++ b/internal/run/owner_manager.go
@@ -1,0 +1,196 @@
+package run
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// OwnerManager holds the authoritative in-memory RunState for the runs this node
+// owns (run-owner in-memory mode, CAESIUM_RUN_OWNER_IN_MEMORY=true).  It is the
+// integration seam the dispatch loop and the /internal/complete handler call:
+//
+//   - Adopt(runID)   — seed a fresh RunState for a run this node just created.
+//   - Recover(runID) — rebuild a run's state from checkpoint + terminal tail on
+//                      lease takeover.
+//   - Ready(runID)   — the ready queue the dispatch loop pulls from.
+//   - MarkDispatched — record a task pushed to a worker.
+//   - Complete(...)  — apply a worker completion: advance the DAG in memory,
+//                      durably write only terminal rows, and checkpoint.
+//   - Drop(runID)    — release a run on completion or lease loss.
+//
+// Per-run mutation is serialized by the manager mutex, so RunState (which is not
+// itself concurrency-safe) is only ever touched under the lock.
+type OwnerManager struct {
+	store *Store
+	cfg   CheckpointConfig
+
+	mu   sync.Mutex
+	runs map[uuid.UUID]*ownedRun
+}
+
+type ownedRun struct {
+	state  *RunState
+	writer *CheckpointWriter
+	gen    int64
+}
+
+// NewOwnerManager builds a manager backed by store, using cfg for checkpoint
+// cadence and retention.
+func NewOwnerManager(store *Store, cfg CheckpointConfig) *OwnerManager {
+	return &OwnerManager{
+		store: store,
+		cfg:   cfg,
+		runs:  make(map[uuid.UUID]*ownedRun),
+	}
+}
+
+// Adopt seeds a fresh in-memory state for a run this node created and owns at
+// the given generation.  Topology is loaded from the catalog.  Idempotent: a
+// second Adopt for an already-tracked run is a no-op.
+func (m *OwnerManager) Adopt(runID uuid.UUID, generation int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.runs[runID]; ok {
+		return nil
+	}
+	topo, err := m.store.LoadRunTopology(runID)
+	if err != nil {
+		return err
+	}
+	m.runs[runID] = &ownedRun{
+		state:  NewRunState(topo, 0),
+		writer: NewCheckpointWriter(m.store, runID, m.cfg),
+		gen:    generation,
+	}
+	return nil
+}
+
+// Recover rebuilds a run's in-memory state after a lease takeover: it loads the
+// topology, the latest checkpoint, and the post-checkpoint terminal rows, then
+// reconstructs RunState.  The RecoveryResult tells the caller which tasks are
+// ready and which running tasks must be re-dispatched.  A forced checkpoint is
+// written immediately so the new generation's view is durable.
+func (m *OwnerManager) Recover(runID uuid.UUID, generation int64) (RecoveryResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	topo, err := m.store.LoadRunTopology(runID)
+	if err != nil {
+		return RecoveryResult{}, err
+	}
+	checkpoint, err := m.store.LatestFullCheckpoint(runID)
+	if err != nil {
+		return RecoveryResult{}, err
+	}
+	var afterSeq int64
+	if checkpoint != nil {
+		afterSeq = checkpoint.SequenceHigh
+	}
+	rows, err := m.store.TerminalTaskRunsSince(runID, afterSeq)
+	if err != nil {
+		return RecoveryResult{}, err
+	}
+	rs, res, err := RecoverRunState(topo, checkpoint, rows)
+	if err != nil {
+		return RecoveryResult{}, err
+	}
+	or := &ownedRun{
+		state:  rs,
+		writer: NewCheckpointWriter(m.store, runID, m.cfg),
+		gen:    generation,
+	}
+	m.runs[runID] = or
+	// Persist a checkpoint stamped with the new generation immediately.
+	_ = or.writer.Force(rs, generation)
+	return res, nil
+}
+
+// Owns reports whether this node is tracking in-memory state for the run.
+func (m *OwnerManager) Owns(runID uuid.UUID) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, ok := m.runs[runID]
+	return ok
+}
+
+// Ready returns the run's current ready queue in dispatch order, or nil if the
+// run is not owned by this node.
+func (m *OwnerManager) Ready(runID uuid.UUID) []uuid.UUID {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	or, ok := m.runs[runID]
+	if !ok {
+		return nil
+	}
+	return or.state.ReadyTasks()
+}
+
+// MarkDispatched records that a ready task was pushed to a worker.
+func (m *OwnerManager) MarkDispatched(runID, taskID uuid.UUID, worker string, attempt int, leaseExpiresAtMs int64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if or, ok := m.runs[runID]; ok {
+		or.state.MarkDispatched(taskID, worker, attempt, leaseExpiresAtMs)
+	}
+}
+
+// CompleteResult reports the outcome of applying a worker completion.
+type CompleteResult struct {
+	Ready    []uuid.UUID // tasks that newly became ready to dispatch
+	Complete bool        // the run reached a terminal state
+	Owned    bool        // false if this node does not own the run (caller should fall back)
+}
+
+// Complete applies a worker-reported terminal outcome to the owned run: it
+// resolves any branch skips, advances the in-memory DAG, durably writes the
+// terminal rows (completed task + skips) via CompleteTaskOwner, and checkpoints
+// on cadence.  Returns the newly-ready tasks and whether the run is complete.
+// Owned is false when this node does not own the run, signalling the caller to
+// fall back to the SQL path.
+func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, result, claimedBy string, output map[string]string, branchSelections []string) (CompleteResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	or, ok := m.runs[runID]
+	if !ok {
+		return CompleteResult{Owned: false}, nil
+	}
+
+	var branchSkips []uuid.UUID
+	if len(branchSelections) > 0 {
+		skips, err := m.store.ResolveBranchSkips(taskID, branchSelections)
+		if err != nil {
+			return CompleteResult{Owned: true}, err
+		}
+		branchSkips = skips
+	}
+
+	res := or.state.ApplyCompletion(taskID, status, branchSkips)
+
+	ownerSkips := make([]OwnerSkip, len(res.Skipped))
+	for i, sk := range res.Skipped {
+		ownerSkips[i] = OwnerSkip{TaskID: sk.TaskID, TerminalSequence: sk.TerminalSequence, Reason: sk.Reason}
+	}
+
+	if err := m.store.CompleteTaskOwner(runID, taskID, status, result, claimedBy, output, branchSelections, res.TerminalSequence, or.gen, ownerSkips); err != nil {
+		return CompleteResult{Owned: true}, err
+	}
+
+	// Checkpoint on cadence (best-effort: a failed checkpoint is recoverable from
+	// the durable terminal rows, so it must not fail the completion).
+	_ = or.writer.Maybe(or.state, or.gen)
+
+	return CompleteResult{Ready: res.Ready, Complete: res.Complete, Owned: true}, nil
+}
+
+// Drop releases the run's in-memory state (on completion or lease loss).  A
+// final checkpoint is forced so a subsequent takeover replays the least tail.
+func (m *OwnerManager) Drop(runID uuid.UUID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if or, ok := m.runs[runID]; ok {
+		_ = or.writer.Force(or.state, or.gen)
+		delete(m.runs, runID)
+	}
+}

--- a/internal/run/owner_manager.go
+++ b/internal/run/owner_manager.go
@@ -21,8 +21,12 @@ import (
 //                      durably write only terminal rows, and checkpoint.
 //   - Drop(runID)    — release a run on completion or lease loss.
 //
-// Per-run mutation is serialized by the manager mutex, so RunState (which is not
-// itself concurrency-safe) is only ever touched under the lock.
+// Concurrency: the global mu guards only the runs map (brief lookups / inserts /
+// deletes).  All per-run work — RunState mutation and the run's DB operations —
+// is serialized by that run's own ownedRun.mu, so different runs proceed
+// concurrently and a slow DB call for one run never blocks the others.  DB work
+// done while building a run (Adopt/Recover) runs before the run is published
+// into the map, so it holds no manager lock at all.
 type OwnerManager struct {
 	store *Store
 	cfg   CheckpointConfig
@@ -32,6 +36,7 @@ type OwnerManager struct {
 }
 
 type ownedRun struct {
+	mu     sync.Mutex
 	state  *RunState
 	writer *CheckpointWriter
 	gen    int64
@@ -47,36 +52,51 @@ func NewOwnerManager(store *Store, cfg CheckpointConfig) *OwnerManager {
 	}
 }
 
-// Adopt seeds a fresh in-memory state for a run this node created and owns at
-// the given generation.  Topology is loaded from the catalog.  Idempotent: a
-// second Adopt for an already-tracked run is a no-op.
-func (m *OwnerManager) Adopt(runID uuid.UUID, generation int64) error {
+// get returns the ownedRun for a run, holding the map lock only briefly.
+func (m *OwnerManager) get(runID uuid.UUID) (*ownedRun, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	or, ok := m.runs[runID]
+	return or, ok
+}
+
+// put publishes a freshly-built ownedRun into the map.  Idempotent: if the run
+// is already tracked it keeps the existing entry and reports false.
+func (m *OwnerManager) put(runID uuid.UUID, or *ownedRun) bool {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.runs[runID]; ok {
+		return false
+	}
+	m.runs[runID] = or
+	return true
+}
+
+// Adopt seeds a fresh in-memory state for a run this node created and owns at
+// the given generation.  Topology is loaded from the catalog (outside any lock).
+// Idempotent: a second Adopt for an already-tracked run is a no-op.
+func (m *OwnerManager) Adopt(runID uuid.UUID, generation int64) error {
+	if _, ok := m.get(runID); ok {
 		return nil
 	}
 	topo, err := m.store.LoadRunTopology(runID)
 	if err != nil {
 		return err
 	}
-	m.runs[runID] = &ownedRun{
+	m.put(runID, &ownedRun{
 		state:  NewRunState(topo, 0),
 		writer: NewCheckpointWriter(m.store, runID, m.cfg),
 		gen:    generation,
-	}
+	})
 	return nil
 }
 
 // Recover rebuilds a run's in-memory state after a lease takeover: it loads the
 // topology, the latest checkpoint, and the post-checkpoint terminal rows, then
-// reconstructs RunState.  The RecoveryResult tells the caller which tasks are
-// ready and which running tasks must be re-dispatched.  A forced checkpoint is
-// written immediately so the new generation's view is durable.
+// reconstructs RunState.  All of this runs outside any manager lock (the run is
+// not yet published).  The RecoveryResult tells the caller which tasks are ready
+// and which running tasks were re-queued for dispatch.
 func (m *OwnerManager) Recover(runID uuid.UUID, generation int64) (RecoveryResult, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	topo, err := m.store.LoadRunTopology(runID)
 	if err != nil {
 		return RecoveryResult{}, err
@@ -111,9 +131,9 @@ func (m *OwnerManager) Recover(runID uuid.UUID, generation int64) (RecoveryResul
 		writer: NewCheckpointWriter(m.store, runID, m.cfg),
 		gen:    generation,
 	}
-	m.runs[runID] = or
 	// Persist a checkpoint stamped with the new generation immediately.
 	_ = or.writer.Force(rs, generation)
+	m.put(runID, or)
 	log.Info("run owner: recovered run on takeover", "run_id", runID, "generation", generation,
 		"ready", len(res.Ready), "redispatch", len(res.ReDispatch), "complete", res.Complete)
 	return res, nil
@@ -121,21 +141,19 @@ func (m *OwnerManager) Recover(runID uuid.UUID, generation int64) (RecoveryResul
 
 // Owns reports whether this node is tracking in-memory state for the run.
 func (m *OwnerManager) Owns(runID uuid.UUID) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	_, ok := m.runs[runID]
+	_, ok := m.get(runID)
 	return ok
 }
 
 // Ready returns the run's current ready queue in dispatch order, or nil if the
 // run is not owned by this node.
 func (m *OwnerManager) Ready(runID uuid.UUID) []uuid.UUID {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	or, ok := m.runs[runID]
+	or, ok := m.get(runID)
 	if !ok {
 		return nil
 	}
+	or.mu.Lock()
+	defer or.mu.Unlock()
 	return or.state.ReadyTasks()
 }
 
@@ -149,12 +167,12 @@ type DispatchableTask struct {
 // ReadyForDispatch returns the run's ready tasks paired with their current
 // attempt, for the dispatch loop to push.  Nil if the run is not owned here.
 func (m *OwnerManager) ReadyForDispatch(runID uuid.UUID) []DispatchableTask {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	or, ok := m.runs[runID]
+	or, ok := m.get(runID)
 	if !ok {
 		return nil
 	}
+	or.mu.Lock()
+	defer or.mu.Unlock()
 	ready := or.state.ReadyTasks()
 	out := make([]DispatchableTask, 0, len(ready))
 	for _, id := range ready {
@@ -169,11 +187,13 @@ func (m *OwnerManager) ReadyForDispatch(runID uuid.UUID) []DispatchableTask {
 
 // MarkDispatched records that a ready task was pushed to a worker.
 func (m *OwnerManager) MarkDispatched(runID, taskID uuid.UUID, worker string, attempt int, leaseExpiresAtMs int64) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if or, ok := m.runs[runID]; ok {
-		or.state.MarkDispatched(taskID, worker, attempt, leaseExpiresAtMs)
+	or, ok := m.get(runID)
+	if !ok {
+		return
 	}
+	or.mu.Lock()
+	defer or.mu.Unlock()
+	or.state.MarkDispatched(taskID, worker, attempt, leaseExpiresAtMs)
 }
 
 // CompleteResult reports the outcome of applying a worker completion.
@@ -189,19 +209,22 @@ type CompleteResult struct {
 // on cadence.  Returns the newly-ready tasks and whether the run is complete.
 // Owned is false when this node does not own the run, signalling the caller to
 // fall back to the SQL path.
+//
+// All run work is serialized by the run's own lock; finalize/drop run after that
+// lock is released, so the brief map lock is never held during a DB call.
 func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, result, errMsg, claimedBy string, output map[string]string, branchSelections []string) (CompleteResult, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	or, ok := m.runs[runID]
+	or, ok := m.get(runID)
 	if !ok {
 		return CompleteResult{Owned: false}, nil
 	}
+
+	or.mu.Lock()
 
 	var branchSkips []uuid.UUID
 	if len(branchSelections) > 0 {
 		skips, err := m.store.ResolveBranchSkips(taskID, branchSelections)
 		if err != nil {
+			or.mu.Unlock()
 			return CompleteResult{Owned: true}, err
 		}
 		branchSkips = skips
@@ -210,6 +233,7 @@ func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, resu
 	res := or.state.ApplyCompletion(taskID, status, branchSkips)
 
 	if err := m.store.CompleteTaskOwner(runID, taskID, status, result, errMsg, claimedBy, output, branchSelections, res.TerminalSequence, or.gen, res.Skipped); err != nil {
+		or.mu.Unlock()
 		return CompleteResult{Owned: true}, err
 	}
 
@@ -217,39 +241,44 @@ func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, resu
 	// the durable terminal rows, so it must not fail the completion).
 	_ = or.writer.Maybe(or.state, or.gen)
 
-	// When the DAG is complete, finalize the run here.  This makes the owner the
+	complete := res.Complete
+	hasFailures := or.state.HasFailures()
+	or.mu.Unlock()
+
+	// When the DAG is complete, finalize the run.  This makes the owner the
 	// authoritative finalizer, which is essential after a takeover (the original
 	// node's waitForRunCompletion is gone); in the normal case the triggering
 	// node's waitForRunCompletion also calls store.Complete, which is an
-	// idempotent no-op once we have set the terminal status.
-	if res.Complete {
+	// idempotent no-op once we have set the terminal status.  Done after the run
+	// lock is released so the finalize DB call doesn't extend the critical
+	// section.
+	if complete {
 		var runErr error
-		if or.state.HasFailures() {
+		if hasFailures {
 			runErr = fmt.Errorf("run %s completed with failed task(s)", runID)
 		}
 		if cErr := m.store.Complete(runID, runErr); cErr != nil {
-			// Don't fail the completion on a finalize error — the terminal rows
-			// are durable and waitForRunCompletion / a later sweep will retry.
 			log.Error("owner manager: run finalize failed", "run_id", runID, "error", cErr)
 		}
-		m.dropLocked(runID)
+		m.Drop(runID)
 	}
 
-	return CompleteResult{Ready: res.Ready, Complete: res.Complete, Owned: true}, nil
+	return CompleteResult{Ready: res.Ready, Complete: complete, Owned: true}, nil
 }
 
 // Drop releases the run's in-memory state (on completion or lease loss).  A
 // final checkpoint is forced so a subsequent takeover replays the least tail.
 func (m *OwnerManager) Drop(runID uuid.UUID) {
 	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.dropLocked(runID)
-}
-
-// dropLocked releases a run; the caller must hold m.mu.
-func (m *OwnerManager) dropLocked(runID uuid.UUID) {
-	if or, ok := m.runs[runID]; ok {
-		_ = or.writer.Force(or.state, or.gen)
+	or, ok := m.runs[runID]
+	if ok {
 		delete(m.runs, runID)
 	}
+	m.mu.Unlock()
+	if !ok {
+		return
+	}
+	or.mu.Lock()
+	_ = or.writer.Force(or.state, or.gen)
+	or.mu.Unlock()
 }

--- a/internal/run/owner_manager.go
+++ b/internal/run/owner_manager.go
@@ -1,8 +1,10 @@
 package run
 
 import (
+	"fmt"
 	"sync"
 
+	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
 )
 
@@ -95,6 +97,14 @@ func (m *OwnerManager) Recover(runID uuid.UUID, generation int64) (RecoveryResul
 	if err != nil {
 		return RecoveryResult{}, err
 	}
+	// Reset the DB rows of tasks left in-flight by the dead owner to pending so
+	// the re-dispatch (RecoveryResult.ReDispatch, already re-queued in RunState)
+	// can re-claim them.  Best-effort: a failure just delays the re-claim.
+	if len(res.ReDispatch) > 0 {
+		if rErr := m.store.ResetInFlightTasks(runID); rErr != nil {
+			log.Warn("owner manager: reset in-flight tasks failed", "run_id", runID, "error", rErr)
+		}
+	}
 	or := &ownedRun{
 		state:  rs,
 		writer: NewCheckpointWriter(m.store, runID, m.cfg),
@@ -126,6 +136,34 @@ func (m *OwnerManager) Ready(runID uuid.UUID) []uuid.UUID {
 	return or.state.ReadyTasks()
 }
 
+// DispatchableTask is a ready task plus the attempt number to stamp on its
+// dispatch (1 for a first run, incremented for a re-dispatch after recovery).
+type DispatchableTask struct {
+	TaskID  uuid.UUID
+	Attempt int
+}
+
+// ReadyForDispatch returns the run's ready tasks paired with their current
+// attempt, for the dispatch loop to push.  Nil if the run is not owned here.
+func (m *OwnerManager) ReadyForDispatch(runID uuid.UUID) []DispatchableTask {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	or, ok := m.runs[runID]
+	if !ok {
+		return nil
+	}
+	ready := or.state.ReadyTasks()
+	out := make([]DispatchableTask, 0, len(ready))
+	for _, id := range ready {
+		attempt := 1
+		if st, ok := or.state.TaskState(id); ok && st.Attempt > 0 {
+			attempt = st.Attempt
+		}
+		out = append(out, DispatchableTask{TaskID: id, Attempt: attempt})
+	}
+	return out
+}
+
 // MarkDispatched records that a ready task was pushed to a worker.
 func (m *OwnerManager) MarkDispatched(runID, taskID uuid.UUID, worker string, attempt int, leaseExpiresAtMs int64) {
 	m.mu.Lock()
@@ -148,7 +186,7 @@ type CompleteResult struct {
 // on cadence.  Returns the newly-ready tasks and whether the run is complete.
 // Owned is false when this node does not own the run, signalling the caller to
 // fall back to the SQL path.
-func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, result, claimedBy string, output map[string]string, branchSelections []string) (CompleteResult, error) {
+func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, result, errMsg, claimedBy string, output map[string]string, branchSelections []string) (CompleteResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -173,13 +211,31 @@ func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, resu
 		ownerSkips[i] = OwnerSkip{TaskID: sk.TaskID, TerminalSequence: sk.TerminalSequence, Reason: sk.Reason}
 	}
 
-	if err := m.store.CompleteTaskOwner(runID, taskID, status, result, claimedBy, output, branchSelections, res.TerminalSequence, or.gen, ownerSkips); err != nil {
+	if err := m.store.CompleteTaskOwner(runID, taskID, status, result, errMsg, claimedBy, output, branchSelections, res.TerminalSequence, or.gen, ownerSkips); err != nil {
 		return CompleteResult{Owned: true}, err
 	}
 
 	// Checkpoint on cadence (best-effort: a failed checkpoint is recoverable from
 	// the durable terminal rows, so it must not fail the completion).
 	_ = or.writer.Maybe(or.state, or.gen)
+
+	// When the DAG is complete, finalize the run here.  This makes the owner the
+	// authoritative finalizer, which is essential after a takeover (the original
+	// node's waitForRunCompletion is gone); in the normal case the triggering
+	// node's waitForRunCompletion also calls store.Complete, which is an
+	// idempotent no-op once we have set the terminal status.
+	if res.Complete {
+		var runErr error
+		if or.state.HasFailures() {
+			runErr = fmt.Errorf("run %s completed with failed task(s)", runID)
+		}
+		if cErr := m.store.Complete(runID, runErr); cErr != nil {
+			// Don't fail the completion on a finalize error — the terminal rows
+			// are durable and waitForRunCompletion / a later sweep will retry.
+			log.Error("owner manager: run finalize failed", "run_id", runID, "error", cErr)
+		}
+		m.dropLocked(runID)
+	}
 
 	return CompleteResult{Ready: res.Ready, Complete: res.Complete, Owned: true}, nil
 }
@@ -189,6 +245,11 @@ func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, resu
 func (m *OwnerManager) Drop(runID uuid.UUID) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.dropLocked(runID)
+}
+
+// dropLocked releases a run; the caller must hold m.mu.
+func (m *OwnerManager) dropLocked(runID uuid.UUID) {
 	if or, ok := m.runs[runID]; ok {
 		_ = or.writer.Force(or.state, or.gen)
 		delete(m.runs, runID)

--- a/internal/run/owner_manager_test.go
+++ b/internal/run/owner_manager_test.go
@@ -79,6 +79,46 @@ func TestOwnerManager_AdoptCompleteAdvancesAndCheckpoints(t *testing.T) {
 	require.True(t, res.Complete, "run should be complete after b")
 }
 
+// TestOwnerManager_RecoverThenLoopFlow mimics the live wiring exactly: the
+// dispatch loop Recovers an owned run (not Adopt), pulls ReadyForDispatch,
+// MarkDispatched, then a completion arrives via Complete.  This reproduces the
+// production path to catch wiring/persistence bugs the Adopt-based test misses.
+func TestOwnerManager_RecoverThenLoopFlow(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	runID, taskA, taskB := seedTwoTaskRun(t, db, store, "node-1")
+
+	mgr := NewOwnerManager(store, CheckpointConfig{Events: 1, Interval: time.Hour, KeepFulls: 3})
+
+	// Loop tick 1: not owned yet → Recover, then dispatch the ready root.
+	require.False(t, mgr.Owns(runID))
+	_, err := mgr.Recover(runID, 1)
+	require.NoError(t, err)
+	require.True(t, mgr.Owns(runID), "Recover must persist the run in the manager")
+
+	ready := mgr.ReadyForDispatch(runID)
+	require.Len(t, ready, 1)
+	require.Equal(t, taskA, ready[0].TaskID, "root a should be ready after recover")
+
+	mgr.MarkDispatched(runID, taskA, "node-1", 1, 0)
+	require.Empty(t, mgr.ReadyForDispatch(runID), "dispatched root must leave the ready queue")
+
+	// Loop tick 2: still owned → must NOT re-Recover (which would discard state).
+	require.True(t, mgr.Owns(runID), "run must stay owned across ticks")
+
+	// Completion arrives at HandleComplete → Complete.
+	res, err := mgr.Complete(runID, taskA, TaskStatusSucceeded, "success", "", "node-1", nil, nil)
+	require.NoError(t, err)
+	require.True(t, res.Owned, "the run is owned, completion must take the in-memory path")
+	require.Equal(t, []uuid.UUID{taskB}, res.Ready, "completing a must advance and ready b")
+
+	var aRow models.TaskRun
+	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runID, taskA).First(&aRow).Error)
+	require.Equal(t, string(TaskStatusSucceeded), aRow.Status)
+	require.Greater(t, aRow.TerminalSequence, int64(0), "owner completion must stamp a terminal_sequence > 0")
+}
+
 func TestOwnerManager_CompleteUnownedRunFallsBack(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })

--- a/internal/run/owner_manager_test.go
+++ b/internal/run/owner_manager_test.go
@@ -56,7 +56,7 @@ func TestOwnerManager_AdoptCompleteAdvancesAndCheckpoints(t *testing.T) {
 	ready := mgr.Ready(runID)
 	require.Equal(t, []uuid.UUID{taskA}, ready, "root task a should be ready after adopt")
 
-	res, err := mgr.Complete(runID, taskA, TaskStatusSucceeded, "success", "node-1", nil, nil)
+	res, err := mgr.Complete(runID, taskA, TaskStatusSucceeded, "success", "", "node-1", nil, nil)
 	require.NoError(t, err)
 	require.True(t, res.Owned)
 	require.False(t, res.Complete)
@@ -74,7 +74,7 @@ func TestOwnerManager_AdoptCompleteAdvancesAndCheckpoints(t *testing.T) {
 	require.NotNil(t, cp, "a checkpoint should have been written")
 
 	// Completing b finishes the run.
-	res, err = mgr.Complete(runID, taskB, TaskStatusSucceeded, "success", "", nil, nil)
+	res, err = mgr.Complete(runID, taskB, TaskStatusSucceeded, "success", "", "", nil, nil)
 	require.NoError(t, err)
 	require.True(t, res.Complete, "run should be complete after b")
 }
@@ -85,7 +85,7 @@ func TestOwnerManager_CompleteUnownedRunFallsBack(t *testing.T) {
 	store := NewStore(db)
 	mgr := NewOwnerManager(store, CheckpointConfig{})
 
-	res, err := mgr.Complete(uuid.New(), uuid.New(), TaskStatusSucceeded, "success", "n", nil, nil)
+	res, err := mgr.Complete(uuid.New(), uuid.New(), TaskStatusSucceeded, "success", "", "n", nil, nil)
 	require.NoError(t, err)
 	require.False(t, res.Owned, "an unowned run must report Owned=false so the caller falls back")
 }

--- a/internal/run/owner_manager_test.go
+++ b/internal/run/owner_manager_test.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -117,6 +118,62 @@ func TestOwnerManager_RecoverThenLoopFlow(t *testing.T) {
 	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runID, taskA).First(&aRow).Error)
 	require.Equal(t, string(TaskStatusSucceeded), aRow.Status)
 	require.Greater(t, aRow.TerminalSequence, int64(0), "owner completion must stamp a terminal_sequence > 0")
+}
+
+// TestOwnerManager_ConcurrentRunsNoDeadlock exercises several runs through the
+// manager concurrently (adopt, ready, dispatch, complete) to validate the
+// per-run-mutex design: independent runs must proceed in parallel without
+// deadlock or data race (run with -race).
+func TestOwnerManager_ConcurrentRunsNoDeadlock(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	mgr := NewOwnerManager(store, CheckpointConfig{Events: 1, Interval: time.Hour, KeepFulls: 3})
+
+	const runs = 8
+	type runInfo struct {
+		runID, a, b uuid.UUID
+	}
+	infos := make([]runInfo, runs)
+	for i := range infos {
+		rid, a, b := seedTwoTaskRun(t, db, store, "node-1")
+		// Simulate both tasks having been claimed by this node (HandleDispatch
+		// does this in the real flow) so the owner-completion claim fence passes.
+		require.NoError(t, db.Model(&models.TaskRun{}).Where("job_run_id = ?", rid).Update("claimed_by", "node-1").Error)
+		infos[i] = runInfo{rid, a, b}
+		require.NoError(t, mgr.Adopt(rid, 1))
+	}
+
+	var wg sync.WaitGroup
+	for _, info := range infos {
+		wg.Add(1)
+		go func(info runInfo) {
+			defer wg.Done()
+			// Drive the run to completion through the manager API concurrently.
+			_ = mgr.ReadyForDispatch(info.runID)
+			mgr.MarkDispatched(info.runID, info.a, "node-1", 1, 0)
+			if _, err := mgr.Complete(info.runID, info.a, TaskStatusSucceeded, "success", "", "node-1", nil, nil); err != nil {
+				t.Errorf("complete a: %v", err)
+			}
+			mgr.MarkDispatched(info.runID, info.b, "node-1", 1, 0)
+			if _, err := mgr.Complete(info.runID, info.b, TaskStatusSucceeded, "success", "", "node-1", nil, nil); err != nil {
+				t.Errorf("complete b: %v", err)
+			}
+		}(info)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("concurrent run operations deadlocked")
+	}
+
+	// Every run finished and was dropped on completion.
+	for _, info := range infos {
+		require.False(t, mgr.Owns(info.runID), "completed run should be dropped: %s", info.runID)
+	}
 }
 
 func TestOwnerManager_CompleteUnownedRunFallsBack(t *testing.T) {

--- a/internal/run/owner_manager_test.go
+++ b/internal/run/owner_manager_test.go
@@ -1,0 +1,91 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedTwoTaskRun creates a job with tasks a -> b (edge) and pending task_runs,
+// returning the run ID and the two task IDs.  Task a is claimed by claimedBy.
+func seedTwoTaskRun(t *testing.T, db *gorm.DB, store *Store, claimedBy string) (uuid.UUID, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	now := time.Now().UTC()
+	trigger := &models.Trigger{ID: uuid.New(), Alias: "om-trig-" + uuid.NewString()[:8], Type: models.TriggerTypeCron, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(trigger).Error)
+	job := &models.Job{ID: uuid.New(), Alias: "om-job-" + uuid.NewString()[:8], TriggerID: trigger.ID, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(job).Error)
+	runRecord, err := store.Start(job.ID, &trigger.ID)
+	require.NoError(t, err)
+	atom := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo","x"]`, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(atom).Error)
+
+	a := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "a", Position: 0, CreatedAt: now, UpdatedAt: now}
+	b := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atom.ID, Name: "b", Position: 1, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create([]*models.Task{a, b}).Error)
+	require.NoError(t, db.Create(&models.TaskEdge{ID: uuid.New(), JobID: job.ID, FromTaskID: a.ID, ToTaskID: b.ID, CreatedAt: now}).Error)
+
+	mk := func(task *models.Task, claimed string, outstanding int) {
+		require.NoError(t, db.Create(&models.TaskRun{
+			ID: uuid.New(), JobRunID: runRecord.ID, TaskID: task.ID, AtomID: atom.ID,
+			Engine: atom.Engine, Image: atom.Image, Command: atom.Command,
+			Status: string(TaskStatusPending), ClaimedBy: claimed, Attempt: 1, MaxAttempts: 1,
+			OutstandingPredecessors: outstanding, CreatedAt: now, UpdatedAt: now,
+		}).Error)
+	}
+	mk(a, claimedBy, 0)
+	mk(b, "", 1)
+	return runRecord.ID, a.ID, b.ID
+}
+
+func TestOwnerManager_AdoptCompleteAdvancesAndCheckpoints(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	runID, taskA, taskB := seedTwoTaskRun(t, db, store, "node-1")
+
+	// Events:1 so every completion triggers a checkpoint (easy to assert).
+	mgr := NewOwnerManager(store, CheckpointConfig{Events: 1, Interval: time.Hour, KeepFulls: 3})
+	require.NoError(t, mgr.Adopt(runID, 1))
+
+	ready := mgr.Ready(runID)
+	require.Equal(t, []uuid.UUID{taskA}, ready, "root task a should be ready after adopt")
+
+	res, err := mgr.Complete(runID, taskA, TaskStatusSucceeded, "success", "node-1", nil, nil)
+	require.NoError(t, err)
+	require.True(t, res.Owned)
+	require.False(t, res.Complete)
+	require.Equal(t, []uuid.UUID{taskB}, res.Ready, "completing a should ready b")
+
+	// a's terminal row is durably written with terminal_sequence stamped.
+	var aRow models.TaskRun
+	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runID, taskA).First(&aRow).Error)
+	require.Equal(t, string(TaskStatusSucceeded), aRow.Status)
+	require.Equal(t, int64(1), aRow.TerminalSequence)
+
+	// A checkpoint was written (Events:1 cadence).
+	cp, err := store.LatestFullCheckpoint(runID)
+	require.NoError(t, err)
+	require.NotNil(t, cp, "a checkpoint should have been written")
+
+	// Completing b finishes the run.
+	res, err = mgr.Complete(runID, taskB, TaskStatusSucceeded, "success", "", nil, nil)
+	require.NoError(t, err)
+	require.True(t, res.Complete, "run should be complete after b")
+}
+
+func TestOwnerManager_CompleteUnownedRunFallsBack(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	mgr := NewOwnerManager(store, CheckpointConfig{})
+
+	res, err := mgr.Complete(uuid.New(), uuid.New(), TaskStatusSucceeded, "success", "n", nil, nil)
+	require.NoError(t, err)
+	require.False(t, res.Owned, "an unowned run must report Owned=false so the caller falls back")
+}

--- a/internal/run/owner_state.go
+++ b/internal/run/owner_state.go
@@ -232,6 +232,74 @@ func (rs *RunState) advanceSuccessors(seeds []uuid.UUID) (ready []uuid.UUID, ski
 	return ready, skipped
 }
 
+// ApplyTerminalRow applies a terminal task_runs row observed during recovery
+// replay.  Unlike ApplyCompletion it does NOT allocate a new sequence (it adopts
+// the row's stored sequence) and does NOT auto-skip unsatisfied successors —
+// every skip was itself persisted as a terminal row and arrives in sequence
+// order, so re-deriving skips here would double-handle them.  It sets the task's
+// terminal status, advances the cursor, and pushes any successor whose trigger
+// rule is now satisfied.  Returns the newly-ready successors.  Idempotent for a
+// task already terminal in the restored snapshot.
+func (rs *RunState) ApplyTerminalRow(taskID uuid.UUID, status TaskStatus, storedSeq int64) []uuid.UUID {
+	if storedSeq > rs.seq {
+		rs.seq = storedSeq
+	}
+	ts := rs.tasks[taskID]
+	if ts == nil {
+		return nil
+	}
+	wasTerminal := IsTerminal(ts.Status)
+	ts.Status = status
+	ts.ClaimedBy = ""
+	ts.LeaseExpiresAtMs = 0
+	rs.outcomes[taskID] = status
+	rs.removeReady(taskID)
+	if !wasTerminal {
+		rs.terminalCount++
+	} else {
+		// Already counted in the snapshot; nothing new to advance.
+		return nil
+	}
+
+	var ready []uuid.UUID
+	for _, succ := range rs.topo.Adjacency[taskID] {
+		st := rs.tasks[succ]
+		if st == nil || IsTerminal(st.Status) {
+			continue
+		}
+		if rs.indegree[succ] > 0 {
+			rs.indegree[succ]--
+		}
+		if rs.indegree[succ] != 0 {
+			continue
+		}
+		predStatuses := CollectPredecessorStatuses(rs.topo.Predecessors[succ], rs.outcomes)
+		if SatisfiesTriggerRule(rs.topo.TriggerRule[succ], predStatuses) {
+			rs.pushReady(succ)
+			ready = append(ready, succ)
+		}
+		// Unsatisfied trigger: leave pending — its own skipped terminal row will
+		// arrive later in sequence order and be applied here.
+	}
+	return ready
+}
+
+// RunningTasks returns the IDs of tasks currently in the running state — used
+// during recovery to identify in-flight work a dead owner had dispatched, which
+// the new owner must re-dispatch.
+func (rs *RunState) RunningTasks() []uuid.UUID {
+	var out []uuid.UUID
+	for id, ts := range rs.tasks {
+		if ts.Status == TaskStatusRunning {
+			out = append(out, id)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return rs.topo.Order[out[i]] < rs.topo.Order[out[j]]
+	})
+	return out
+}
+
 // MarkDispatched records that a ready task was pushed to a worker: it leaves the
 // ready queue and becomes running with the given claim metadata.
 func (rs *RunState) MarkDispatched(taskID uuid.UUID, claimedBy string, attempt int, leaseExpiresAtMs int64) {

--- a/internal/run/owner_state.go
+++ b/internal/run/owner_state.go
@@ -1,0 +1,331 @@
+package run
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+)
+
+// OwnerTaskState is the per-task state the run owner holds in memory for a run
+// it owns (run-owner mode).  It mirrors the subset of task_runs columns the
+// owner needs to coordinate dispatch and reconstruct after a crash.
+type OwnerTaskState struct {
+	Status           TaskStatus `json:"status"`
+	Attempt          int        `json:"attempt"`
+	ClaimedBy        string     `json:"claimed_by,omitempty"`
+	LeaseExpiresAtMs int64      `json:"lease_expires_at_ms,omitempty"`
+}
+
+// RunTopology is the immutable DAG shape for a run, loaded once at construction.
+// Every task ID must appear as a key in Order (it is the authoritative task
+// set); Adjacency/Predecessors/TriggerRule may omit tasks with no edges/rule.
+type RunTopology struct {
+	Adjacency    map[uuid.UUID][]uuid.UUID // task -> direct successors
+	Predecessors map[uuid.UUID][]uuid.UUID // task -> direct predecessors
+	TriggerRule  map[uuid.UUID]string      // task -> trigger rule ("" = all_success)
+	Order        map[uuid.UUID]int         // task -> deterministic dispatch order
+}
+
+// SkippedTask records a task the owner transitioned to skipped (a DAG decision,
+// never reported by a worker) along with the terminal_sequence stamped on it.
+type SkippedTask struct {
+	TaskID           uuid.UUID
+	TerminalSequence int64
+	Reason           string
+}
+
+// CompletionResult is what ApplyCompletion returns: the sequence stamped on the
+// completed task, the tasks that newly became ready to dispatch, the tasks the
+// owner skipped as a consequence, and whether the run is now complete.
+type CompletionResult struct {
+	TerminalSequence int64
+	Ready            []uuid.UUID
+	Skipped          []SkippedTask
+	Complete         bool
+}
+
+// RunState is the run owner's authoritative in-memory DAG state for one run.
+//
+// It reproduces the advancement semantics of the local executor
+// (internal/job): a completion decrements each successor's outstanding
+// predecessor count, and when a successor reaches zero it either becomes ready
+// (its trigger rule is satisfied by the predecessor outcomes) or is skipped and
+// the skip propagates downstream.  The terminal vocabulary and trigger-rule
+// evaluation are shared with the local path (run.IsTerminal,
+// run.SatisfiesTriggerRule) so the two cannot diverge.
+//
+// Branch selection (a branch task choosing which successors run) is applied by
+// the caller passing the non-selected successor IDs to ApplyCompletion as
+// branchSkipped; resolving branch names to task IDs is the owner integration's
+// responsibility, not this engine's.
+//
+// RunState is not safe for concurrent use; the owner serializes mutations.
+type RunState struct {
+	topo          RunTopology
+	tasks         map[uuid.UUID]*OwnerTaskState
+	indegree      map[uuid.UUID]int
+	outcomes      map[uuid.UUID]TaskStatus // terminal outcomes, for trigger-rule eval
+	ready         []uuid.UUID
+	inReady       map[uuid.UUID]bool
+	seq           int64 // per-run terminal_sequence cursor (monotonic, dense)
+	terminalCount int
+	total         int
+}
+
+// NewRunState builds a fresh RunState for a run that has not started executing:
+// every task is pending with indegree equal to its predecessor count, and tasks
+// with no predecessors are seeded into the ready queue.  startSeq is the
+// terminal_sequence to count up from (0 for a new run; the checkpoint's
+// sequence_high when seeding before replay).
+func NewRunState(topo RunTopology, startSeq int64) *RunState {
+	rs := &RunState{
+		topo:     topo,
+		tasks:    make(map[uuid.UUID]*OwnerTaskState, len(topo.Order)),
+		indegree: make(map[uuid.UUID]int, len(topo.Order)),
+		outcomes: make(map[uuid.UUID]TaskStatus),
+		inReady:  make(map[uuid.UUID]bool),
+		seq:      startSeq,
+	}
+	for id := range topo.Order {
+		rs.tasks[id] = &OwnerTaskState{Status: TaskStatusPending, Attempt: 1}
+		rs.indegree[id] = len(topo.Predecessors[id])
+		rs.total++
+	}
+	for id := range rs.tasks {
+		if rs.indegree[id] == 0 {
+			rs.pushReady(id)
+		}
+	}
+	return rs
+}
+
+// pushReady adds a pending task to the ready queue (idempotent), keeping the
+// queue ordered by the topology's deterministic Order so dispatch is stable.
+func (rs *RunState) pushReady(id uuid.UUID) {
+	if rs.inReady[id] {
+		return
+	}
+	if ts := rs.tasks[id]; ts == nil || IsTerminal(ts.Status) {
+		return
+	}
+	rs.ready = append(rs.ready, id)
+	rs.inReady[id] = true
+	sort.SliceStable(rs.ready, func(i, j int) bool {
+		return rs.topo.Order[rs.ready[i]] < rs.topo.Order[rs.ready[j]]
+	})
+}
+
+func (rs *RunState) removeReady(id uuid.UUID) {
+	if !rs.inReady[id] {
+		return
+	}
+	delete(rs.inReady, id)
+	for i, r := range rs.ready {
+		if r == id {
+			rs.ready = append(rs.ready[:i], rs.ready[i+1:]...)
+			return
+		}
+	}
+}
+
+// markTerminal sets a task's terminal status, records its outcome, allocates and
+// stamps the next terminal_sequence, removes it from the ready queue, and bumps
+// the terminal count.  Returns the stamped sequence.  No-op (returns 0) if the
+// task is unknown or already terminal.
+func (rs *RunState) markTerminal(id uuid.UUID, status TaskStatus) int64 {
+	ts := rs.tasks[id]
+	if ts == nil || IsTerminal(ts.Status) {
+		return 0
+	}
+	rs.seq++
+	ts.Status = status
+	ts.ClaimedBy = ""
+	ts.LeaseExpiresAtMs = 0
+	rs.outcomes[id] = status
+	rs.removeReady(id)
+	rs.terminalCount++
+	return rs.seq
+}
+
+// ApplyCompletion records a worker-reported terminal outcome for taskID and
+// advances the DAG.  branchSkipped lists the task's immediate successors that a
+// branch decision excluded (nil for non-branch tasks); they are skipped and the
+// skip propagates.  Remaining successors have their predecessor count
+// decremented and, on reaching zero, are pushed ready or skipped per their
+// trigger rule.  Returns the sequence stamped on taskID plus the newly ready and
+// skipped tasks.  Applying a completion to an unknown or already-terminal task
+// is a no-op.
+func (rs *RunState) ApplyCompletion(taskID uuid.UUID, status TaskStatus, branchSkipped []uuid.UUID) CompletionResult {
+	var res CompletionResult
+	ts := rs.tasks[taskID]
+	if ts == nil || IsTerminal(ts.Status) {
+		res.Complete = rs.terminalCount >= rs.total
+		return res
+	}
+
+	res.TerminalSequence = rs.markTerminal(taskID, status)
+
+	seeds := []uuid.UUID{taskID}
+	for _, b := range branchSkipped {
+		st := rs.tasks[b]
+		if st == nil || IsTerminal(st.Status) {
+			continue
+		}
+		seq := rs.markTerminal(b, TaskStatusSkipped)
+		res.Skipped = append(res.Skipped, SkippedTask{
+			TaskID:           b,
+			TerminalSequence: seq,
+			Reason:           "branch not selected",
+		})
+		seeds = append(seeds, b)
+	}
+
+	ready, skipped := rs.advanceSuccessors(seeds)
+	res.Ready = ready
+	res.Skipped = append(res.Skipped, skipped...)
+	res.Complete = rs.terminalCount >= rs.total
+	return res
+}
+
+// advanceSuccessors performs the breadth-first DAG advancement shared by the
+// success and skip paths: for each newly-terminal task, decrement each
+// non-terminal successor's predecessor count, and when it reaches zero either
+// push it ready (trigger rule satisfied) or skip it and enqueue the skip to
+// propagate downstream.  This mirrors the local executor's propagateSkipped +
+// successor-decrement loops exactly.
+func (rs *RunState) advanceSuccessors(seeds []uuid.UUID) (ready []uuid.UUID, skipped []SkippedTask) {
+	queue := append([]uuid.UUID{}, seeds...)
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		for _, succ := range rs.topo.Adjacency[current] {
+			st := rs.tasks[succ]
+			if st == nil || IsTerminal(st.Status) {
+				continue
+			}
+			if rs.indegree[succ] > 0 {
+				rs.indegree[succ]--
+			}
+			if rs.indegree[succ] != 0 {
+				continue
+			}
+
+			predStatuses := CollectPredecessorStatuses(rs.topo.Predecessors[succ], rs.outcomes)
+			if SatisfiesTriggerRule(rs.topo.TriggerRule[succ], predStatuses) {
+				rs.pushReady(succ)
+				ready = append(ready, succ)
+				continue
+			}
+
+			seq := rs.markTerminal(succ, TaskStatusSkipped)
+			skipped = append(skipped, SkippedTask{
+				TaskID:           succ,
+				TerminalSequence: seq,
+				Reason:           fmt.Sprintf("trigger rule %q not satisfied", rs.topo.TriggerRule[succ]),
+			})
+			queue = append(queue, succ)
+		}
+	}
+	return ready, skipped
+}
+
+// MarkDispatched records that a ready task was pushed to a worker: it leaves the
+// ready queue and becomes running with the given claim metadata.
+func (rs *RunState) MarkDispatched(taskID uuid.UUID, claimedBy string, attempt int, leaseExpiresAtMs int64) {
+	ts := rs.tasks[taskID]
+	if ts == nil || IsTerminal(ts.Status) {
+		return
+	}
+	ts.Status = TaskStatusRunning
+	ts.ClaimedBy = claimedBy
+	ts.Attempt = attempt
+	ts.LeaseExpiresAtMs = leaseExpiresAtMs
+	rs.removeReady(taskID)
+}
+
+// ReadyTasks returns a copy of the current ready queue in dispatch order.
+func (rs *RunState) ReadyTasks() []uuid.UUID {
+	out := make([]uuid.UUID, len(rs.ready))
+	copy(out, rs.ready)
+	return out
+}
+
+// TaskState returns a copy of a task's current state, or false if unknown.
+func (rs *RunState) TaskState(id uuid.UUID) (OwnerTaskState, bool) {
+	ts, ok := rs.tasks[id]
+	if !ok {
+		return OwnerTaskState{}, false
+	}
+	return *ts, true
+}
+
+// IsComplete reports whether every task in the run has reached a terminal state.
+func (rs *RunState) IsComplete() bool { return rs.terminalCount >= rs.total }
+
+// Sequence returns the current terminal_sequence cursor (the highest stamped).
+func (rs *RunState) Sequence() int64 { return rs.seq }
+
+// runStateSnapshot is the JSON-serializable form of a RunState's mutable state,
+// persisted in a run_checkpoints row.  Topology is NOT serialized — it is
+// reloaded from the catalog on recovery (constant for the run's lifetime).
+type runStateSnapshot struct {
+	Tasks         map[uuid.UUID]*OwnerTaskState `json:"tasks"`
+	Indegree      map[uuid.UUID]int             `json:"indegree"`
+	Outcomes      map[uuid.UUID]TaskStatus      `json:"outcomes"`
+	Ready         []uuid.UUID                   `json:"ready"`
+	Sequence      int64                         `json:"sequence"`
+	TerminalCount int                           `json:"terminal_count"`
+	Total         int                           `json:"total"`
+}
+
+// Snapshot serializes the mutable run state to a checkpoint blob (JSON in v1).
+// The active-only / incremental size optimizations from the design are layered
+// by the checkpoint writer; this produces a complete, self-contained snapshot.
+func (rs *RunState) Snapshot() ([]byte, error) {
+	snap := runStateSnapshot{
+		Tasks:         rs.tasks,
+		Indegree:      rs.indegree,
+		Outcomes:      rs.outcomes,
+		Ready:         rs.ready,
+		Sequence:      rs.seq,
+		TerminalCount: rs.terminalCount,
+		Total:         rs.total,
+	}
+	return json.Marshal(snap)
+}
+
+// Restore rebuilds a RunState from a checkpoint blob produced by Snapshot,
+// rehydrating the immutable topology from topo (reloaded from the catalog).
+func Restore(topo RunTopology, blob []byte) (*RunState, error) {
+	var snap runStateSnapshot
+	if err := json.Unmarshal(blob, &snap); err != nil {
+		return nil, fmt.Errorf("run state: unmarshal checkpoint: %w", err)
+	}
+	rs := &RunState{
+		topo:          topo,
+		tasks:         snap.Tasks,
+		indegree:      snap.Indegree,
+		outcomes:      snap.Outcomes,
+		ready:         snap.Ready,
+		inReady:       make(map[uuid.UUID]bool, len(snap.Ready)),
+		seq:           snap.Sequence,
+		terminalCount: snap.TerminalCount,
+		total:         snap.Total,
+	}
+	if rs.tasks == nil {
+		rs.tasks = make(map[uuid.UUID]*OwnerTaskState)
+	}
+	if rs.indegree == nil {
+		rs.indegree = make(map[uuid.UUID]int)
+	}
+	if rs.outcomes == nil {
+		rs.outcomes = make(map[uuid.UUID]TaskStatus)
+	}
+	for _, id := range rs.ready {
+		rs.inReady[id] = true
+	}
+	return rs, nil
+}

--- a/internal/run/owner_state.go
+++ b/internal/run/owner_state.go
@@ -300,6 +300,23 @@ func (rs *RunState) RunningTasks() []uuid.UUID {
 	return out
 }
 
+// requeueRunning moves every task left running (in-flight when the previous
+// owner died, with no terminal row) back to pending and onto the ready queue
+// with an incremented attempt, returning their IDs in dispatch order.  Recovery
+// calls this so lost in-flight work is re-dispatched fresh.
+func (rs *RunState) requeueRunning() []uuid.UUID {
+	out := rs.RunningTasks()
+	for _, id := range out {
+		ts := rs.tasks[id]
+		ts.Status = TaskStatusPending
+		ts.Attempt++
+		ts.ClaimedBy = ""
+		ts.LeaseExpiresAtMs = 0
+		rs.pushReady(id)
+	}
+	return out
+}
+
 // MarkDispatched records that a ready task was pushed to a worker: it leaves the
 // ready queue and becomes running with the given claim metadata.
 func (rs *RunState) MarkDispatched(taskID uuid.UUID, claimedBy string, attempt int, leaseExpiresAtMs int64) {
@@ -332,6 +349,17 @@ func (rs *RunState) TaskState(id uuid.UUID) (OwnerTaskState, bool) {
 
 // IsComplete reports whether every task in the run has reached a terminal state.
 func (rs *RunState) IsComplete() bool { return rs.terminalCount >= rs.total }
+
+// HasFailures reports whether any task reached the failed terminal state — used
+// to decide the run's final status when the DAG completes.
+func (rs *RunState) HasFailures() bool {
+	for _, status := range rs.outcomes {
+		if status == TaskStatusFailed {
+			return true
+		}
+	}
+	return false
+}
 
 // Sequence returns the current terminal_sequence cursor (the highest stamped).
 func (rs *RunState) Sequence() int64 { return rs.seq }

--- a/internal/run/owner_state_test.go
+++ b/internal/run/owner_state_test.go
@@ -1,0 +1,295 @@
+package run
+
+import (
+	"sort"
+	"testing"
+
+	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+)
+
+// topoBuilder assembles a RunTopology from named tasks, edges, and rules.
+type topoBuilder struct {
+	ids   []uuid.UUID
+	edges [][2]uuid.UUID
+	rules map[uuid.UUID]string
+}
+
+func newTopoBuilder() *topoBuilder { return &topoBuilder{rules: map[uuid.UUID]string{}} }
+
+func (b *topoBuilder) task(rule string) uuid.UUID {
+	id := uuid.New()
+	b.ids = append(b.ids, id)
+	if rule != "" {
+		b.rules[id] = rule
+	}
+	return id
+}
+
+func (b *topoBuilder) edge(from, to uuid.UUID) { b.edges = append(b.edges, [2]uuid.UUID{from, to}) }
+
+func (b *topoBuilder) build() RunTopology {
+	adj := make(map[uuid.UUID][]uuid.UUID, len(b.ids))
+	pred := make(map[uuid.UUID][]uuid.UUID, len(b.ids))
+	order := make(map[uuid.UUID]int, len(b.ids))
+	for i, id := range b.ids {
+		adj[id] = nil
+		pred[id] = nil
+		order[id] = i
+	}
+	for _, e := range b.edges {
+		adj[e[0]] = append(adj[e[0]], e[1])
+		pred[e[1]] = append(pred[e[1]], e[0])
+	}
+	return RunTopology{Adjacency: adj, Predecessors: pred, TriggerRule: b.rules, Order: order}
+}
+
+func contains(ids []uuid.UUID, want uuid.UUID) bool {
+	for _, id := range ids {
+		if id == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRunState_LinearChain(t *testing.T) {
+	b := newTopoBuilder()
+	a, c1, c2 := b.task(""), b.task(""), b.task("")
+	b.edge(a, c1)
+	b.edge(c1, c2)
+	rs := NewRunState(b.build(), 0)
+
+	if got := rs.ReadyTasks(); len(got) != 1 || got[0] != a {
+		t.Fatalf("expected [a] ready at start, got %v", got)
+	}
+
+	r := rs.ApplyCompletion(a, TaskStatusSucceeded, nil)
+	if !contains(r.Ready, c1) || len(r.Ready) != 1 {
+		t.Fatalf("completing a should ready c1, got %v", r.Ready)
+	}
+	if r.TerminalSequence != 1 {
+		t.Fatalf("first terminal sequence should be 1, got %d", r.TerminalSequence)
+	}
+	if r.Complete {
+		t.Fatal("run not complete after a")
+	}
+
+	r = rs.ApplyCompletion(c1, TaskStatusSucceeded, nil)
+	if !contains(r.Ready, c2) {
+		t.Fatalf("completing c1 should ready c2, got %v", r.Ready)
+	}
+
+	r = rs.ApplyCompletion(c2, TaskStatusSucceeded, nil)
+	if !r.Complete {
+		t.Fatal("run should be complete after c2")
+	}
+	if r.TerminalSequence != 3 {
+		t.Fatalf("third terminal sequence should be 3, got %d", r.TerminalSequence)
+	}
+}
+
+func TestRunState_FanOutFanIn(t *testing.T) {
+	b := newTopoBuilder()
+	a, l, r2, j := b.task(""), b.task(""), b.task(""), b.task("")
+	b.edge(a, l)
+	b.edge(a, r2)
+	b.edge(l, j)
+	b.edge(r2, j)
+	rs := NewRunState(b.build(), 0)
+
+	res := rs.ApplyCompletion(a, TaskStatusSucceeded, nil)
+	if len(res.Ready) != 2 || !contains(res.Ready, l) || !contains(res.Ready, r2) {
+		t.Fatalf("fan-out should ready both l and r2, got %v", res.Ready)
+	}
+
+	// j has two predecessors; first completion must NOT ready it.
+	res = rs.ApplyCompletion(l, TaskStatusSucceeded, nil)
+	if contains(res.Ready, j) {
+		t.Fatalf("j must wait for both predecessors, got %v", res.Ready)
+	}
+	res = rs.ApplyCompletion(r2, TaskStatusSucceeded, nil)
+	if !contains(res.Ready, j) {
+		t.Fatalf("j should ready after both predecessors, got %v", res.Ready)
+	}
+}
+
+func TestRunState_AllSuccessSkipsOnFailure(t *testing.T) {
+	b := newTopoBuilder()
+	a, c := b.task(""), b.task(jobdefschema.TriggerRuleAllSuccess)
+	b.edge(a, c)
+	rs := NewRunState(b.build(), 0)
+
+	res := rs.ApplyCompletion(a, TaskStatusFailed, nil)
+	if len(res.Ready) != 0 {
+		t.Fatalf("c must not be ready when predecessor failed (all_success), got %v", res.Ready)
+	}
+	if len(res.Skipped) != 1 || res.Skipped[0].TaskID != c {
+		t.Fatalf("c should be skipped, got %v", res.Skipped)
+	}
+	if !res.Complete {
+		t.Fatal("run should be complete (a failed, c skipped)")
+	}
+	if res.Skipped[0].TerminalSequence != 2 {
+		t.Fatalf("skip sequence should be 2 (after a=1), got %d", res.Skipped[0].TerminalSequence)
+	}
+}
+
+func TestRunState_AllDoneRunsAfterFailure(t *testing.T) {
+	b := newTopoBuilder()
+	a, c := b.task(""), b.task(jobdefschema.TriggerRuleAllDone)
+	b.edge(a, c)
+	rs := NewRunState(b.build(), 0)
+
+	res := rs.ApplyCompletion(a, TaskStatusFailed, nil)
+	if !contains(res.Ready, c) {
+		t.Fatalf("all_done successor should run even after failure, got ready=%v skipped=%v", res.Ready, res.Skipped)
+	}
+}
+
+func TestRunState_OneSuccess(t *testing.T) {
+	b := newTopoBuilder()
+	a, a2, c := b.task(""), b.task(""), b.task(jobdefschema.TriggerRuleOneSuccess)
+	b.edge(a, c)
+	b.edge(a2, c)
+	rs := NewRunState(b.build(), 0)
+
+	rs.ApplyCompletion(a, TaskStatusFailed, nil)
+	res := rs.ApplyCompletion(a2, TaskStatusSucceeded, nil)
+	if !contains(res.Ready, c) {
+		t.Fatalf("one_success should run when at least one predecessor succeeded, got %v", res.Ready)
+	}
+}
+
+func TestRunState_SkipPropagates(t *testing.T) {
+	// a -> b (all_success) -> c (all_success); a fails => b skipped => c skipped.
+	b := newTopoBuilder()
+	a := b.task("")
+	bb := b.task(jobdefschema.TriggerRuleAllSuccess)
+	c := b.task(jobdefschema.TriggerRuleAllSuccess)
+	b.edge(a, bb)
+	b.edge(bb, c)
+	rs := NewRunState(b.build(), 0)
+
+	res := rs.ApplyCompletion(a, TaskStatusFailed, nil)
+	if len(res.Skipped) != 2 {
+		t.Fatalf("both b and c should skip-propagate, got %v", res.Skipped)
+	}
+	skippedIDs := []uuid.UUID{res.Skipped[0].TaskID, res.Skipped[1].TaskID}
+	if !contains(skippedIDs, bb) || !contains(skippedIDs, c) {
+		t.Fatalf("expected b and c skipped, got %v", skippedIDs)
+	}
+	if !res.Complete {
+		t.Fatal("run should be complete")
+	}
+}
+
+func TestRunState_BranchSkipped(t *testing.T) {
+	// a -> b, a -> c.  a completes selecting only b; c is branch-skipped.
+	b := newTopoBuilder()
+	a, br, c := b.task(""), b.task(""), b.task("")
+	b.edge(a, br)
+	b.edge(a, c)
+	rs := NewRunState(b.build(), 0)
+
+	res := rs.ApplyCompletion(a, TaskStatusSucceeded, []uuid.UUID{c})
+	if !contains(res.Ready, br) {
+		t.Fatalf("selected branch b should be ready, got %v", res.Ready)
+	}
+	if contains(res.Ready, c) {
+		t.Fatalf("non-selected branch c must not be ready, got %v", res.Ready)
+	}
+	if len(res.Skipped) != 1 || res.Skipped[0].TaskID != c {
+		t.Fatalf("c should be branch-skipped, got %v", res.Skipped)
+	}
+}
+
+func TestRunState_MarkDispatchedLeavesReady(t *testing.T) {
+	b := newTopoBuilder()
+	a := b.task("")
+	rs := NewRunState(b.build(), 0)
+
+	rs.MarkDispatched(a, "10.0.0.1:9001", 1, 12345)
+	if len(rs.ReadyTasks()) != 0 {
+		t.Fatal("dispatched task should leave the ready queue")
+	}
+	st, ok := rs.TaskState(a)
+	if !ok || st.Status != TaskStatusRunning || st.ClaimedBy != "10.0.0.1:9001" {
+		t.Fatalf("dispatched task state wrong: %+v ok=%v", st, ok)
+	}
+}
+
+func TestRunState_ApplyCompletionIdempotentOnTerminal(t *testing.T) {
+	b := newTopoBuilder()
+	a, c := b.task(""), b.task("")
+	b.edge(a, c)
+	rs := NewRunState(b.build(), 0)
+
+	rs.ApplyCompletion(a, TaskStatusSucceeded, nil)
+	seqBefore := rs.Sequence()
+	// Re-applying a's completion must not double-advance or re-stamp.
+	res := rs.ApplyCompletion(a, TaskStatusSucceeded, nil)
+	if res.TerminalSequence != 0 {
+		t.Fatalf("re-completing a terminal task should not stamp a sequence, got %d", res.TerminalSequence)
+	}
+	if rs.Sequence() != seqBefore {
+		t.Fatalf("sequence should not advance on duplicate completion: before=%d after=%d", seqBefore, rs.Sequence())
+	}
+}
+
+func TestRunState_SnapshotRestoreRoundTrip(t *testing.T) {
+	b := newTopoBuilder()
+	a, l, r2, j := b.task(""), b.task(""), b.task(""), b.task("")
+	b.edge(a, l)
+	b.edge(a, r2)
+	b.edge(l, j)
+	b.edge(r2, j)
+	topo := b.build()
+	rs := NewRunState(topo, 0)
+
+	rs.ApplyCompletion(a, TaskStatusSucceeded, nil)
+	rs.MarkDispatched(l, "node-1", 1, 999)
+	rs.ApplyCompletion(r2, TaskStatusSucceeded, nil)
+
+	blob, err := rs.Snapshot()
+	if err != nil {
+		t.Fatalf("snapshot: %v", err)
+	}
+	restored, err := Restore(topo, blob)
+	if err != nil {
+		t.Fatalf("restore: %v", err)
+	}
+
+	if restored.Sequence() != rs.Sequence() {
+		t.Fatalf("sequence mismatch: %d vs %d", restored.Sequence(), rs.Sequence())
+	}
+	if restored.IsComplete() != rs.IsComplete() {
+		t.Fatal("completeness mismatch after restore")
+	}
+
+	// Ready sets must match immediately after restore (before any divergent
+	// mutation): both have l running (dispatched), r2 + a terminal, j waiting.
+	pre := rs.ReadyTasks()
+	post := restored.ReadyTasks()
+	sortIDs(pre)
+	sortIDs(post)
+	if len(pre) != len(post) {
+		t.Fatalf("ready set size mismatch after restore: %d vs %d", len(pre), len(post))
+	}
+	for i := range pre {
+		if pre[i] != post[i] {
+			t.Fatalf("ready set mismatch after restore: %v vs %v", pre, post)
+		}
+	}
+
+	// Advancement survives the round-trip: completing the still-running l on the
+	// restored state should ready the join task j.
+	res := restored.ApplyCompletion(l, TaskStatusSucceeded, nil)
+	if !contains(res.Ready, j) {
+		t.Fatalf("restored state should ready j after l completes, got %v", res.Ready)
+	}
+}
+
+func sortIDs(ids []uuid.UUID) {
+	sort.Slice(ids, func(i, j int) bool { return ids[i].String() < ids[j].String() })
+}

--- a/internal/run/owner_topology.go
+++ b/internal/run/owner_topology.go
@@ -1,0 +1,124 @@
+package run
+
+import (
+	"fmt"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+)
+
+// LoadRunTopology reads a run's immutable DAG shape from the catalog — the tasks
+// and edges of its job — and builds the RunTopology the owner's in-memory
+// RunState needs.  Edge resolution (including the implicit sequential fallback
+// when a job declares no explicit edges) reuses successorEdgesTx, so the graph
+// matches exactly what the local executor and completeTask see.
+func (s *Store) LoadRunTopology(runID uuid.UUID) (RunTopology, error) {
+	var jobRun models.JobRun
+	if err := s.db.Select("job_id").First(&jobRun, "id = ?", runID).Error; err != nil {
+		return RunTopology{}, fmt.Errorf("run topology: job run %s: %w", runID, err)
+	}
+
+	var tasks []models.Task
+	if err := s.db.
+		Where("job_id = ?", jobRun.JobID).
+		Order("position asc").
+		Order("created_at asc").
+		Find(&tasks).Error; err != nil {
+		return RunTopology{}, err
+	}
+
+	topo := RunTopology{
+		Adjacency:    make(map[uuid.UUID][]uuid.UUID, len(tasks)),
+		Predecessors: make(map[uuid.UUID][]uuid.UUID, len(tasks)),
+		TriggerRule:  make(map[uuid.UUID]string, len(tasks)),
+		Order:        make(map[uuid.UUID]int, len(tasks)),
+	}
+	for i := range tasks {
+		t := &tasks[i]
+		topo.Adjacency[t.ID] = nil
+		topo.Predecessors[t.ID] = nil
+		topo.Order[t.ID] = i
+		rule := t.TriggerRule
+		if rule == "" {
+			rule = jobdefschema.TriggerRuleAllSuccess
+		}
+		topo.TriggerRule[t.ID] = rule
+	}
+
+	for i := range tasks {
+		t := &tasks[i]
+		edges, err := s.successorEdgesTx(s.db, *t)
+		if err != nil {
+			return RunTopology{}, err
+		}
+		for _, e := range edges {
+			to := e.ToTaskID
+			if _, ok := topo.Adjacency[to]; !ok {
+				continue
+			}
+			topo.Adjacency[t.ID] = append(topo.Adjacency[t.ID], to)
+			topo.Predecessors[to] = append(topo.Predecessors[to], t.ID)
+		}
+	}
+
+	return topo, nil
+}
+
+// ResolveBranchSkips returns the immediate successor task IDs a branch task
+// excluded at runtime via its branch selections — i.e. the successors to skip.
+// It returns nil for non-branch tasks (which skip nothing here).  It errors if a
+// selection names a step that is not a valid successor, matching completeTask's
+// validation.
+func (s *Store) ResolveBranchSkips(taskID uuid.UUID, branchSelections []string) ([]uuid.UUID, error) {
+	var task models.Task
+	if err := s.db.First(&task, "id = ?", taskID).Error; err != nil {
+		return nil, err
+	}
+	if task.Type != "branch" {
+		return nil, nil
+	}
+
+	edges, err := s.successorEdgesTx(s.db, task)
+	if err != nil {
+		return nil, err
+	}
+	if len(edges) == 0 {
+		return nil, nil
+	}
+
+	successorIDs := make([]uuid.UUID, 0, len(edges))
+	for _, e := range edges {
+		successorIDs = append(successorIDs, e.ToTaskID)
+	}
+	var successorTasks []models.Task
+	if err := s.db.Where("id IN ?", successorIDs).Find(&successorTasks).Error; err != nil {
+		return nil, err
+	}
+
+	nameToID := make(map[string]uuid.UUID, len(successorTasks))
+	validTargets := make([]string, 0, len(successorTasks))
+	for _, st := range successorTasks {
+		if st.Name != "" {
+			nameToID[st.Name] = st.ID
+			validTargets = append(validTargets, st.Name)
+		}
+	}
+
+	selected := make(map[uuid.UUID]bool, len(branchSelections))
+	for _, name := range branchSelections {
+		id, ok := nameToID[name]
+		if !ok {
+			return nil, fmt.Errorf("branch selected unknown step %q; valid targets: %v", name, validTargets)
+		}
+		selected[id] = true
+	}
+
+	skips := make([]uuid.UUID, 0, len(successorIDs))
+	for _, id := range successorIDs {
+		if !selected[id] {
+			skips = append(skips, id)
+		}
+	}
+	return skips, nil
+}

--- a/internal/run/recovery.go
+++ b/internal/run/recovery.go
@@ -1,0 +1,86 @@
+package run
+
+import (
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+// RecoveryResult summarizes what a recovering owner must do after reconstructing
+// a run's state from a checkpoint plus the post-checkpoint terminal rows.
+type RecoveryResult struct {
+	// Ready are pending tasks whose predecessors are satisfied — dispatch them.
+	Ready []uuid.UUID
+	// ReDispatch are tasks left running by the previous owner with no terminal
+	// row, i.e. in-flight work whose worker outcome never reached the owner.
+	// They are re-dispatched with attempt+1 and a fresh claim.
+	ReDispatch []uuid.UUID
+	// MaxSequence is the highest terminal_sequence observed (checkpoint or row);
+	// the recovered owner continues allocating from here.
+	MaxSequence int64
+	// SequenceGaps are missing terminal_sequence values between the checkpoint
+	// and the highest observed row.  A gap means the previous owner allocated a
+	// sequence but crashed before persisting the row; the affected task is
+	// treated as never-completed and recovered via ReDispatch.  Reported for
+	// observability; not an error.
+	SequenceGaps []int64
+	// Complete is true when every task is already terminal (nothing to do).
+	Complete bool
+}
+
+// RecoverRunState reconstructs a RunState for an owned run after an ownership
+// change.  topo is reloaded from the catalog; checkpoint is the latest full
+// snapshot (nil to replay from scratch); terminalRows are the post-checkpoint
+// terminal task_runs rows ordered by terminal_sequence ascending (from
+// Store.TerminalTaskRunsSince).
+//
+// It restores the snapshot (or a fresh state), replays each terminal row to
+// advance the DAG, then classifies the leftover non-terminal tasks: running
+// tasks become ReDispatch (their worker outcome was lost), and ready tasks
+// become Ready.  Wall-clock time is never consulted; ordering is by
+// terminal_sequence so recovery is deterministic and clock-skew-safe.
+func RecoverRunState(topo RunTopology, checkpoint *models.RunCheckpoint, terminalRows []models.TaskRun) (*RunState, RecoveryResult, error) {
+	var (
+		rs    *RunState
+		start int64
+		err   error
+	)
+	if checkpoint != nil {
+		start = checkpoint.SequenceHigh
+		rs, err = Restore(topo, checkpoint.StateBlob)
+		if err != nil {
+			// Corrupt checkpoint: fall back to a from-scratch replay over all
+			// terminal rows (the design's "rebuild from terminal rows only").
+			rs = NewRunState(topo, 0)
+			start = 0
+		}
+	} else {
+		rs = NewRunState(topo, 0)
+	}
+
+	var res RecoveryResult
+	expected := start + 1
+	for i := range terminalRows {
+		row := &terminalRows[i]
+		rs.ApplyTerminalRow(row.TaskID, TaskStatus(row.Status), row.TerminalSequence)
+
+		// Dense-sequence gap check: every persisted terminal_sequence should be
+		// the next after the previous. A hole means a sequence was allocated but
+		// its row never landed (owner crashed mid-write).
+		for expected < row.TerminalSequence {
+			res.SequenceGaps = append(res.SequenceGaps, expected)
+			expected++
+		}
+		if row.TerminalSequence >= expected {
+			expected = row.TerminalSequence + 1
+		}
+	}
+
+	res.MaxSequence = rs.Sequence()
+	res.ReDispatch = rs.RunningTasks()
+	// The reconstructed ready queue is authoritative: it holds every pending task
+	// whose predecessors are satisfied (roots of a from-scratch replay plus
+	// successors freed by the replayed tail).
+	res.Ready = rs.ReadyTasks()
+	res.Complete = rs.IsComplete()
+	return rs, res, nil
+}

--- a/internal/run/recovery.go
+++ b/internal/run/recovery.go
@@ -76,10 +76,11 @@ func RecoverRunState(topo RunTopology, checkpoint *models.RunCheckpoint, termina
 	}
 
 	res.MaxSequence = rs.Sequence()
-	res.ReDispatch = rs.RunningTasks()
-	// The reconstructed ready queue is authoritative: it holds every pending task
-	// whose predecessors are satisfied (roots of a from-scratch replay plus
-	// successors freed by the replayed tail).
+	// Re-queue tasks the previous owner left running (no terminal row): they move
+	// back onto the ready queue with attempt+1 so the new owner re-dispatches
+	// them.  After this, the ready queue is authoritative — it holds every
+	// dispatchable task (roots, tail-freed successors, and re-dispatches).
+	res.ReDispatch = rs.requeueRunning()
 	res.Ready = rs.ReadyTasks()
 	res.Complete = rs.IsComplete()
 	return rs, res, nil

--- a/internal/run/recovery_test.go
+++ b/internal/run/recovery_test.go
@@ -1,0 +1,178 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+)
+
+func row(taskID uuid.UUID, status TaskStatus, seq int64) models.TaskRun {
+	return models.TaskRun{TaskID: taskID, Status: string(status), TerminalSequence: seq}
+}
+
+// TestRecover_CheckpointPlusTail builds a linear run, checkpoints mid-flight,
+// continues, then reconstructs from the checkpoint + the post-checkpoint
+// terminal rows and asserts the recovered state matches the crash point.
+func TestRecover_CheckpointPlusTail(t *testing.T) {
+	b := newTopoBuilder()
+	a, bb, c := b.task(""), b.task(""), b.task("")
+	b.edge(a, bb)
+	b.edge(bb, c)
+	topo := b.build()
+
+	// Live owner: complete a, dispatch b, then checkpoint at sequence 1.
+	live := NewRunState(topo, 0)
+	live.ApplyCompletion(a, TaskStatusSucceeded, nil) // seq 1, readies b
+	live.MarkDispatched(bb, "node-1", 1, 1000)
+	blob, err := live.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	checkpoint := &models.RunCheckpoint{SequenceHigh: 1, StateBlob: blob}
+
+	// After the checkpoint: b completes (seq 2) and c gets dispatched, then the
+	// owner crashes (c's dispatch is not yet a terminal row).
+	tail := []models.TaskRun{row(bb, TaskStatusSucceeded, 2)}
+
+	rs, res, err := RecoverRunState(topo, checkpoint, tail)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Complete {
+		t.Fatal("run is not complete (c still pending)")
+	}
+	if len(res.Ready) != 1 || res.Ready[0] != c {
+		t.Fatalf("c should be ready after replaying b's completion, got %v", res.Ready)
+	}
+	if len(res.ReDispatch) != 0 {
+		t.Fatalf("nothing should need re-dispatch (b completed), got %v", res.ReDispatch)
+	}
+	if res.MaxSequence != 2 {
+		t.Fatalf("max sequence should be 2, got %d", res.MaxSequence)
+	}
+	if st, _ := rs.TaskState(bb); st.Status != TaskStatusSucceeded {
+		t.Fatalf("b should be reconstructed as succeeded, got %s", st.Status)
+	}
+}
+
+// TestRecover_RunningTaskReDispatched covers the in-flight-loss case: a task was
+// running in the checkpoint and never produced a terminal row.
+func TestRecover_RunningTaskReDispatched(t *testing.T) {
+	b := newTopoBuilder()
+	a, bb := b.task(""), b.task("")
+	b.edge(a, bb)
+	topo := b.build()
+
+	live := NewRunState(topo, 0)
+	live.ApplyCompletion(a, TaskStatusSucceeded, nil) // seq 1, readies b
+	live.MarkDispatched(bb, "dead-node", 1, 1000)     // b running
+	blob, _ := live.Snapshot()
+	checkpoint := &models.RunCheckpoint{SequenceHigh: 1, StateBlob: blob}
+
+	// No terminal rows after the checkpoint — b's worker outcome was lost.
+	_, res, err := RecoverRunState(topo, checkpoint, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.ReDispatch) != 1 || res.ReDispatch[0] != bb {
+		t.Fatalf("running b should be re-dispatched, got %v", res.ReDispatch)
+	}
+}
+
+// TestRecover_FromScratch replays a finished run from all its terminal rows with
+// no checkpoint, covering succeeded + cached + skipped statuses.
+func TestRecover_FromScratch(t *testing.T) {
+	// a -> b (all_success), a -> c (all_success); a fails so both b and c skip.
+	b := newTopoBuilder()
+	a := b.task("")
+	bb := b.task(jobdefschema.TriggerRuleAllSuccess)
+	c := b.task(jobdefschema.TriggerRuleAllSuccess)
+	b.edge(a, bb)
+	b.edge(a, c)
+	topo := b.build()
+
+	// Terminal rows as a finished run would have persisted them, in sequence.
+	rows := []models.TaskRun{
+		row(a, TaskStatusFailed, 1),
+		row(bb, TaskStatusSkipped, 2),
+		row(c, TaskStatusSkipped, 3),
+	}
+
+	rs, res, err := RecoverRunState(topo, nil, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Complete {
+		t.Fatal("a failed and b,c skipped → run should be complete")
+	}
+	if len(res.Ready) != 0 || len(res.ReDispatch) != 0 {
+		t.Fatalf("finished run should have nothing to do, ready=%v redispatch=%v", res.Ready, res.ReDispatch)
+	}
+	for _, id := range []uuid.UUID{bb, c} {
+		if st, _ := rs.TaskState(id); st.Status != TaskStatusSkipped {
+			t.Fatalf("task %v should be skipped, got %s", id, st.Status)
+		}
+	}
+}
+
+func TestRecover_CachedStatusSatisfiesSuccessors(t *testing.T) {
+	b := newTopoBuilder()
+	a, c := b.task(""), b.task(jobdefschema.TriggerRuleAllSuccess)
+	b.edge(a, c)
+	topo := b.build()
+
+	// a was satisfied from cache (terminal success); c should become ready.
+	rows := []models.TaskRun{row(a, TaskStatusCached, 1)}
+	_, res, err := RecoverRunState(topo, nil, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Ready) != 1 || res.Ready[0] != c {
+		t.Fatalf("cached predecessor should ready c, got %v", res.Ready)
+	}
+}
+
+func TestRecover_SequenceGapReported(t *testing.T) {
+	b := newTopoBuilder()
+	a, bb, c := b.task(""), b.task(""), b.task("")
+	b.edge(a, bb)
+	b.edge(a, c)
+	topo := b.build()
+
+	// Sequences 1 and 3 present, 2 missing → gap at 2.
+	rows := []models.TaskRun{
+		row(a, TaskStatusSucceeded, 1),
+		row(bb, TaskStatusSucceeded, 3),
+	}
+	_, res, err := RecoverRunState(topo, nil, rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.SequenceGaps) != 1 || res.SequenceGaps[0] != 2 {
+		t.Fatalf("expected gap at sequence 2, got %v", res.SequenceGaps)
+	}
+}
+
+func TestRecover_CorruptCheckpointFallsBack(t *testing.T) {
+	b := newTopoBuilder()
+	a, c := b.task(""), b.task("")
+	b.edge(a, c)
+	topo := b.build()
+
+	checkpoint := &models.RunCheckpoint{SequenceHigh: 1, StateBlob: []byte("{not valid json")}
+	// Even with a corrupt checkpoint, a from-scratch replay over the terminal
+	// rows must reconstruct without error.
+	rows := []models.TaskRun{row(a, TaskStatusSucceeded, 1)}
+	rs, res, err := RecoverRunState(topo, checkpoint, rows)
+	if err != nil {
+		t.Fatalf("corrupt checkpoint should fall back, not error: %v", err)
+	}
+	if len(res.Ready) != 1 || res.Ready[0] != c {
+		t.Fatalf("fallback replay should ready c, got %v", res.Ready)
+	}
+	if st, _ := rs.TaskState(a); st.Status != TaskStatusSucceeded {
+		t.Fatalf("a should be succeeded after fallback replay, got %s", st.Status)
+	}
+}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1715,7 +1715,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 func (s *Store) CompleteTaskOwner(
 	runID, taskID uuid.UUID,
 	status TaskStatus,
-	result, claimedBy string,
+	result, errMsg, claimedBy string,
 	output map[string]string,
 	branchSelections []string,
 	completedSeq, ownerGen int64,
@@ -1771,7 +1771,11 @@ func (s *Store) CompleteTaskOwner(
 				updates["branch_selections"] = encoded
 			}
 			if status == TaskStatusFailed {
-				updates["error"] = failureMessage(result)
+				if errMsg != "" {
+					updates["error"] = errMsg
+				} else {
+					updates["error"] = failureMessage(result)
+				}
 			}
 
 			res := tx.Model(&models.TaskRun{}).
@@ -2178,6 +2182,11 @@ func (s *Store) SkipTask(runID, taskID uuid.UUID, reason string) error {
 	return err
 }
 
+// errRunAlreadyTerminal is an internal sentinel: Complete's idempotency guard
+// returns it when the run is already in a terminal status, so the caller treats
+// the call as a successful no-op rather than re-emitting completion events.
+var errRunAlreadyTerminal = errors.New("run already terminal")
+
 func (s *Store) Complete(runID uuid.UUID, result error) error {
 	now := time.Now().UTC()
 	status := StatusSucceeded
@@ -2207,14 +2216,23 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 			attemptStartedAt time.Time
 		)
 		txErr := s.db.Transaction(func(tx *gorm.DB) error {
-			if err := tx.Model(&models.JobRun{}).
-				Where("id = ?", runID).
+			// Idempotency guard: skip if the run is already terminal.  Run-owner
+			// in-memory mode can finalize a run from the owner (on takeover) and
+			// from the triggering node's waitForRunCompletion; this keeps the
+			// second call a no-op so run_completed/run_failed events fire once.
+			res := tx.Model(&models.JobRun{}).
+				Where("id = ? AND status NOT IN ?", runID, []string{string(StatusSucceeded), string(StatusFailed)}).
 				Updates(map[string]interface{}{
 					"status":       string(status),
 					"completed_at": now,
 					"error":        errMsg,
-				}).Error; err != nil {
-				return err
+				})
+			if res.Error != nil {
+				return res.Error
+			}
+			if res.RowsAffected == 0 {
+				// Already finalized by another path; nothing more to do.
+				return errRunAlreadyTerminal
 			}
 
 			// Read jobID + startedAt inside the same retried transaction so the
@@ -2275,6 +2293,11 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 		}
 		return txErr
 	})
+	if errors.Is(err, errRunAlreadyTerminal) {
+		// Run was already finalized by another path (idempotent no-op): no
+		// events, metrics, or gauge bookkeeping to repeat.
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1704,6 +1704,184 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 	return skippedTaskIDs, err
 }
 
+// CompleteTaskOwner is the run-owner in-memory path's durable terminal write.
+// The owner has already advanced the DAG in memory (run.RunState), so this only
+// persists terminal rows — it does NOT decrement predecessors, evaluate trigger
+// rules, or resolve branches in SQL.  It writes the completed task's terminal
+// row (succeeded/failed) plus each owner-decided skip, stamping terminal_sequence
+// and owner_generation so a recovering owner can replay in order.  Claim-fenced
+// by claimedBy.  Cache-hit completions are not handled here (they remain on the
+// CacheHitTaskClaimed path); the owner routes only succeeded/failed through this.
+func (s *Store) CompleteTaskOwner(
+	runID, taskID uuid.UUID,
+	result, claimedBy string,
+	output map[string]string,
+	branchSelections []string,
+	completedSeq, ownerGen int64,
+	skips []OwnerSkip,
+) error {
+	var pendingEvents []event.Event
+	var counts dbWriteCounts
+	err := withStoreBusyRetry(func() error {
+		counts.reset()
+		attemptEvents := make([]event.Event, 0, 8+len(skips))
+
+		txErr := s.db.Transaction(func(tx *gorm.DB) error {
+			now := time.Now().UTC()
+			status := taskStatusFromResult(result)
+
+			// Metrics for the completed task (mirrors completeTask).
+			var taskRun models.TaskRun
+			tq := tx.Where("job_run_id = ? AND task_id = ? AND claimed_by = ?", runID, taskID, claimedBy)
+			if err := tq.First(&taskRun).Error; err == nil {
+				var jobRun models.JobRun
+				if err := tx.First(&jobRun, "id = ?", runID).Error; err == nil {
+					jobID := jobRun.JobID.String()
+					engine := string(taskRun.Engine)
+					metrics.TaskRunsTotal.WithLabelValues(jobID, taskID.String(), engine, string(status)).Inc()
+					if taskRun.StartedAt != nil {
+						metrics.TaskRunDurationSeconds.WithLabelValues(jobID, engine, string(status)).
+							Observe(now.Sub(*taskRun.StartedAt).Seconds())
+					}
+				}
+			} else if errors.Is(err, gorm.ErrRecordNotFound) {
+				return ErrTaskClaimMismatch
+			}
+
+			updates := map[string]interface{}{
+				"status":              string(status),
+				"completed_at":        now,
+				"result":              result,
+				"terminal_sequence":   completedSeq,
+				"owner_generation":    ownerGen,
+				"cache_hit":           false,
+				"cache_origin_run_id": nil,
+				"cache_created_at":    nil,
+				"cache_expires_at":    nil,
+			}
+			if len(output) > 0 {
+				encoded, mErr := json.Marshal(output)
+				if mErr != nil {
+					return fmt.Errorf("marshalling task output: %w", mErr)
+				}
+				updates["output"] = encoded
+			}
+			if len(branchSelections) > 0 {
+				encoded, mErr := json.Marshal(branchSelections)
+				if mErr != nil {
+					return fmt.Errorf("marshalling branch selections: %w", mErr)
+				}
+				updates["branch_selections"] = encoded
+			}
+			if status == TaskStatusFailed {
+				updates["error"] = failureMessage(result)
+			}
+
+			res := tx.Model(&models.TaskRun{}).
+				Where("job_run_id = ? AND task_id = ? AND claimed_by = ?", runID, taskID, claimedBy).
+				Updates(updates)
+			if res.Error != nil {
+				return res.Error
+			}
+			if res.RowsAffected == 0 {
+				return ErrTaskClaimMismatch
+			}
+			counts.addTaskRunStatus(1)
+
+			if s.eventStore != nil {
+				evtType := event.TypeTaskSucceeded
+				if status == TaskStatusFailed {
+					evtType = event.TypeTaskFailed
+				}
+				evt, err := s.recordTaskEventTx(tx, evtType, runID, taskID, &counts)
+				if err != nil {
+					return err
+				}
+				attemptEvents = append(attemptEvents, *evt)
+			}
+
+			// Persist owner-decided skips (branch + trigger-rule), each stamped
+			// with its own terminal_sequence.  RunState already enumerated the
+			// full transitive skip set, so this writes them directly without
+			// re-walking descendants.
+			for _, sk := range skips {
+				skRes := tx.Model(&models.TaskRun{}).
+					Where("job_run_id = ? AND task_id = ?", runID, sk.TaskID).
+					Where("status NOT IN ?", terminalStatusStrings()).
+					Updates(map[string]interface{}{
+						"status":            string(TaskStatusSkipped),
+						"completed_at":      now,
+						"error":             sk.Reason,
+						"terminal_sequence": sk.TerminalSequence,
+						"owner_generation":  ownerGen,
+					})
+				if skRes.Error != nil {
+					return skRes.Error
+				}
+				if skRes.RowsAffected == 0 {
+					continue // already terminal; nothing to emit
+				}
+				counts.addTaskRunStatus(1)
+				if s.eventStore != nil {
+					evt, err := s.recordTaskEventTx(tx, event.TypeTaskSkipped, runID, sk.TaskID, &counts)
+					if err != nil {
+						return err
+					}
+					attemptEvents = append(attemptEvents, *evt)
+				}
+			}
+			return nil
+		})
+		if txErr == nil {
+			pendingEvents = attemptEvents
+		}
+		return txErr
+	})
+	if err == nil {
+		counts.commit()
+		s.publishEvents(pendingEvents...)
+	}
+	return err
+}
+
+// OwnerSkip is a task the run owner decided to skip in memory, paired with the
+// terminal_sequence to stamp on its durable row.
+type OwnerSkip struct {
+	TaskID           uuid.UUID
+	TerminalSequence int64
+	Reason           string
+}
+
+// failureMessage maps a failure result string to a human-readable error, matching
+// the messages completeTask writes.
+func failureMessage(result string) string {
+	switch Result(result) {
+	case "failure":
+		return "command exited with non-zero status"
+	case "startup_failure":
+		return "atom failed to start (check image/command)"
+	case "resource_failure":
+		return "atom exhausted resources (e.g. OOM)"
+	case "killed":
+		return "atom was forcefully killed"
+	case "terminated":
+		return "atom was gracefully terminated"
+	default:
+		return result
+	}
+}
+
+// terminalStatusStrings returns the terminal task statuses as strings for SQL IN
+// clauses.
+func terminalStatusStrings() []string {
+	return []string{
+		string(TaskStatusSucceeded),
+		string(TaskStatusFailed),
+		string(TaskStatusSkipped),
+		string(TaskStatusCached),
+	}
+}
+
 // skipTaskAndDescendantsTx marks a task and all its transitive descendants as
 // skipped within the given transaction. Descendants are only skipped once all
 // of their predecessors are terminal and their trigger rules remain

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1719,7 +1719,7 @@ func (s *Store) CompleteTaskOwner(
 	output map[string]string,
 	branchSelections []string,
 	completedSeq, ownerGen int64,
-	skips []OwnerSkip,
+	skips []SkippedTask,
 ) error {
 	var pendingEvents []event.Event
 	var counts dbWriteCounts
@@ -1843,14 +1843,6 @@ func (s *Store) CompleteTaskOwner(
 		s.publishEvents(pendingEvents...)
 	}
 	return err
-}
-
-// OwnerSkip is a task the run owner decided to skip in memory, paired with the
-// terminal_sequence to stamp on its durable row.
-type OwnerSkip struct {
-	TaskID           uuid.UUID
-	TerminalSequence int64
-	Reason           string
 }
 
 // failureMessage maps a failure result string to a human-readable error, matching

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1714,6 +1714,7 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 // CacheHitTaskClaimed path); the owner routes only succeeded/failed through this.
 func (s *Store) CompleteTaskOwner(
 	runID, taskID uuid.UUID,
+	status TaskStatus,
 	result, claimedBy string,
 	output map[string]string,
 	branchSelections []string,
@@ -1728,7 +1729,6 @@ func (s *Store) CompleteTaskOwner(
 
 		txErr := s.db.Transaction(func(tx *gorm.DB) error {
 			now := time.Now().UTC()
-			status := taskStatusFromResult(result)
 
 			// Metrics for the completed task (mirrors completeTask).
 			var taskRun models.TaskRun
@@ -1749,15 +1749,12 @@ func (s *Store) CompleteTaskOwner(
 			}
 
 			updates := map[string]interface{}{
-				"status":              string(status),
-				"completed_at":        now,
-				"result":              result,
-				"terminal_sequence":   completedSeq,
-				"owner_generation":    ownerGen,
-				"cache_hit":           false,
-				"cache_origin_run_id": nil,
-				"cache_created_at":    nil,
-				"cache_expires_at":    nil,
+				"status":            string(status),
+				"completed_at":      now,
+				"result":            result,
+				"terminal_sequence": completedSeq,
+				"owner_generation":  ownerGen,
+				"cache_hit":         status == TaskStatusCached,
 			}
 			if len(output) > 0 {
 				encoded, mErr := json.Marshal(output)

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -53,6 +53,19 @@ func IsTerminalSuccess(status TaskStatus) bool {
 	return status == TaskStatusSucceeded || status == TaskStatusCached
 }
 
+// IsTerminal reports whether a task status is terminal — the task will not
+// transition again.  This is the single definition of the terminal vocabulary
+// (succeeded, failed, skipped, cached), reused by owner replay, the recovery
+// scan, and archival so the set lives in exactly one place.
+func IsTerminal(status TaskStatus) bool {
+	switch status {
+	case TaskStatusSucceeded, TaskStatusFailed, TaskStatusSkipped, TaskStatusCached:
+		return true
+	default:
+		return false
+	}
+}
+
 type CallbackStatus string
 
 const (

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -726,7 +726,7 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 // (already claimed, wrong status, wrong run, stale generation).  The caller
 // should fall back to writing the task with claimed_by="" and letting
 // ClaimNext pick it up.
-func (s *Store) ClaimTaskForDispatch(runID, taskID uuid.UUID, workerNode string, ownerGeneration int64, leaseTTL time.Duration) error {
+func (s *Store) ClaimTaskForDispatch(runID, taskID uuid.UUID, workerNode string, ownerGeneration int64, leaseTTL time.Duration, trustOwnerReadiness bool) error {
 	var pendingEvents []event.Event
 	var counts dbWriteCounts
 	err := withStoreBusyRetry(func() error {
@@ -736,9 +736,18 @@ func (s *Store) ClaimTaskForDispatch(runID, taskID uuid.UUID, workerNode string,
 			now := time.Now().UTC()
 			leaseExpiry := now.Add(leaseTTL)
 
+			// The owner is authoritative for readiness.  In SQL mode the owner
+			// dispatches only outstanding_predecessors=0 tasks, so the check is a
+			// redundant safety net.  In in-memory mode the owner advanced the DAG
+			// in memory and did NOT decrement the DB counter, so the dispatched
+			// successor still shows outstanding>0 here — trustOwnerReadiness drops
+			// the predecessor check so the claim reflects the owner's decision.
+			where := "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0 AND (owner_generation = ? OR owner_generation = 0)"
+			if trustOwnerReadiness {
+				where = "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND (owner_generation = ? OR owner_generation = 0)"
+			}
 			result := tx.Model(&models.TaskRun{}).
-				Where("job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0 AND (owner_generation = ? OR owner_generation = 0)",
-					runID, taskID, string(TaskStatusPending), ownerGeneration).
+				Where(where, runID, taskID, string(TaskStatusPending), ownerGeneration).
 				Updates(map[string]interface{}{
 					"status":           string(TaskStatusRunning),
 					"claimed_by":       workerNode,
@@ -2319,7 +2328,12 @@ func (s *Store) ResetInFlightTasks(runID uuid.UUID) error {
 	return s.db.Model(&models.TaskRun{}).
 		Where("job_run_id = ? AND status = ?", runID, string(TaskStatusRunning)).
 		Updates(map[string]interface{}{
-			"status":              string(TaskStatusPending),
+			"status": string(TaskStatusPending),
+			// Clear the claim too, so a new owner taking over a run can re-claim
+			// these rows (ClaimTaskForDispatch requires claimed_by = '').  The old
+			// owner's worker that held the claim is gone (its lease expired).
+			"claimed_by":          "",
+			"claim_expires_at":    nil,
 			"runtime_id":          "",
 			"started_at":          nil,
 			"cache_hit":           false,

--- a/internal/run/terminal_test.go
+++ b/internal/run/terminal_test.go
@@ -1,0 +1,29 @@
+package run
+
+import "testing"
+
+func TestIsTerminal(t *testing.T) {
+	terminal := []TaskStatus{
+		TaskStatusSucceeded,
+		TaskStatusFailed,
+		TaskStatusSkipped,
+		TaskStatusCached,
+	}
+	for _, s := range terminal {
+		if !IsTerminal(s) {
+			t.Errorf("IsTerminal(%q) = false, want true", s)
+		}
+	}
+
+	nonTerminal := []TaskStatus{
+		TaskStatusPending,
+		TaskStatusRunning,
+		TaskStatus("bogus"),
+		TaskStatus(""),
+	}
+	for _, s := range nonTerminal {
+		if IsTerminal(s) {
+			t.Errorf("IsTerminal(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/run/trigger_rule.go
+++ b/internal/run/trigger_rule.go
@@ -1,0 +1,86 @@
+package run
+
+import (
+	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+)
+
+// CollectPredecessorStatuses returns the known statuses for the given set of
+// predecessor task IDs using the in-memory outcomes map.  Predecessors with no
+// recorded outcome yet are omitted.
+//
+// This and SatisfiesTriggerRule are the single source of truth for trigger-rule
+// evaluation, shared by the local executor (internal/job) and the run-owner
+// in-memory state machine (RunState) so DAG advancement semantics cannot drift
+// between the two paths.
+func CollectPredecessorStatuses(predIDs []uuid.UUID, taskOutcomes map[uuid.UUID]TaskStatus) []TaskStatus {
+	statuses := make([]TaskStatus, 0, len(predIDs))
+	for _, id := range predIDs {
+		if status, ok := taskOutcomes[id]; ok {
+			statuses = append(statuses, status)
+		}
+	}
+	return statuses
+}
+
+// SatisfiesTriggerRule evaluates the trigger rule against the provided
+// predecessor statuses.  It returns true when the task should run, false when
+// it should be skipped.  An empty rule defaults to all_success; a task with no
+// predecessors always runs.
+func SatisfiesTriggerRule(rule string, predStatuses []TaskStatus) bool {
+	if rule == "" {
+		rule = jobdefschema.TriggerRuleAllSuccess
+	}
+
+	// A task with no predecessors always runs regardless of rule.
+	if len(predStatuses) == 0 {
+		return true
+	}
+
+	isTerminal := func(s TaskStatus) bool {
+		return s == TaskStatusSucceeded || s == TaskStatusCached || s == TaskStatusFailed || s == TaskStatusSkipped
+	}
+
+	switch rule {
+	case jobdefschema.TriggerRuleAllSuccess:
+		for _, s := range predStatuses {
+			if !IsTerminalSuccess(s) {
+				return false
+			}
+		}
+		return true
+
+	case jobdefschema.TriggerRuleAllDone, jobdefschema.TriggerRuleAlways:
+		for _, s := range predStatuses {
+			if !isTerminal(s) {
+				return false
+			}
+		}
+		return true
+
+	case jobdefschema.TriggerRuleAllFailed:
+		for _, s := range predStatuses {
+			if s != TaskStatusFailed {
+				return false
+			}
+		}
+		return true
+
+	case jobdefschema.TriggerRuleOneSuccess:
+		for _, s := range predStatuses {
+			if IsTerminalSuccess(s) {
+				return true
+			}
+		}
+		return false
+
+	default:
+		// Unknown rule: default to all_success behaviour.
+		for _, s := range predStatuses {
+			if !IsTerminalSuccess(s) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -253,5 +253,8 @@ func hotPathModels() []interface{} {
 		&models.TaskRun{},
 		&models.CallbackRun{},
 		&models.ExecutionEvent{},
+		// run_checkpoints is per-run and transactionally local to task_runs, so
+		// when sharding is enabled it must be migrated onto every hot shard.
+		&models.RunCheckpoint{},
 	}
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -163,4 +163,20 @@ type Environment struct {
 	// to time.Now() in each DispatchRequest.  Workers use this to bound how long
 	// they hold the claim before returning it.  Default 5m.
 	RunOwnerDispatchDeadline time.Duration `envconfig:"RUN_OWNER_DISPATCH_DEADLINE" default:"5m"`
+
+	// CAESIUM_INTERNAL_PORT is the port for the dedicated internal mTLS listener
+	// that hosts the run-owner endpoints (/internal/dispatch, /internal/complete).
+	// It is separate from the public API port so the public server can remain
+	// plain HTTP while node-to-node coordination traffic is mutually
+	// authenticated.  Only bound when owner mode is enabled.  Default 8443.
+	InternalPort int `envconfig:"INTERNAL_PORT" default:"8443"`
+	// CAESIUM_INTERNAL_MTLS_CA/CERT/KEY are PEM file paths configuring mutual TLS
+	// on the internal listener.  CA validates peer (client) certificates;
+	// CERT/KEY are this node's own identity — presented both as the listener's
+	// server certificate and as the client certificate when this node POSTs to a
+	// peer's internal endpoints.  All three are required when owner mode is
+	// enabled (enforced at startup).
+	InternalMTLSCA   string `envconfig:"INTERNAL_MTLS_CA" default:""`
+	InternalMTLSCert string `envconfig:"INTERNAL_MTLS_CERT" default:""`
+	InternalMTLSKey  string `envconfig:"INTERNAL_MTLS_KEY" default:""`
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -179,4 +179,13 @@ type Environment struct {
 	InternalMTLSCA   string `envconfig:"INTERNAL_MTLS_CA" default:""`
 	InternalMTLSCert string `envconfig:"INTERNAL_MTLS_CERT" default:""`
 	InternalMTLSKey  string `envconfig:"INTERNAL_MTLS_KEY" default:""`
+
+	// Run-owner checkpointing (Phase 2 B3).  The owner persists an in-memory
+	// state checkpoint whichever comes first of RUN_CHECKPOINT_EVENTS terminal
+	// transitions or RUN_CHECKPOINT_INTERVAL elapsed.  RUN_CHECKPOINT_FULL_EVERY
+	// is the number of checkpoints between full snapshots (intervening ones are
+	// deltas); v1 writes full snapshots only, so it is currently advisory.
+	RunCheckpointEvents    int           `envconfig:"RUN_CHECKPOINT_EVENTS" default:"100"`
+	RunCheckpointInterval  time.Duration `envconfig:"RUN_CHECKPOINT_INTERVAL" default:"2s"`
+	RunCheckpointFullEvery int           `envconfig:"RUN_CHECKPOINT_FULL_EVERY" default:"10"`
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -188,4 +188,11 @@ type Environment struct {
 	RunCheckpointEvents    int           `envconfig:"RUN_CHECKPOINT_EVENTS" default:"100"`
 	RunCheckpointInterval  time.Duration `envconfig:"RUN_CHECKPOINT_INTERVAL" default:"2s"`
 	RunCheckpointFullEvery int           `envconfig:"RUN_CHECKPOINT_FULL_EVERY" default:"10"`
+
+	// CAESIUM_RUN_OWNER_IN_MEMORY gates the B3 in-memory advancement path: the
+	// owner advances the DAG in memory (run.RunState), writes only terminal
+	// task_runs rows (no per-transition predecessor UPDATEs), and checkpoints for
+	// fast failover.  Default false — when off, completions take the proven
+	// SQL-advancement path (B2), byte-identical.  Requires RUN_OWNER_ENABLED.
+	RunOwnerInMemory bool `envconfig:"RUN_OWNER_IN_MEMORY" default:"false"`
 }


### PR DESCRIPTION
Run-owner mode previously only warned when mTLS material was absent. Make it a
hard requirement and actually authenticate node-to-node traffic.

- pkg/env: add CAESIUM_INTERNAL_PORT (default 8443) and CAESIUM_INTERNAL_MTLS_
  CA/CERT/KEY.
- dispatch/mtls.go: ServerTLSConfig (RequireAndVerifyClientCert) and
  ClientTLSConfig built from the shared key pair + CA.
- dispatch/internal_server.go: a dedicated mTLS listener hosting
  /internal/dispatch + /internal/complete, separate from the public API so the
  public server can stay plain HTTP behind the operator's proxy.
- api/api.go: stop serving the run-owner endpoints on the public server.
- dispatch.go: ConfigureInternalMTLS swaps internalClient for a TLS transport;
  remove the now-obsolete WarnIfNoMTLS.
- loop.go: when InternalPort is set, build peer/owner base URLs as
  https://host:InternalPort.
- cmd/start: fail fast when owner mode is enabled without all three mTLS files;
  build client+server TLS, start the internal listener after the worker
  submitter is wired.

Tests: mTLS handshake accepts a CA-signed client cert and rejects both an
absent cert and one signed by an untrusted CA; config validation.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>