### PR TITLE
Auto-provision internal mTLS from a shared token

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -16,6 +16,7 @@ import (
 	runsvc "github.com/caesium-cloud/caesium/api/rest/service/run"
 	"github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/caesium-cloud/caesium/internal/dispatch"
+	dispatchpki "github.com/caesium-cloud/caesium/internal/dispatch/pki"
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/executor"
 	"github.com/caesium-cloud/caesium/internal/jobdef"
@@ -162,24 +163,72 @@ func start(cmd *cobra.Command, args []string) error {
 	var ownerDispatchHandler *dispatch.Handler
 	var ownerInternalServerTLS *tls.Config
 	if vars.RunOwnerEnabled {
-		// Run-owner mode requires mutual TLS on the internal endpoints.  Fail
-		// fast (rather than the earlier Phase-A warning) when any material is
-		// missing, so a misconfigured cluster never silently runs unauthenticated
-		// node-to-node dispatch.
 		mtls := dispatch.MTLSConfig{
 			CAFile:   vars.InternalMTLSCA,
 			CertFile: vars.InternalMTLSCert,
 			KeyFile:  vars.InternalMTLSKey,
 		}
-		if !mtls.Configured() {
-			return fmt.Errorf("run-owner mode (CAESIUM_RUN_OWNER_ENABLED=true) requires mutual TLS: set CAESIUM_INTERNAL_MTLS_CA, CAESIUM_INTERNAL_MTLS_CERT, and CAESIUM_INTERNAL_MTLS_KEY")
+		configuredFields := 0
+		for _, value := range []string{mtls.CAFile, mtls.CertFile, mtls.KeyFile} {
+			if strings.TrimSpace(value) != "" {
+				configuredFields++
+			}
 		}
-		clientTLS, err := dispatch.ClientTLSConfig(mtls)
+		if configuredFields > 0 && !mtls.Configured() {
+			return fmt.Errorf("run-owner mode: set all explicit mTLS material paths (CAESIUM_INTERNAL_MTLS_CA/CERT/KEY) or leave all three unset for automatic provisioning")
+		}
+
+		var holder *dispatchpki.MaterialHolder
+		if mtls.Configured() {
+			var err error
+			holder, err = dispatchpki.NewStaticMaterialHolder(mtls.CAFile, mtls.CertFile, mtls.KeyFile)
+			if err != nil {
+				return fmt.Errorf("run-owner mode: load explicit internal mTLS material: %w", err)
+			}
+		} else {
+			mtlsToken := strings.TrimSpace(vars.InternalMTLSToken)
+			if mtlsToken == "" {
+				mtlsToken = strings.TrimSpace(vars.InternalWakeupToken)
+			}
+			if mtlsToken == "" {
+				return fmt.Errorf("run-owner mode requires either explicit mTLS material (CAESIUM_INTERNAL_MTLS_CA/CERT/KEY) or a shared token (CAESIUM_INTERNAL_WAKEUP_TOKEN) for automatic provisioning")
+			}
+			if len(mtlsToken) < 32 {
+				log.Warn("CAESIUM_INTERNAL_WAKEUP_TOKEN/CAESIUM_INTERNAL_MTLS_TOKEN is shorter than 32 bytes; use a high-entropy random token for internal mTLS auto-provisioning")
+			}
+			provisioner, err := dispatchpki.NewProvisioner(dispatchpki.Config{
+				Store:             dispatchpki.NewStore(db.Connection()),
+				NodeID:            vars.NodeAddress,
+				Token:             mtlsToken,
+				CATTL:             vars.InternalMTLSCATTL,
+				LeafTTL:           vars.InternalMTLSLeafTTL,
+				LeafRenewBefore:   vars.InternalMTLSLeafRenewBefore,
+				CARenewBefore:     vars.InternalMTLSCARenewBefore,
+				EnrollmentTimeout: vars.InternalMTLSEnrollmentTimeout,
+				LeaderCheck:       dqlite.IsLocalLeader,
+			})
+			if err != nil {
+				return fmt.Errorf("run-owner mode: configure internal mTLS auto-provisioning: %w", err)
+			}
+			log.Info("provisioning internal mTLS material", "node_address", vars.NodeAddress)
+			if err := provisioner.Bootstrap(ctx); err != nil {
+				return fmt.Errorf("run-owner mode: auto-provision internal mTLS: %w", err)
+			}
+			holder = provisioner.Holder()
+			go func() {
+				log.Info("launching internal mTLS auto-provisioner")
+				if err := provisioner.Run(ctx); err != nil && ctx.Err() == nil {
+					errs <- err
+				}
+			}()
+		}
+
+		clientTLS, err := dispatch.ClientTLSConfigFromHolder(holder)
 		if err != nil {
 			return fmt.Errorf("run-owner mode: build internal client TLS: %w", err)
 		}
 		dispatch.ConfigureInternalMTLS(clientTLS)
-		ownerInternalServerTLS, err = dispatch.ServerTLSConfig(mtls)
+		ownerInternalServerTLS, err = dispatch.ServerTLSConfigFromHolder(holder)
 		if err != nil {
 			return fmt.Errorf("run-owner mode: build internal server TLS: %w", err)
 		}

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ These files are useful context, but each should be treated according to its stat
 - [design-task-templates.md](design-task-templates.md)
 - [design-helm-kubernetes-deployment.md](design-helm-kubernetes-deployment.md)
 - [design-incremental-execution.md](design-incremental-execution.md)
+- [design-internal-mtls-auto-provisioning.md](design-internal-mtls-auto-provisioning.md)
 - [design-parallel-job-execution.md](design-parallel-job-execution.md)
 - [design-scaling-job-execution.md](design-scaling-job-execution.md)
 - [brainstorm-differentiators.md](brainstorm-differentiators.md)

--- a/docs/design-internal-mtls-auto-provisioning.md
+++ b/docs/design-internal-mtls-auto-provisioning.md
@@ -1,0 +1,283 @@
+# Design: Auto-provisioning internal mTLS
+
+Status: proposed (2026-05-26)
+Owner: Christopher Ryan
+
+## Goal
+
+Make run-owner mode secure node-to-node **with zero operator certificate work**.
+Today `CAESIUM_RUN_OWNER_ENABLED=true` hard-fails at startup unless the operator
+has provisioned a CA + per-node cert/key and mounted all three files
+(`CAESIUM_INTERNAL_MTLS_CA/CERT/KEY`). That friction is the blocker to making
+owner mode (and owner+in-memory) a sensible default for distributed deployments.
+
+This design auto-provisions the internal CA and per-node leaf certificates,
+bootstrapped from a single shared secret, so that setting one env var (the
+existing internal token) yields full mutual-TLS on the internal endpoints with
+no `openssl`, no cert files, and no manual rotation.
+
+## Requirements (decided)
+
+- **Runtime-agnostic.** No dependency on Kubernetes (or cert-manager, the CSR
+  API, projected service-account tokens). Must work identically on bare metal,
+  docker, podman, and k8s. Trust bootstraps through Caesium itself.
+- **Token-bootstrapped.** A single shared secret authenticates the trust
+  bootstrap. Reuse the existing cluster token rather than introducing a new one.
+- **Rotation in v1.** Leaf renewal, expiry handling, and CA roll are in scope —
+  not a follow-up.
+- **BYO override retained.** If the operator sets explicit
+  `CAESIUM_INTERNAL_MTLS_{CA,CERT,KEY}`, use them unchanged (existing behavior).
+  Auto-provisioning only engages when those are unset.
+- **Ephemeral-storage-safe.** Deployments commonly run with `persistence.enabled=false`
+  (ephemeral pod storage). Durable PKI state must survive node restarts and
+  leader failover without requiring a PVC.
+
+## Non-goals (v1)
+
+- Certificate revocation (CRL/OCSP). Short leaf lifetimes + rotation cover the
+  common case; revocation is a follow-up.
+- External CA / PKI integration beyond the existing BYO file path (Vault,
+  cert-manager). BYO remains the escape hatch.
+- Securing the dqlite replication transport itself (separate concern; see
+  "Security analysis" for why this design does not depend on it).
+- Per-task or per-tenant identity. Identity is per-node.
+
+## Background / current state
+
+- Owner mode exposes internal RPC endpoints (`/internal/dispatch`,
+  `/internal/complete`, `/internal/wakeup`) on a dedicated listener
+  (`CAESIUM_INTERNAL_PORT`, default 8443). These let nodes drive each other's
+  task execution and report completions+outputs, so they must be authenticated.
+- `internal/dispatch/mtls.go` already builds the TLS configs:
+  `ServerTLSConfig` (`RequireAndVerifyClientCert`) and `ClientTLSConfig`
+  (`InsecureSkipVerify` + `verifyChainAgainst` — hostname is intentionally
+  skipped for dynamic pod IPs; the chain is verified against the CA, and the
+  peer cert must be valid for the appropriate EKU). The **same key pair is each
+  node's identity in both directions** (server cert on its listener, client cert
+  when POSTing to peers), so a leaf needs **both** `serverAuth` and `clientAuth`
+  EKUs.
+- A bearer token (`CAESIUM_INTERNAL_WAKEUP_TOKEN`) already gates every internal
+  endpoint via `Handler.authorized`. It is currently *optional* (warned), while
+  mTLS material is *mandatory* (fatal if missing).
+- `cmd/start/start.go` builds the mTLS configs inside `if vars.RunOwnerEnabled`
+  and fatally errors if `MTLSConfig.Configured()` is false.
+- The **dqlite catalog** is replicated shared state every node already trusts,
+  riding dqlite's own transport (separate from the HTTP endpoints we are
+  securing). `pkg/dqlite` exposes `IsLocalLeader(ctx)` and `Cluster(ctx)`.
+
+## Architecture (Approach A: catalog-mediated, leader-signed, token-encrypted CA)
+
+The dqlite leader is the certificate authority. CA material lives in the
+replicated catalog so it survives leader failover and ephemeral node storage.
+The CA private key is encrypted at rest with a key derived from the shared
+token, so possession of the catalog alone does not grant signing power. Nodes
+generate their own leaf key pairs locally and obtain signed certs through a
+catalog-mediated CSR exchange authenticated by a token HMAC. **The token itself
+is never transmitted** — it is used only locally to derive the CA-key encryption
+key and to HMAC/verify CSRs; CSRs and certs flow over the dqlite transport.
+
+### Shared secret
+
+Reuse `CAESIUM_INTERNAL_WAKEUP_TOKEN` as the one cluster secret. Derive distinct
+keys from it via labeled HKDF-SHA256 so the usages don't overlap:
+
+- bearer auth: the raw token (unchanged).
+- CA-key encryption key (KEK): `HKDF-SHA256(token, info="caesium-internal-mtls-ca-kek-v1")` → 32 bytes.
+- CSR-authentication MAC key: `HKDF-SHA256(token, info="caesium-internal-mtls-csr-mac-v1")` → 32 bytes.
+
+The token becomes **required** when owner mode is on and no explicit cert files
+are provided. Emit a startup warning if it is shorter than 32 bytes (low
+entropy weakens the KEK; document that a high-entropy random token is expected).
+A dedicated `CAESIUM_INTERNAL_MTLS_TOKEN` may override the wakeup token if an
+operator wants to separate them, but reuse is the default.
+
+### Catalog schema (new models + migration)
+
+`internal_ca_generations` — overlapping CA generations (multiple rows during a roll):
+- `generation` INTEGER PRIMARY KEY (monotonic; highest non-expired is "active" for new issuance)
+- `cert_pem` TEXT (CA certificate, public)
+- `key_ciphertext` BLOB (CA private key, AES-256-GCM under the KEK)
+- `key_nonce` BLOB (12-byte GCM nonce)
+- `not_before`, `not_after` TIMESTAMP
+- `created_at` TIMESTAMP
+
+`internal_node_enrollments` — the CSR→cert rendezvous (rows GC'd after retrieval + TTL):
+- `id` TEXT PRIMARY KEY (uuid)
+- `node_id` TEXT (requesting node's `CAESIUM_NODE_ADDRESS`)
+- `csr_pem` TEXT
+- `csr_mac` BLOB (HMAC-SHA256(csr-mac-key, csr_der) — proves cluster membership)
+- `ca_generation` INTEGER (which CA the requester wants to be signed under; the
+  signer may upgrade to the newest)
+- `cert_pem` TEXT NULL (filled by the signer)
+- `status` TEXT ("pending" | "signed" | "rejected")
+- `requested_at`, `signed_at` TIMESTAMP
+
+These are catalog (not hot-shard) tables; migrate on the catalog connection
+alongside the other models.
+
+### Crypto parameters
+
+- KEK derivation: HKDF-SHA256 as above; CA key sealed with AES-256-GCM (random
+  12-byte nonce per seal, tag appended).
+- CA cert: self-signed, `BasicConstraintsValid` + `IsCA=true`, `KeyUsage =
+  CertSign|CRLSign`, CN `caesium-internal-ca`, lifetime
+  `CAESIUM_INTERNAL_MTLS_CA_TTL` (default ~5y).
+- Leaf cert: signed by the active CA, `ExtKeyUsage =
+  {ServerAuth, ClientAuth}` (both — node is client and server), `KeyUsage =
+  DigitalSignature|KeyEncipherment`, `IsCA=false`, CN/SAN = node address,
+  `NotBefore = now-5m` (clock-skew backdate), lifetime
+  `CAESIUM_INTERNAL_MTLS_LEAF_TTL` (default ~30d).
+- The signer builds the leaf template itself and takes **only the public key**
+  (and validates the claimed node identity) from the CSR — it must NOT honor
+  CSR-requested extensions (no `CA:TRUE`, no arbitrary EKU). It must verify the
+  CSR signature (proves the requester holds the private key) before signing.
+
+### Enrollment sequence
+
+On startup, when auto-provisioning is engaged, owner-mode wiring **blocks until
+this node holds a signed leaf + a trust pool** (bounded by a timeout, with
+retry/backoff). Steps:
+
+1. Connect to dqlite (already done before this point).
+2. **Genesis (leader only):** if `internal_ca_generations` is empty and this
+   node `IsLocalLeader`, generate CA generation 1, seal its key under the KEK,
+   and insert. Use the `generation` PK (and/or a conditional insert) so
+   concurrent genesis attempts are idempotent — exactly one CA wins; the others
+   read it. Non-leaders poll until a CA row appears.
+3. **Trust pool:** read all non-expired rows from `internal_ca_generations`;
+   the union of their `cert_pem` is the trust pool (`ClientCAs` / `RootCAs`).
+4. **Leaf request:** generate a leaf key pair locally (private key stays in
+   memory), build a CSR, compute `csr_mac = HMAC(csr-mac-key, csr_der)`, and
+   insert a `pending` enrollment row (under the newest CA generation).
+5. **Signing (leader signer loop):** the leader polls `pending` enrollments;
+   for each, constant-time-verify `csr_mac`, verify the CSR signature, build a
+   constrained leaf template, sign with the decrypted CA key, write `cert_pem` +
+   `status=signed`. On MAC mismatch, set `status=rejected` (token mismatch).
+6. **Retrieval:** the requester polls its enrollment row; on `signed`, load the
+   leaf into the material holder. On `rejected`, fail with a clear "token
+   mismatch?" error.
+7. Start the internal mTLS listener + dispatch loop only after the holder has a
+   valid leaf + trust pool.
+
+The leader enrolls its own leaf through the same table (its signer loop signs
+its own row), so there is no special-case path for the leader's own cert.
+
+### Dynamic TLS material (hot reload)
+
+Introduce a `MaterialHolder` (atomic pointer) holding the current leaf
+`tls.Certificate` + trust pool. Rebuild `ServerTLSConfig`/`ClientTLSConfig` to
+read from it via callbacks:
+- server: `GetCertificate` (and `GetConfigForClient` for the current `ClientCAs`).
+- client: `GetClientCertificate` + a `VerifyPeerCertificate` that verifies
+  against the holder's current pool (preserving the hostname-skip behavior).
+
+The BYO path wraps the static files in a holder that never changes, so both
+paths share one code path.
+
+### Rotation (v1)
+
+A per-node rotation goroutine:
+- **Leaf renewal:** when the current leaf passes `renewBefore` (default ~1/3 of
+  lifetime remaining), re-run enrollment (steps 3–6) under the newest CA and
+  atomically swap the holder's certificate. No restart.
+- **Trust-pool refresh:** periodically re-read `internal_ca_generations` and
+  update the holder's pool, so a freshly rolled CA becomes trusted clusterwide
+  *before* any leaf is issued under it.
+- **CA roll (leader only):** when the active CA passes `caRenewBefore`, generate
+  generation N+1 and insert it alongside N. During the overlap the trust pool is
+  the union of both, so leaves under either verify. New leaves are issued under
+  N+1. Prune a generation only after `not_after` + grace, when no live leaf
+  depends on it.
+
+### Startup wiring changes (`cmd/start/start.go`)
+
+Replace the `MTLSConfig.Configured()` hard-fail with:
+- explicit `CAESIUM_INTERNAL_MTLS_{CA,CERT,KEY}` set → BYO path (static holder), unchanged.
+- else token present → auto-provision: run enrollment (blocking, with timeout),
+  build dynamic configs from the holder, start the rotation goroutine.
+- else → fatal with the friendlier message: *"run-owner mode requires either
+  explicit mTLS material (CAESIUM_INTERNAL_MTLS_CA/CERT/KEY) or a shared token
+  (CAESIUM_INTERNAL_WAKEUP_TOKEN) for automatic provisioning."*
+
+## Config additions (`pkg/env`)
+
+- `CAESIUM_INTERNAL_MTLS_TOKEN` (optional; defaults to `CAESIUM_INTERNAL_WAKEUP_TOKEN`).
+- `CAESIUM_INTERNAL_MTLS_CA_TTL` (default ~43800h / 5y).
+- `CAESIUM_INTERNAL_MTLS_LEAF_TTL` (default ~720h / 30d).
+- `CAESIUM_INTERNAL_MTLS_LEAF_RENEW_BEFORE` / `..._CA_RENEW_BEFORE` (durations or
+  fractions; sensible defaults).
+- Auto-provisioning engages implicitly when owner mode is on, no explicit certs
+  are set, and a token is present (no separate enable flag needed).
+
+## Suggested package / file layout
+
+- `internal/dispatch/pki/` — new package:
+  - `kek.go` (HKDF derivation, AES-GCM seal/open),
+  - `ca.go` (genesis, leaf template, CSR signing with constraints),
+  - `store.go` (gorm access to the two new tables),
+  - `provisioner.go` (enrollment orchestration + rotation goroutine + `MaterialHolder`).
+- `internal/models/` — the two new table models + register in `models.All`.
+- `internal/dispatch/mtls.go` — dynamic `ServerTLSConfig`/`ClientTLSConfig` backed by the holder.
+- `cmd/start/start.go` — wiring + the new fatal/branch logic.
+- `pkg/env/env.go` — config fields above.
+
+## Failure modes & edge cases
+
+- **Token mismatch across nodes** → CSR MAC fails → `status=rejected` → the node
+  fails enrollment with a clear message. (Most likely operator error.)
+- **No leader / dqlite unavailable at boot** → enrollment retries with backoff
+  until quorum; bounded by the enrollment timeout.
+- **Genesis race** (multiple fresh leaders) → idempotent insert; one CA wins.
+- **Leader failover mid-roll / mid-sign** → any new leader can decrypt the CA
+  key (it has the token) and continue signing.
+- **Clock skew** → `NotBefore` backdated 5m; document that gross skew breaks TLS.
+- **Wrong token on a would-be signer** → cannot decrypt the CA key → logs +
+  cannot sign (it should not have become a signer; covered by the same path).
+
+## Security analysis
+
+- The **token is the root of trust** (same as today — it was already the shared
+  secret). Compromise grants CA-key decryption + bearer auth. Acceptable given
+  the chosen bootstrap model.
+- The token is **never transmitted**; only HKDF outputs and HMACs derived from
+  it touch the catalog. CSRs/certs are not secret.
+- The CA private key at rest is AES-256-GCM-sealed under the KEK, so a catalog
+  reader without the token cannot sign.
+- A rogue dqlite member **without** the token cannot get a leaf signed (CSR MAC
+  fails) and cannot use the CA key. dqlite membership alone is insufficient.
+- Leaf private keys are generated per node and never leave it.
+- The design does **not** depend on the dqlite transport being encrypted: the
+  only secret that transits it is the already-encrypted CA-key ciphertext.
+- Use `hmac.Equal` (constant-time) for MAC verification; also fix the existing
+  non-constant-time bearer-token compare (`== h.token`) while in this area.
+
+## Test plan
+
+Unit (`internal/dispatch/pki`):
+- HKDF determinism; AES-GCM seal/open roundtrip; open fails under a wrong KEK.
+- CA genesis produces a valid CA cert that signs verifiable leaves.
+- Leaf template has both EKUs, correct validity, `IsCA=false`.
+- Signer verifies the CSR signature and **ignores** CSR-requested extensions
+  (a CSR asking for `CA:TRUE` yields a non-CA leaf).
+- CSR-MAC accept/reject (constant-time).
+- Trust-pool union across multiple CA generations; a leaf under an old gen still
+  verifies against a pool containing both.
+- Renewal/roll trigger logic (time-based, deterministic with an injected clock).
+
+Integration (`test/`, `-tags=integration`, real store):
+- End-to-end enrollment: a node obtains a signed leaf; a second node trusts it.
+- Genesis race is idempotent.
+- Leader failover: signing continues under a new leader.
+- CA roll: both CAs trusted during overlap; new leaves under the new gen.
+- Token mismatch → enrollment rejected.
+- BYO override path unchanged (explicit files bypass provisioning).
+
+3-node k8s confirmation (deploy with only the token set, no cert files; confirm
+the cluster comes up mutually-authenticated and a job completes) is the final
+acceptance check — run separately, not in CI.
+
+## Rollout
+
+Ships behind the existing owner-mode gate; no behavior change for
+`RUN_OWNER_ENABLED=false`. Once verified, it removes the cert-provisioning
+friction that blocks making owner+in-memory the distributed default.

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -16,7 +16,8 @@ package dispatch
 import (
 	"bytes"
 	"context"
-	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -233,7 +234,14 @@ func (h *Handler) authorized(r *http.Request) bool {
 	}
 	auth := strings.TrimSpace(r.Header.Get("Authorization"))
 	if strings.EqualFold(auth[:min(len(auth), 7)], "bearer ") {
-		return hmac.Equal([]byte(strings.TrimSpace(auth[7:])), []byte(h.token))
+		// Hash both sides to a fixed 32-byte digest before the constant-time
+		// compare. A direct ConstantTimeCompare/hmac.Equal short-circuits when the
+		// lengths differ, which would leak the token's byte-length via a timing
+		// oracle (an attacker submits 1-, 2-, 3-byte tokens until the comparison
+		// stops short-circuiting). Comparing equal-length digests removes that.
+		got := sha256.Sum256([]byte(strings.TrimSpace(auth[7:])))
+		want := sha256.Sum256([]byte(h.token))
+		return subtle.ConstantTimeCompare(got[:], want[:]) == 1
 	}
 	return false
 }

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -6,9 +6,8 @@
 //	POST /internal/complete  – worker → owner: report task outcome back to owner.
 //
 // Both endpoints are guarded by the existing CAESIUM_INTERNAL_WAKEUP_TOKEN
-// bearer-token check.  mTLS is recommended but not yet enforced in Phase A
-// (Phase B will require it).  A startup log.Warn is emitted when owner mode
-// is on without mTLS material configured.
+// bearer-token check and run on the dedicated internal mTLS listener when owner
+// mode is enabled.
 //
 // When CAESIUM_RUN_OWNER_ENABLED=false (default), these handlers are never
 // registered and the system behaves byte-identically to Phase 1.
@@ -17,6 +16,7 @@ package dispatch
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -233,7 +233,7 @@ func (h *Handler) authorized(r *http.Request) bool {
 	}
 	auth := strings.TrimSpace(r.Header.Get("Authorization"))
 	if strings.EqualFold(auth[:min(len(auth), 7)], "bearer ") {
-		return strings.TrimSpace(auth[7:]) == h.token
+		return hmac.Equal([]byte(strings.TrimSpace(auth[7:])), []byte(h.token))
 	}
 	return false
 }

--- a/internal/dispatch/mtls.go
+++ b/internal/dispatch/mtls.go
@@ -4,7 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
+
+	dispatchpki "github.com/caesium-cloud/caesium/internal/dispatch/pki"
 )
 
 // MTLSConfig holds the file paths for the internal mutual-TLS material
@@ -23,38 +24,45 @@ func (c MTLSConfig) Configured() bool {
 	return c.CAFile != "" && c.CertFile != "" && c.KeyFile != ""
 }
 
-// loadCertPool reads a PEM CA bundle into an x509 pool.
-func loadCertPool(caFile string) (*x509.CertPool, error) {
-	pem, err := os.ReadFile(caFile)
-	if err != nil {
-		return nil, fmt.Errorf("mtls: read CA %q: %w", caFile, err)
-	}
-	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(pem) {
-		return nil, fmt.Errorf("mtls: no certificates found in CA %q", caFile)
-	}
-	return pool, nil
-}
-
 // ServerTLSConfig builds the *tls.Config for the internal listener: it presents
 // this node's certificate and requires + verifies a client certificate signed
 // by the configured CA on every connection.  A peer with no certificate, or one
 // signed by an unknown CA, fails the TLS handshake before reaching a handler.
 func ServerTLSConfig(c MTLSConfig) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("mtls: load server keypair: %w", err)
-	}
-	pool, err := loadCertPool(c.CAFile)
+	holder, err := dispatchpki.NewStaticMaterialHolder(c.CAFile, c.CertFile, c.KeyFile)
 	if err != nil {
 		return nil, err
 	}
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		ClientCAs:    pool,
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		MinVersion:   tls.VersionTLS12,
-	}, nil
+	return ServerTLSConfigFromHolder(holder)
+}
+
+func ServerTLSConfigFromHolder(holder *dispatchpki.MaterialHolder) (*tls.Config, error) {
+	if _, ok := holder.Material(); !ok {
+		return nil, fmt.Errorf("mtls: TLS material not initialized")
+	}
+	pool, err := holder.CertPool()
+	if err != nil {
+		return nil, err
+	}
+	cfg := &tls.Config{
+		ClientCAs:  pool,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		MinVersion: tls.VersionTLS12,
+	}
+	cfg.GetCertificate = func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+		return holder.Certificate()
+	}
+	cfg.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		pool, err := holder.CertPool()
+		if err != nil {
+			return nil, err
+		}
+		next := cfg.Clone()
+		next.ClientCAs = pool
+		next.GetConfigForClient = nil
+		return next, nil
+	}
+	return cfg, nil
 }
 
 // ClientTLSConfig builds the *tls.Config used when this node POSTs to a peer's
@@ -70,21 +78,40 @@ func ServerTLSConfig(c MTLSConfig) (*tls.Config, error) {
 // set InsecureSkipVerify (which only disables the name/standard verification)
 // and re-implement chain verification in VerifyPeerCertificate.
 func ClientTLSConfig(c MTLSConfig) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(c.CertFile, c.KeyFile)
+	holder, err := dispatchpki.NewStaticMaterialHolder(c.CAFile, c.CertFile, c.KeyFile)
 	if err != nil {
-		return nil, fmt.Errorf("mtls: load client keypair: %w", err)
+		return nil, err
 	}
-	pool, err := loadCertPool(c.CAFile)
+	return ClientTLSConfigFromHolder(holder)
+}
+
+func ClientTLSConfigFromHolder(holder *dispatchpki.MaterialHolder) (*tls.Config, error) {
+	if _, ok := holder.Material(); !ok {
+		return nil, fmt.Errorf("mtls: TLS material not initialized")
+	}
+	pool, err := holder.CertPool()
 	if err != nil {
 		return nil, err
 	}
 	return &tls.Config{
-		Certificates:          []tls.Certificate{cert},
-		RootCAs:               pool,
-		MinVersion:            tls.VersionTLS12,
-		InsecureSkipVerify:    true, //nolint:gosec // chain verified below; hostname intentionally skipped for dynamic pod IPs
-		VerifyPeerCertificate: verifyChainAgainst(pool),
+		RootCAs:            pool,
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, //nolint:gosec // chain verified below; hostname intentionally skipped for dynamic pod IPs
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return holder.Certificate()
+		},
+		VerifyPeerCertificate: verifyChainAgainstHolder(holder),
 	}, nil
+}
+
+func verifyChainAgainstHolder(holder *dispatchpki.MaterialHolder) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		pool, err := holder.CertPool()
+		if err != nil {
+			return err
+		}
+		return verifyChainAgainst(pool)(rawCerts, verifiedChains)
+	}
 }
 
 // verifyChainAgainst returns a VerifyPeerCertificate callback that validates the

--- a/internal/dispatch/pki/ca.go
+++ b/internal/dispatch/pki/ca.go
@@ -1,0 +1,322 @@
+package pki
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+const (
+	caCommonName = "caesium-internal-ca"
+	leafBackdate = 5 * time.Minute
+)
+
+const (
+	EnrollmentStatusPending  = "pending"
+	EnrollmentStatusSigned   = "signed"
+	EnrollmentStatusRejected = "rejected"
+)
+
+// NewCAGeneration creates a sealed catalog CA generation row.
+func NewCAGeneration(generation int, kek []byte, now time.Time, ttl time.Duration) (*models.InternalCAGeneration, *x509.Certificate, error) {
+	if generation < 1 {
+		return nil, nil, fmt.Errorf("pki: CA generation must be positive")
+	}
+	certPEM, keyPEM, cert, err := GenerateCA(now, ttl)
+	if err != nil {
+		return nil, nil, err
+	}
+	ciphertext, nonce, err := SealCAKey(kek, keyPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &models.InternalCAGeneration{
+		Generation:    generation,
+		CertPEM:       string(certPEM),
+		KeyCiphertext: ciphertext,
+		KeyNonce:      nonce,
+		NotBefore:     cert.NotBefore,
+		NotAfter:      cert.NotAfter,
+		CreatedAt:     now.UTC(),
+	}, cert, nil
+}
+
+// GenerateCA creates a self-signed Caesium internal CA certificate and key.
+func GenerateCA(now time.Time, ttl time.Duration) (certPEM, keyPEM []byte, cert *x509.Certificate, err error) {
+	if ttl <= 0 {
+		return nil, nil, nil, fmt.Errorf("pki: CA TTL must be positive")
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("pki: generate CA key: %w", err)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: caCommonName},
+		NotBefore:             now.UTC(),
+		NotAfter:              now.Add(ttl).UTC(),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("pki: create CA certificate: %w", err)
+	}
+	cert, err = x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("pki: parse generated CA certificate: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("pki: marshal CA key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+		cert,
+		nil
+}
+
+// LeafRequest holds a locally generated private key and CSR. KeyPEM must never
+// be written to the catalog.
+type LeafRequest struct {
+	CSRPEM []byte
+	CSRDER []byte
+	KeyPEM []byte
+}
+
+// GenerateLeafRequest creates a node-local leaf keypair and CSR.
+func GenerateLeafRequest(nodeID string) (LeafRequest, error) {
+	if nodeID == "" {
+		return LeafRequest{}, fmt.Errorf("pki: node ID is required")
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return LeafRequest{}, fmt.Errorf("pki: generate leaf key: %w", err)
+	}
+	csrTmpl := &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: nodeID},
+	}
+	host, ips, dns := nodeAddressNames(nodeID)
+	csrTmpl.DNSNames = dns
+	csrTmpl.IPAddresses = ips
+	if len(csrTmpl.DNSNames) == 0 && len(csrTmpl.IPAddresses) == 0 && host != "" {
+		csrTmpl.DNSNames = []string{host}
+	}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTmpl, key)
+	if err != nil {
+		return LeafRequest{}, fmt.Errorf("pki: create leaf CSR: %w", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		return LeafRequest{}, fmt.Errorf("pki: marshal leaf key: %w", err)
+	}
+	return LeafRequest{
+		CSRPEM: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}),
+		CSRDER: csrDER,
+		KeyPEM: pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+	}, nil
+}
+
+// CSRMac returns HMAC-SHA256(csr-mac-key, csrDER).
+func CSRMac(macKey, csrDER []byte) []byte {
+	mac := hmac.New(sha256.New, macKey)
+	_, _ = mac.Write(csrDER)
+	return mac.Sum(nil)
+}
+
+// VerifyCSRMac checks a CSR HMAC using hmac.Equal.
+func VerifyCSRMac(macKey, csrDER, got []byte) bool {
+	expected := CSRMac(macKey, csrDER)
+	return hmac.Equal(expected, got)
+}
+
+// SignCSR verifies csrPEM and signs a constrained non-CA leaf for nodeID. The
+// resulting certificate uses only the CSR public key and the validated node
+// identity; CSR-requested extensions are intentionally ignored.
+func SignCSR(csrPEM []byte, nodeID string, caCert *x509.Certificate, caKey crypto.Signer, now time.Time, ttl time.Duration) ([]byte, *x509.Certificate, error) {
+	if nodeID == "" {
+		return nil, nil, fmt.Errorf("pki: node ID is required")
+	}
+	if caCert == nil || caKey == nil {
+		return nil, nil, fmt.Errorf("pki: CA certificate and key are required")
+	}
+	if ttl <= 0 {
+		return nil, nil, fmt.Errorf("pki: leaf TTL must be positive")
+	}
+	csr, err := ParseCSRPEM(csrPEM)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := csr.CheckSignature(); err != nil {
+		return nil, nil, fmt.Errorf("pki: CSR signature invalid: %w", err)
+	}
+	if csr.Subject.CommonName != nodeID {
+		return nil, nil, fmt.Errorf("pki: CSR common name %q does not match node ID %q", csr.Subject.CommonName, nodeID)
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	host, ips, dns := nodeAddressNames(nodeID)
+	if len(dns) == 0 && len(ips) == 0 && host != "" {
+		dns = []string{host}
+	}
+	notAfter := now.Add(ttl).UTC()
+	if caCert.NotAfter.Before(notAfter) {
+		notAfter = caCert.NotAfter.UTC()
+	}
+	notBefore := now.Add(-leafBackdate).UTC()
+	if !notAfter.After(notBefore) {
+		return nil, nil, fmt.Errorf("pki: CA generation expires before requested leaf validity")
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: nodeID},
+		DNSNames:              dns,
+		IPAddresses:           ips,
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  false,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, csr.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pki: sign leaf certificate: %w", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pki: parse signed leaf certificate: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), cert, nil
+}
+
+// TrustPoolFromGenerations builds the union trust pool from every non-expired
+// CA generation.
+func TrustPoolFromGenerations(gens []models.InternalCAGeneration, now time.Time) (*x509.CertPool, []*x509.Certificate, error) {
+	pool := x509.NewCertPool()
+	certs := make([]*x509.Certificate, 0, len(gens))
+	for _, gen := range gens {
+		if !gen.NotAfter.After(now) {
+			continue
+		}
+		parsed, err := ParseCertificatesPEM([]byte(gen.CertPEM))
+		if err != nil {
+			return nil, nil, fmt.Errorf("pki: parse CA generation %d: %w", gen.Generation, err)
+		}
+		for _, cert := range parsed {
+			if !cert.IsCA {
+				return nil, nil, fmt.Errorf("pki: generation %d certificate is not a CA", gen.Generation)
+			}
+			pool.AddCert(cert)
+			certs = append(certs, cert)
+		}
+	}
+	if len(certs) == 0 {
+		return nil, nil, fmt.Errorf("pki: no non-expired CA generations")
+	}
+	return pool, certs, nil
+}
+
+// ParseCSRPEM parses a single PEM-encoded certificate request.
+func ParseCSRPEM(data []byte) (*x509.CertificateRequest, error) {
+	block, rest := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, fmt.Errorf("pki: no certificate request PEM block found")
+	}
+	if len(bytes.TrimSpace(rest)) != 0 {
+		return nil, fmt.Errorf("pki: trailing data after certificate request PEM")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("pki: parse CSR: %w", err)
+	}
+	return csr, nil
+}
+
+// ParseCertificatesPEM parses one or more PEM certificates.
+func ParseCertificatesPEM(data []byte) ([]*x509.Certificate, error) {
+	var certs []*x509.Certificate
+	rest := data
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" {
+			continue
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse certificate: %w", err)
+		}
+		certs = append(certs, cert)
+	}
+	if len(certs) == 0 {
+		return nil, fmt.Errorf("no certificate PEM blocks found")
+	}
+	return certs, nil
+}
+
+// ParsePrivateKeyPEM parses an ECDSA or PKCS#8 private key PEM.
+func ParsePrivateKeyPEM(data []byte) (crypto.Signer, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("pki: no private key PEM block found")
+	}
+	if key, err := x509.ParseECPrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("pki: parse private key: %w", err)
+	}
+	signer, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, fmt.Errorf("pki: private key does not implement crypto.Signer")
+	}
+	return signer, nil
+}
+
+func randomSerial() (*big.Int, error) {
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return nil, fmt.Errorf("pki: generate certificate serial: %w", err)
+	}
+	return serial, nil
+}
+
+func nodeAddressNames(nodeID string) (host string, ips []net.IP, dns []string) {
+	host = nodeID
+	if h, _, err := net.SplitHostPort(nodeID); err == nil {
+		host = h
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return host, []net.IP{ip}, nil
+	}
+	if host != "" {
+		return host, nil, []string{host}
+	}
+	return "", nil, nil
+}

--- a/internal/dispatch/pki/kek.go
+++ b/internal/dispatch/pki/kek.go
@@ -1,0 +1,86 @@
+package pki
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hkdf"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+)
+
+const (
+	caKEKInfo    = "caesium-internal-mtls-ca-kek-v1"
+	csrMACInfo   = "caesium-internal-mtls-csr-mac-v1"
+	derivedBytes = 32
+	gcmNonceSize = 12
+)
+
+// DerivedKeys are independent HKDF-SHA256 outputs derived from the operator's
+// shared internal token. The raw token is never used for CA encryption or CSR
+// authentication.
+type DerivedKeys struct {
+	CAKEK  []byte
+	CSRMac []byte
+}
+
+// DeriveKeys expands token into the CA-key encryption key and CSR MAC key.
+func DeriveKeys(token string) (DerivedKeys, error) {
+	if token == "" {
+		return DerivedKeys{}, fmt.Errorf("pki: empty internal mTLS token")
+	}
+	kek, err := hkdf.Key(sha256.New, []byte(token), nil, caKEKInfo, derivedBytes)
+	if err != nil {
+		return DerivedKeys{}, fmt.Errorf("pki: derive CA KEK: %w", err)
+	}
+	mac, err := hkdf.Key(sha256.New, []byte(token), nil, csrMACInfo, derivedBytes)
+	if err != nil {
+		return DerivedKeys{}, fmt.Errorf("pki: derive CSR MAC key: %w", err)
+	}
+	return DerivedKeys{CAKEK: kek, CSRMac: mac}, nil
+}
+
+// SealCAKey encrypts a PEM-encoded CA private key under kek using AES-256-GCM.
+func SealCAKey(kek, plaintext []byte) (ciphertext, nonce []byte, err error) {
+	aead, err := caKeyAEAD(kek)
+	if err != nil {
+		return nil, nil, err
+	}
+	nonce = make([]byte, gcmNonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, fmt.Errorf("pki: generate CA key nonce: %w", err)
+	}
+	return aead.Seal(nil, nonce, plaintext, nil), nonce, nil
+}
+
+// OpenCAKey decrypts a PEM-encoded CA private key sealed by SealCAKey.
+func OpenCAKey(kek, ciphertext, nonce []byte) ([]byte, error) {
+	if len(nonce) != gcmNonceSize {
+		return nil, fmt.Errorf("pki: invalid CA key nonce length %d", len(nonce))
+	}
+	aead, err := caKeyAEAD(kek)
+	if err != nil {
+		return nil, err
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("pki: open CA key: %w", err)
+	}
+	return plaintext, nil
+}
+
+func caKeyAEAD(kek []byte) (cipher.AEAD, error) {
+	if len(kek) != derivedBytes {
+		return nil, fmt.Errorf("pki: CA KEK must be %d bytes, got %d", derivedBytes, len(kek))
+	}
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("pki: init CA key cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("pki: init CA key GCM: %w", err)
+	}
+	return aead, nil
+}

--- a/internal/dispatch/pki/pki_test.go
+++ b/internal/dispatch/pki/pki_test.go
@@ -1,0 +1,340 @@
+package pki
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+const testToken = "0123456789abcdef0123456789abcdef"
+
+type fakeClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newFakeClock(now time.Time) *fakeClock {
+	return &fakeClock{now: now}
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeClock) Set(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = now
+}
+
+func leader(context.Context) (bool, error)    { return true, nil }
+func nonLeader(context.Context) (bool, error) { return false, nil }
+
+func TestDeriveKeysDeterministic(t *testing.T) {
+	first, err := DeriveKeys(testToken)
+	require.NoError(t, err)
+	second, err := DeriveKeys(testToken)
+	require.NoError(t, err)
+	other, err := DeriveKeys(testToken + "-other")
+	require.NoError(t, err)
+
+	require.Equal(t, first.CAKEK, second.CAKEK)
+	require.Equal(t, first.CSRMac, second.CSRMac)
+	require.NotEqual(t, first.CAKEK, first.CSRMac)
+	require.NotEqual(t, first.CAKEK, other.CAKEK)
+	require.Len(t, first.CAKEK, 32)
+	require.Len(t, first.CSRMac, 32)
+}
+
+func TestSealCAKeyRoundTripAndWrongKeyFailure(t *testing.T) {
+	keys, err := DeriveKeys(testToken)
+	require.NoError(t, err)
+	wrong, err := DeriveKeys(testToken + "-wrong")
+	require.NoError(t, err)
+
+	plaintext := []byte("ca-private-key-pem")
+	ciphertext, nonce, err := SealCAKey(keys.CAKEK, plaintext)
+	require.NoError(t, err)
+	require.Len(t, nonce, 12)
+	require.NotEqual(t, plaintext, ciphertext)
+
+	opened, err := OpenCAKey(keys.CAKEK, ciphertext, nonce)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, opened)
+
+	_, err = OpenCAKey(wrong.CAKEK, ciphertext, nonce)
+	require.Error(t, err)
+}
+
+func TestCAGenesisSignsVerifiableLeaf(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	keys, err := DeriveKeys(testToken)
+	require.NoError(t, err)
+	gen, caCert, err := NewCAGeneration(1, keys.CAKEK, now, time.Hour)
+	require.NoError(t, err)
+	require.True(t, caCert.IsCA)
+	require.Equal(t, x509.KeyUsageCertSign|x509.KeyUsageCRLSign, caCert.KeyUsage)
+
+	caKey := signerForTestGeneration(t, gen, keys.CAKEK)
+	req, err := GenerateLeafRequest("node-a:9001")
+	require.NoError(t, err)
+	leafPEM, leaf, err := SignCSR(req.CSRPEM, "node-a:9001", caCert, caKey, now, 30*time.Minute)
+	require.NoError(t, err)
+	require.NotEmpty(t, leafPEM)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+	_, err = leaf.Verify(x509.VerifyOptions{
+		Roots:       pool,
+		CurrentTime: now,
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	require.NoError(t, err)
+}
+
+func TestLeafTemplateHasBothEKUsAndIsNonCA(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	_, caCert, caKey := caForTest(t, now)
+	req, err := GenerateLeafRequest("127.0.0.1:9001")
+	require.NoError(t, err)
+
+	_, leaf, err := SignCSR(req.CSRPEM, "127.0.0.1:9001", caCert, caKey, now, time.Hour)
+	require.NoError(t, err)
+	require.False(t, leaf.IsCA)
+	require.Contains(t, leaf.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+	require.Contains(t, leaf.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+	require.Equal(t, x509.KeyUsageDigitalSignature|x509.KeyUsageKeyEncipherment, leaf.KeyUsage)
+	require.Equal(t, now.Add(-leafBackdate), leaf.NotBefore)
+}
+
+func TestSignerIgnoresCSRRequestedExtensions(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	_, caCert, caKey := caForTest(t, now)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	basicConstraints, err := asn1.Marshal(struct {
+		IsCA bool `asn1:"optional"`
+	}{IsCA: true})
+	require.NoError(t, err)
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, &x509.CertificateRequest{
+		Subject: pkix.Name{CommonName: "node-b:9001"},
+		ExtraExtensions: []pkix.Extension{
+			{Id: []int{2, 5, 29, 19}, Critical: true, Value: basicConstraints},
+		},
+	}, key)
+	require.NoError(t, err)
+	csrPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+
+	_, leaf, err := SignCSR(csrPEM, "node-b:9001", caCert, caKey, now, time.Hour)
+	require.NoError(t, err)
+	require.False(t, leaf.IsCA)
+	require.Contains(t, leaf.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+	require.Contains(t, leaf.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+}
+
+func TestCSRMacAcceptReject(t *testing.T) {
+	keys, err := DeriveKeys(testToken)
+	require.NoError(t, err)
+	wrong, err := DeriveKeys(testToken + "-wrong")
+	require.NoError(t, err)
+	req, err := GenerateLeafRequest("node-c:9001")
+	require.NoError(t, err)
+
+	mac := CSRMac(keys.CSRMac, req.CSRDER)
+	require.True(t, VerifyCSRMac(keys.CSRMac, req.CSRDER, mac))
+	require.False(t, VerifyCSRMac(wrong.CSRMac, req.CSRDER, mac))
+	require.False(t, VerifyCSRMac(keys.CSRMac, []byte("different-csr"), mac))
+}
+
+func TestTrustPoolUnionAcrossGenerations(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	keys, err := DeriveKeys(testToken)
+	require.NoError(t, err)
+	oldGen, oldCA, err := NewCAGeneration(1, keys.CAKEK, now.Add(-time.Hour), 2*time.Hour)
+	require.NoError(t, err)
+	newGen, _, err := NewCAGeneration(2, keys.CAKEK, now, 3*time.Hour)
+	require.NoError(t, err)
+	req, err := GenerateLeafRequest("node-old:9001")
+	require.NoError(t, err)
+	_, oldLeaf, err := SignCSR(req.CSRPEM, "node-old:9001", oldCA, signerForTestGeneration(t, oldGen, keys.CAKEK), now, time.Hour)
+	require.NoError(t, err)
+
+	pool, _, err := TrustPoolFromGenerations([]models.InternalCAGeneration{*oldGen, *newGen}, now)
+	require.NoError(t, err)
+	_, err = oldLeaf.Verify(x509.VerifyOptions{
+		Roots:       pool,
+		CurrentTime: now,
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	require.NoError(t, err)
+}
+
+func TestRenewAndRollTriggersUseInjectedClock(t *testing.T) {
+	base := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	clock := newFakeClock(base)
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	p, err := NewProvisioner(Config{
+		Store:             NewStore(db),
+		NodeID:            "node-renew:9001",
+		Token:             testToken,
+		CATTL:             30 * time.Minute,
+		LeafTTL:           20 * time.Minute,
+		LeafRenewBefore:   5 * time.Minute,
+		CARenewBefore:     5 * time.Minute,
+		EnrollmentTimeout: time.Second,
+		PollInterval:      time.Millisecond,
+		LeaderCheck:       leader,
+		Clock:             clock,
+	})
+	require.NoError(t, err)
+	require.NoError(t, p.Bootstrap(context.Background()))
+	require.False(t, p.LeafRenewalDue())
+
+	clock.Set(base.Add(26 * time.Minute))
+	require.True(t, p.LeafRenewalDue())
+	require.NoError(t, p.RollCAIfNeeded(context.Background()))
+	count, err := p.store.CountCAGenerations(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(2), count)
+}
+
+func TestStoreEndToEndEnrollmentAndTrust(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	store := NewStore(db)
+
+	first := newTestProvisioner(t, store, "node-1:9001", testToken, leader, newFakeClock(now))
+	require.NoError(t, first.Bootstrap(context.Background()))
+	second := newTestProvisioner(t, store, "node-2:9001", testToken, leader, newFakeClock(now))
+	require.NoError(t, second.Bootstrap(context.Background()))
+
+	firstMat, ok := first.Holder().Material()
+	require.True(t, ok)
+	secondPool, err := second.Holder().CertPool()
+	require.NoError(t, err)
+	_, err = firstMat.Leaf.Verify(x509.VerifyOptions{
+		Roots:       secondPool,
+		CurrentTime: now,
+		KeyUsages:   []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	require.NoError(t, err)
+}
+
+func TestGenesisRaceIsIdempotent(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	store := NewStore(db)
+	const contenders = 8
+
+	provisioners := make([]*Provisioner, contenders)
+	for i := 0; i < contenders; i++ {
+		provisioners[i] = newTestProvisioner(t, store, "node-race-"+string(rune('a'+i))+":9001", testToken, leader, newFakeClock(now))
+	}
+	start := make(chan struct{})
+	errs := make(chan error, contenders)
+	var wg sync.WaitGroup
+	for i := 0; i < contenders; i++ {
+		wg.Add(1)
+		go func(p *Provisioner) {
+			defer wg.Done()
+			<-start
+			errs <- p.ensureCA(context.Background())
+		}(provisioners[i])
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	count, err := store.CountCAGenerations(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, int64(1), count)
+}
+
+func TestTokenMismatchEnrollmentRejected(t *testing.T) {
+	now := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	store := NewStore(db)
+
+	good := newTestProvisioner(t, store, "good-node:9001", testToken, leader, newFakeClock(now))
+	require.NoError(t, good.Bootstrap(context.Background()))
+	bad := newTestProvisioner(t, store, "bad-node:9001", testToken+"-wrong", nonLeader, newFakeClock(now))
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- bad.Enroll(ctx)
+	}()
+
+	for {
+		select {
+		case err := <-errCh:
+			require.Error(t, err)
+			require.True(t, strings.Contains(err.Error(), "rejected"))
+			return
+		default:
+			_, err := good.SignPending(ctx, 32)
+			require.NoError(t, err)
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func newTestProvisioner(t *testing.T, store *Store, nodeID, token string, leaderCheck LeaderCheckFunc, clock Clock) *Provisioner {
+	t.Helper()
+	p, err := NewProvisioner(Config{
+		Store:             store,
+		NodeID:            nodeID,
+		Token:             token,
+		CATTL:             time.Hour,
+		LeafTTL:           30 * time.Minute,
+		LeafRenewBefore:   10 * time.Minute,
+		CARenewBefore:     10 * time.Minute,
+		EnrollmentTimeout: time.Second,
+		PollInterval:      time.Millisecond,
+		LeaderCheck:       leaderCheck,
+		Clock:             clock,
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func caForTest(t *testing.T, now time.Time) (*models.InternalCAGeneration, *x509.Certificate, crypto.Signer) {
+	t.Helper()
+	keys, err := DeriveKeys(testToken)
+	require.NoError(t, err)
+	gen, caCert, err := NewCAGeneration(1, keys.CAKEK, now, time.Hour)
+	require.NoError(t, err)
+	return gen, caCert, signerForTestGeneration(t, gen, keys.CAKEK)
+}
+
+func signerForTestGeneration(t *testing.T, gen *models.InternalCAGeneration, kek []byte) crypto.Signer {
+	t.Helper()
+	keyPEM, err := OpenCAKey(kek, gen.KeyCiphertext, gen.KeyNonce)
+	require.NoError(t, err)
+	key, err := ParsePrivateKeyPEM(keyPEM)
+	require.NoError(t, err)
+	return key
+}

--- a/internal/dispatch/pki/provisioner.go
+++ b/internal/dispatch/pki/provisioner.go
@@ -1,0 +1,623 @@
+package pki
+
+import (
+	"context"
+	"crypto"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+const (
+	DefaultCATTL                = 43800 * time.Hour
+	DefaultLeafTTL              = 720 * time.Hour
+	DefaultEnrollmentTimeout    = 2 * time.Minute
+	DefaultPollInterval         = 500 * time.Millisecond
+	DefaultRotationInterval     = 1 * time.Minute
+	DefaultTrustRefreshInterval = 5 * time.Minute
+	defaultSignBatchSize        = 32
+)
+
+// Clock lets tests make renewal and roll decisions deterministic.
+type Clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now().UTC() }
+
+type LeaderCheckFunc func(context.Context) (bool, error)
+
+// Material is the currently usable node certificate and trust bundle.
+type Material struct {
+	Certificate tls.Certificate
+	Leaf        *x509.Certificate
+	Pool        *x509.CertPool
+	CACerts     []*x509.Certificate
+}
+
+// MaterialHolder atomically publishes TLS material to server/client callbacks.
+type MaterialHolder struct {
+	current atomic.Pointer[Material]
+}
+
+func NewMaterialHolder() *MaterialHolder {
+	return &MaterialHolder{}
+}
+
+func NewStaticMaterialHolder(caFile, certFile, keyFile string) (*MaterialHolder, error) {
+	caPEM, err := os.ReadFile(caFile)
+	if err != nil {
+		return nil, fmt.Errorf("mtls: read CA %q: %w", caFile, err)
+	}
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return nil, fmt.Errorf("mtls: read cert %q: %w", certFile, err)
+	}
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("mtls: read key %q: %w", keyFile, err)
+	}
+	holder := NewMaterialHolder()
+	cert, err := TLSCertificate(certPEM, keyPEM)
+	if err != nil {
+		return nil, err
+	}
+	pool, caCerts, err := CertPool(caPEM)
+	if err != nil {
+		return nil, err
+	}
+	holder.Set(cert, pool, caCerts)
+	return holder, nil
+}
+
+func TLSCertificate(certPEM, keyPEM []byte) (tls.Certificate, error) {
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("mtls: load keypair: %w", err)
+	}
+	if len(cert.Certificate) == 0 {
+		return tls.Certificate{}, fmt.Errorf("mtls: keypair contains no certificate")
+	}
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("mtls: parse leaf certificate: %w", err)
+	}
+	cert.Leaf = leaf
+	return cert, nil
+}
+
+func CertPool(caPEM []byte) (*x509.CertPool, []*x509.Certificate, error) {
+	certs, err := ParseCertificatesPEM(caPEM)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mtls: parse CA bundle: %w", err)
+	}
+	pool := x509.NewCertPool()
+	for _, cert := range certs {
+		pool.AddCert(cert)
+	}
+	return pool, certs, nil
+}
+
+func (h *MaterialHolder) Set(cert tls.Certificate, pool *x509.CertPool, caCerts []*x509.Certificate) {
+	h.current.Store(&Material{
+		Certificate: cert,
+		Leaf:        cert.Leaf,
+		Pool:        clonePool(pool),
+		CACerts:     append([]*x509.Certificate(nil), caCerts...),
+	})
+}
+
+func (h *MaterialHolder) UpdateTrust(pool *x509.CertPool, caCerts []*x509.Certificate) error {
+	mat, ok := h.Material()
+	if !ok {
+		return fmt.Errorf("mtls: TLS material not initialized")
+	}
+	h.Set(mat.Certificate, pool, caCerts)
+	return nil
+}
+
+func (h *MaterialHolder) Material() (*Material, bool) {
+	if h == nil {
+		return nil, false
+	}
+	mat := h.current.Load()
+	if mat == nil {
+		return nil, false
+	}
+	return mat, true
+}
+
+func (h *MaterialHolder) Certificate() (*tls.Certificate, error) {
+	mat, ok := h.Material()
+	if !ok {
+		return nil, fmt.Errorf("mtls: TLS material not initialized")
+	}
+	cert := mat.Certificate
+	return &cert, nil
+}
+
+func (h *MaterialHolder) CertPool() (*x509.CertPool, error) {
+	mat, ok := h.Material()
+	if !ok {
+		return nil, fmt.Errorf("mtls: TLS material not initialized")
+	}
+	return clonePool(mat.Pool), nil
+}
+
+func clonePool(pool *x509.CertPool) *x509.CertPool {
+	if pool == nil {
+		return x509.NewCertPool()
+	}
+	return pool.Clone()
+}
+
+// Config controls internal mTLS auto-provisioning.
+type Config struct {
+	Store                *Store
+	NodeID               string
+	Token                string
+	CATTL                time.Duration
+	LeafTTL              time.Duration
+	LeafRenewBefore      time.Duration
+	CARenewBefore        time.Duration
+	EnrollmentTimeout    time.Duration
+	PollInterval         time.Duration
+	RotationInterval     time.Duration
+	TrustRefreshInterval time.Duration
+	SignBatchSize        int
+	LeaderCheck          LeaderCheckFunc
+	Clock                Clock
+}
+
+type Provisioner struct {
+	store                *Store
+	holder               *MaterialHolder
+	keys                 DerivedKeys
+	nodeID               string
+	caTTL                time.Duration
+	leafTTL              time.Duration
+	leafRenewBefore      time.Duration
+	caRenewBefore        time.Duration
+	enrollmentTimeout    time.Duration
+	pollInterval         time.Duration
+	rotationInterval     time.Duration
+	trustRefreshInterval time.Duration
+	signBatchSize        int
+	leaderCheck          LeaderCheckFunc
+	clock                Clock
+}
+
+func NewProvisioner(cfg Config) (*Provisioner, error) {
+	if cfg.Store == nil {
+		return nil, fmt.Errorf("pki: store is required")
+	}
+	if cfg.NodeID == "" {
+		return nil, fmt.Errorf("pki: node ID is required")
+	}
+	if cfg.LeaderCheck == nil {
+		return nil, fmt.Errorf("pki: leader check is required")
+	}
+	keys, err := DeriveKeys(cfg.Token)
+	if err != nil {
+		return nil, err
+	}
+	caTTL := cfg.CATTL
+	if caTTL <= 0 {
+		caTTL = DefaultCATTL
+	}
+	leafTTL := cfg.LeafTTL
+	if leafTTL <= 0 {
+		leafTTL = DefaultLeafTTL
+	}
+	leafRenewBefore := cfg.LeafRenewBefore
+	if leafRenewBefore <= 0 {
+		leafRenewBefore = leafTTL / 3
+	}
+	caRenewBefore := cfg.CARenewBefore
+	if caRenewBefore <= 0 {
+		caRenewBefore = 30 * 24 * time.Hour
+		if caRenewBefore >= caTTL {
+			caRenewBefore = caTTL / 3
+		}
+	}
+	enrollmentTimeout := cfg.EnrollmentTimeout
+	if enrollmentTimeout <= 0 {
+		enrollmentTimeout = DefaultEnrollmentTimeout
+	}
+	pollInterval := cfg.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = DefaultPollInterval
+	}
+	rotationInterval := cfg.RotationInterval
+	if rotationInterval <= 0 {
+		rotationInterval = DefaultRotationInterval
+	}
+	trustRefreshInterval := cfg.TrustRefreshInterval
+	if trustRefreshInterval <= 0 {
+		trustRefreshInterval = DefaultTrustRefreshInterval
+	}
+	signBatchSize := cfg.SignBatchSize
+	if signBatchSize <= 0 {
+		signBatchSize = defaultSignBatchSize
+	}
+	clock := cfg.Clock
+	if clock == nil {
+		clock = realClock{}
+	}
+	return &Provisioner{
+		store:                cfg.Store,
+		holder:               NewMaterialHolder(),
+		keys:                 keys,
+		nodeID:               cfg.NodeID,
+		caTTL:                caTTL,
+		leafTTL:              leafTTL,
+		leafRenewBefore:      leafRenewBefore,
+		caRenewBefore:        caRenewBefore,
+		enrollmentTimeout:    enrollmentTimeout,
+		pollInterval:         pollInterval,
+		rotationInterval:     rotationInterval,
+		trustRefreshInterval: trustRefreshInterval,
+		signBatchSize:        signBatchSize,
+		leaderCheck:          cfg.LeaderCheck,
+		clock:                clock,
+	}, nil
+}
+
+func (p *Provisioner) Holder() *MaterialHolder {
+	return p.holder
+}
+
+// Bootstrap blocks until this node has a signed leaf and a non-empty trust
+// pool. The caller should complete this before starting the internal mTLS
+// listener or dispatch loop.
+func (p *Provisioner) Bootstrap(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, p.enrollmentTimeout)
+	defer cancel()
+
+	for {
+		if err := p.ensureCA(ctx); err != nil {
+			return err
+		}
+		gen, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now())
+		if err != nil {
+			return err
+		}
+		if gen != nil {
+			break
+		}
+		if err := sleep(ctx, p.pollInterval); err != nil {
+			return fmt.Errorf("pki: wait for internal CA: %w", err)
+		}
+	}
+	return p.Enroll(ctx)
+}
+
+// Run starts the signer/rotation loop. It returns when ctx is cancelled or a
+// non-recoverable PKI operation fails.
+func (p *Provisioner) Run(ctx context.Context) error {
+	rotationTicker := time.NewTicker(p.rotationInterval)
+	defer rotationTicker.Stop()
+	trustTicker := time.NewTicker(p.trustRefreshInterval)
+	defer trustTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-rotationTicker.C:
+			if err := p.rotationTick(ctx); err != nil {
+				return err
+			}
+		case <-trustTicker.C:
+			if err := p.RefreshTrust(ctx); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (p *Provisioner) rotationTick(ctx context.Context) error {
+	leader, err := p.isLeader(ctx)
+	if err != nil {
+		return err
+	}
+	if leader {
+		if err := p.RollCAIfNeeded(ctx); err != nil {
+			return err
+		}
+		if _, err := p.SignPending(ctx, p.signBatchSize); err != nil {
+			return err
+		}
+		if _, err := p.PruneExpiredCAs(ctx); err != nil {
+			return err
+		}
+	}
+	if err := p.RefreshTrust(ctx); err != nil {
+		return err
+	}
+	if p.LeafRenewalDue() {
+		enrollCtx, cancel := context.WithTimeout(ctx, p.enrollmentTimeout)
+		defer cancel()
+		if err := p.Enroll(enrollCtx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p *Provisioner) Enroll(ctx context.Context) error {
+	gen, _, _, err := p.activeTrust(ctx)
+	if err != nil {
+		return err
+	}
+	req, err := GenerateLeafRequest(p.nodeID)
+	if err != nil {
+		return err
+	}
+	id := uuid.NewString()
+	now := p.clock.Now()
+	if err := p.store.CreateEnrollment(ctx, &models.InternalNodeEnrollment{
+		ID:           id,
+		NodeID:       p.nodeID,
+		CSRPEM:       string(req.CSRPEM),
+		CSRMac:       CSRMac(p.keys.CSRMac, req.CSRDER),
+		CAGeneration: gen.Generation,
+		Status:       EnrollmentStatusPending,
+		RequestedAt:  now.UTC(),
+	}); err != nil {
+		return fmt.Errorf("pki: create node enrollment: %w", err)
+	}
+
+	for {
+		if _, err := p.SignPending(ctx, p.signBatchSize); err != nil {
+			return err
+		}
+		enrollment, err := p.store.Enrollment(ctx, id)
+		if err != nil {
+			return fmt.Errorf("pki: read node enrollment: %w", err)
+		}
+		switch enrollment.Status {
+		case EnrollmentStatusSigned:
+			if enrollment.CertPEM == nil || *enrollment.CertPEM == "" {
+				return fmt.Errorf("pki: signed enrollment has no certificate")
+			}
+			_, pool, caCerts, err := p.activeTrust(ctx)
+			if err != nil {
+				return err
+			}
+			cert, err := TLSCertificate([]byte(*enrollment.CertPEM), req.KeyPEM)
+			if err != nil {
+				return err
+			}
+			p.holder.Set(cert, pool, caCerts)
+			if err := p.store.DeleteEnrollment(ctx, id); err != nil {
+				return err
+			}
+			return nil
+		case EnrollmentStatusRejected:
+			return fmt.Errorf("pki: internal mTLS enrollment rejected; token mismatch or invalid CSR")
+		case EnrollmentStatusPending:
+			if err := sleep(ctx, p.pollInterval); err != nil {
+				return fmt.Errorf("pki: wait for signed enrollment: %w", err)
+			}
+		default:
+			return fmt.Errorf("pki: unknown enrollment status %q", enrollment.Status)
+		}
+	}
+}
+
+func (p *Provisioner) RefreshTrust(ctx context.Context) error {
+	_, pool, caCerts, err := p.activeTrust(ctx)
+	if err != nil {
+		return err
+	}
+	return p.holder.UpdateTrust(pool, caCerts)
+}
+
+func (p *Provisioner) SignPending(ctx context.Context, limit int) (int, error) {
+	leader, err := p.isLeader(ctx)
+	if err != nil {
+		return 0, err
+	}
+	if !leader {
+		return 0, nil
+	}
+	gen, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now())
+	if err != nil {
+		return 0, err
+	}
+	if gen == nil {
+		return 0, nil
+	}
+	caCert, caKey, err := p.signerForGeneration(gen)
+	if err != nil {
+		return 0, err
+	}
+	pending, err := p.store.PendingEnrollments(ctx, limit)
+	if err != nil {
+		return 0, err
+	}
+	signed := 0
+	for _, enrollment := range pending {
+		csr, parseErr := ParseCSRPEM([]byte(enrollment.CSRPEM))
+		if parseErr != nil {
+			if _, err := p.store.MarkEnrollmentRejected(ctx, enrollment.ID, p.clock.Now()); err != nil {
+				return signed, err
+			}
+			continue
+		}
+		if !VerifyCSRMac(p.keys.CSRMac, csr.Raw, enrollment.CSRMac) {
+			if _, err := p.store.MarkEnrollmentRejected(ctx, enrollment.ID, p.clock.Now()); err != nil {
+				return signed, err
+			}
+			continue
+		}
+		certPEM, _, signErr := SignCSR([]byte(enrollment.CSRPEM), enrollment.NodeID, caCert, caKey, p.clock.Now(), p.leafTTL)
+		if signErr != nil {
+			if _, err := p.store.MarkEnrollmentRejected(ctx, enrollment.ID, p.clock.Now()); err != nil {
+				return signed, err
+			}
+			continue
+		}
+		updated, err := p.store.MarkEnrollmentSigned(ctx, enrollment.ID, gen.Generation, string(certPEM), p.clock.Now())
+		if err != nil {
+			return signed, err
+		}
+		if updated {
+			signed++
+		}
+	}
+	return signed, nil
+}
+
+func (p *Provisioner) RollCAIfNeeded(ctx context.Context) error {
+	leader, err := p.isLeader(ctx)
+	if err != nil {
+		return err
+	}
+	if !leader {
+		return nil
+	}
+	gen, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now())
+	if err != nil {
+		return err
+	}
+	if gen != nil && !ShouldRollCA(gen, p.clock.Now(), p.caRenewBefore) {
+		return nil
+	}
+	if latest, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now()); err != nil || latest != nil && !ShouldRollCA(latest, p.clock.Now(), p.caRenewBefore) {
+		return err
+	}
+	next, err := p.store.MaxCAGeneration(ctx)
+	if err != nil {
+		return err
+	}
+	return p.createCAGeneration(ctx, next+1)
+}
+
+func (p *Provisioner) PruneExpiredCAs(ctx context.Context) (int64, error) {
+	if p.leafTTL <= 0 {
+		return 0, nil
+	}
+	cutoff := p.clock.Now().Add(-p.leafTTL)
+	return p.store.PruneExpiredCAGenerations(ctx, cutoff)
+}
+
+func (p *Provisioner) LeafRenewalDue() bool {
+	mat, ok := p.holder.Material()
+	if !ok || mat.Leaf == nil {
+		return true
+	}
+	return ShouldRenewLeaf(mat.Leaf, p.clock.Now(), p.leafRenewBefore)
+}
+
+func ShouldRenewLeaf(cert *x509.Certificate, now time.Time, renewBefore time.Duration) bool {
+	if cert == nil {
+		return true
+	}
+	return !cert.NotAfter.After(now.Add(renewBefore))
+}
+
+func ShouldRollCA(gen *models.InternalCAGeneration, now time.Time, renewBefore time.Duration) bool {
+	if gen == nil {
+		return true
+	}
+	return !gen.NotAfter.After(now.Add(renewBefore))
+}
+
+func (p *Provisioner) ensureCA(ctx context.Context) error {
+	if gen, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now()); err != nil || gen != nil {
+		return err
+	}
+	leader, err := p.isLeader(ctx)
+	if err != nil {
+		return err
+	}
+	if !leader {
+		return nil
+	}
+	count, err := p.store.CountCAGenerations(ctx)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return p.createCAGeneration(ctx, 1)
+	}
+	if gen, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now()); err != nil || gen != nil {
+		return err
+	}
+	maxGen, err := p.store.MaxCAGeneration(ctx)
+	if err != nil {
+		return err
+	}
+	return p.createCAGeneration(ctx, maxGen+1)
+}
+
+func (p *Provisioner) createCAGeneration(ctx context.Context, generation int) error {
+	if generation < 1 {
+		generation = 1
+	}
+	gen, _, err := NewCAGeneration(generation, p.keys.CAKEK, p.clock.Now(), p.caTTL)
+	if err != nil {
+		return err
+	}
+	_, err = p.store.CreateCAGenerationIfAbsent(ctx, gen)
+	return err
+}
+
+func (p *Provisioner) activeTrust(ctx context.Context) (*models.InternalCAGeneration, *x509.CertPool, []*x509.Certificate, error) {
+	now := p.clock.Now()
+	gens, err := p.store.ActiveCAGenerations(ctx, now)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	pool, caCerts, err := TrustPoolFromGenerations(gens, now)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	active := &gens[len(gens)-1]
+	return active, pool, caCerts, nil
+}
+
+func (p *Provisioner) signerForGeneration(gen *models.InternalCAGeneration) (*x509.Certificate, crypto.Signer, error) {
+	certs, err := ParseCertificatesPEM([]byte(gen.CertPEM))
+	if err != nil {
+		return nil, nil, fmt.Errorf("pki: parse CA generation %d certificate: %w", gen.Generation, err)
+	}
+	keyPEM, err := OpenCAKey(p.keys.CAKEK, gen.KeyCiphertext, gen.KeyNonce)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pki: decrypt CA generation %d key: %w", gen.Generation, err)
+	}
+	key, err := ParsePrivateKeyPEM(keyPEM)
+	if err != nil {
+		return nil, nil, fmt.Errorf("pki: parse CA generation %d key: %w", gen.Generation, err)
+	}
+	return certs[0], key, nil
+}
+
+func (p *Provisioner) isLeader(ctx context.Context) (bool, error) {
+	leader, err := p.leaderCheck(ctx)
+	if err != nil {
+		return false, fmt.Errorf("pki: check dqlite leader: %w", err)
+	}
+	return leader, nil
+}
+
+func sleep(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/internal/dispatch/pki/provisioner.go
+++ b/internal/dispatch/pki/provisioner.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
 )
 
@@ -140,8 +141,7 @@ func (h *MaterialHolder) Certificate() (*tls.Certificate, error) {
 	if !ok {
 		return nil, fmt.Errorf("mtls: TLS material not initialized")
 	}
-	cert := mat.Certificate
-	return &cert, nil
+	return &mat.Certificate, nil
 }
 
 func (h *MaterialHolder) CertPool() (*x509.CertPool, error) {
@@ -314,11 +314,11 @@ func (p *Provisioner) Run(ctx context.Context) error {
 			return nil
 		case <-rotationTicker.C:
 			if err := p.rotationTick(ctx); err != nil {
-				return err
+				log.Error("pki: rotation tick failed", "error", err)
 			}
 		case <-trustTicker.C:
 			if err := p.RefreshTrust(ctx); err != nil {
-				return err
+				log.Error("pki: trust refresh failed", "error", err)
 			}
 		}
 	}
@@ -375,6 +375,14 @@ func (p *Provisioner) Enroll(ctx context.Context) error {
 	}); err != nil {
 		return fmt.Errorf("pki: create node enrollment: %w", err)
 	}
+	// The enrollment row is a short-lived signing request. Delete it on every
+	// exit path (success, rejection, timeout, error) using a fresh background
+	// context, since the method's ctx may already be cancelled on timeout.
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_ = p.store.DeleteEnrollment(cleanupCtx, id)
+	}()
 
 	for {
 		if _, err := p.SignPending(ctx, p.signBatchSize); err != nil {
@@ -398,9 +406,6 @@ func (p *Provisioner) Enroll(ctx context.Context) error {
 				return err
 			}
 			p.holder.Set(cert, pool, caCerts)
-			if err := p.store.DeleteEnrollment(ctx, id); err != nil {
-				return err
-			}
 			return nil
 		case EnrollmentStatusRejected:
 			return fmt.Errorf("pki: internal mTLS enrollment rejected; token mismatch or invalid CSR")

--- a/internal/dispatch/pki/provisioner.go
+++ b/internal/dispatch/pki/provisioner.go
@@ -228,6 +228,15 @@ func NewProvisioner(cfg Config) (*Provisioner, error) {
 			caRenewBefore = caTTL / 3
 		}
 	}
+	// Reject a renew-before window that is not shorter than its lifetime: it
+	// would make ShouldRenewLeaf / ShouldRollCA return true on every tick,
+	// spinning the node into perpetual re-enrollment / CA rolls.
+	if leafRenewBefore >= leafTTL {
+		return nil, fmt.Errorf("pki: leaf renew-before (%s) must be less than leaf TTL (%s)", leafRenewBefore, leafTTL)
+	}
+	if caRenewBefore >= caTTL {
+		return nil, fmt.Errorf("pki: CA renew-before (%s) must be less than CA TTL (%s)", caRenewBefore, caTTL)
+	}
 	enrollmentTimeout := cfg.EnrollmentTimeout
 	if enrollmentTimeout <= 0 {
 		enrollmentTimeout = DefaultEnrollmentTimeout
@@ -498,8 +507,15 @@ func (p *Provisioner) RollCAIfNeeded(ctx context.Context) error {
 	if gen != nil && !ShouldRollCA(gen, p.clock.Now(), p.caRenewBefore) {
 		return nil
 	}
-	if latest, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now()); err != nil || latest != nil && !ShouldRollCA(latest, p.clock.Now(), p.caRenewBefore) {
+	// Re-read under (potentially) changed state before issuing a new generation,
+	// so a concurrent roll by another leader isn't duplicated. Keep the DB-error
+	// and the no-roll-needed exits separate so each is explicit.
+	latest, err := p.store.NewestActiveCAGeneration(ctx, p.clock.Now())
+	if err != nil {
 		return err
+	}
+	if latest != nil && !ShouldRollCA(latest, p.clock.Now(), p.caRenewBefore) {
+		return nil
 	}
 	next, err := p.store.MaxCAGeneration(ctx)
 	if err != nil {

--- a/internal/dispatch/pki/store.go
+++ b/internal/dispatch/pki/store.go
@@ -1,0 +1,191 @@
+package pki
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// Store wraps catalog access for internal mTLS CA generations and enrollment
+// rows.
+type Store struct {
+	db *gorm.DB
+}
+
+func NewStore(db *gorm.DB) *Store {
+	return &Store{db: db}
+}
+
+func (s *Store) CreateCAGenerationIfAbsent(ctx context.Context, gen *models.InternalCAGeneration) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, fmt.Errorf("pki: nil store")
+	}
+	result := s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{DoNothing: true}).
+		Create(gen)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected == 1, nil
+}
+
+func (s *Store) CountCAGenerations(ctx context.Context) (int64, error) {
+	if s == nil || s.db == nil {
+		return 0, fmt.Errorf("pki: nil store")
+	}
+	var count int64
+	if err := s.db.WithContext(ctx).Model(&models.InternalCAGeneration{}).Count(&count).Error; err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (s *Store) MaxCAGeneration(ctx context.Context) (int, error) {
+	if s == nil || s.db == nil {
+		return 0, fmt.Errorf("pki: nil store")
+	}
+	var gen models.InternalCAGeneration
+	result := s.db.WithContext(ctx).
+		Order("generation DESC").
+		Limit(1).
+		Find(&gen)
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return 0, nil
+	}
+	return gen.Generation, nil
+}
+
+func (s *Store) ActiveCAGenerations(ctx context.Context, now time.Time) ([]models.InternalCAGeneration, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("pki: nil store")
+	}
+	var gens []models.InternalCAGeneration
+	if err := s.db.WithContext(ctx).
+		Where("not_after > ?", now.UTC()).
+		Order("generation ASC").
+		Find(&gens).
+		Error; err != nil {
+		return nil, err
+	}
+	return gens, nil
+}
+
+func (s *Store) NewestActiveCAGeneration(ctx context.Context, now time.Time) (*models.InternalCAGeneration, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("pki: nil store")
+	}
+	var gen models.InternalCAGeneration
+	result := s.db.WithContext(ctx).
+		Where("not_after > ?", now.UTC()).
+		Order("generation DESC").
+		Limit(1).
+		Find(&gen)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, nil
+	}
+	return &gen, nil
+}
+
+func (s *Store) CreateEnrollment(ctx context.Context, enrollment *models.InternalNodeEnrollment) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("pki: nil store")
+	}
+	return s.db.WithContext(ctx).Create(enrollment).Error
+}
+
+func (s *Store) Enrollment(ctx context.Context, id string) (*models.InternalNodeEnrollment, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("pki: nil store")
+	}
+	var enrollment models.InternalNodeEnrollment
+	err := s.db.WithContext(ctx).First(&enrollment, "id = ?", id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &enrollment, nil
+}
+
+func (s *Store) PendingEnrollments(ctx context.Context, limit int) ([]models.InternalNodeEnrollment, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("pki: nil store")
+	}
+	if limit <= 0 {
+		limit = 32
+	}
+	var enrollments []models.InternalNodeEnrollment
+	if err := s.db.WithContext(ctx).
+		Where("status = ?", EnrollmentStatusPending).
+		Order("requested_at ASC").
+		Limit(limit).
+		Find(&enrollments).
+		Error; err != nil {
+		return nil, err
+	}
+	return enrollments, nil
+}
+
+func (s *Store) MarkEnrollmentSigned(ctx context.Context, id string, caGeneration int, certPEM string, signedAt time.Time) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, fmt.Errorf("pki: nil store")
+	}
+	result := s.db.WithContext(ctx).
+		Model(&models.InternalNodeEnrollment{}).
+		Where("id = ? AND status = ?", id, EnrollmentStatusPending).
+		Updates(map[string]interface{}{
+			"ca_generation": caGeneration,
+			"cert_pem":      certPEM,
+			"status":        EnrollmentStatusSigned,
+			"signed_at":     signedAt.UTC(),
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected == 1, nil
+}
+
+func (s *Store) MarkEnrollmentRejected(ctx context.Context, id string, signedAt time.Time) (bool, error) {
+	if s == nil || s.db == nil {
+		return false, fmt.Errorf("pki: nil store")
+	}
+	result := s.db.WithContext(ctx).
+		Model(&models.InternalNodeEnrollment{}).
+		Where("id = ? AND status = ?", id, EnrollmentStatusPending).
+		Updates(map[string]interface{}{
+			"status":    EnrollmentStatusRejected,
+			"signed_at": signedAt.UTC(),
+		})
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected == 1, nil
+}
+
+func (s *Store) DeleteEnrollment(ctx context.Context, id string) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("pki: nil store")
+	}
+	return s.db.WithContext(ctx).Delete(&models.InternalNodeEnrollment{}, "id = ?", id).Error
+}
+
+func (s *Store) PruneExpiredCAGenerations(ctx context.Context, cutoff time.Time) (int64, error) {
+	if s == nil || s.db == nil {
+		return 0, fmt.Errorf("pki: nil store")
+	}
+	result := s.db.WithContext(ctx).
+		Where("not_after < ?", cutoff.UTC()).
+		Delete(&models.InternalCAGeneration{})
+	if result.Error != nil {
+		return 0, result.Error
+	}
+	return result.RowsAffected, nil
+}

--- a/internal/models/internal_mtls.go
+++ b/internal/models/internal_mtls.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+// InternalCAGeneration stores one internal mTLS CA generation. The certificate
+// is public; the private key is AES-GCM sealed by the dispatch/pki package.
+type InternalCAGeneration struct {
+	Generation    int       `gorm:"primaryKey" json:"generation"`
+	CertPEM       string    `gorm:"type:text;not null" json:"cert_pem"`
+	KeyCiphertext []byte    `gorm:"type:blob;not null" json:"key_ciphertext"`
+	KeyNonce      []byte    `gorm:"type:blob;not null" json:"key_nonce"`
+	NotBefore     time.Time `gorm:"not null;index" json:"not_before"`
+	NotAfter      time.Time `gorm:"not null;index" json:"not_after"`
+	CreatedAt     time.Time `gorm:"not null" json:"created_at"`
+}
+
+// InternalNodeEnrollment is the catalog rendezvous for a node CSR and the
+// leader-signed certificate produced from it.
+type InternalNodeEnrollment struct {
+	ID           string     `gorm:"type:text;primaryKey" json:"id"`
+	NodeID       string     `gorm:"type:text;not null;index" json:"node_id"`
+	CSRPEM       string     `gorm:"type:text;not null" json:"csr_pem"`
+	CSRMac       []byte     `gorm:"type:blob;not null" json:"csr_mac"`
+	CAGeneration int        `gorm:"not null;index" json:"ca_generation"`
+	CertPEM      *string    `gorm:"type:text" json:"cert_pem,omitempty"`
+	Status       string     `gorm:"type:text;not null;index" json:"status"`
+	RequestedAt  time.Time  `gorm:"not null;index" json:"requested_at"`
+	SignedAt     *time.Time `json:"signed_at,omitempty"`
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -22,6 +22,8 @@ var All = []interface{}{
 	&NotificationPolicy{},
 	// Phase 2 run-owner coordination tables (catalog DB, cross-run, low-volume).
 	&RunLease{},
+	&InternalCAGeneration{},
+	&InternalNodeEnrollment{},
 	// run_checkpoints is per-run and lives with task_runs (catalog when
 	// unsharded, hot shard when sharded — see hotPathModels), so it is listed
 	// here for the unsharded case and in hotPathModels for the sharded case.

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -179,6 +179,17 @@ type Environment struct {
 	InternalMTLSCA   string `envconfig:"INTERNAL_MTLS_CA" default:""`
 	InternalMTLSCert string `envconfig:"INTERNAL_MTLS_CERT" default:""`
 	InternalMTLSKey  string `envconfig:"INTERNAL_MTLS_KEY" default:""`
+	// CAESIUM_INTERNAL_MTLS_TOKEN optionally separates the auto-provisioning
+	// PKI token from CAESIUM_INTERNAL_WAKEUP_TOKEN. When empty, the wakeup token
+	// is used for HKDF key derivation.
+	InternalMTLSToken string `envconfig:"INTERNAL_MTLS_TOKEN" default:""`
+	// Auto-provisioned internal mTLS rotation settings. These apply only when
+	// owner mode is on and explicit mTLS files are not provided.
+	InternalMTLSCATTL             time.Duration `envconfig:"INTERNAL_MTLS_CA_TTL" default:"43800h"`
+	InternalMTLSLeafTTL           time.Duration `envconfig:"INTERNAL_MTLS_LEAF_TTL" default:"720h"`
+	InternalMTLSLeafRenewBefore   time.Duration `envconfig:"INTERNAL_MTLS_LEAF_RENEW_BEFORE" default:"240h"`
+	InternalMTLSCARenewBefore     time.Duration `envconfig:"INTERNAL_MTLS_CA_RENEW_BEFORE" default:"720h"`
+	InternalMTLSEnrollmentTimeout time.Duration `envconfig:"INTERNAL_MTLS_ENROLLMENT_TIMEOUT" default:"2m"`
 
 	// Run-owner checkpointing (Phase 2 B3).  The owner persists an in-memory
 	// state checkpoint whichever comes first of RUN_CHECKPOINT_EVENTS terminal


### PR DESCRIPTION
## Summary
- Run-owner mode comes up mutually-authenticated with **zero operator cert work**: set one shared token and the cluster provisions its own internal CA + per-node leaf certs. Replaces the startup hard-fail that required `CAESIUM_INTERNAL_MTLS_{CA,CERT,KEY}` files.
- **Catalog-mediated, leader-signed, token-encrypted CA** (runtime-agnostic — no Kubernetes/cert-manager dependency): the dqlite leader mints the CA, its private key AES-256-GCM-sealed under an HKDF key derived from the token; nodes generate leaf keypairs locally and get them signed via a catalog CSR exchange authenticated by a token HMAC. The token is never transmitted. Includes automatic leaf renewal and CA roll with an overlap window.
- BYO cert files still override (explicit `CAESIUM_INTERNAL_MTLS_*` bypasses auto-provisioning); `RUN_OWNER_ENABLED=false` stays byte-identical.
- Also hardens the internal bearer-token comparison to constant-time.

Design: `docs/design-internal-mtls-auto-provisioning.md`.

## Test plan
- [x] Unit (`internal/dispatch/pki`): HKDF determinism, AES-GCM roundtrip + wrong-key failure, CA genesis, leaf has both EKUs + non-CA, **signer ignores CSR-requested extensions** (CA:TRUE CSR → non-CA leaf), CSR-MAC accept/reject, trust-pool union across generations, clock-injected renew/roll triggers; integration: end-to-end enrollment, genesis-race idempotency, token-mismatch rejection. All pass.
- [x] `just lint` clean (0 issues); `just unit-test` green (full suite, 65 packages).
- [x] 3-node k8s acceptance: deployed with **only the token** (no cert files, no mounted secret) → all nodes self-provisioned mTLS, 0 TLS/cert errors, 0 restarts, and a job ran end-to-end over the auto-provisioned mutual TLS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)