### PR TITLE
Clean up CI flake mitigations now that the read/write split fixes the root cause

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -377,7 +377,6 @@ jobs:
             -e CAESIUM_PODMAN_URI=unix:///run/podman/podman.sock \
             -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
             -e CAESIUM_LOG_LEVEL=debug \
-            -e CAESIUM_DATABASE_SHARDS=4 \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
       - name: Extract caesium CLI

--- a/helm/caesium/ci/test-values-k8s.yaml
+++ b/helm/caesium/ci/test-values-k8s.yaml
@@ -8,11 +8,6 @@ config:
   extraEnv:
     - name: CAESIUM_MANUAL_TRIGGER_API_KEY
       value: integration-test-key
-    # Shard hot-path models off the catalog, matching the docker/podman CI
-    # integration paths (#184). Without this the k8s deploy runs unsharded and
-    # task_runs writes contend on the single catalog DB under the suite's load.
-    - name: CAESIUM_DATABASE_SHARDS
-      value: "4"
 
 kubernetes:
   engine:
@@ -22,18 +17,12 @@ persistence:
   enabled: false
 
 resources:
-  # Low requests keep scheduling trivial on the kind node; generous limits let
-  # the single dqlite node burst instead of being CPU-throttled. At 250m the
-  # node was throttled enough that catalog write-locks (backfills/triggers)
-  # outlasted the busy-retry budget and flaked the suite, while the unthrottled
-  # docker/podman CI servers passed. A CPU limit only caps throttling, it does
-  # not reserve cores, so this is safe on the 4-vCPU public runner.
   requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
     cpu: 250m
     memory: 256Mi
-  limits:
-    cpu: "2"
-    memory: 1Gi
 
 podDisruptionBudget:
   enabled: false

--- a/justfile
+++ b/justfile
@@ -190,7 +190,6 @@ integration-test-podman: build
         -e CAESIUM_PODMAN_URI=unix:///run/podman/podman.sock \
         -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
         -e CAESIUM_LOG_LEVEL=debug \
-        -e CAESIUM_DATABASE_SHARDS=4 \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
     if docker run --rm --platform {{ platform }} \
@@ -217,6 +216,7 @@ hydrate:
 
 integration-up: build-test
     {{ container_cli }} rm -f {{ it_container }} >/dev/null 2>&1 || true
+    # Keep this CI path sharded to exercise the multi-shard database router.
     {{ container_cli }} run -d --platform {{ platform }} \
         --name {{ it_container }} \
         --privileged \


### PR DESCRIPTION
## Summary
With #188 (dqlite read/write split) fixing the write-collision flake at the source, the CI-only mitigations added during the investigation are no longer needed. This peels them back and confirms the suite stays green on the in-app fix alone.

- **`helm/caesium/ci/test-values-k8s.yaml`**: removed the `CAESIUM_DATABASE_SHARDS=4` override and reverted the test-pod resources to their original `requests: 50m/64Mi`, `limits: 250m/256Mi`. (The CPU bump was added to stop *throttling-induced contention*; historically the helm suite completed within timeout at 250m and only failed on contention, which #188 fixes — so 250m + the split should be green.)
- **`.github/workflows/ci.yml`** + **`justfile` (`integration-test-podman`)**: removed the `SHARDS=4` podman overrides.
- Removed the now-stale comments that justified these settings by the (resolved) flake.

## Sharding coverage — kept
`CAESIUM_DATABASE_SHARDS=4` is **kept** on the Docker `integration-up` path (used by `just integration-test` and the amd64/arm64 Docker integration jobs), so the multi-shard database router stays exercised. Podman and helm CI paths now run unsharded, focusing on engine-specific coverage. Flagging this split for review — easy to add sharding back elsewhere if you'd prefer broader coverage.

## Validation
- `helm lint` + `helm template` pass; resources render as `250m/256Mi`; no `CAESIUM_DATABASE_SHARDS` in the k8s template.
- `just --dump` + YAML parse clean.
- CI here is the real test: helm/podman integration should be green **without** the shard/CPU band-aids, proving the split alone holds.

Implemented by Codex; diff reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)