### PR TITLE
Coalesce backfill progress writes to cut catalog contention

### DIFF
--- a/internal/backfill/store.go
+++ b/internal/backfill/store.go
@@ -116,7 +116,10 @@ func (s *Store) Complete(id uuid.UUID, failed bool) error {
 // failed_runs write per run, all on the same backfills row, which serialize
 // through dqlite's single writer and starve concurrent control-plane writes
 // (e.g. cancellation) past the busy-retry budget.
-func (s *Store) AddProgress(id uuid.UUID, completedDelta, failedDelta int) error {
+//
+// completedDelta and failedDelta are the counts to add and must be
+// non-negative; the executor's source counters are increment-only.
+func (s *Store) AddProgress(id uuid.UUID, completedDelta, failedDelta int64) error {
 	if completedDelta == 0 && failedDelta == 0 {
 		return nil
 	}

--- a/internal/backfill/store.go
+++ b/internal/backfill/store.go
@@ -110,19 +110,27 @@ func (s *Store) Complete(id uuid.UUID, failed bool) error {
 	})
 }
 
-func (s *Store) IncrementCompleted(id uuid.UUID) error {
+// AddProgress applies accumulated run-completion counts to a backfill in a
+// single UPDATE. The executor batches per-run increments and flushes them
+// periodically: a large backfill otherwise issues one completed_runs/
+// failed_runs write per run, all on the same backfills row, which serialize
+// through dqlite's single writer and starve concurrent control-plane writes
+// (e.g. cancellation) past the busy-retry budget.
+func (s *Store) AddProgress(id uuid.UUID, completedDelta, failedDelta int) error {
+	if completedDelta == 0 && failedDelta == 0 {
+		return nil
+	}
+	updates := make(map[string]interface{}, 2)
+	if completedDelta != 0 {
+		updates["completed_runs"] = gorm.Expr("completed_runs + ?", completedDelta)
+	}
+	if failedDelta != 0 {
+		updates["failed_runs"] = gorm.Expr("failed_runs + ?", failedDelta)
+	}
 	return s.withBusyRetry(func() error {
 		return s.db.Model(&models.Backfill{}).
 			Where("id = ?", id).
-			UpdateColumn("completed_runs", gorm.Expr("completed_runs + 1")).Error
-	})
-}
-
-func (s *Store) IncrementFailed(id uuid.UUID) error {
-	return s.withBusyRetry(func() error {
-		return s.db.Model(&models.Backfill{}).
-			Where("id = ?", id).
-			UpdateColumn("failed_runs", gorm.Expr("failed_runs + 1")).Error
+			UpdateColumns(updates).Error
 	})
 }
 

--- a/internal/backfill/store_test.go
+++ b/internal/backfill/store_test.go
@@ -180,6 +180,22 @@ func TestCompleteDoesNotOverwriteCancelledBackfill(t *testing.T) {
 	require.NotNil(t, backfill.CompletedAt)
 }
 
+func TestAddProgressAccumulatesBatchedCounts(t *testing.T) {
+	store, db, backfillID := newBackfillTestStore(t)
+
+	// A zero delta is a no-op — the flusher calls AddProgress on every tick,
+	// including ticks where no run finished.
+	require.NoError(t, store.AddProgress(backfillID, 0, 0))
+
+	require.NoError(t, store.AddProgress(backfillID, 3, 0))
+	require.NoError(t, store.AddProgress(backfillID, 2, 1))
+
+	var backfill models.Backfill
+	require.NoError(t, db.First(&backfill, "id = ?", backfillID).Error)
+	require.Equal(t, 5, backfill.CompletedRuns)
+	require.Equal(t, 1, backfill.FailedRuns)
+}
+
 func newBackfillTestStore(t *testing.T) (*Store, *gorm.DB, uuid.UUID) {
 	t.Helper()
 

--- a/internal/job/backfill.go
+++ b/internal/job/backfill.go
@@ -172,7 +172,45 @@ func RunBackfill(
 	sem := semaphore.NewWeighted(int64(maxConcurrent))
 	var wg sync.WaitGroup
 	var failCount atomic.Int64
+	var completed atomic.Int64
 	cancelled := false
+
+	// Coalesce per-run progress into periodic batched writes. One UPDATE per run
+	// on the same backfills row serializes through dqlite's single writer and can
+	// starve concurrent control-plane writes (e.g. cancellation) past the
+	// busy-retry budget. The flusher persists accumulated deltas ~once a second,
+	// with a final flush below, so the counters lag at most one interval during
+	// the run and are exact once it drains.
+	flushStop := make(chan struct{})
+	flusherDone := make(chan struct{})
+	go func() {
+		defer close(flusherDone)
+		const flushInterval = time.Second
+		ticker := time.NewTicker(flushInterval)
+		defer ticker.Stop()
+		var lastCompleted, lastFailed int64
+		flush := func() {
+			c, f := completed.Load(), failCount.Load()
+			dc, df := int(c-lastCompleted), int(f-lastFailed)
+			if dc == 0 && df == 0 {
+				return
+			}
+			if err := bStore.AddProgress(b.ID, dc, df); err != nil {
+				log.Error("backfill: failed to flush progress", "backfill_id", b.ID, "error", err)
+				return // keep last* so the delta retries on the next flush
+			}
+			lastCompleted, lastFailed = c, f
+		}
+		for {
+			select {
+			case <-flushStop:
+				flush()
+				return
+			case <-ticker.C:
+				flush()
+			}
+		}
+	}()
 
 	for _, d := range filtered {
 		if shouldStopBackfill(ctx, bStore, b.ID) {
@@ -201,9 +239,6 @@ func RunBackfill(
 			sem.Release(1)
 			log.Error("backfill: failed to create run", "backfill_id", b.ID, "logical_date", logicalDate, "error", err)
 			failCount.Add(1)
-			if incErr := bStore.IncrementFailed(b.ID); incErr != nil {
-				log.Error("backfill: failed to increment failed_runs", "backfill_id", b.ID, "error", incErr)
-			}
 			continue
 		}
 
@@ -221,19 +256,20 @@ func RunBackfill(
 				log.Error("backfill: run failed", "backfill_id", b.ID, "logical_date", ld, "run_id", id, "error", runErr)
 				metrics.BackfillRunsTotal.WithLabelValues(j.Alias, "failed").Inc()
 				failCount.Add(1)
-				if incErr := bStore.IncrementFailed(b.ID); incErr != nil {
-					log.Error("backfill: failed to increment failed_runs", "backfill_id", b.ID, "error", incErr)
-				}
 			} else {
 				metrics.BackfillRunsTotal.WithLabelValues(j.Alias, "succeeded").Inc()
-				if incErr := bStore.IncrementCompleted(b.ID); incErr != nil {
-					log.Error("backfill: failed to increment completed_runs", "backfill_id", b.ID, "error", incErr)
-				}
+				completed.Add(1)
 			}
 		}(runID, logicalDate)
 	}
 
 	wg.Wait()
+
+	// Stop the flusher and persist any remaining counts before the terminal
+	// status write, so completed_runs/failed_runs are exact once the backfill
+	// finishes.
+	close(flushStop)
+	<-flusherDone
 
 	if cancelled {
 		// Mark terminal cancellation only after the backfill has stopped

--- a/internal/job/backfill.go
+++ b/internal/job/backfill.go
@@ -191,7 +191,7 @@ func RunBackfill(
 		var lastCompleted, lastFailed int64
 		flush := func() {
 			c, f := completed.Load(), failCount.Load()
-			dc, df := int(c-lastCompleted), int(f-lastFailed)
+			dc, df := c-lastCompleted, f-lastFailed
 			if dc == 0 && df == 0 {
 				return
 			}


### PR DESCRIPTION
## Summary
Eliminates the residual integration-test flake that sharding (#184) and the raised retry budget (#185) reduced but didn't fully kill.

**Root cause:** a backfill issued one `completed_runs`/`failed_runs` UPDATE *per run*, all targeting the same `backfills` row. For a large backfill (the suite uses `total_runs=300`) those serialize through dqlite's single writer and — together with the per-run `job_run` inserts — hold the catalog write lock long enough to starve concurrent control-plane writes. The clearest victim was the cancel path: `MarkCancelled` burned the full ~2.27s busy-retry budget across 9 attempts (`updated_at` 56.693→58.734 in the logs) and then failed — that *is* the `TestBackfillCancel` flake.

**Fix:** replace the per-run `IncrementCompleted`/`IncrementFailed` writes with in-memory atomic counters and a ~1s flusher that batches accumulated deltas into a single `AddProgress` UPDATE, with a final flush before the terminal status write. Up to N per-run writes collapse into a handful, removing the write storm.

**Tradeoff:** `completed_runs`/`failed_runs` are now eventually-consistent (lag ≤1s) during the run, and exact once it drains. Fine for a progress counter.

## Test plan
- [x] `go build ./...`, `go vet`, and **race** tests for `internal/backfill` + `internal/job` pass in the builder container
- [x] New `TestAddProgressAccumulatesBatchedCounts` covers the batched UPDATE + zero-delta no-op
- [ ] CI integration suite green (the suite that exhibited the flake), ideally across a few `TestBackfill*` runs

## Notes
Once merged, #181 (and any other open branch) inherits this on rebase, so the backfill cancel flake should stop recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)