### PR TITLE
Apply jobs in a single transaction to cut per-job write round-trips

### DIFF
--- a/api/rest/controller/job/post.go
+++ b/api/rest/controller/job/post.go
@@ -9,6 +9,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/service/task"
 	"github.com/caesium-cloud/caesium/api/rest/service/taskedge"
 	"github.com/caesium-cloud/caesium/api/rest/service/trigger"
+	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/caesium-cloud/caesium/pkg/log"
@@ -26,14 +27,19 @@ func Post(c *echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(fmt.Errorf("trigger is required"))
 	}
 
-	ctx := c.Request().Context()
-
 	// Apply the whole job — trigger, job, atoms, tasks, edges — in one
 	// transaction so it commits atomically in a single dqlite/Raft round-trip
 	// (instead of ~6-8 autocommit writes) and never leaves a partial job behind
-	// if a later step fails.
+	// if a later step fails. Defer event publishing (job.Create emits
+	// TypeJobCreated) until the transaction commits, so a rolled-back or retried
+	// attempt never leaks an event onto the bus.
+	ctx, flushEvents := event.WithDeferredPublish(c.Request().Context())
+
 	var created *models.Job
 	err := db.Transaction(ctx, func(tx *gorm.DB) error {
+		// Drop any events accumulated by a prior (rolled-back) attempt.
+		event.ResetDeferred(ctx)
+
 		var (
 			tsvc          = task.Service(ctx).WithDatabase(tx)
 			asvc          = atom.Service(ctx).WithDatabase(tx)
@@ -55,8 +61,6 @@ func Post(c *echo.Context) error {
 		if err != nil {
 			return err
 		}
-		created = j
-
 		for _, t := range req.Tasks {
 			a, err := asvc.Create(&atom.CreateRequest{
 				Engine:  t.Atom.Engine,
@@ -110,12 +114,16 @@ func Post(c *echo.Context) error {
 			}
 		}
 
+		created = j
 		return nil
 	})
 	if err != nil {
 		log.Error("failed to apply job", "alias", req.Alias, "error", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 	}
+
+	// The transaction committed — now publish the accumulated events.
+	flushEvents()
 
 	return c.JSON(http.StatusCreated, created)
 }

--- a/api/rest/controller/job/post.go
+++ b/api/rest/controller/job/post.go
@@ -30,16 +30,13 @@ func Post(c *echo.Context) error {
 	// Apply the whole job — trigger, job, atoms, tasks, edges — in one
 	// transaction so it commits atomically in a single dqlite/Raft round-trip
 	// (instead of ~6-8 autocommit writes) and never leaves a partial job behind
-	// if a later step fails. Defer event publishing (job.Create emits
-	// TypeJobCreated) until the transaction commits, so a rolled-back or retried
-	// attempt never leaks an event onto the bus.
-	ctx, flushEvents := event.WithDeferredPublish(c.Request().Context())
+	// if a later step fails. Defer bus dispatch of the TypeJobCreated event
+	// (emitted by job.Create) so the BusDispatcher delivers it only after the
+	// transaction commits — never for a rolled-back or retried attempt.
+	ctx := event.WithDeferredBusDispatch(c.Request().Context())
 
 	var created *models.Job
 	err := db.Transaction(ctx, func(tx *gorm.DB) error {
-		// Drop any events accumulated by a prior (rolled-back) attempt.
-		event.ResetDeferred(ctx)
-
 		var (
 			tsvc          = task.Service(ctx).WithDatabase(tx)
 			asvc          = atom.Service(ctx).WithDatabase(tx)
@@ -121,9 +118,6 @@ func Post(c *echo.Context) error {
 		log.Error("failed to apply job", "alias", req.Alias, "error", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 	}
-
-	// The transaction committed — now publish the accumulated events.
-	flushEvents()
 
 	return c.JSON(http.StatusCreated, created)
 }

--- a/api/rest/controller/job/post.go
+++ b/api/rest/controller/job/post.go
@@ -9,19 +9,15 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/service/task"
 	"github.com/caesium-cloud/caesium/api/rest/service/taskedge"
 	"github.com/caesium-cloud/caesium/api/rest/service/trigger"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
 )
 
 func Post(c *echo.Context) error {
-	var (
-		req           = &PostRequest{}
-		tsvc          = task.Service(c.Request().Context())
-		asvc          = atom.Service(c.Request().Context())
-		createdTasks  []string
-		explicitEdges []edgeSpec
-	)
-
+	req := &PostRequest{}
 	if err := c.Bind(req); err != nil {
 		return err
 	}
@@ -30,102 +26,98 @@ func Post(c *echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(fmt.Errorf("trigger is required"))
 	}
 
-	log.Info(
-		"creating trigger",
-		"type", req.Trigger.Type,
-		"config", req.Trigger.Configuration)
+	ctx := c.Request().Context()
 
-	trig, err := trigger.Service(c.Request().Context()).Create(req.Trigger)
-	if err != nil {
-		log.Error("failed to create trigger", "error", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
-	}
+	// Apply the whole job — trigger, job, atoms, tasks, edges — in one
+	// transaction so it commits atomically in a single dqlite/Raft round-trip
+	// (instead of ~6-8 autocommit writes) and never leaves a partial job behind
+	// if a later step fails.
+	var created *models.Job
+	err := db.Transaction(ctx, func(tx *gorm.DB) error {
+		var (
+			tsvc          = task.Service(ctx).WithDatabase(tx)
+			asvc          = atom.Service(ctx).WithDatabase(tx)
+			createdTasks  []string
+			explicitEdges []edgeSpec
+		)
 
-	log.Info("creating job", "alias", req.Alias)
+		trig, err := trigger.Service(ctx).WithDatabase(tx).Create(req.Trigger)
+		if err != nil {
+			return err
+		}
 
-	j, err := job.Service(c.Request().Context()).Create(&job.CreateRequest{
-		TriggerID:   trig.ID,
-		Alias:       req.Alias,
-		Labels:      metadataLabels(req.Metadata),
-		Annotations: metadataAnnotations(req.Metadata),
+		j, err := job.Service(ctx).WithDatabase(tx).Create(&job.CreateRequest{
+			TriggerID:   trig.ID,
+			Alias:       req.Alias,
+			Labels:      metadataLabels(req.Metadata),
+			Annotations: metadataAnnotations(req.Metadata),
+		})
+		if err != nil {
+			return err
+		}
+		created = j
+
+		for _, t := range req.Tasks {
+			a, err := asvc.Create(&atom.CreateRequest{
+				Engine:  t.Atom.Engine,
+				Image:   t.Atom.Image,
+				Command: t.Atom.Command,
+				Spec:    t.Atom.Spec,
+			})
+			if err != nil {
+				return err
+			}
+
+			taskModel, err := tsvc.Create(&task.CreateRequest{
+				JobID:        j.ID.String(),
+				AtomID:       a.ID.String(),
+				NodeSelector: t.NodeSelector,
+			})
+			if err != nil {
+				return err
+			}
+
+			createdTasks = append(createdTasks, taskModel.ID.String())
+			for _, dep := range t.DependsOn {
+				explicitEdges = append(explicitEdges, edgeSpec{
+					from: dep,
+					to:   taskModel.ID.String(),
+				})
+			}
+		}
+
+		edgeSvc := taskedge.Service(ctx).WithDatabase(tx)
+		switch {
+		case len(explicitEdges) > 0:
+			for _, edge := range explicitEdges {
+				if _, err := edgeSvc.Create(&taskedge.CreateRequest{
+					JobID:      j.ID.String(),
+					FromTaskID: edge.from,
+					ToTaskID:   edge.to,
+				}); err != nil {
+					return err
+				}
+			}
+		case len(createdTasks) > 1:
+			for idx := 0; idx < len(createdTasks)-1; idx++ {
+				if _, err := edgeSvc.Create(&taskedge.CreateRequest{
+					JobID:      j.ID.String(),
+					FromTaskID: createdTasks[idx],
+					ToTaskID:   createdTasks[idx+1],
+				}); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
 	})
 	if err != nil {
-		log.Error("failed to create job", "error", err)
+		log.Error("failed to apply job", "alias", req.Alias, "error", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 	}
 
-	for _, t := range req.Tasks {
-		log.Info(
-			"creating atom",
-			"job_id", j.ID,
-			"engine", t.Atom.Engine,
-			"image", t.Atom.Image,
-			"cmd", t.Atom.Command,
-		)
-
-		a, err := asvc.Create(&atom.CreateRequest{
-			Engine:  t.Atom.Engine,
-			Image:   t.Atom.Image,
-			Command: t.Atom.Command,
-			Spec:    t.Atom.Spec,
-		})
-		if err != nil {
-			log.Error("failed to create atom", "error", err)
-			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
-		}
-
-		log.Info(
-			"creating task",
-			"job_id", j.ID,
-			"atom_id", a.ID,
-		)
-
-		taskModel, err := tsvc.Create(&task.CreateRequest{
-			JobID:        j.ID.String(),
-			AtomID:       a.ID.String(),
-			NodeSelector: t.NodeSelector,
-		})
-		if err != nil {
-			log.Error("failed to create task", "error", err)
-			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
-		}
-
-		createdTasks = append(createdTasks, taskModel.ID.String())
-		for _, dep := range t.DependsOn {
-			explicitEdges = append(explicitEdges, edgeSpec{
-				from: dep,
-				to:   taskModel.ID.String(),
-			})
-		}
-	}
-
-	edgeSvc := taskedge.Service(c.Request().Context())
-	switch {
-	case len(explicitEdges) > 0:
-		for _, edge := range explicitEdges {
-			if _, err := edgeSvc.Create(&taskedge.CreateRequest{
-				JobID:      j.ID.String(),
-				FromTaskID: edge.from,
-				ToTaskID:   edge.to,
-			}); err != nil {
-				log.Error("failed to create task edge", "error", err)
-				return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
-			}
-		}
-	case len(createdTasks) > 1:
-		for idx := 0; idx < len(createdTasks)-1; idx++ {
-			if _, err := edgeSvc.Create(&taskedge.CreateRequest{
-				JobID:      j.ID.String(),
-				FromTaskID: createdTasks[idx],
-				ToTaskID:   createdTasks[idx+1],
-			}); err != nil {
-				log.Error("failed to create task edge", "error", err)
-				return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
-			}
-		}
-	}
-
-	return c.JSON(http.StatusCreated, j)
+	return c.JSON(http.StatusCreated, created)
 }
 
 func metadataLabels(md *MetadataRequest) map[string]string {

--- a/internal/event/bus_dispatch.go
+++ b/internal/event/bus_dispatch.go
@@ -99,11 +99,11 @@ func PublishAndMarkBusDispatched(ctx context.Context, bus Bus, store *Store, eve
 		return
 	}
 
-	if d := deferredFrom(ctx); d != nil {
-		// Inside a deferred-publish scope (an enclosing transaction): accumulate
-		// and let the caller flush after commit, so events for writes that roll
-		// back or get retried never reach the bus.
-		d.record(bus, store, events...)
+	if busDispatchDeferred(ctx) {
+		// Inside a transaction (see WithDeferredBusDispatch): skip the immediate
+		// publish. The event row is written transactionally and the BusDispatcher
+		// delivers it after the transaction commits — and never if it rolls back
+		// — keeping bus delivery consistent with the commit.
 		return
 	}
 

--- a/internal/event/bus_dispatch.go
+++ b/internal/event/bus_dispatch.go
@@ -99,6 +99,14 @@ func PublishAndMarkBusDispatched(ctx context.Context, bus Bus, store *Store, eve
 		return
 	}
 
+	if d := deferredFrom(ctx); d != nil {
+		// Inside a deferred-publish scope (an enclosing transaction): accumulate
+		// and let the caller flush after commit, so events for writes that roll
+		// back or get retried never reach the bus.
+		d.record(bus, store, events...)
+		return
+	}
+
 	for _, evt := range events {
 		bus.Publish(evt)
 	}

--- a/internal/event/deferred.go
+++ b/internal/event/deferred.go
@@ -1,84 +1,27 @@
 package event
 
-import (
-	"context"
-	"sync"
-)
+import "context"
 
-type deferredPublishKey struct{}
+type deferBusDispatchKey struct{}
 
-// deferredPublisher accumulates bus publishes so they can be dispatched after
-// an enclosing transaction commits, instead of immediately. This keeps event
-// delivery consistent with the transaction: an event only reaches the bus once
-// the writes it describes have actually committed.
-type deferredPublisher struct {
-	mu      sync.Mutex
-	pending []pendingPublish
-}
-
-type pendingPublish struct {
-	bus    Bus
-	store  *Store
-	events []Event
-}
-
-func (d *deferredPublisher) record(bus Bus, store *Store, events ...Event) {
-	if len(events) == 0 {
-		return
-	}
-	d.mu.Lock()
-	d.pending = append(d.pending, pendingPublish{bus: bus, store: store, events: events})
-	d.mu.Unlock()
-}
-
-// WithDeferredPublish returns a child context in which
-// PublishAndMarkBusDispatched accumulates events instead of dispatching them,
-// plus a flush func that dispatches everything accumulated. Use it around a
-// transaction whose events must not reach the bus until the transaction
-// commits:
+// WithDeferredBusDispatch marks ctx so that PublishAndMarkBusDispatched skips
+// the immediate in-memory publish for events emitted within it.
 //
-//	ctx, flush := event.WithDeferredPublish(ctx)
-//	if err := db.Transaction(ctx, func(tx *gorm.DB) error {
-//	    event.ResetDeferred(ctx) // drop a prior failed attempt's events
-//	    ...
-//	}); err != nil {
-//	    return err // nothing published
-//	}
-//	flush() // commit succeeded — publish now
-//
-// flush dispatches against the parent context, so it performs the real publish
-// rather than re-accumulating.
-func WithDeferredPublish(ctx context.Context) (context.Context, func()) {
-	parent := ctx
-	d := &deferredPublisher{}
-	child := context.WithValue(ctx, deferredPublishKey{}, d)
-	flush := func() {
-		d.mu.Lock()
-		pending := d.pending
-		d.pending = nil
-		d.mu.Unlock()
-		for _, p := range pending {
-			PublishAndMarkBusDispatched(parent, p.bus, p.store, p.events...)
-		}
-	}
-	return child, flush
+// Use it around a transaction. Events are still written to the store
+// transactionally (AppendTx) with bus_dispatch_pending=true; once the
+// transaction commits, the BusDispatcher delivers each pending event to the bus
+// exactly once and marks it dispatched, using its own live connection. If the
+// transaction rolls back or is retried, the event rows never commit, so nothing
+// is published — which avoids the orphan events (on rollback) and duplicate
+// events (on retry) that an immediate, tx-scoped publish would cause.
+func WithDeferredBusDispatch(ctx context.Context) context.Context {
+	return context.WithValue(ctx, deferBusDispatchKey{}, true)
 }
 
-// ResetDeferred discards any accumulated-but-unflushed publishes on ctx. Call
-// it at the start of each transaction attempt so a rolled-back/retried
-// attempt's events are dropped and only the committed attempt's are flushed.
-func ResetDeferred(ctx context.Context) {
-	if d := deferredFrom(ctx); d != nil {
-		d.mu.Lock()
-		d.pending = nil
-		d.mu.Unlock()
-	}
-}
-
-func deferredFrom(ctx context.Context) *deferredPublisher {
+func busDispatchDeferred(ctx context.Context) bool {
 	if ctx == nil {
-		return nil
+		return false
 	}
-	d, _ := ctx.Value(deferredPublishKey{}).(*deferredPublisher)
-	return d
+	deferred, _ := ctx.Value(deferBusDispatchKey{}).(bool)
+	return deferred
 }

--- a/internal/event/deferred.go
+++ b/internal/event/deferred.go
@@ -1,0 +1,84 @@
+package event
+
+import (
+	"context"
+	"sync"
+)
+
+type deferredPublishKey struct{}
+
+// deferredPublisher accumulates bus publishes so they can be dispatched after
+// an enclosing transaction commits, instead of immediately. This keeps event
+// delivery consistent with the transaction: an event only reaches the bus once
+// the writes it describes have actually committed.
+type deferredPublisher struct {
+	mu      sync.Mutex
+	pending []pendingPublish
+}
+
+type pendingPublish struct {
+	bus    Bus
+	store  *Store
+	events []Event
+}
+
+func (d *deferredPublisher) record(bus Bus, store *Store, events ...Event) {
+	if len(events) == 0 {
+		return
+	}
+	d.mu.Lock()
+	d.pending = append(d.pending, pendingPublish{bus: bus, store: store, events: events})
+	d.mu.Unlock()
+}
+
+// WithDeferredPublish returns a child context in which
+// PublishAndMarkBusDispatched accumulates events instead of dispatching them,
+// plus a flush func that dispatches everything accumulated. Use it around a
+// transaction whose events must not reach the bus until the transaction
+// commits:
+//
+//	ctx, flush := event.WithDeferredPublish(ctx)
+//	if err := db.Transaction(ctx, func(tx *gorm.DB) error {
+//	    event.ResetDeferred(ctx) // drop a prior failed attempt's events
+//	    ...
+//	}); err != nil {
+//	    return err // nothing published
+//	}
+//	flush() // commit succeeded — publish now
+//
+// flush dispatches against the parent context, so it performs the real publish
+// rather than re-accumulating.
+func WithDeferredPublish(ctx context.Context) (context.Context, func()) {
+	parent := ctx
+	d := &deferredPublisher{}
+	child := context.WithValue(ctx, deferredPublishKey{}, d)
+	flush := func() {
+		d.mu.Lock()
+		pending := d.pending
+		d.pending = nil
+		d.mu.Unlock()
+		for _, p := range pending {
+			PublishAndMarkBusDispatched(parent, p.bus, p.store, p.events...)
+		}
+	}
+	return child, flush
+}
+
+// ResetDeferred discards any accumulated-but-unflushed publishes on ctx. Call
+// it at the start of each transaction attempt so a rolled-back/retried
+// attempt's events are dropped and only the committed attempt's are flushed.
+func ResetDeferred(ctx context.Context) {
+	if d := deferredFrom(ctx); d != nil {
+		d.mu.Lock()
+		d.pending = nil
+		d.mu.Unlock()
+	}
+}
+
+func deferredFrom(ctx context.Context) *deferredPublisher {
+	if ctx == nil {
+		return nil
+	}
+	d, _ := ctx.Value(deferredPublishKey{}).(*deferredPublisher)
+	return d
+}

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -106,6 +106,43 @@ func TestPublishAndMarkBusDispatchedPublishesAndMarksEvent(t *testing.T) {
 	require.NotNil(t, row.BusDispatchedAt)
 }
 
+// TestPublishAndMarkBusDispatchedDefersWhenScoped proves that inside a
+// WithDeferredBusDispatch scope the immediate publish is skipped: the bus
+// receives nothing and the event stays pending so the BusDispatcher delivers it
+// after the enclosing transaction commits. This is what keeps transactional
+// callers from leaking orphan/duplicate events.
+func TestPublishAndMarkBusDispatchedDefersWhenScoped(t *testing.T) {
+	s := openStore(t)
+	bus := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ch, err := bus.Subscribe(ctx, Filter{})
+	require.NoError(t, err)
+
+	evt := &Event{Type: TypeRunStarted, JobID: uuid.New()}
+	tx := s.db.Begin()
+	require.NoError(t, s.AppendTx(tx, evt))
+	require.NoError(t, tx.Commit().Error)
+
+	PublishAndMarkBusDispatched(WithDeferredBusDispatch(ctx), bus, s, *evt)
+
+	select {
+	case got := <-ch:
+		t.Fatalf("expected no immediate publish in a deferred scope, got event %d", got.Sequence)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	pending, err := s.ListPendingBusDispatch(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "deferred event must stay pending for the dispatcher")
+
+	var row models.ExecutionEvent
+	require.NoError(t, s.db.First(&row, "sequence = ?", evt.Sequence).Error)
+	require.True(t, row.BusDispatchPending)
+	require.Nil(t, row.BusDispatchedAt)
+}
+
 func TestBusDispatcherDispatchOncePublishesPendingEvent(t *testing.T) {
 	s := openStore(t)
 	bus := New()

--- a/pkg/db/retry.go
+++ b/pkg/db/retry.go
@@ -28,6 +28,33 @@ var BusyRetryBackoffs = []time.Duration{
 	1000 * time.Millisecond,
 }
 
+// Transaction runs fn inside a single transaction against the default
+// connection, retrying the whole transaction on transient dqlite contention.
+//
+// Use this for multi-statement units that must commit atomically. Statements
+// issued inside a transaction bypass the connection pool's per-statement retry
+// (re-running one statement of a partially-applied transaction would be
+// unsafe), so the entire BEGIN..COMMIT is retried here on the shared
+// BusyRetryBackoffs budget. A rolled-back transaction leaves no state, so
+// re-running fn from the top is safe.
+func Transaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
+	conn := Connection().WithContext(ctx)
+	var err error
+	for attempt := 0; ; attempt++ {
+		err = conn.Transaction(fn)
+		if err == nil || !dqlite.IsContentionError(err) {
+			return err
+		}
+		if attempt >= len(BusyRetryBackoffs) {
+			return err
+		}
+		metrics.DBBusyRetriesTotal.Inc()
+		if sleepErr := sleepRetry(ctx, BusyRetryBackoffs[attempt]); sleepErr != nil {
+			return err
+		}
+	}
+}
+
 // retryConnPool is a gorm.ConnPool decorator that transparently retries a
 // single autocommit statement when it fails with a transient contention error
 // (e.g. "database is locked", "checkpoint in progress").

--- a/pkg/db/retry.go
+++ b/pkg/db/retry.go
@@ -38,7 +38,11 @@ var BusyRetryBackoffs = []time.Duration{
 // BusyRetryBackoffs budget. A rolled-back transaction leaves no state, so
 // re-running fn from the top is safe.
 func Transaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
-	conn := Connection().WithContext(ctx)
+	return transaction(ctx, Connection(), fn)
+}
+
+func transaction(ctx context.Context, conn *gorm.DB, fn func(tx *gorm.DB) error) error {
+	conn = conn.WithContext(ctx)
 	var err error
 	for attempt := 0; ; attempt++ {
 		err = conn.Transaction(fn)
@@ -50,7 +54,10 @@ func Transaction(ctx context.Context, fn func(tx *gorm.DB) error) error {
 		}
 		metrics.DBBusyRetriesTotal.Inc()
 		if sleepErr := sleepRetry(ctx, BusyRetryBackoffs[attempt]); sleepErr != nil {
-			return err
+			// Context cancelled/timed out during backoff: surface that, not the
+			// contention error, so callers see context.Canceled/DeadlineExceeded
+			// rather than a misleading DB failure.
+			return sleepErr
 		}
 	}
 }

--- a/pkg/db/retry_test.go
+++ b/pkg/db/retry_test.go
@@ -199,3 +199,55 @@ func TestInTransactionStatementNotIndividuallyRetried(t *testing.T) {
 	_, isCommitter := connPoolInsideTx.(gorm.TxCommitter)
 	require.True(t, isCommitter, "in-transaction ConnPool should be a TxCommitter (*sql.Tx)")
 }
+
+// TestTransactionRetriesContentionThenCommits proves the whole-transaction
+// helper re-runs the entire closure on transient contention and commits once it
+// succeeds — the path the per-statement pool retry deliberately does not cover.
+func TestTransactionRetriesContentionThenCommits(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{SkipDefaultTransaction: true})
+	require.NoError(t, err)
+
+	calls := 0
+	err = transaction(context.Background(), gdb, func(tx *gorm.DB) error {
+		calls++
+		if calls < 3 {
+			return errors.New("database is locked")
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 3, calls, "expected two contention retries before the closure committed")
+}
+
+// TestTransactionDoesNotRetryNonContention proves a non-contention error from
+// the closure is returned immediately without re-running the transaction.
+func TestTransactionDoesNotRetryNonContention(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{SkipDefaultTransaction: true})
+	require.NoError(t, err)
+
+	calls := 0
+	err = transaction(context.Background(), gdb, func(tx *gorm.DB) error {
+		calls++
+		return errors.New("not retryable")
+	})
+	require.Error(t, err)
+	require.Equal(t, 1, calls, "non-contention errors must not be retried")
+}
+
+// TestTransactionSurfacesContextCancellation proves that when the context is
+// cancelled during the retry backoff, the helper returns the context error
+// rather than masking it as a DB contention error.
+func TestTransactionSurfacesContextCancellation(t *testing.T) {
+	gdb, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{SkipDefaultTransaction: true})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err = transaction(ctx, gdb, func(tx *gorm.DB) error {
+		calls++
+		cancel() // cancel before the backoff sleep on this contention error
+		return errors.New("database is locked")
+	})
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, calls, "a cancelled context must stop the retry loop")
+}


### PR DESCRIPTION
## Summary
Part of reducing dqlite write contention by writing **fewer, larger transactions** (see analysis on the helm flake: throughput is bottlenecked by the *number* of Raft commits, not the volume of data).

`POST /job` created the trigger → job → atoms → tasks → edges as **~6–8 separate autocommit statements**. On dqlite each commit is its own Raft log append + fsync, so one job apply paid 6–8 commit round-trips — a meaningful chunk of the `triggers`/`jobs`/`tasks` catalog contention we kept hitting. A mid-sequence failure also left a **partial job** behind (e.g. orphan trigger).

This wraps the whole apply in **one transaction**:
- New reusable `db.Transaction(ctx, fn)` helper in `pkg/db` — runs fn in a gorm transaction and retries the entire `BEGIN..COMMIT` on transient contention using the shared `BusyRetryBackoffs` budget. (The per-statement pool retry deliberately can't cover in-transaction statements, so whole-transaction retry is required.)
- `Post` now runs all creates through the services' existing `WithDatabase(tx)` hooks inside that transaction.

Net: **one Raft commit per job instead of 6–8**, and apply is **atomic** — any failure rolls back cleanly instead of leaving partial state.

## Test plan
- [x] `go build ./...`, `go vet`, and unit tests for `pkg/db` + all `api/rest/service/*` pass in the builder container
- [ ] CI integration suite green — every integration test applies jobs through this path, so it's heavily exercised (docker/podman/helm)

## Notes
This is the first of the throughput levers; `execution_events` batching is a separate follow-up. dqlite snapshot/checkpoint-cadence tuning can be trialed alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)