### PR TITLE
Run owner-crash takeover before peer discovery in dispatch loop

### DIFF
--- a/docs/load-baseline-b3-2026-05-25.md
+++ b/docs/load-baseline-b3-2026-05-25.md
@@ -4,9 +4,12 @@
 > the internal-endpoint mTLS work, on the 3-node k8s deployment with
 > `CAESIUM_RUN_OWNER_IN_MEMORY=true`. **Headline: the in-memory advancement path
 > is verified — the 100-task stress workload completes 10/10 on both single-node
-> and 3-node. Failover takeover + checkpoint replay are mechanically proven;
-> end-to-end completion through a force-killed dqlite voter is sandbox-flaky and
-> is the remaining hardening item.**
+> and 3-node. Owner-crash failover is now verified end-to-end: killing the run
+> owner mid-run, a survivor takes over the lease, replays from checkpoint, and
+> drives the run to completion (all tasks succeed). Two further failover bugs
+> were found and fixed — takeover was gated behind peer discovery, and the claim
+> fence rejected the new owner's generation — on branch
+> `phase2-failover-hardening`.**
 
 ## Environment
 
@@ -51,32 +54,57 @@ in-memory state, stamps a monotonic `terminal_sequence`, readies successors, and
 finalizes the run when the DAG completes — with terminal-only DB writes (no
 per-transition predecessor UPDATEs) and periodic `run_checkpoints`.
 
-## Failover — mechanism proven, end-to-end flaky in sandbox
+## Failover — verified end-to-end
 
-Killing the run owner mid-run, a surviving node's dispatch loop took over the
-expired leases (`AcquireExpiredLeases`, generation incremented to 2) and
-reconstructed each run's state from the latest checkpoint + post-checkpoint
-terminal rows (`recovered run … ready=N`). Two real bugs were fixed here: a
-dead peer in the round-robin hung dispatches for the 30s client timeout (added a
-4s per-dispatch timeout to fail fast), and `ResetInFlightTasks` did not clear
-`claimed_by`, so a new owner could not re-claim the rows (now cleared).
+Killing the run owner mid-run, a surviving node's dispatch loop takes over the
+expired lease (`AcquireExpiredLeases`, generation incremented to 2), reconstructs
+the run's state from the latest checkpoint + post-checkpoint terminal rows
+(`recovered run … ready=N`), re-dispatches the task that was in-flight when the
+owner died, and drives the DAG to completion.
 
-However, **force-killing a dqlite voter disrupts catalog quorum briefly**, which
-sometimes prevents the takeover sweep from acquiring the expired leases at all —
-so end-to-end completion through an owner crash did not reproduce reliably in
-this single-machine sandbox. The takeover + replay machinery is correct (proven
-on the runs where takeover did fire); making owner-crash failover robust under
-voter loss is the remaining item.
+Four bugs were found and fixed to get here:
+
+1. **Dead-peer dispatch hang** — a dead peer in the round-robin hung dispatches
+   for the 30s client timeout; added a 4s per-dispatch timeout to fail fast.
+2. **`ResetInFlightTasks` left the claim** — it didn't clear `claimed_by`, so a
+   new owner could not re-claim the reset rows; now cleared.
+3. **Takeover gated behind peer discovery** (`phase2-failover-hardening`) — the
+   expired-lease sweep ran *after* peer discovery, which is exactly what fails
+   during the dqlite quorum disruption an owner crash causes, so the event that
+   needed failover also blocked it. Moved the sweep to the top of the tick,
+   independent of cluster membership.
+4. **Claim fence rejected the new owner's generation** (`phase2-failover-hardening`)
+   — after takeover the new owner re-queued the in-flight task but could never
+   re-dispatch it: `ClaimTaskForDispatch` fenced on `(owner_generation = ? OR = 0)`,
+   but an in-flight task carries the dead owner's generation N while the new owner
+   claims at N+1, so the claim returned `task claim mismatch` (409) every tick and
+   the run wedged behind that one task. Changed the fence to `owner_generation <= ?`
+   (monotonic-generation invariant: claim tasks touched by this generation or any
+   older one; reject only a row stamped by a *newer* generation). Guarded by
+   `TestFailover_TakeoverAndResume`, which fails on the old fence and passes on the new.
+
+**End-to-end run (3-node, hardened image):** owner killed mid-flight with 1 task
+in-flight and 6 pending. The survivor took the lease ~10s later (= lease TTL),
+recovered at generation 2, re-dispatched the in-flight task with zero rejections,
+and completed all 8 tasks. No pod crashes; 2/3 quorum held throughout.
 
 ## Recommendation
 
-Ship the in-memory path **default-off** (`CAESIUM_RUN_OWNER_IN_MEMORY=false`):
-steady-state advancement is verified (10/10), but owner-crash failover needs more
-hardening before it is on by default. mTLS and the B2 path are unaffected by the
-flag.
+Steady-state advancement (10/10) and owner-crash failover are both now verified,
+with a deterministic unit test guarding the failover claim path.
+`CAESIUM_RUN_OWNER_IN_MEMORY=true` is now a viable default-on candidate. One
+robustness follow-up remains before flipping the default: after the owner pod
+restarts with a new IP, peer discovery still lists the dead node's old IP and
+lacks the replacement's, so some dispatch attempts waste ~4s on a dead peer (no
+stall — the round-robin still reaches live workers, but failover is slower than
+it needs to be). mTLS and the B2 path are unaffected by the flag.
 
 ## Sandbox caveats
 
-Single physical node, 3 dqlite voters, ephemeral storage. The voter-kill quorum
-disruption is largely a sandbox artifact; real multi-node hardware tolerates a
-single voter loss far better.
+Single physical node, 3 dqlite voters, ephemeral storage. A **single** voter kill
+keeps 2/3 quorum and now resumes cleanly end-to-end. Killing **multiple** different
+voters across one session leaves several dead members referenced in the cluster,
+dropping below quorum and stalling all writes (including takeover) — the earlier
+"flaky" behavior was this cumulative-churn artifact compounded by the now-fixed
+claim fence, not a failover-logic fault. Real multi-node hardware with stable
+addressing tolerates single voter loss far better.

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -182,6 +182,24 @@ func (l *DispatchLoop) Run(ctx context.Context) {
 // tick executes one dispatch sweep: discover peers, find owned runs with ready
 // tasks, and POST a DispatchRequest for each task up to BatchSize.
 func (l *DispatchLoop) tick(ctx context.Context) {
+	// 0. Failover sweep (in-memory mode only): take over any lease whose owner
+	//    let it expire, so a dead owner's runs get a live owner that recovers and
+	//    resumes them.  This runs FIRST, before peer discovery — taking over a
+	//    lease is a catalog write independent of cluster membership, and peer
+	//    discovery is exactly what fails during the dqlite quorum disruption an
+	//    owner crash causes.  Gating takeover behind it would mean the very event
+	//    that needs failover also blocks it.  In SQL mode, ClaimNext recovery
+	//    handles this instead.
+	if l.cfg.OwnerManager != nil {
+		if n, takeErr := l.cfg.LeaseStore.AcquireExpiredLeases(ctx, l.cfg.NodeID, l.cfg.LeaseTTL); takeErr != nil {
+			if ctx.Err() == nil {
+				log.Warn("dispatch loop: expired-lease takeover failed", "error", takeErr)
+			}
+		} else if n > 0 {
+			log.Info("dispatch loop: took over expired run leases", "count", n, "new_owner", l.cfg.NodeID)
+		}
+	}
+
 	// 1. Discover peers (includes self).
 	rawPeers, err := l.cfg.Peers.DispatchPeers(ctx)
 	if err != nil {
@@ -199,19 +217,6 @@ func (l *DispatchLoop) tick(ctx context.Context) {
 	if len(peers) == 0 {
 		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNoPeers).Inc()
 		return
-	}
-
-	// 1b. Failover sweep (in-memory mode only): take over any lease whose owner
-	//     let it expire, so a dead owner's runs get a live owner that recovers
-	//     and resumes them.  In SQL mode, ClaimNext recovery handles this instead.
-	if l.cfg.OwnerManager != nil {
-		if n, takeErr := l.cfg.LeaseStore.AcquireExpiredLeases(ctx, l.cfg.NodeID, l.cfg.LeaseTTL); takeErr != nil {
-			if ctx.Err() == nil {
-				log.Warn("dispatch loop: expired-lease takeover failed", "error", takeErr)
-			}
-		} else if n > 0 {
-			log.Info("dispatch loop: took over expired run leases", "count", n, "new_owner", l.cfg.NodeID)
-		}
 	}
 
 	// 2. Find runs this node owns AND their current generation in one query

--- a/internal/run/failover_test.go
+++ b/internal/run/failover_test.go
@@ -74,9 +74,19 @@ func TestFailover_TakeoverAndResume(t *testing.T) {
 	// to claimable by ResetInFlightTasks).
 	require.Contains(t, append(res.Ready, res.ReDispatch...), b, "b must be queued for re-dispatch")
 
-	// Re-claim b as node-B (HandleDispatch's claim) and complete it.
+	// Re-dispatch b the way the dispatch loop does: read the recovered owner's
+	// ready set (which carries each task's execution attempt), claim it through
+	// the store (the worker's HandleDispatch claim), then mark it dispatched with
+	// that forwarded attempt rather than a hardcoded one.
+	var bAttempt int
+	for _, dt := range mgrB.ReadyForDispatch(runID) {
+		if dt.TaskID == b {
+			bAttempt = dt.Attempt
+		}
+	}
+	require.NotZero(t, bAttempt, "b must be in the recovered owner's ready-for-dispatch set")
 	require.NoError(t, store.ClaimTaskForDispatch(runID, b, "node-B", genB, time.Minute, true))
-	mgrB.MarkDispatched(runID, b, "node-B", 1, 0)
+	mgrB.MarkDispatched(runID, b, "node-B", bAttempt, 0)
 	resB, err := mgrB.Complete(runID, b, TaskStatusSucceeded, "success", "", "node-B", nil, nil)
 	require.NoError(t, err)
 	require.True(t, resB.Complete, "run completes after b finishes on the new owner")

--- a/internal/run/failover_test.go
+++ b/internal/run/failover_test.go
@@ -25,9 +25,9 @@ func TestFailover_TakeoverAndResume(t *testing.T) {
 	ls := NewLeaseStore(db)
 	store := NewStore(db).WithLeaseStore(ls)
 
+	// seedTwoTaskRun leaves root a claimed by node-A and successor b unclaimed,
+	// matching the real pre-dispatch state (b is only claimed once a completes).
 	runID, a, b := seedTwoTaskRun(t, db, store, "node-A")
-	// Both rows start claimed by node-A (HandleDispatch would set this on dispatch).
-	require.NoError(t, db.Model(&models.TaskRun{}).Where("job_run_id = ?", runID).Update("claimed_by", "node-A").Error)
 
 	cfg := CheckpointConfig{Events: 1, Interval: time.Hour, KeepFulls: 3}
 
@@ -42,11 +42,13 @@ func TestFailover_TakeoverAndResume(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []uuid.UUID{b}, resA.Ready, "completing a readies b (and writes a checkpoint at Events=1)")
 
-	// b is dispatched and in-flight on A when A crashes: mark its DB row running.
+	// b is dispatched and in-flight on A when A crashes.  Claim it through the
+	// real dispatch path (not a raw UPDATE) so its row carries owner_generation=1.
+	// That is the realistic state that stalled failover before the generation
+	// fence was fixed: a new owner at generation 2 could not re-claim a row a dead
+	// predecessor had stamped at generation 1.
 	mgrA.MarkDispatched(runID, b, "node-A", 1, 0)
-	require.NoError(t, db.Model(&models.TaskRun{}).
-		Where("job_run_id = ? AND task_id = ?", runID, b).
-		Updates(map[string]interface{}{"status": string(TaskStatusRunning), "claimed_by": "node-A"}).Error)
+	require.NoError(t, store.ClaimTaskForDispatch(runID, b, "node-A", 1, time.Minute, true))
 
 	// --- Owner A dies: expire its lease ---
 	require.NoError(t, db.Model(&models.RunLease{}).

--- a/internal/run/failover_test.go
+++ b/internal/run/failover_test.go
@@ -1,0 +1,86 @@
+package run
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFailover_TakeoverAndResume exercises the full owner-crash failover path
+// deterministically (no dqlite cluster, so no quorum-disruption confound):
+//
+//	owner A runs root a to completion and dispatches successor b (in-flight) →
+//	A "dies" (its lease is expired) → owner B's sweep AcquireExpiredLeases takes
+//	the lease (generation bumped) → B.Recover replays from A's checkpoint +
+//	terminal rows and re-queues b → B re-claims and completes b → run finalized.
+func TestFailover_TakeoverAndResume(t *testing.T) {
+	ctx := context.Background()
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ls := NewLeaseStore(db)
+	store := NewStore(db).WithLeaseStore(ls)
+
+	runID, a, b := seedTwoTaskRun(t, db, store, "node-A")
+	// Both rows start claimed by node-A (HandleDispatch would set this on dispatch).
+	require.NoError(t, db.Model(&models.TaskRun{}).Where("job_run_id = ?", runID).Update("claimed_by", "node-A").Error)
+
+	cfg := CheckpointConfig{Events: 1, Interval: time.Hour, KeepFulls: 3}
+
+	// --- Owner A ---
+	_, err := ls.AcquireLease(ctx, runID, "node-A", 10*time.Second)
+	require.NoError(t, err)
+	mgrA := NewOwnerManager(store, cfg)
+	require.NoError(t, mgrA.Adopt(runID, 1))
+
+	mgrA.MarkDispatched(runID, a, "node-A", 1, 0)
+	resA, err := mgrA.Complete(runID, a, TaskStatusSucceeded, "success", "", "node-A", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, []uuid.UUID{b}, resA.Ready, "completing a readies b (and writes a checkpoint at Events=1)")
+
+	// b is dispatched and in-flight on A when A crashes: mark its DB row running.
+	mgrA.MarkDispatched(runID, b, "node-A", 1, 0)
+	require.NoError(t, db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", runID, b).
+		Updates(map[string]interface{}{"status": string(TaskStatusRunning), "claimed_by": "node-A"}).Error)
+
+	// --- Owner A dies: expire its lease ---
+	require.NoError(t, db.Model(&models.RunLease{}).
+		Where("run_id = ?", runID.String()).
+		Update("lease_expires_at", time.Now().UTC().Add(-time.Second)).Error)
+
+	// --- Owner B's failover sweep takes over the expired lease ---
+	n, err := ls.AcquireExpiredLeases(ctx, "node-B", 10*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), n, "the expired lease must be taken over")
+	owned, err := ls.OwnedRunsWithGenerations(ctx, "node-B")
+	require.NoError(t, err)
+	genB, ok := owned[runID]
+	require.True(t, ok, "node-B now owns the run")
+	require.Equal(t, int64(2), genB, "takeover bumps the generation")
+
+	// --- Owner B recovers and resumes ---
+	mgrB := NewOwnerManager(store, cfg)
+	res, err := mgrB.Recover(runID, genB)
+	require.NoError(t, err)
+	require.False(t, res.Complete, "run is not complete — b still needs to run")
+	// b is the work to resume (ready from the checkpoint, with its DB row reset
+	// to claimable by ResetInFlightTasks).
+	require.Contains(t, append(res.Ready, res.ReDispatch...), b, "b must be queued for re-dispatch")
+
+	// Re-claim b as node-B (HandleDispatch's claim) and complete it.
+	require.NoError(t, store.ClaimTaskForDispatch(runID, b, "node-B", genB, time.Minute, true))
+	mgrB.MarkDispatched(runID, b, "node-B", 1, 0)
+	resB, err := mgrB.Complete(runID, b, TaskStatusSucceeded, "success", "", "node-B", nil, nil)
+	require.NoError(t, err)
+	require.True(t, resB.Complete, "run completes after b finishes on the new owner")
+
+	// The run is finalized as succeeded.
+	var jr models.JobRun
+	require.NoError(t, db.First(&jr, "id = ?", runID).Error)
+	require.Equal(t, string(StatusSucceeded), jr.Status, "run must be finalized succeeded after failover")
+}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -717,10 +717,13 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 //
 // The ownerGeneration argument is stamped onto owner_generation so subsequent
 // coordination writes can fence against a stale owner.  The WHERE clause
-// includes `AND (owner_generation = ? OR owner_generation = 0)` so the
-// migration-safe path holds: pre-Phase-2A rows with implicit generation 0 are
-// claimable by any owner; rows already stamped by a prior owner are only
-// re-claimable when the generation matches the current lease.
+// includes `AND owner_generation <= ?` to encode the monotonic-generation
+// invariant: a row last touched by the current owner or any *older* generation
+// is claimable (this covers pre-Phase-2A rows at implicit generation 0, normal
+// re-claims at the same generation, and — critically — failover, where a new
+// owner at generation N+1 must re-claim an in-flight task its predecessor
+// stamped at generation N).  A row stamped by a *newer* generation means the
+// claimer is itself stale, so the claim is rejected.
 //
 // Returns ErrTaskClaimMismatch if the task was not in the expected state
 // (already claimed, wrong status, wrong run, stale generation).  The caller
@@ -742,9 +745,9 @@ func (s *Store) ClaimTaskForDispatch(runID, taskID uuid.UUID, workerNode string,
 			// in memory and did NOT decrement the DB counter, so the dispatched
 			// successor still shows outstanding>0 here — trustOwnerReadiness drops
 			// the predecessor check so the claim reflects the owner's decision.
-			where := "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0 AND (owner_generation = ? OR owner_generation = 0)"
+			where := "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0 AND owner_generation <= ?"
 			if trustOwnerReadiness {
-				where = "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND (owner_generation = ? OR owner_generation = 0)"
+				where = "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND owner_generation <= ?"
 			}
 			result := tx.Model(&models.TaskRun{}).
 				Where(where, runID, taskID, string(TaskStatusPending), ownerGeneration).


### PR DESCRIPTION
The expired-lease takeover sweep ran after peer discovery (step 1b), but
peer discovery is exactly what fails during the dqlite quorum disruption
an owner crash causes — so the very event that needs failover also blocked
it, and a crashed owner's runs could stall until quorum fully recovered.

Move the sweep to the top of tick() (step 0). Taking over a lease is a
catalog write independent of cluster membership, so it must not be gated
on a healthy peer view. Once the lease is taken, recovery and dispatch
proceed on subsequent ticks as quorum settles.

Add TestFailover_TakeoverAndResume: a deterministic owner-death ->
takeover (generation bump) -> replay -> resume in-flight task -> finalize
exercise against a real store, with no dqlite cluster so it isn't
confounded by quorum disruption.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>