### PR TITLE
Shard the integration-test database to cut write contention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,6 +377,7 @@ jobs:
             -e CAESIUM_PODMAN_URI=unix:///run/podman/podman.sock \
             -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
             -e CAESIUM_LOG_LEVEL=debug \
+            -e CAESIUM_DATABASE_SHARDS=4 \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
       - name: Extract caesium CLI

--- a/justfile
+++ b/justfile
@@ -190,6 +190,7 @@ integration-test-podman: build
         -e CAESIUM_PODMAN_URI=unix:///run/podman/podman.sock \
         -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
         -e CAESIUM_LOG_LEVEL=debug \
+        -e CAESIUM_DATABASE_SHARDS=4 \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
     if docker run --rm --platform {{ platform }} \

--- a/justfile
+++ b/justfile
@@ -224,6 +224,7 @@ integration-up: build-test
         --user 0:0 \
         -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
         -e CAESIUM_LOG_LEVEL=debug \
+        -e CAESIUM_DATABASE_SHARDS=4 \
         {{ local_image_ref }}:{{ tag }}-test start
 
 lint: builder-full


### PR DESCRIPTION
## Summary
- Environmental fix for the recurring `TestBackfillCancel` / `TestBranch*` integration flake. The integration server ran single-DB (`CAESIUM_DATABASE_SHARDS=1`), so hot-path run-execution writes (`task_runs`/`job_runs`) raced with `job apply` catalog writes on **one** dqlite catalog through a 4-connection pool — surfacing as `database is locked` → `apply failed: internal server error` and the downstream cascade.
- Set `CAESIUM_DATABASE_SHARDS=4` for the integration server (`build-and-integration-test` via the `integration-up` recipe, and `podman-integration-test` in CI). Hot-path writes now go to separate shard DBs, off the catalog where `job apply` writes, so they stop colliding. This uses the sharding feature for exactly its intended purpose (isolating hot-path write volume) and adds coverage of the sharded path.
- App-level mitigations were already maxed (`busy_timeout=5s`, global statement retry #176, whole-tx retries #162/#178, and the BeginTx poison-retry in #183); this addresses the contention at its source rather than recovering from it.

## Test plan
- [x] Verified the server boots healthy with `CAESIUM_DATABASE_SHARDS=4` (internal dqlite): `database router initialized … shards: 4`, health OK, no fatals.
- [ ] CI: `build-and-integration-test` (amd64 + arm64) and `podman-integration-test` exercise the full suite under sharding — the real validation that the flake is reduced and the suite passes sharded.

Companion to #183 (which fixes the poison-BEGIN failure mode); together they target both observed contention modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)