### PR TITLE
Add ordered graceful shutdown/drain

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"crypto/subtle"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/caesium-cloud/caesium/api/gql"
 	authmw "github.com/caesium-cloud/caesium/api/middleware"
@@ -23,6 +26,11 @@ import (
 )
 
 type InternalWakeupHandler func(ctx context.Context, id string, ttl int)
+
+var apiServer struct {
+	sync.Mutex
+	srv *http.Server
+}
 
 // Start launches Caesium's API.
 //
@@ -52,10 +60,34 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 	// Embedded web UI
 	RegisterUI(e)
 
-	sc := echo.StartConfig{
-		Address: fmt.Sprintf(":%v", vars.Port),
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%v", vars.Port),
+		Handler:      e,
+		ReadTimeout:  30 * time.Second,
+		WriteTimeout: 30 * time.Second,
 	}
-	return sc.Start(ctx, e)
+	apiServer.Lock()
+	apiServer.srv = srv
+	apiServer.Unlock()
+	defer func() {
+		apiServer.Lock()
+		if apiServer.srv == srv {
+			apiServer.srv = nil
+		}
+		apiServer.Unlock()
+	}()
+
+	var lc net.ListenConfig
+	ln, err := lc.Listen(ctx, "tcp", srv.Addr)
+	if err != nil {
+		return err
+	}
+
+	log.Info("api listener started", "addr", ln.Addr().String())
+	if err := srv.Serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
 type internalWakeupRequest struct {
@@ -191,6 +223,12 @@ func parseTrustedProxyRanges(raw string) []*net.IPNet {
 	return ranges
 }
 
-func Shutdown() error {
-	return nil
+func Shutdown(ctx context.Context) error {
+	apiServer.Lock()
+	srv := apiServer.srv
+	apiServer.Unlock()
+	if srv == nil {
+		return nil
+	}
+	return srv.Shutdown(ctx)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -61,10 +61,11 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 	RegisterUI(e)
 
 	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%v", vars.Port),
-		Handler:      e,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		Addr:              fmt.Sprintf(":%v", vars.Port),
+		Handler:           e,
+		ReadHeaderTimeout: 10 * time.Second,
+		ReadTimeout:       30 * time.Second,
+		WriteTimeout:      30 * time.Second,
 	}
 	apiServer.Lock()
 	apiServer.srv = srv

--- a/cmd/start/shutdown.go
+++ b/cmd/start/shutdown.go
@@ -1,0 +1,163 @@
+package start
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/caesium-cloud/caesium/api"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"golang.org/x/sync/errgroup"
+)
+
+const defaultShutdownGracePeriod = 30 * time.Second
+
+type shutdownConfig struct {
+	cancel           context.CancelFunc
+	gracePeriod      time.Duration
+	apiShutdown      func(context.Context) error
+	internalShutdown func(context.Context) error
+	closeDB          func() error
+}
+
+type shutdownCoordinator struct {
+	once sync.Once
+	wg   sync.WaitGroup
+
+	cancel           context.CancelFunc
+	gracePeriod      time.Duration
+	apiShutdown      func(context.Context) error
+	internalShutdown func(context.Context) error
+	closeDB          func() error
+
+	err error
+}
+
+var (
+	activeShutdownMu sync.Mutex
+	activeShutdown   *shutdownCoordinator
+)
+
+func newShutdownCoordinator(config shutdownConfig) *shutdownCoordinator {
+	if config.gracePeriod <= 0 {
+		config.gracePeriod = defaultShutdownGracePeriod
+	}
+	if config.apiShutdown == nil {
+		config.apiShutdown = api.Shutdown
+	}
+	if config.internalShutdown == nil {
+		config.internalShutdown = func(context.Context) error { return nil }
+	}
+	if config.closeDB == nil {
+		config.closeDB = func() error {
+			return db.DefaultRouter().Close()
+		}
+	}
+
+	return &shutdownCoordinator{
+		cancel:           config.cancel,
+		gracePeriod:      config.gracePeriod,
+		apiShutdown:      config.apiShutdown,
+		internalShutdown: config.internalShutdown,
+		closeDB:          config.closeDB,
+	}
+}
+
+func activateShutdownCoordinator(coordinator *shutdownCoordinator) func() {
+	activeShutdownMu.Lock()
+	previous := activeShutdown
+	activeShutdown = coordinator
+	activeShutdownMu.Unlock()
+
+	return func() {
+		activeShutdownMu.Lock()
+		if activeShutdown == coordinator {
+			activeShutdown = previous
+		}
+		activeShutdownMu.Unlock()
+	}
+}
+
+func (s *shutdownCoordinator) runAsync(fn func()) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		fn()
+	}()
+}
+
+func shutdown() error {
+	activeShutdownMu.Lock()
+	coordinator := activeShutdown
+	activeShutdownMu.Unlock()
+
+	if coordinator == nil {
+		return nil
+	}
+	return coordinator.Shutdown()
+}
+
+func (s *shutdownCoordinator) Shutdown() error {
+	if s == nil {
+		return nil
+	}
+
+	s.once.Do(func() {
+		s.err = s.shutdown()
+	})
+	return s.err
+}
+
+func (s *shutdownCoordinator) shutdown() error {
+	graceCtx, cancel := context.WithTimeout(context.Background(), s.gracePeriod)
+	defer cancel()
+
+	var shutdownErrs []error
+	if err := s.drainHTTP(graceCtx); err != nil {
+		shutdownErrs = append(shutdownErrs, err)
+	}
+
+	if s.cancel != nil {
+		s.cancel()
+	}
+
+	if err := s.wait(graceCtx); err != nil {
+		log.Error("shutdown timed out waiting for background routines", "error", err)
+		shutdownErrs = append(shutdownErrs, err)
+	}
+
+	if err := s.closeDB(); err != nil {
+		log.Error("database close failed during shutdown", "error", err)
+		shutdownErrs = append(shutdownErrs, err)
+	}
+
+	return errors.Join(shutdownErrs...)
+}
+
+func (s *shutdownCoordinator) drainHTTP(ctx context.Context) error {
+	var group errgroup.Group
+	group.Go(func() error {
+		return s.apiShutdown(ctx)
+	})
+	group.Go(func() error {
+		return s.internalShutdown(ctx)
+	})
+	return group.Wait()
+}
+
+func (s *shutdownCoordinator) wait(ctx context.Context) error {
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/cmd/start/shutdown.go
+++ b/cmd/start/shutdown.go
@@ -114,8 +114,17 @@ func (s *shutdownCoordinator) shutdown() error {
 	graceCtx, cancel := context.WithTimeout(context.Background(), s.gracePeriod)
 	defer cancel()
 
+	// Cap HTTP drain at a fraction of the grace period so a slow drain cannot
+	// starve the goroutine-wait phase. Background loops (e.g. the auth
+	// last-used flusher) do a final DB write when their context is cancelled,
+	// and that write must land before closeDB() runs. Both contexts start now,
+	// so total shutdown time stays bounded by the grace period while wait() is
+	// guaranteed the remainder.
+	drainCtx, cancelDrain := context.WithTimeout(context.Background(), s.gracePeriod/3)
+	defer cancelDrain()
+
 	var shutdownErrs []error
-	if err := s.drainHTTP(graceCtx); err != nil {
+	if err := s.drainHTTP(drainCtx); err != nil {
 		shutdownErrs = append(shutdownErrs, err)
 	}
 

--- a/cmd/start/shutdown_test.go
+++ b/cmd/start/shutdown_test.go
@@ -1,0 +1,99 @@
+package start
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestShutdownCoordinatorIdempotentAndWaitsForAsync(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	started := make(chan struct{})
+	cancelled := make(chan struct{})
+	release := make(chan struct{})
+	finished := make(chan struct{})
+
+	var apiShutdowns int32
+	var internalShutdowns int32
+	var closeDBs int32
+
+	coordinator := newShutdownCoordinator(shutdownConfig{
+		cancel:      cancel,
+		gracePeriod: time.Second,
+		apiShutdown: func(context.Context) error {
+			atomic.AddInt32(&apiShutdowns, 1)
+			return nil
+		},
+		internalShutdown: func(context.Context) error {
+			atomic.AddInt32(&internalShutdowns, 1)
+			return nil
+		},
+		closeDB: func() error {
+			atomic.AddInt32(&closeDBs, 1)
+			return nil
+		},
+	})
+	deactivate := activateShutdownCoordinator(coordinator)
+	defer deactivate()
+
+	coordinator.runAsync(func() {
+		close(started)
+		<-ctx.Done()
+		close(cancelled)
+		<-release
+		close(finished)
+	})
+	<-started
+
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() {
+		firstDone <- shutdown()
+	}()
+	go func() {
+		secondDone <- shutdown()
+	}()
+
+	select {
+	case <-cancelled:
+	case <-time.After(time.Second):
+		t.Fatal("shutdown did not cancel root context")
+	}
+
+	select {
+	case err := <-firstDone:
+		t.Fatalf("shutdown returned before tracked goroutine stopped: %v", err)
+	case err := <-secondDone:
+		t.Fatalf("second shutdown returned before tracked goroutine stopped: %v", err)
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-finished:
+	case <-time.After(time.Second):
+		t.Fatal("tracked goroutine did not finish")
+	}
+
+	for _, ch := range []chan error{firstDone, secondDone} {
+		select {
+		case err := <-ch:
+			if err != nil {
+				t.Fatalf("shutdown returned error: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("shutdown did not return")
+		}
+	}
+
+	if got := atomic.LoadInt32(&apiShutdowns); got != 1 {
+		t.Fatalf("api shutdown count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&internalShutdowns); got != 1 {
+		t.Fatalf("internal shutdown count = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&closeDBs); got != 1 {
+		t.Fatalf("db close count = %d, want 1", got)
+	}
+}

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -78,38 +78,65 @@ var (
 	}
 )
 
-var cancel context.CancelFunc
-
 func start(cmd *cobra.Command, args []string) error {
 	if err := log.CaptureStderr(); err != nil {
 		log.Warn("failed to capture stderr for unified logging", "error", err)
 	}
 
-	signalChan := make(chan os.Signal, 1)
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	vars := env.Variables()
+	var internalSrv *dispatch.InternalServer
+	shutdownCoordinator := newShutdownCoordinator(shutdownConfig{
+		cancel:      cancelFunc,
+		gracePeriod: vars.ShutdownGracePeriod,
+		internalShutdown: func(ctx context.Context) error {
+			if internalSrv == nil {
+				return nil
+			}
+			return internalSrv.Shutdown(ctx)
+		},
+	})
+	deactivateShutdown := activateShutdownCoordinator(shutdownCoordinator)
+	defer deactivateShutdown()
+	defer shutdown()
 
-	go func() {
-		for s := range signalChan {
-			switch s {
-			case syscall.SIGUSR1:
+	runAsync := shutdownCoordinator.runAsync
+	errs := make(chan error, 1)
+	reportErr := func(err error) {
+		if err == nil || ctx.Err() != nil {
+			return
+		}
+		select {
+		case errs <- err:
+		default:
+			log.Error("background routine exited after an error was already reported", "error", err)
+		}
+	}
+
+	signalCtx, stopSignals := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stopSignals()
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, syscall.SIGUSR1)
+	defer signal.Stop(signalChan)
+	runAsync(func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case s := <-signalChan:
+				if s != syscall.SIGUSR1 {
+					continue
+				}
 				log.Info("dumping stack traces due to SIGUSR1 signal")
 				if profile := pprof.Lookup("goroutine"); profile != nil {
 					if err := profile.WriteTo(os.Stdout, 1); err != nil {
 						log.Error("write goroutine profile", "error", err)
 					}
 				}
-			case syscall.SIGINT:
-				log.Info("gracefully shutting down due to SIGINT signal")
-				shutdown()
-				os.Exit(0)
 			}
 		}
-	}()
-
-	signal.Notify(signalChan, syscall.SIGUSR1, syscall.SIGINT)
-
-	var errs = make(chan error)
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	cancel = cancelFunc
+	})
 
 	log.Info("migrating database")
 	if err := db.Migrate(); err != nil {
@@ -122,7 +149,6 @@ func start(cmd *cobra.Command, args []string) error {
 	jsvc.Service(ctx).SetBus(bus)
 	runsvc.New(ctx).SetBus(bus)
 
-	vars := env.Variables()
 	distributedMode := strings.EqualFold(strings.TrimSpace(vars.ExecutionMode), "distributed")
 	wakeupSignaler := worker.NewWakeupSignaler()
 	var distributedWakeups *worker.DistributedWakeups
@@ -141,12 +167,12 @@ func start(cmd *cobra.Command, args []string) error {
 			internalWakeupHandler = func(ctx context.Context, id string, ttl int) {
 				distributedWakeups.HandleRemote(ctx, worker.WakeupMessage{ID: id, TTL: ttl})
 			}
-			go func() {
+			runAsync(func() {
 				log.Info("launching distributed wakeup fanout", "mode", vars.WakeupFanoutMode)
 				if err := distributedWakeups.Start(ctx, bus); err != nil && ctx.Err() == nil {
 					log.Error("distributed wakeup fanout exited", "error", err)
 				}
-			}()
+			})
 		} else {
 			log.Warn("distributed wakeups disabled; set CAESIUM_INTERNAL_WAKEUP_TOKEN to enable cross-node wakeups")
 		}
@@ -215,12 +241,12 @@ func start(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("run-owner mode: auto-provision internal mTLS: %w", err)
 			}
 			holder = provisioner.Holder()
-			go func() {
+			runAsync(func() {
 				log.Info("launching internal mTLS auto-provisioner")
 				if err := provisioner.Run(ctx); err != nil && ctx.Err() == nil {
-					errs <- err
+					reportErr(err)
 				}
-			}()
+			})
 		}
 
 		clientTLS, err := dispatch.ClientTLSConfigFromHolder(holder)
@@ -284,17 +310,17 @@ func start(cmd *cobra.Command, args []string) error {
 			Peers:        dqliteDispatchPeerResolver(),
 			OwnerManager: ownerManager,
 		})
-		go func() {
+		runAsync(func() {
 			log.Info("launching owner dispatch loop",
 				"node_address", vars.NodeAddress,
 				"interval", vars.RunOwnerDispatchInterval,
 			)
 			dispatchLoop.Run(ctx)
-		}()
+		})
 	}
 
 	// --- Authentication & Authorization ---
-	authSvc, auditor, limiter := initAuth(ctx, vars)
+	authSvc, auditor, limiter := initAuth(ctx, vars, runAsync)
 
 	log.Info(
 		"execution configuration",
@@ -342,7 +368,7 @@ func start(cmd *cobra.Command, args []string) error {
 			lineage.RegisterMetrics()
 			sub := lineage.NewSubscriber(bus, transport, vars.OpenLineageNamespace, db.Connection())
 			sub.SetTransportName(vars.OpenLineageTransport)
-			go func() {
+			runAsync(func() {
 				log.Info("launching openlineage subscriber",
 					"transport", vars.OpenLineageTransport,
 					"namespace", vars.OpenLineageNamespace,
@@ -350,7 +376,7 @@ func start(cmd *cobra.Command, args []string) error {
 				if err := sub.Start(ctx); err != nil && ctx.Err() == nil {
 					log.Error("openlineage subscriber exited", "error", err)
 				}
-			}()
+			})
 		}
 	}
 
@@ -363,28 +389,28 @@ func start(cmd *cobra.Command, args []string) error {
 		notifSub.RegisterSender(models.ChannelTypeSlack, notification.NewSlackSender())
 		notifSub.RegisterSender(models.ChannelTypeEmail, notification.NewEmailSender())
 		notifSub.RegisterSender(models.ChannelTypePagerDuty, notification.NewPagerDutySender())
-		go func() {
+		runAsync(func() {
 			log.Info("launching notification subscriber")
 			if err := notifSub.Start(ctx); err != nil && ctx.Err() == nil {
 				log.Error("notification subscriber exited", "error", err)
 			}
-		}()
+		})
 
 		watcher := notification.NewWatcher(conn, bus, event.NewStore(conn), vars.NotificationWatcherInterval)
-		go func() {
+		runAsync(func() {
 			log.Info("launching notification watcher (timeout/SLA)")
 			if err := watcher.Start(ctx); err != nil && ctx.Err() == nil {
 				log.Error("notification watcher exited", "error", err)
 			}
-		}()
+		})
 	}
 
-	go func() {
+	runAsync(func() {
 		log.Info("launching event bus dispatcher")
 		if err := event.NewBusDispatcher(event.NewStore(db.Connection()), bus).Start(ctx); err != nil && ctx.Err() == nil {
 			log.Error("event bus dispatcher exited", "error", err)
 		}
-	}()
+	})
 
 	importer := jobdef.NewImporter(db.Connection())
 	resolver, err := runtime.BuildSecretResolver(vars)
@@ -400,14 +426,14 @@ func start(cmd *cobra.Command, args []string) error {
 
 	for _, watch := range watches {
 		watch := watch
-		go func() {
+		runAsync(func() {
 			log.Info("starting job definition git sync", "url", watch.Source.URL, "ref", watch.Source.Ref, "once", watch.Once, "interval", watch.Interval)
 			opts := git.WatchOptions{Source: watch.Source, Interval: watch.Interval, Once: watch.Once}
 			if err := git.Watch(ctx, importer, opts); err != nil && ctx.Err() == nil {
 				log.Error("job definition git sync exited", "url", watch.Source.URL, "error", err)
-				errs <- err
+				reportErr(err)
 			}
-		}()
+		})
 	}
 
 	// Construct the distributed worker synchronously (cheap, no I/O) so that,
@@ -483,34 +509,45 @@ func start(cmd *cobra.Command, args []string) error {
 	// never arrive at a handler with no worker attached.
 	if ownerDispatchHandler != nil && ownerInternalServerTLS != nil {
 		internalAddr := fmt.Sprintf(":%d", vars.InternalPort)
-		internalSrv := dispatch.NewInternalServer(ownerDispatchHandler, internalAddr, ownerInternalServerTLS)
-		go func() {
+		internalSrv = dispatch.NewInternalServer(ownerDispatchHandler, internalAddr, ownerInternalServerTLS)
+		runAsync(func() {
 			log.Info("spinning up internal mTLS listener", "addr", internalAddr)
 			if err := internalSrv.Run(ctx); err != nil && ctx.Err() == nil {
-				errs <- err
+				reportErr(err)
 			}
-		}()
+		})
 	}
 
-	go func() {
+	runAsync(func() {
 		log.Info("spinning up api")
-		errs <- api.Start(ctx, bus, authSvc, auditor, limiter, internalWakeupHandler)
-	}()
+		if err := api.Start(ctx, bus, authSvc, auditor, limiter, internalWakeupHandler); err != nil && ctx.Err() == nil {
+			reportErr(err)
+		}
+	})
 
-	go func() {
+	runAsync(func() {
 		log.Info("launching execution routine")
-		errs <- executor.Start(ctx)
-	}()
+		if err := executor.Start(ctx); err != nil && ctx.Err() == nil {
+			reportErr(err)
+		}
+	})
 
 	if distributedWorker != nil {
-		go func() {
-			errs <- distributedWorker.Run(ctx)
-		}()
+		runAsync(func() {
+			if err := distributedWorker.Run(ctx); err != nil && ctx.Err() == nil {
+				reportErr(err)
+			}
+		})
 	}
 
-	defer shutdown()
-
-	return <-errs
+	select {
+	case err := <-errs:
+		_ = shutdown()
+		return err
+	case <-signalCtx.Done():
+		log.Info("gracefully shutting down due to OS signal")
+		return shutdown()
+	}
 }
 
 func usesInternalDqlite(databaseType string) bool {
@@ -547,7 +584,7 @@ func dqliteWakeupPeerResolver(localNodeAddress string, apiPort int) worker.Wakeu
 
 // initAuth sets up authentication services based on CAESIUM_AUTH_MODE.
 // Returns nil services when auth is disabled so callers can pass them through safely.
-func initAuth(ctx context.Context, vars env.Environment) (*auth.Service, *auth.AuditLogger, *auth.RateLimiter) {
+func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) (*auth.Service, *auth.AuditLogger, *auth.RateLimiter) {
 	conn := db.Connection()
 	authSvc := auth.NewService(conn, auth.WithKeyHashSecret(vars.AuthKeyHashSecret))
 	auditor := auth.NewAuditLogger(conn)
@@ -609,18 +646,16 @@ func initAuth(ctx context.Context, vars env.Environment) (*auth.Service, *auth.A
 			}
 		}
 
-		authSvc.StartLastUsedFlusher(ctx)
-		limiter.StartCleanup(ctx.Done())
+		runAsync(func() {
+			authSvc.RunLastUsedFlusher(ctx)
+		})
+		runAsync(func() {
+			limiter.RunCleanup(ctx.Done())
+		})
 		return authSvc, auditor, limiter
 
 	default:
 		log.Fatal("unknown CAESIUM_AUTH_MODE value", "mode", vars.AuthMode)
 		return nil, nil, nil // unreachable
-	}
-}
-
-func shutdown() {
-	if cancel != nil {
-		cancel()
 	}
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -98,7 +98,11 @@ func start(cmd *cobra.Command, args []string) error {
 	})
 	deactivateShutdown := activateShutdownCoordinator(shutdownCoordinator)
 	defer deactivateShutdown()
-	defer shutdown()
+	defer func() {
+		if err := shutdown(); err != nil {
+			log.Error("graceful shutdown failed", "error", err)
+		}
+	}()
 
 	runAsync := shutdownCoordinator.runAsync
 	errs := make(chan error, 1)

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -93,18 +93,17 @@ func (r *RateLimiter) Cleanup() {
 	}
 }
 
-// StartCleanup runs a periodic cleanup goroutine.
-func (r *RateLimiter) StartCleanup(done <-chan struct{}) {
-	go func() {
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-ticker.C:
-				r.Cleanup()
-			}
+// RunCleanup periodically removes expired windows until done is closed. The
+// caller owns the goroutine lifecycle so shutdown can wait for the loop.
+func (r *RateLimiter) RunCleanup(done <-chan struct{}) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			r.Cleanup()
 		}
-	}()
+	}
 }

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -98,23 +98,21 @@ func NewService(db *gorm.DB, opts ...ServiceOption) *Service {
 	return s
 }
 
-// StartLastUsedFlusher runs a background goroutine that periodically flushes
-// buffered last_used_at timestamps to the database. This keeps the hot auth
-// path free of writes.
-func (s *Service) StartLastUsedFlusher(ctx context.Context) {
-	go func() {
-		ticker := time.NewTicker(30 * time.Second)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				s.flushLastUsed()
-				return
-			case <-ticker.C:
-				s.flushLastUsed()
-			}
+// RunLastUsedFlusher periodically flushes buffered last_used_at timestamps to
+// the database until ctx is cancelled. This keeps the hot auth path free of
+// writes while allowing the caller to own goroutine lifecycle.
+func (s *Service) RunLastUsedFlusher(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.flushLastUsed()
+			return
+		case <-ticker.C:
+			s.flushLastUsed()
 		}
-	}()
+	}
 }
 
 func (s *Service) flushLastUsed() {

--- a/internal/dispatch/internal_server.go
+++ b/internal/dispatch/internal_server.go
@@ -41,9 +41,9 @@ func NewInternalServer(handler *Handler, addr string, tlsConfig *tls.Config) *In
 	}
 }
 
-// Run serves until ctx is cancelled, then shuts down gracefully.  It blocks; run
-// it in a goroutine.  The certificate comes from srv.TLSConfig.Certificates, so
-// ServeTLS is called with empty file arguments.
+// Run serves until Shutdown is called. It blocks; run it in a goroutine. The
+// certificate comes from srv.TLSConfig.Certificates, so ServeTLS is called with
+// empty file arguments.
 func (s *InternalServer) Run(ctx context.Context) error {
 	var lc net.ListenConfig
 	ln, err := lc.Listen(ctx, "tcp", s.srv.Addr)
@@ -51,16 +51,17 @@ func (s *InternalServer) Run(ctx context.Context) error {
 		return err
 	}
 
-	go func() {
-		<-ctx.Done()
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = s.srv.Shutdown(shutdownCtx)
-	}()
-
 	log.Info("internal mTLS listener started", "addr", s.srv.Addr)
 	if err := s.srv.ServeTLS(ln, "", ""); err != nil && err != http.ErrServerClosed {
 		return err
 	}
 	return nil
+}
+
+// Shutdown gracefully drains the internal mTLS listener.
+func (s *InternalServer) Shutdown(ctx context.Context) error {
+	if s == nil || s.srv == nil {
+		return nil
+	}
+	return s.srv.Shutdown(ctx)
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -97,6 +97,7 @@ type Environment struct {
 	WorkerLeaseTTL                time.Duration `default:"5m" split_words:"true"`
 	WorkerLeaseRenewInterval      time.Duration `default:"0" split_words:"true"`
 	WorkerPoolSize                int           `default:"4" split_words:"true"`
+	ShutdownGracePeriod           time.Duration `envconfig:"SHUTDOWN_GRACE_PERIOD" default:"30s"`
 	InternalWakeupToken           string        `default:"" split_words:"true"`
 	WakeupFanoutMode              string        `default:"full" split_words:"true"`
 	AtomPollInterval              time.Duration `default:"1s" split_words:"true"`


### PR DESCRIPTION
## Summary
Implements ordered graceful shutdown — the follow-up flagged in #188's review (`Router.Close()` existed but nothing called it; `shutdown()` only cancelled the context, and `api.Shutdown()` was a `return nil` stub).

On SIGINT/SIGTERM (and via the shutdown hook), a `shutdownCoordinator` (`cmd/start/shutdown.go`) runs an ordered, grace-period-bounded, idempotent (`sync.Once`) sequence:
1. **Drain HTTP** — `api.Shutdown(ctx)` + the internal dispatch server's `Shutdown(ctx)` concurrently (both now real `*http.Server.Shutdown`).
2. **`cancel()`** the root context.
3. **Wait** for every background goroutine — all bare `go func()` loops (distributed wakeup, owner dispatch, **mTLS provisioner rotation**, OpenLineage, notification subscriber + watcher, event `BusDispatcher`, git-sync, executor, distributed worker, auth flusher/cleanup) are converted to a tracked `runAsync` helper — bounded by the grace period.
4. **Close DB pools last** — `db.DefaultRouter().Close()` (releases the read/write split pools), only after all HTTP + loops have stopped (no use-after-close).

Errors are collected (`errors.Join`) so the full teardown always runs. Configurable via `CAESIUM_SHUTDOWN_GRACE_PERIOD` (default 30s).

## Test plan
- [x] `go build ./...`, `go vet`, and tests for `cmd/...`, `pkg/db/...`, `internal/auth/...`, `internal/dispatch/...` green in the builder image
- [x] New `cmd/start/shutdown_test.go`: idempotency + that tracked goroutines are waited for
- [ ] Worth a manual runtime check of real signal → drain → close behavior before merge (it's a lifecycle change)

Implemented by Codex; diff reviewed (ordering, idempotency, full goroutine tracking incl. the mTLS provisioner, DB-close-last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)