### PR TITLE
[codex] Implement SSO auth foundation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -39,7 +39,7 @@ var apiServer struct {
 // are deliberately NOT served here — they live on a dedicated mutually
 // authenticated TLS listener (see dispatch.InternalServer) so the public API
 // can remain plain HTTP behind the operator's proxy.
-func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore, wakeupHandler InternalWakeupHandler) error {
+func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore, sso *auth.SSOService, wakeupHandler InternalWakeupHandler) error {
 	e := echo.New()
 	vars := env.Variables()
 	configureIPExtractor(e, vars)
@@ -47,7 +47,7 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 	// health
 	e.GET("/health", Health)
 	e.GET("/auth/status", authStatus(vars))
-	registerSSORoutes(e, vars, authSvc, auditor, limiter, sessions)
+	registerSSORoutes(e, vars, authSvc, auditor, limiter, sessions, sso)
 	registerInternalWakeup(e, vars, wakeupHandler)
 
 	// metrics
@@ -173,19 +173,20 @@ func authStatus(vars env.Environment) echo.HandlerFunc {
 	}
 }
 
-func registerSSORoutes(e *echo.Echo, vars env.Environment, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore) {
+func registerSSORoutes(e *echo.Echo, vars env.Environment, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore, sso *auth.SSOService) {
 	if sessions == nil {
 		return
 	}
-	controller := authctrl.NewSSO(sessions, vars.AuthSessionCookieName)
-	e.GET("/auth/whoami", controller.Whoami, authmw.Auth(authmw.AuthDeps{
+	controller := authctrl.NewSSO(sessions, sso, vars.AuthSessionCookieName)
+	authMiddleware := authmw.Auth(authmw.AuthDeps{
 		Service:    authSvc,
 		Auditor:    auditor,
 		Limiter:    limiter,
 		Sessions:   sessions,
 		CookieName: vars.AuthSessionCookieName,
-	}))
-	e.POST("/auth/logout", controller.Logout)
+	})
+	e.GET("/auth/whoami", controller.Whoami, authMiddleware)
+	e.POST("/auth/logout", controller.Logout, authMiddleware)
 }
 
 func registerMetrics(e *echo.Echo, vars env.Environment, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore) {

--- a/api/api.go
+++ b/api/api.go
@@ -177,7 +177,7 @@ func registerSSORoutes(e *echo.Echo, vars env.Environment, authSvc *auth.Service
 	if sessions == nil {
 		return
 	}
-	controller := authctrl.NewSSO(sessions, sso, vars.AuthSessionCookieName)
+	controller := authctrl.NewSSO(sessions, sso, vars.AuthSessionCookieName, authmw.ParseTrustedProxyRanges(vars.TrustedProxies)...)
 	authMiddleware := authmw.Auth(authmw.AuthDeps{
 		Service:    authSvc,
 		Auditor:    auditor,
@@ -217,7 +217,7 @@ func registerGraphQL(e *echo.Echo, vars env.Environment) {
 }
 
 func configureIPExtractor(e *echo.Echo, vars env.Environment) {
-	trusted := parseTrustedProxyRanges(vars.TrustedProxies)
+	trusted := authmw.ParseTrustedProxyRanges(vars.TrustedProxies)
 	if len(trusted) == 0 {
 		e.IPExtractor = echo.ExtractIPDirect()
 		return
@@ -232,34 +232,6 @@ func configureIPExtractor(e *echo.Echo, vars env.Environment) {
 		options = append(options, echo.TrustIPRange(ipNet))
 	}
 	e.IPExtractor = echo.ExtractIPFromXFFHeader(options...)
-}
-
-func parseTrustedProxyRanges(raw string) []*net.IPNet {
-	parts := strings.Split(raw, ",")
-	ranges := make([]*net.IPNet, 0, len(parts))
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-
-		if _, ipNet, err := net.ParseCIDR(part); err == nil {
-			ranges = append(ranges, ipNet)
-			continue
-		}
-
-		if ip := net.ParseIP(part); ip != nil {
-			bits := 32
-			if ip.To4() == nil {
-				bits = 128
-			}
-			ranges = append(ranges, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
-			continue
-		}
-
-		log.Warn("ignoring invalid trusted proxy entry", "value", part)
-	}
-	return ranges
 }
 
 func Shutdown(ctx context.Context) error {

--- a/api/api.go
+++ b/api/api.go
@@ -16,6 +16,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/gql"
 	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	"github.com/caesium-cloud/caesium/api/rest/bind"
+	authctrl "github.com/caesium-cloud/caesium/api/rest/controller/auth"
 	"github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/metrics"
@@ -38,7 +39,7 @@ var apiServer struct {
 // are deliberately NOT served here — they live on a dedicated mutually
 // authenticated TLS listener (see dispatch.InternalServer) so the public API
 // can remain plain HTTP behind the operator's proxy.
-func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, wakeupHandler InternalWakeupHandler) error {
+func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore, wakeupHandler InternalWakeupHandler) error {
 	e := echo.New()
 	vars := env.Variables()
 	configureIPExtractor(e, vars)
@@ -46,14 +47,15 @@ func Start(ctx context.Context, bus event.Bus, authSvc *auth.Service, auditor *a
 	// health
 	e.GET("/health", Health)
 	e.GET("/auth/status", authStatus(vars))
+	registerSSORoutes(e, vars, authSvc, auditor, limiter, sessions)
 	registerInternalWakeup(e, vars, wakeupHandler)
 
 	// metrics
 	e.Use(echoprometheus.NewMiddleware("caesium"))
-	registerMetrics(e, vars, authSvc, auditor, limiter)
+	registerMetrics(e, vars, authSvc, auditor, limiter, sessions)
 
 	// REST
-	bind.All(e.Group("/v1"), bus, authSvc, auditor, limiter)
+	bind.All(e.Group("/v1"), bus, authSvc, auditor, limiter, sessions)
 
 	registerGraphQL(e, vars)
 
@@ -151,18 +153,53 @@ func constantTimeEqual(a, b string) bool {
 
 func authStatus(vars env.Environment) echo.HandlerFunc {
 	return func(c *echo.Context) error {
-		return c.JSON(http.StatusOK, map[string]bool{
-			"enabled": vars.AuthMode == "api-key",
+		methods := make([]map[string]string, 0, 4)
+		if vars.AuthMode == "api-key" {
+			methods = append(methods, map[string]string{"type": "api-key"})
+		}
+		if vars.AuthOIDCEnabled {
+			methods = append(methods, map[string]string{"type": "oidc", "loginUrl": "/auth/sso/oidc/login"})
+		}
+		if vars.AuthSAMLEnabled {
+			methods = append(methods, map[string]string{"type": "saml", "loginUrl": "/auth/sso/saml/login"})
+		}
+		if vars.AuthLDAPEnabled {
+			methods = append(methods, map[string]string{"type": "ldap"})
+		}
+		return c.JSON(http.StatusOK, map[string]any{
+			"enabled": vars.AuthMode == "api-key" || vars.SSOEnabled(),
+			"methods": methods,
 		})
 	}
 }
 
-func registerMetrics(e *echo.Echo, vars env.Environment, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) {
+func registerSSORoutes(e *echo.Echo, vars env.Environment, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore) {
+	if sessions == nil {
+		return
+	}
+	controller := authctrl.NewSSO(sessions, vars.AuthSessionCookieName)
+	e.GET("/auth/whoami", controller.Whoami, authmw.Auth(authmw.AuthDeps{
+		Service:    authSvc,
+		Auditor:    auditor,
+		Limiter:    limiter,
+		Sessions:   sessions,
+		CookieName: vars.AuthSessionCookieName,
+	}))
+	e.POST("/auth/logout", controller.Logout)
+}
+
+func registerMetrics(e *echo.Echo, vars env.Environment, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore) {
 	metrics.Register()
 
 	handler := echoprometheus.NewHandler()
-	if vars.AuthMode == "api-key" && authSvc != nil {
-		e.GET("/metrics", handler, authmw.Auth(authSvc, auditor, limiter))
+	if (vars.AuthMode == "api-key" || vars.SSOEnabled()) && authSvc != nil {
+		e.GET("/metrics", handler, authmw.Auth(authmw.AuthDeps{
+			Service:    authSvc,
+			Auditor:    auditor,
+			Limiter:    limiter,
+			Sessions:   sessions,
+			CookieName: vars.AuthSessionCookieName,
+		}))
 		return
 	}
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -121,6 +122,46 @@ func TestRegisterMetricsProtectedWhenAuthEnabled(t *testing.T) {
 	e.ServeHTTP(rec, req)
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.Contains(t, rec.Body.String(), "caesium_")
+}
+
+func TestRegisterSSORoutesProtectsLogoutWithCSRF(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := iauth.NewService(db)
+	auditor := iauth.NewAuditLogger(db)
+	limiter := iauth.NewRateLimiter(5, time.Minute)
+	sessions := iauth.NewSessionStore(db)
+	user := &models.User{
+		ID:        uuid.New(),
+		Issuer:    "oidc",
+		Subject:   "sub-1",
+		Email:     "viewer@example.com",
+		Role:      models.RoleViewer,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(user).Error)
+	token, sess, err := sessions.Create(t.Context(), iauth.CreateSessionRequest{UserID: user.ID})
+	require.NoError(t, err)
+
+	e := echo.New()
+	registerSSORoutes(e, env.Environment{AuthSessionCookieName: "caesium_session"}, svc, auditor, limiter, sessions, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusForbidden, rec.Code)
+
+	req = httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
+	req.Header.Set("X-CSRF-Token", sess.CSRFToken)
+	rec = httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	_, _, err = sessions.Validate(t.Context(), token)
+	require.ErrorIs(t, err, iauth.ErrSessionRevoked)
 }
 
 func TestRegisterInternalWakeupRequiresToken(t *testing.T) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -37,24 +37,53 @@ func TestAuthStatusReflectsAuthMode(t *testing.T) {
 		rec := performRequest(t, authStatus(env.Environment{AuthMode: "api-key"}), http.MethodGet, "/auth/status")
 
 		require.Equal(t, http.StatusOK, rec.Code)
-		var body map[string]bool
+		var body struct {
+			Enabled bool                `json:"enabled"`
+			Methods []map[string]string `json:"methods"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-		require.True(t, body["enabled"])
+		require.True(t, body.Enabled)
+		require.Contains(t, body.Methods, map[string]string{"type": "api-key"})
 	})
 
 	t.Run("disabled", func(t *testing.T) {
 		rec := performRequest(t, authStatus(env.Environment{AuthMode: "none"}), http.MethodGet, "/auth/status")
 
 		require.Equal(t, http.StatusOK, rec.Code)
-		var body map[string]bool
+		var body struct {
+			Enabled bool                `json:"enabled"`
+			Methods []map[string]string `json:"methods"`
+		}
 		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
-		require.False(t, body["enabled"])
+		require.False(t, body.Enabled)
+		require.Empty(t, body.Methods)
 	})
+}
+
+func TestAuthStatusListsSSOMethods(t *testing.T) {
+	rec := performRequest(t, authStatus(env.Environment{
+		AuthMode:        "api-key",
+		AuthOIDCEnabled: true,
+		AuthSAMLEnabled: true,
+		AuthLDAPEnabled: true,
+	}), http.MethodGet, "/auth/status")
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var body struct {
+		Enabled bool                `json:"enabled"`
+		Methods []map[string]string `json:"methods"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.True(t, body.Enabled)
+	require.Contains(t, body.Methods, map[string]string{"type": "api-key"})
+	require.Contains(t, body.Methods, map[string]string{"type": "oidc", "loginUrl": "/auth/sso/oidc/login"})
+	require.Contains(t, body.Methods, map[string]string{"type": "saml", "loginUrl": "/auth/sso/saml/login"})
+	require.Contains(t, body.Methods, map[string]string{"type": "ldap"})
 }
 
 func TestRegisterMetricsPublicWhenAuthDisabled(t *testing.T) {
 	e := echo.New()
-	registerMetrics(e, env.Environment{AuthMode: "none"}, nil, nil, nil)
+	registerMetrics(e, env.Environment{AuthMode: "none"}, nil, nil, nil, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -79,7 +108,7 @@ func TestRegisterMetricsProtectedWhenAuthEnabled(t *testing.T) {
 	require.NoError(t, err)
 
 	e := echo.New()
-	registerMetrics(e, env.Environment{AuthMode: "api-key"}, svc, auditor, limiter)
+	registerMetrics(e, env.Environment{AuthMode: "api-key"}, svc, auditor, limiter, nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rec := httptest.NewRecorder()

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -67,27 +67,9 @@ func Auth(d AuthDeps) echo.MiddlewareFunc {
 				validKey, err := d.Service.ValidateKey(token)
 				if err != nil {
 					reason := classifyAuthError(err)
-					metrics.AuthFailuresTotal.WithLabelValues(reason).Inc()
-
-					limited := d.Limiter.RecordFailure(ip)
-					logAuditFailure(d.Auditor.Log(auth.AuditEntry{
-						Actor:    tokenPrefix(token),
-						Action:   auth.ActionAuthDenied,
-						SourceIP: ip,
-						Outcome:  auth.OutcomeDenied,
-						Metadata: map[string]interface{}{
-							"reason": reason,
-							"method": c.Request().Method,
-							"path":   path,
-						},
-					}))
-
-					if limited {
-						retryAfter := d.Limiter.RetryAfter(ip)
-						c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
-						return echo.NewHTTPError(http.StatusTooManyRequests, "too many failed authentication attempts")
+					if recordCredentialFailure(c, d, ip, tokenPrefix(token), reason) {
+						return rateLimitError(c, d.Limiter, ip)
 					}
-
 					return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired api key")
 				}
 
@@ -97,10 +79,15 @@ func Auth(d AuthDeps) echo.MiddlewareFunc {
 				if cookie, err := c.Request().Cookie(d.CookieName); err == nil && cookie.Value != "" {
 					sess, user, verr := d.Sessions.Validate(c.Request().Context(), cookie.Value)
 					if verr != nil {
-						metrics.AuthFailuresTotal.WithLabelValues("session_invalid").Inc()
+						if recordCredentialFailure(c, d, ip, tokenPrefix(cookie.Value), classifySessionAuthError(verr)) {
+							return rateLimitError(c, d.Limiter, ip)
+						}
 						return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired session")
 					}
 					if err := EnforceSessionCSRF(c, sess.CSRFToken); err != nil {
+						if recordCredentialFailure(c, d, ip, tokenPrefix(cookie.Value), "csrf") {
+							return rateLimitError(c, d.Limiter, ip)
+						}
 						return err
 					}
 					principal = auth.PrincipalFromUser(user)
@@ -196,6 +183,45 @@ func classifyAuthError(err error) string {
 		log.Error("unexpected auth validation error", "error", err)
 		return "error"
 	}
+}
+
+func classifySessionAuthError(err error) string {
+	switch err {
+	case auth.ErrSessionInvalid:
+		return "session_invalid"
+	case auth.ErrSessionExpired:
+		return "session_expired"
+	case auth.ErrSessionRevoked:
+		return "session_revoked"
+	case auth.ErrUserDisabled:
+		return "user_disabled"
+	default:
+		log.Error("unexpected session validation error", "error", err)
+		return "session_error"
+	}
+}
+
+func recordCredentialFailure(c *echo.Context, d AuthDeps, ip, actor, reason string) bool {
+	metrics.AuthFailuresTotal.WithLabelValues(reason).Inc()
+	limited := d.Limiter.RecordFailure(ip)
+	logAuditFailure(d.Auditor.Log(auth.AuditEntry{
+		Actor:    actor,
+		Action:   auth.ActionAuthDenied,
+		SourceIP: ip,
+		Outcome:  auth.OutcomeDenied,
+		Metadata: map[string]interface{}{
+			"reason": reason,
+			"method": c.Request().Method,
+			"path":   c.Request().URL.Path,
+		},
+	}))
+	return limited
+}
+
+func rateLimitError(c *echo.Context, limiter *auth.RateLimiter, ip string) error {
+	retryAfter := limiter.RetryAfter(ip)
+	c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+	return echo.NewHTTPError(http.StatusTooManyRequests, "too many failed authentication attempts")
 }
 
 func denyAccess(

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -17,6 +17,9 @@ import (
 // ContextKeyAuth is the key used to store the authenticated API key in the Echo context.
 const ContextKeyAuth = "auth"
 
+// ContextKeyPrincipal stores the unified authenticated identity for the request.
+const ContextKeyPrincipal = "auth.principal"
+
 // uuidPattern matches UUID path segments for route normalisation.
 var uuidPattern = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
 var namedParamPattern = regexp.MustCompile(`:[^/]+`)
@@ -26,8 +29,18 @@ var skipPaths = map[string]bool{
 	"/health": true,
 }
 
-// Auth returns Echo middleware that enforces API key authentication and RBAC.
-func Auth(svc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) echo.MiddlewareFunc {
+// AuthDeps bundles the dependencies the auth middleware needs.
+type AuthDeps struct {
+	Service    *auth.Service
+	Auditor    *auth.AuditLogger
+	Limiter    *auth.RateLimiter
+	Sessions   *auth.SessionStore
+	CookieName string
+}
+
+// Auth returns Echo middleware that enforces API-key or session-cookie
+// authentication and RBAC.
+func Auth(d AuthDeps) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c *echo.Context) error {
 			path := c.Request().URL.Path
@@ -40,77 +53,98 @@ func Auth(svc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimite
 			ip := c.RealIP()
 
 			// Rate limit check before doing any work.
-			if limiter.IsLimited(ip) {
+			if d.Limiter.IsLimited(ip) {
 				metrics.AuthFailuresTotal.WithLabelValues("rate_limited").Inc()
-				retryAfter := limiter.RetryAfter(ip)
+				retryAfter := d.Limiter.RetryAfter(ip)
 				c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
 				return echo.NewHTTPError(http.StatusTooManyRequests, "too many failed authentication attempts")
 			}
 
-			// Extract bearer token.
-			token := extractBearerToken(c)
-			if token == "" {
-				metrics.AuthFailuresTotal.WithLabelValues("missing").Inc()
-				return echo.NewHTTPError(http.StatusUnauthorized, "missing authorization header")
-			}
+			var key *models.APIKey
+			var principal *auth.Principal
 
-			// Validate the API key.
-			key, err := svc.ValidateKey(token)
-			if err != nil {
-				reason := classifyAuthError(err)
-				metrics.AuthFailuresTotal.WithLabelValues(reason).Inc()
+			if token := extractBearerToken(c); token != "" {
+				validKey, err := d.Service.ValidateKey(token)
+				if err != nil {
+					reason := classifyAuthError(err)
+					metrics.AuthFailuresTotal.WithLabelValues(reason).Inc()
 
-				limited := limiter.RecordFailure(ip)
-				logAuditFailure(auditor.Log(auth.AuditEntry{
-					Actor:    tokenPrefix(token),
-					Action:   auth.ActionAuthDenied,
-					SourceIP: ip,
-					Outcome:  auth.OutcomeDenied,
-					Metadata: map[string]interface{}{
-						"reason": reason,
-						"method": c.Request().Method,
-						"path":   path,
-					},
-				}))
+					limited := d.Limiter.RecordFailure(ip)
+					logAuditFailure(d.Auditor.Log(auth.AuditEntry{
+						Actor:    tokenPrefix(token),
+						Action:   auth.ActionAuthDenied,
+						SourceIP: ip,
+						Outcome:  auth.OutcomeDenied,
+						Metadata: map[string]interface{}{
+							"reason": reason,
+							"method": c.Request().Method,
+							"path":   path,
+						},
+					}))
 
-				if limited {
-					retryAfter := limiter.RetryAfter(ip)
-					c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
-					return echo.NewHTTPError(http.StatusTooManyRequests, "too many failed authentication attempts")
+					if limited {
+						retryAfter := d.Limiter.RetryAfter(ip)
+						c.Response().Header().Set("Retry-After", fmt.Sprintf("%d", retryAfter))
+						return echo.NewHTTPError(http.StatusTooManyRequests, "too many failed authentication attempts")
+					}
+
+					return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired api key")
 				}
 
-				return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired api key")
+				key = validKey
+				principal = auth.PrincipalFromKey(validKey)
+			} else if d.Sessions != nil {
+				if cookie, err := c.Request().Cookie(d.CookieName); err == nil && cookie.Value != "" {
+					sess, user, verr := d.Sessions.Validate(c.Request().Context(), cookie.Value)
+					if verr != nil {
+						metrics.AuthFailuresTotal.WithLabelValues("session_invalid").Inc()
+						return echo.NewHTTPError(http.StatusUnauthorized, "invalid or expired session")
+					}
+					if err := EnforceSessionCSRF(c, sess.CSRFToken); err != nil {
+						return err
+					}
+					principal = auth.PrincipalFromUser(user)
+					c.Set(ContextKeyCSRFToken, sess.CSRFToken)
+				}
+			}
+
+			if principal == nil {
+				metrics.AuthFailuresTotal.WithLabelValues("missing").Inc()
+				return echo.NewHTTPError(http.StatusUnauthorized, "missing credentials")
 			}
 
 			// Determine the required role for this endpoint.
 			routePath := normalisePath(c)
 			required, ok := auth.RequiredRole(c.Request().Method, routePath)
 			if !ok {
-				return denyAccess(c, auditor, key.KeyPrefix, key.Role, routePath, "unknown_route", "")
+				return denyAccess(c, d.Auditor, principal.Subject, principal.Role, routePath, "unknown_route", "")
 			}
 
-			if !auth.HasRole(key.Role, required) {
-				return denyAccess(c, auditor, key.KeyPrefix, key.Role, routePath, "insufficient_role", required)
+			if !auth.HasRole(principal.Role, required) {
+				return denyAccess(c, d.Auditor, principal.Subject, principal.Role, routePath, "insufficient_role", required)
 			}
 
 			// Store authenticated identity in context for downstream handlers.
-			scopeContext, err := authorizeScope(c, svc, key, routePath)
+			scopeContext, err := authorizeScope(c, d.Service, principal.Scope, routePath)
 			if err != nil {
 				if he, ok := err.(*echo.HTTPError); ok && he.Code == http.StatusForbidden {
-					return denyAccess(c, auditor, key.KeyPrefix, key.Role, routePath, "insufficient_scope", required)
+					return denyAccess(c, d.Auditor, principal.Subject, principal.Role, routePath, "insufficient_scope", required)
 				}
 				return err
 			}
 
-			c.Set(ContextKeyAuth, key)
-			metrics.AuthKeyAgeSeconds.Observe(time.Since(key.CreatedAt).Seconds())
+			if key != nil {
+				c.Set(ContextKeyAuth, key)
+				metrics.AuthKeyAgeSeconds.Observe(time.Since(key.CreatedAt).Seconds())
+			}
+			c.Set(ContextKeyPrincipal, principal)
 
 			if err := next(c); err != nil {
 				return err
 			}
 
-			metrics.AuthRequestsTotal.WithLabelValues("success", string(key.Role), c.Request().Method, routePath).Inc()
-			logSuccessfulAction(auditor, c, key, routePath, scopeContext)
+			metrics.AuthRequestsTotal.WithLabelValues("success", string(principal.Role), c.Request().Method, routePath).Inc()
+			logSuccessfulAction(d.Auditor, c, principal, routePath, scopeContext)
 			return nil
 		}
 	}
@@ -199,7 +233,7 @@ func denyAccess(
 func logSuccessfulAction(
 	auditor *auth.AuditLogger,
 	c *echo.Context,
-	key *models.APIKey,
+	principal *auth.Principal,
 	routePath string,
 	scopeContext *scopeAuditContext,
 ) {
@@ -213,7 +247,7 @@ func logSuccessfulAction(
 	}
 
 	entry := auth.AuditEntry{
-		Actor:    key.KeyPrefix,
+		Actor:    principal.Subject,
 		Action:   action,
 		SourceIP: c.RealIP(),
 		Outcome:  auth.OutcomeSuccess,
@@ -290,4 +324,17 @@ func GetAuthKey(c *echo.Context) *models.APIKey {
 		return nil
 	}
 	return key
+}
+
+// GetPrincipal returns the unified authenticated identity, or nil if unauthenticated.
+func GetPrincipal(c *echo.Context) *auth.Principal {
+	v := c.Get(ContextKeyPrincipal)
+	if v == nil {
+		return nil
+	}
+	principal, ok := v.(*auth.Principal)
+	if !ok {
+		return nil
+	}
+	return principal
 }

--- a/api/middleware/auth_scope.go
+++ b/api/middleware/auth_scope.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/caesium-cloud/caesium/internal/auth"
-	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"gorm.io/gorm"
@@ -35,8 +34,8 @@ func GetAllowedJobAliases(c *echo.Context) []string {
 	return append([]string(nil), aliases...)
 }
 
-func authorizeScope(c *echo.Context, svc *auth.Service, key *models.APIKey, routePath string) (*scopeAuditContext, error) {
-	scopeJobs, err := auth.ScopeJobs(key.Scope)
+func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routePath string) (*scopeAuditContext, error) {
+	scopeJobs, err := auth.ScopeJobs(scopeJSON)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
 	}
@@ -57,7 +56,7 @@ func authorizeScope(c *echo.Context, svc *auth.Service, key *models.APIKey, rout
 			if err != nil {
 				return nil, echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
 			}
-			if len(aliases) != 1 || !auth.CheckScope(key.Scope, aliases[0]) {
+			if len(aliases) != 1 || !auth.CheckScope(scopeJSON, aliases[0]) {
 				return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
 			}
 			state.jobAliases = aliases
@@ -72,7 +71,7 @@ func authorizeScope(c *echo.Context, svc *auth.Service, key *models.APIKey, rout
 			return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
 		}
 		for _, alias := range aliases {
-			if !auth.CheckScope(key.Scope, alias) {
+			if !auth.CheckScope(scopeJSON, alias) {
 				return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
 			}
 		}
@@ -88,7 +87,7 @@ func authorizeScope(c *echo.Context, svc *auth.Service, key *models.APIKey, rout
 			}
 			return nil, echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 		}
-		if !auth.CheckScope(key.Scope, jobAlias) {
+		if !auth.CheckScope(scopeJSON, jobAlias) {
 			return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
 		}
 		state.jobAliases = []string{jobAlias}

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -123,7 +123,7 @@ func callMiddleware(
 		c.InitializeRoute(route, &pv)
 	}
 
-	handler := authmw.Auth(svc, auditor, limiter)(next)
+	handler := authmw.Auth(authmw.AuthDeps{Service: svc, Auditor: auditor, Limiter: limiter})(next)
 	err := handler(c)
 	return rec, err
 }
@@ -179,6 +179,7 @@ func TestMiddlewareStoresAuthInContext(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+key)
 
 	var capturedKey *models.APIKey
+	var capturedPrincipal *auth.Principal
 	rec, err := callMiddleware(
 		t,
 		svc,
@@ -189,6 +190,7 @@ func TestMiddlewareStoresAuthInContext(t *testing.T) {
 		nil,
 		func(c *echo.Context) error {
 			capturedKey = authmw.GetAuthKey(c)
+			capturedPrincipal = authmw.GetPrincipal(c)
 			return c.String(http.StatusOK, "ok")
 		},
 	)
@@ -196,6 +198,67 @@ func TestMiddlewareStoresAuthInContext(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 	require.NotNil(t, capturedKey)
 	require.Equal(t, models.RoleAdmin, capturedKey.Role)
+	require.NotNil(t, capturedPrincipal)
+	require.Equal(t, auth.PrincipalAPIKey, capturedPrincipal.Kind)
+	require.Equal(t, capturedKey.KeyPrefix, capturedPrincipal.Subject)
+	require.Equal(t, models.RoleAdmin, capturedPrincipal.Role)
+}
+
+func TestAuthAcceptsSessionCookie(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+	sessions := auth.NewSessionStore(db)
+
+	user := &models.User{
+		ID:        uuid.New(),
+		Issuer:    "oidc",
+		Subject:   "sub-1",
+		Email:     "viewer@example.com",
+		Role:      models.RoleViewer,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	token, _, err := sessions.Create(t.Context(), auth.CreateSessionRequest{
+		UserID:     user.ID,
+		AuthMethod: "oidc",
+		SourceIP:   "198.51.100.8",
+		UserAgent:  "test",
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	pv := echo.PathValues(nil)
+	c.InitializeRoute(&echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, &pv)
+
+	var capturedPrincipal *auth.Principal
+	handler := authmw.Auth(authmw.AuthDeps{
+		Service:    svc,
+		Auditor:    auditor,
+		Limiter:    limiter,
+		Sessions:   sessions,
+		CookieName: "caesium_session",
+	})(func(c *echo.Context) error {
+		capturedPrincipal = authmw.GetPrincipal(c)
+		return c.String(http.StatusOK, "ok")
+	})
+
+	err = handler(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotNil(t, capturedPrincipal)
+	require.Equal(t, auth.PrincipalUser, capturedPrincipal.Kind)
+	require.Equal(t, "viewer@example.com", capturedPrincipal.Subject)
+	require.Equal(t, models.RoleViewer, capturedPrincipal.Role)
+	require.Nil(t, authmw.GetAuthKey(c))
 }
 
 func TestMiddlewareRejectsExpiredKey(t *testing.T) {
@@ -497,4 +560,17 @@ func TestGetAuthKeyReturnsNilWhenNotSet(t *testing.T) {
 
 	key := authmw.GetAuthKey(c)
 	require.Nil(t, key)
+}
+
+func TestGetPrincipal(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.Nil(t, authmw.GetPrincipal(c))
+
+	p := &auth.Principal{Kind: auth.PrincipalUser, Subject: "a@b.com"}
+	c.Set(authmw.ContextKeyPrincipal, p)
+	require.Equal(t, p, authmw.GetPrincipal(c))
 }

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -1,6 +1,7 @@
 package middleware_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -106,6 +107,17 @@ func callMiddleware(
 	pathValues echo.PathValues,
 	next echo.HandlerFunc,
 ) (*httptest.ResponseRecorder, error) {
+	return callMiddlewareWithDeps(t, authmw.AuthDeps{Service: svc, Auditor: auditor, Limiter: limiter}, req, route, pathValues, next)
+}
+
+func callMiddlewareWithDeps(
+	t *testing.T,
+	deps authmw.AuthDeps,
+	req *http.Request,
+	route *echo.RouteInfo,
+	pathValues echo.PathValues,
+	next echo.HandlerFunc,
+) (*httptest.ResponseRecorder, error) {
 	t.Helper()
 
 	if next == nil {
@@ -123,7 +135,7 @@ func callMiddleware(
 		c.InitializeRoute(route, &pv)
 	}
 
-	handler := authmw.Auth(authmw.AuthDeps{Service: svc, Auditor: auditor, Limiter: limiter})(next)
+	handler := authmw.Auth(deps)(next)
 	err := handler(c)
 	return rec, err
 }
@@ -259,6 +271,87 @@ func TestAuthAcceptsSessionCookie(t *testing.T) {
 	require.Equal(t, "viewer@example.com", capturedPrincipal.Subject)
 	require.Equal(t, models.RoleViewer, capturedPrincipal.Role)
 	require.Nil(t, authmw.GetAuthKey(c))
+}
+
+func TestAuthRejectsInvalidSessionCookieRecordsFailureAndAudit(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(1, time.Minute)
+	sessions := auth.NewSessionStore(db)
+	deps := authmw.AuthDeps{
+		Service:    svc,
+		Auditor:    auditor,
+		Limiter:    limiter,
+		Sessions:   sessions,
+		CookieName: "caesium_session",
+	}
+
+	for i := 0; i < 2; i++ {
+		req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+		req.RemoteAddr = "203.0.113.10:1234"
+		req.AddCookie(&http.Cookie{Name: "caesium_session", Value: "bad-session-token"})
+		_, err := callMiddlewareWithDeps(t, deps, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, nil)
+		require.Error(t, err)
+	}
+
+	require.True(t, limiter.IsLimited("203.0.113.10"))
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Action: auth.ActionAuthDenied, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+	require.Equal(t, "bad-session-t", entries[0].Actor)
+	requireAuditReason(t, entries[0], "session_invalid")
+}
+
+func TestAuthRejectsBadSessionCSRFRecordsFailureAndAudit(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+	sessions := auth.NewSessionStore(db)
+	user := &models.User{
+		ID:        uuid.New(),
+		Issuer:    "oidc",
+		Subject:   "sub-1",
+		Email:     "viewer@example.com",
+		Role:      models.RoleViewer,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(user).Error)
+	token, _, err := sessions.Create(t.Context(), auth.CreateSessionRequest{UserID: user.ID})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.RemoteAddr = "203.0.113.11:1234"
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
+	_, err = callMiddlewareWithDeps(t, authmw.AuthDeps{
+		Service:    svc,
+		Auditor:    auditor,
+		Limiter:    limiter,
+		Sessions:   sessions,
+		CookieName: "caesium_session",
+	}, req, &echo.RouteInfo{Path: "/auth/logout", Method: http.MethodPost}, nil, nil)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Action: auth.ActionAuthDenied, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	requireAuditReason(t, entries[0], "csrf")
+}
+
+func requireAuditReason(t *testing.T, entry models.AuditLog, want string) {
+	t.Helper()
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
+	require.Equal(t, want, metadata["reason"])
 }
 
 func TestMiddlewareRejectsExpiredKey(t *testing.T) {

--- a/api/middleware/csrf.go
+++ b/api/middleware/csrf.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+
+	"github.com/labstack/echo/v5"
+)
+
+// ContextKeyCSRFToken stores the resolved session's CSRF token for handlers.
+const ContextKeyCSRFToken = "auth.csrf_token"
+
+// EnforceSessionCSRF validates the synchronizer CSRF token for cookie-authenticated
+// unsafe requests. Bearer/API-key requests are exempt at the auth middleware
+// call site because they are not ambient browser credentials.
+func EnforceSessionCSRF(c *echo.Context, expected string) error {
+	if isSafeMethod(c.Request().Method) {
+		return nil
+	}
+
+	header := c.Request().Header.Get("X-CSRF-Token")
+	if expected == "" || header == "" || subtle.ConstantTimeCompare([]byte(header), []byte(expected)) != 1 {
+		return echo.NewHTTPError(http.StatusForbidden, "invalid csrf token")
+	}
+	return nil
+}
+
+// GetCSRFToken returns the session CSRF token stashed by auth middleware, or "".
+func GetCSRFToken(c *echo.Context) string {
+	if v, ok := c.Get(ContextKeyCSRFToken).(string); ok {
+		return v
+	}
+	return ""
+}
+
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}

--- a/api/middleware/csrf_test.go
+++ b/api/middleware/csrf_test.go
@@ -1,0 +1,53 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func newMiddlewareContext(method, target string, headers map[string]string) *echo.Context {
+	e := echo.New()
+	req := httptest.NewRequest(method, target, nil)
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec)
+}
+
+func TestEnforceSessionCSRF(t *testing.T) {
+	c := newMiddlewareContext(http.MethodGet, "/v1/jobs", nil)
+	require.NoError(t, authmw.EnforceSessionCSRF(c, "tok123"))
+
+	c = newMiddlewareContext(http.MethodPost, "/v1/jobs", map[string]string{"X-CSRF-Token": "tok123"})
+	require.NoError(t, authmw.EnforceSessionCSRF(c, "tok123"))
+
+	c = newMiddlewareContext(http.MethodPost, "/v1/jobs", nil)
+	err := authmw.EnforceSessionCSRF(c, "tok123")
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+
+	c = newMiddlewareContext(http.MethodPost, "/v1/jobs", map[string]string{"X-CSRF-Token": "wrong"})
+	err = authmw.EnforceSessionCSRF(c, "tok123")
+	require.Error(t, err)
+
+	he, ok = err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestGetCSRFToken(t *testing.T) {
+	c := newMiddlewareContext(http.MethodGet, "/v1/jobs", nil)
+	require.Empty(t, authmw.GetCSRFToken(c))
+
+	c.Set(authmw.ContextKeyCSRFToken, "tok123")
+	require.Equal(t, "tok123", authmw.GetCSRFToken(c))
+}

--- a/api/middleware/proxy.go
+++ b/api/middleware/proxy.go
@@ -1,0 +1,72 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/pkg/log"
+)
+
+// ParseTrustedProxyRanges parses a comma-separated proxy allowlist into IP
+// ranges. Entries may be CIDR ranges or individual IP addresses.
+func ParseTrustedProxyRanges(raw string) []*net.IPNet {
+	parts := strings.Split(raw, ",")
+	ranges := make([]*net.IPNet, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+
+		if _, ipNet, err := net.ParseCIDR(part); err == nil {
+			ranges = append(ranges, ipNet)
+			continue
+		}
+
+		if ip := net.ParseIP(part); ip != nil {
+			bits := 32
+			if ip.To4() == nil {
+				bits = 128
+			}
+			ranges = append(ranges, &net.IPNet{IP: ip, Mask: net.CIDRMask(bits, bits)})
+			continue
+		}
+
+		log.Warn("ignoring invalid trusted proxy entry", "value", part)
+	}
+	return ranges
+}
+
+// RequestIsSecure reports whether the original request is HTTPS. Forwarded
+// protocol headers are trusted only when the immediate peer is allowlisted.
+func RequestIsSecure(r *http.Request, trustedProxies []*net.IPNet) bool {
+	if r.TLS != nil {
+		return true
+	}
+	if !requestFromTrustedProxy(r, trustedProxies) {
+		return false
+	}
+	proto := strings.TrimSpace(strings.Split(r.Header.Get("X-Forwarded-Proto"), ",")[0])
+	return strings.EqualFold(proto, "https")
+}
+
+func requestFromTrustedProxy(r *http.Request, trustedProxies []*net.IPNet) bool {
+	if len(trustedProxies) == 0 {
+		return false
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	for _, ipNet := range trustedProxies {
+		if ipNet.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -41,9 +41,6 @@ func All(g *echo.Group, bus internal_event.Bus, authSvc *auth.Service, auditor *
 		if authSvc != nil {
 			bindAuth(protected, authctrl.New(authSvc, auditor))
 		}
-		if sessions != nil {
-			bindSSO(protected, authctrl.NewSSO(sessions, vars.AuthSessionCookieName))
-		}
 	}
 
 	Protected(protected, bus)
@@ -175,9 +172,4 @@ func bindAuth(g *echo.Group, controller *authctrl.Controller) {
 	g.POST("/auth/keys/:id/revoke", controller.RevokeKey)
 	g.POST("/auth/keys/:id/rotate", controller.RotateKey)
 	g.GET("/auth/audit", controller.QueryAudit)
-}
-
-func bindSSO(g *echo.Group, controller *authctrl.SSOController) {
-	g.GET("/auth/whoami", controller.Whoami)
-	g.POST("/auth/logout", controller.Logout)
 }

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -12,8 +12,8 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/job/run"
 	jobdef "github.com/caesium-cloud/caesium/api/rest/controller/jobdef"
 	"github.com/caesium-cloud/caesium/api/rest/controller/logs"
-	notifctrl "github.com/caesium-cloud/caesium/api/rest/controller/notification"
 	"github.com/caesium-cloud/caesium/api/rest/controller/node"
+	notifctrl "github.com/caesium-cloud/caesium/api/rest/controller/notification"
 	"github.com/caesium-cloud/caesium/api/rest/controller/stats"
 	"github.com/caesium-cloud/caesium/api/rest/controller/system"
 	"github.com/caesium-cloud/caesium/api/rest/controller/trigger"
@@ -25,14 +25,24 @@ import (
 )
 
 // All binds all routes to the given group, optionally with auth middleware.
-func All(g *echo.Group, bus internal_event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter) {
+func All(g *echo.Group, bus internal_event.Bus, authSvc *auth.Service, auditor *auth.AuditLogger, limiter *auth.RateLimiter, sessions *auth.SessionStore) {
 	bindWebhooks(g, auditor)
 
 	protected := g.Group("")
-	if env.Variables().AuthMode == "api-key" {
-		protected.Use(authmw.Auth(authSvc, auditor, limiter))
+	vars := env.Variables()
+	if vars.AuthMode == "api-key" || vars.SSOEnabled() {
+		protected.Use(authmw.Auth(authmw.AuthDeps{
+			Service:    authSvc,
+			Auditor:    auditor,
+			Limiter:    limiter,
+			Sessions:   sessions,
+			CookieName: vars.AuthSessionCookieName,
+		}))
 		if authSvc != nil {
 			bindAuth(protected, authctrl.New(authSvc, auditor))
+		}
+		if sessions != nil {
+			bindSSO(protected, authctrl.NewSSO(sessions, vars.AuthSessionCookieName))
 		}
 	}
 
@@ -165,4 +175,9 @@ func bindAuth(g *echo.Group, controller *authctrl.Controller) {
 	g.POST("/auth/keys/:id/revoke", controller.RevokeKey)
 	g.POST("/auth/keys/:id/rotate", controller.RotateKey)
 	g.GET("/auth/audit", controller.QueryAudit)
+}
+
+func bindSSO(g *echo.Group, controller *authctrl.SSOController) {
+	g.GET("/auth/whoami", controller.Whoami)
+	g.POST("/auth/logout", controller.Logout)
 }

--- a/api/rest/bind/bind_test.go
+++ b/api/rest/bind/bind_test.go
@@ -40,7 +40,7 @@ func TestAllProtectsRESTButLeavesWebhooksPublic(t *testing.T) {
 	}
 
 	e := echo.New()
-	All(e.Group("/v1"), nil, svc, auditor, limiter)
+	All(e.Group("/v1"), nil, svc, auditor, limiter, nil)
 
 	protectedReq := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
 	protectedRec := httptest.NewRecorder()

--- a/api/rest/controller/auth/sso.go
+++ b/api/rest/controller/auth/sso.go
@@ -1,25 +1,32 @@
 package auth
 
 import (
+	"net"
 	"net/http"
-	"strings"
 
 	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/labstack/echo/v5"
 )
 
 // SSOController serves session-aware endpoints. Provider-specific login and
 // callback handlers are added by the OIDC/SAML/LDAP plans.
 type SSOController struct {
-	sessions   *iauth.SessionStore
-	sso        *iauth.SSOService
-	cookieName string
+	sessions       *iauth.SessionStore
+	sso            *iauth.SSOService
+	cookieName     string
+	trustedProxies []*net.IPNet
 }
 
 // NewSSO constructs a controller for cookie-session endpoints.
-func NewSSO(sessions *iauth.SessionStore, sso *iauth.SSOService, cookieName string) *SSOController {
-	return &SSOController{sessions: sessions, sso: sso, cookieName: cookieName}
+func NewSSO(sessions *iauth.SessionStore, sso *iauth.SSOService, cookieName string, trustedProxies ...*net.IPNet) *SSOController {
+	return &SSOController{
+		sessions:       sessions,
+		sso:            sso,
+		cookieName:     cookieName,
+		trustedProxies: append([]*net.IPNet(nil), trustedProxies...),
+	}
 }
 
 // SSOService returns the shared login completion service for provider handlers.
@@ -51,7 +58,10 @@ func (s *SSOController) Logout(c *echo.Context) error {
 	if s.sessions != nil {
 		if cookie, err := c.Request().Cookie(s.cookieName); err == nil && cookie.Value != "" {
 			if sess, _, err := s.sessions.Validate(c.Request().Context(), cookie.Value); err == nil {
-				_ = s.sessions.Revoke(c.Request().Context(), sess.ID)
+				if err := s.sessions.Revoke(c.Request().Context(), sess.ID); err != nil {
+					log.Warn("failed to revoke session during logout", "error", err)
+					return echo.NewHTTPError(http.StatusInternalServerError, "logout failed").Wrap(err)
+				}
 			}
 		}
 	}
@@ -62,15 +72,12 @@ func (s *SSOController) Logout(c *echo.Context) error {
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   requestIsSecure(c.Request()),
+		Secure:   requestIsSecure(c.Request(), s.trustedProxies),
 		SameSite: http.SameSiteLaxMode,
 	})
 	return c.NoContent(http.StatusNoContent)
 }
 
-func requestIsSecure(r *http.Request) bool {
-	if r.TLS != nil {
-		return true
-	}
-	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
+func requestIsSecure(r *http.Request, trustedProxies []*net.IPNet) bool {
+	return authmw.RequestIsSecure(r, trustedProxies)
 }

--- a/api/rest/controller/auth/sso.go
+++ b/api/rest/controller/auth/sso.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"net/http"
+	"strings"
 
 	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	iauth "github.com/caesium-cloud/caesium/internal/auth"
@@ -12,12 +13,18 @@ import (
 // callback handlers are added by the OIDC/SAML/LDAP plans.
 type SSOController struct {
 	sessions   *iauth.SessionStore
+	sso        *iauth.SSOService
 	cookieName string
 }
 
 // NewSSO constructs a controller for cookie-session endpoints.
-func NewSSO(sessions *iauth.SessionStore, cookieName string) *SSOController {
-	return &SSOController{sessions: sessions, cookieName: cookieName}
+func NewSSO(sessions *iauth.SessionStore, sso *iauth.SSOService, cookieName string) *SSOController {
+	return &SSOController{sessions: sessions, sso: sso, cookieName: cookieName}
+}
+
+// SSOService returns the shared login completion service for provider handlers.
+func (s *SSOController) SSOService() *iauth.SSOService {
+	return s.sso
 }
 
 func (s *SSOController) Whoami(c *echo.Context) error {
@@ -55,8 +62,15 @@ func (s *SSOController) Logout(c *echo.Context) error {
 		Path:     "/",
 		MaxAge:   -1,
 		HttpOnly: true,
-		Secure:   true,
+		Secure:   requestIsSecure(c.Request()),
 		SameSite: http.SameSiteLaxMode,
 	})
 	return c.NoContent(http.StatusNoContent)
+}
+
+func requestIsSecure(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	return strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https")
 }

--- a/api/rest/controller/auth/sso.go
+++ b/api/rest/controller/auth/sso.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"net/http"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/labstack/echo/v5"
+)
+
+// SSOController serves session-aware endpoints. Provider-specific login and
+// callback handlers are added by the OIDC/SAML/LDAP plans.
+type SSOController struct {
+	sessions   *iauth.SessionStore
+	cookieName string
+}
+
+// NewSSO constructs a controller for cookie-session endpoints.
+func NewSSO(sessions *iauth.SessionStore, cookieName string) *SSOController {
+	return &SSOController{sessions: sessions, cookieName: cookieName}
+}
+
+func (s *SSOController) Whoami(c *echo.Context) error {
+	principal := authmw.GetPrincipal(c)
+	if principal == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not authenticated")
+	}
+
+	body := map[string]any{
+		"kind":    principal.Kind,
+		"subject": principal.Subject,
+		"role":    principal.Role,
+	}
+	if principal.Kind == iauth.PrincipalUser {
+		body["email"] = principal.Subject
+	}
+	if csrf := authmw.GetCSRFToken(c); csrf != "" {
+		body["csrf_token"] = csrf
+	}
+	return c.JSON(http.StatusOK, body)
+}
+
+func (s *SSOController) Logout(c *echo.Context) error {
+	if s.sessions != nil {
+		if cookie, err := c.Request().Cookie(s.cookieName); err == nil && cookie.Value != "" {
+			if sess, _, err := s.sessions.Validate(c.Request().Context(), cookie.Value); err == nil {
+				_ = s.sessions.Revoke(c.Request().Context(), sess.ID)
+			}
+		}
+	}
+
+	c.SetCookie(&http.Cookie{
+		Name:     s.cookieName,
+		Value:    "",
+		Path:     "/",
+		MaxAge:   -1,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: http.SameSiteLaxMode,
+	})
+	return c.NoContent(http.StatusNoContent)
+}

--- a/api/rest/controller/auth/sso_test.go
+++ b/api/rest/controller/auth/sso_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 func TestWhoamiRequiresPrincipal(t *testing.T) {
-	ctrl := NewSSO(nil, "caesium_session")
-	c, _ := newAuthContext(t, http.MethodGet, "/v1/auth/whoami", "")
+	ctrl := NewSSO(nil, nil, "caesium_session")
+	c, _ := newAuthContext(t, http.MethodGet, "/auth/whoami", "")
 
 	err := ctrl.Whoami(c)
 	require.Error(t, err)
@@ -29,8 +29,8 @@ func TestWhoamiRequiresPrincipal(t *testing.T) {
 }
 
 func TestWhoamiReturnsPrincipalAndCSRF(t *testing.T) {
-	ctrl := NewSSO(nil, "caesium_session")
-	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/whoami", "")
+	ctrl := NewSSO(nil, nil, "caesium_session")
+	c, rec := newAuthContext(t, http.MethodGet, "/auth/whoami", "")
 	c.Set(authmw.ContextKeyPrincipal, &iauth.Principal{
 		Kind:    iauth.PrincipalUser,
 		Subject: "viewer@example.com",
@@ -49,6 +49,13 @@ func TestWhoamiReturnsPrincipalAndCSRF(t *testing.T) {
 	require.Equal(t, "viewer@example.com", body["email"])
 	require.Equal(t, string(models.RoleViewer), body["role"])
 	require.Equal(t, "csrf-token", body["csrf_token"])
+}
+
+func TestNewSSORetainsCompletionService(t *testing.T) {
+	sso := iauth.NewSSOService(nil, nil, nil)
+	ctrl := NewSSO(nil, sso, "caesium_session")
+
+	require.Equal(t, sso, ctrl.SSOService())
 }
 
 func TestLogoutRevokesSessionAndClearsCookie(t *testing.T) {
@@ -72,7 +79,7 @@ func TestLogoutRevokesSessionAndClearsCookie(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ctrl := NewSSO(sessions, "caesium_session")
+	ctrl := NewSSO(sessions, nil, "caesium_session")
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
 	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
@@ -91,6 +98,21 @@ func TestLogoutRevokesSessionAndClearsCookie(t *testing.T) {
 	require.Equal(t, "caesium_session", cookies[0].Name)
 	require.LessOrEqual(t, cookies[0].MaxAge, 0)
 	require.True(t, cookies[0].HttpOnly)
-	require.True(t, cookies[0].Secure)
+	require.False(t, cookies[0].Secure)
 	require.Equal(t, http.SameSiteLaxMode, cookies[0].SameSite)
+}
+
+func TestLogoutClearsSecureCookieBehindHTTPSProxy(t *testing.T) {
+	ctrl := NewSSO(nil, nil, "caesium_session")
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, ctrl.Logout(c))
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	require.True(t, cookies[0].Secure)
 }

--- a/api/rest/controller/auth/sso_test.go
+++ b/api/rest/controller/auth/sso_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -14,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestWhoamiRequiresPrincipal(t *testing.T) {
@@ -102,10 +105,54 @@ func TestLogoutRevokesSessionAndClearsCookie(t *testing.T) {
 	require.Equal(t, http.SameSiteLaxMode, cookies[0].SameSite)
 }
 
-func TestLogoutClearsSecureCookieBehindHTTPSProxy(t *testing.T) {
-	ctrl := NewSSO(nil, nil, "caesium_session")
+func TestLogoutReturnsErrorWhenSessionRevokeFails(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	sessions := iauth.NewSessionStore(db)
+	user := &models.User{
+		ID:        uuid.New(),
+		Issuer:    "oidc",
+		Subject:   "sub-1",
+		Email:     "viewer@example.com",
+		Role:      models.RoleViewer,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(user).Error)
+	token, _, err := sessions.Create(t.Context(), iauth.CreateSessionRequest{UserID: user.ID})
+	require.NoError(t, err)
+
+	const callbackName = "test:fail_session_revoke"
+	require.NoError(t, db.Callback().Update().Before("gorm:update").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Name == "Session" {
+			tx.AddError(errors.New("forced revoke failure"))
+		}
+	}))
+
+	ctrl := NewSSO(sessions, nil, "caesium_session")
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = ctrl.Logout(c)
+	require.Error(t, err)
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusInternalServerError, he.Code)
+	require.Empty(t, rec.Result().Cookies())
+	_, _, err = sessions.Validate(t.Context(), token)
+	require.NoError(t, err)
+}
+
+func TestLogoutClearsSecureCookieBehindHTTPSProxy(t *testing.T) {
+	_, trustedProxy, err := net.ParseCIDR("127.0.0.1/32")
+	require.NoError(t, err)
+	ctrl := NewSSO(nil, nil, "caesium_session", trustedProxy)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
 	req.Header.Set("X-Forwarded-Proto", "https")
 	rec := httptest.NewRecorder()
 	c := e.NewContext(req, rec)
@@ -115,4 +162,22 @@ func TestLogoutClearsSecureCookieBehindHTTPSProxy(t *testing.T) {
 	cookies := rec.Result().Cookies()
 	require.Len(t, cookies, 1)
 	require.True(t, cookies[0].Secure)
+}
+
+func TestLogoutIgnoresForwardedProtoFromUntrustedPeer(t *testing.T) {
+	_, trustedProxy, err := net.ParseCIDR("127.0.0.1/32")
+	require.NoError(t, err)
+	ctrl := NewSSO(nil, nil, "caesium_session", trustedProxy)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.RemoteAddr = "203.0.113.12:12345"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	require.NoError(t, ctrl.Logout(c))
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	require.False(t, cookies[0].Secure)
 }

--- a/api/rest/controller/auth/sso_test.go
+++ b/api/rest/controller/auth/sso_test.go
@@ -1,0 +1,96 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhoamiRequiresPrincipal(t *testing.T) {
+	ctrl := NewSSO(nil, "caesium_session")
+	c, _ := newAuthContext(t, http.MethodGet, "/v1/auth/whoami", "")
+
+	err := ctrl.Whoami(c)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
+}
+
+func TestWhoamiReturnsPrincipalAndCSRF(t *testing.T) {
+	ctrl := NewSSO(nil, "caesium_session")
+	c, rec := newAuthContext(t, http.MethodGet, "/v1/auth/whoami", "")
+	c.Set(authmw.ContextKeyPrincipal, &iauth.Principal{
+		Kind:    iauth.PrincipalUser,
+		Subject: "viewer@example.com",
+		Role:    models.RoleViewer,
+	})
+	c.Set(authmw.ContextKeyCSRFToken, "csrf-token")
+
+	err := ctrl.Whoami(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Equal(t, string(iauth.PrincipalUser), body["kind"])
+	require.Equal(t, "viewer@example.com", body["subject"])
+	require.Equal(t, "viewer@example.com", body["email"])
+	require.Equal(t, string(models.RoleViewer), body["role"])
+	require.Equal(t, "csrf-token", body["csrf_token"])
+}
+
+func TestLogoutRevokesSessionAndClearsCookie(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	sessions := iauth.NewSessionStore(db)
+	user := &models.User{
+		ID:        uuid.New(),
+		Issuer:    "oidc",
+		Subject:   "sub-1",
+		Email:     "viewer@example.com",
+		Role:      models.RoleViewer,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	token, _, err := sessions.Create(t.Context(), iauth.CreateSessionRequest{
+		UserID:     user.ID,
+		AuthMethod: "oidc",
+	})
+	require.NoError(t, err)
+
+	ctrl := NewSSO(sessions, "caesium_session")
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	err = ctrl.Logout(c)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	_, _, err = sessions.Validate(t.Context(), token)
+	require.Error(t, err)
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	require.Equal(t, "caesium_session", cookies[0].Name)
+	require.LessOrEqual(t, cookies[0].MaxAge, 0)
+	require.True(t, cookies[0].HttpOnly)
+	require.True(t, cookies[0].Secure)
+	require.Equal(t, http.SameSiteLaxMode, cookies[0].SameSite)
+}

--- a/api/ui.go
+++ b/api/ui.go
@@ -24,7 +24,7 @@ func RegisterUI(e *echo.Echo) {
 		path := c.Request().URL.Path
 
 		// If it's a request for an API or health, don't handle it here
-		if strings.HasPrefix(path, "/v1") || strings.HasPrefix(path, "/gql") || path == "/health" || path == "/metrics" || path == "/auth/status" {
+		if strings.HasPrefix(path, "/v1") || strings.HasPrefix(path, "/gql") || path == "/health" || path == "/metrics" || strings.HasPrefix(path, "/auth/") {
 			return echo.ErrNotFound
 		}
 

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -324,7 +324,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	// --- Authentication & Authorization ---
-	authSvc, auditor, limiter := initAuth(ctx, vars, runAsync)
+	authSvc, auditor, limiter, sessions := initAuth(ctx, vars, runAsync)
 
 	log.Info(
 		"execution configuration",
@@ -524,7 +524,7 @@ func start(cmd *cobra.Command, args []string) error {
 
 	runAsync(func() {
 		log.Info("spinning up api")
-		if err := api.Start(ctx, bus, authSvc, auditor, limiter, internalWakeupHandler); err != nil && ctx.Err() == nil {
+		if err := api.Start(ctx, bus, authSvc, auditor, limiter, sessions, internalWakeupHandler); err != nil && ctx.Err() == nil {
 			reportErr(err)
 		}
 	})
@@ -588,16 +588,20 @@ func dqliteWakeupPeerResolver(localNodeAddress string, apiPort int) worker.Wakeu
 
 // initAuth sets up authentication services based on CAESIUM_AUTH_MODE.
 // Returns nil services when auth is disabled so callers can pass them through safely.
-func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) (*auth.Service, *auth.AuditLogger, *auth.RateLimiter) {
+func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) (*auth.Service, *auth.AuditLogger, *auth.RateLimiter, *auth.SessionStore) {
 	conn := db.Connection()
 	authSvc := auth.NewService(conn, auth.WithKeyHashSecret(vars.AuthKeyHashSecret))
 	auditor := auth.NewAuditLogger(conn)
 	limiter := auth.NewRateLimiter(vars.AuthRateLimitPerMinute, time.Minute)
+	var sessions *auth.SessionStore
 
 	switch vars.AuthMode {
 	case "none", "":
+		if vars.SSOEnabled() {
+			log.Fatal("SSO providers require authentication to be enabled (set CAESIUM_AUTH_MODE=api-key)")
+		}
 		log.Warn("authentication is disabled — all endpoints are publicly accessible")
-		return authSvc, auditor, limiter
+		return authSvc, auditor, limiter, nil
 
 	case "api-key":
 		log.Info("authentication enabled", "mode", vars.AuthMode)
@@ -650,16 +654,34 @@ func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) 
 			}
 		}
 
+		sessions = auth.NewSessionStore(conn,
+			auth.WithSessionHashSecret(vars.AuthKeyHashSecret),
+			auth.WithSessionTTLs(vars.AuthSessionIdleTTL, vars.AuthSessionAbsoluteTTL),
+		)
+		if vars.SSOEnabled() {
+			mapper, err := auth.NewRoleMapper(vars.AuthRoleMapping, vars.AuthDefaultRole)
+			if err != nil {
+				log.Fatal("invalid CAESIUM_AUTH_ROLE_MAPPING", "error", err)
+			}
+			_ = auth.NewSSOService(auth.NewUserStore(conn), sessions, mapper)
+			runAsync(func() {
+				sessions.RunLastSeenFlusher(ctx)
+			})
+			runAsync(func() {
+				sessions.RunReaper(ctx)
+			})
+		}
+
 		runAsync(func() {
 			authSvc.RunLastUsedFlusher(ctx)
 		})
 		runAsync(func() {
 			limiter.RunCleanup(ctx.Done())
 		})
-		return authSvc, auditor, limiter
+		return authSvc, auditor, limiter, sessions
 
 	default:
 		log.Fatal("unknown CAESIUM_AUTH_MODE value", "mode", vars.AuthMode)
-		return nil, nil, nil // unreachable
+		return nil, nil, nil, nil // unreachable
 	}
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -324,7 +324,7 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 
 	// --- Authentication & Authorization ---
-	authSvc, auditor, limiter, sessions := initAuth(ctx, vars, runAsync)
+	authSvc, auditor, limiter, sessions, sso := initAuth(ctx, vars, runAsync)
 
 	log.Info(
 		"execution configuration",
@@ -524,7 +524,7 @@ func start(cmd *cobra.Command, args []string) error {
 
 	runAsync(func() {
 		log.Info("spinning up api")
-		if err := api.Start(ctx, bus, authSvc, auditor, limiter, sessions, internalWakeupHandler); err != nil && ctx.Err() == nil {
+		if err := api.Start(ctx, bus, authSvc, auditor, limiter, sessions, sso, internalWakeupHandler); err != nil && ctx.Err() == nil {
 			reportErr(err)
 		}
 	})
@@ -588,12 +588,13 @@ func dqliteWakeupPeerResolver(localNodeAddress string, apiPort int) worker.Wakeu
 
 // initAuth sets up authentication services based on CAESIUM_AUTH_MODE.
 // Returns nil services when auth is disabled so callers can pass them through safely.
-func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) (*auth.Service, *auth.AuditLogger, *auth.RateLimiter, *auth.SessionStore) {
+func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) (*auth.Service, *auth.AuditLogger, *auth.RateLimiter, *auth.SessionStore, *auth.SSOService) {
 	conn := db.Connection()
 	authSvc := auth.NewService(conn, auth.WithKeyHashSecret(vars.AuthKeyHashSecret))
 	auditor := auth.NewAuditLogger(conn)
 	limiter := auth.NewRateLimiter(vars.AuthRateLimitPerMinute, time.Minute)
 	var sessions *auth.SessionStore
+	var sso *auth.SSOService
 
 	switch vars.AuthMode {
 	case "none", "":
@@ -601,7 +602,7 @@ func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) 
 			log.Fatal("SSO providers require authentication to be enabled (set CAESIUM_AUTH_MODE=api-key)")
 		}
 		log.Warn("authentication is disabled — all endpoints are publicly accessible")
-		return authSvc, auditor, limiter, nil
+		return authSvc, auditor, limiter, nil, nil
 
 	case "api-key":
 		log.Info("authentication enabled", "mode", vars.AuthMode)
@@ -663,7 +664,7 @@ func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) 
 			if err != nil {
 				log.Fatal("invalid CAESIUM_AUTH_ROLE_MAPPING", "error", err)
 			}
-			_ = auth.NewSSOService(auth.NewUserStore(conn), sessions, mapper)
+			sso = auth.NewSSOService(auth.NewUserStore(conn), sessions, mapper)
 			runAsync(func() {
 				sessions.RunLastSeenFlusher(ctx)
 			})
@@ -678,10 +679,10 @@ func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) 
 		runAsync(func() {
 			limiter.RunCleanup(ctx.Done())
 		})
-		return authSvc, auditor, limiter, sessions
+		return authSvc, auditor, limiter, sessions, sso
 
 	default:
 		log.Fatal("unknown CAESIUM_AUTH_MODE value", "mode", vars.AuthMode)
-		return nil, nil, nil, nil // unreachable
+		return nil, nil, nil, nil, nil // unreachable
 	}
 }

--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -59,7 +59,7 @@
 - Create: `internal/auth/principal.go`
 - Test: `internal/auth/principal_test.go`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```go
 package auth
@@ -98,12 +98,12 @@ func TestPrincipalFromUser(t *testing.T) {
 
 (`TestPrincipalFromUser` won't compile until `models.User` exists — Task 1.2. To keep P0 self-contained, write only `TestPrincipalFromKey` now and add `TestPrincipalFromUser` plus `PrincipalFromUser` in Task 1.2. The `principal.go` file below already includes `PrincipalFromUser` referencing `models.User`, so introduce `models.User` first if compiling P0 standalone, **or** temporarily omit `PrincipalFromUser` and add it in Task 1.2. Recommended: omit `PrincipalFromUser` here; add in 1.2.)
 
-- [ ] **Step 2: Run test to verify it fails**
+- [x] **Step 2: Run test to verify it fails**
 
 Run: `go test ./internal/auth/ -run TestPrincipalFromKey -v`
 Expected: FAIL — `undefined: PrincipalFromKey`.
 
-- [ ] **Step 3: Write minimal implementation** (`internal/auth/principal.go`)
+- [x] **Step 3: Write minimal implementation** (`internal/auth/principal.go`)
 
 ```go
 package auth
@@ -145,12 +145,12 @@ func PrincipalFromKey(k *models.APIKey) *Principal {
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [x] **Step 4: Run test to verify it passes**
 
 Run: `go test ./internal/auth/ -run TestPrincipalFromKey -v`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add internal/auth/principal.go internal/auth/principal_test.go
@@ -164,7 +164,7 @@ git commit   # "Add Principal abstraction to auth package"
 - Modify: `api/middleware/auth_scope.go` (`authorizeScope` signature)
 - Test: `api/middleware/auth_test.go` (existing — must stay green)
 
-- [ ] **Step 1: Change `authorizeScope` to take scope bytes (not the key)**
+- [x] **Step 1: Change `authorizeScope` to take scope bytes (not the key)**
 
 In `api/middleware/auth_scope.go`, change the signature and the one field access:
 
@@ -177,7 +177,7 @@ func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routeP
 
 Replace the three `key.Scope` references in that function with `scopeJSON`.
 
-- [ ] **Step 2: Build a `Principal` in `Auth` and use it for RBAC/scope**
+- [x] **Step 2: Build a `Principal` in `Auth` and use it for RBAC/scope**
 
 In `api/middleware/auth.go`, after `key, err := svc.ValidateKey(token)` succeeds, replace the role/scope/context block (currently lines ~85–106) with:
 
@@ -213,17 +213,17 @@ Add the new context key constant near `ContextKeyAuth`:
 const ContextKeyPrincipal = "auth.principal"
 ```
 
-- [ ] **Step 3: Run the existing middleware suite to verify no behavior change**
+- [x] **Step 3: Run the existing middleware suite to verify no behavior change**
 
 Run: `go test ./api/middleware/ -v`
 Expected: PASS (all existing tests). If any reference `authorizeScope(... key ...)` directly, update them to pass `key.Scope`.
 
-- [ ] **Step 4: Run the auth package + full gate**
+- [x] **Step 4: Run the auth package + full gate**
 
 Run: `go test ./api/middleware/ ./internal/auth/ -v` then `just unit-test`
 Expected: PASS.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add api/middleware/auth.go api/middleware/auth_scope.go api/middleware/auth_test.go
@@ -236,7 +236,7 @@ git commit   # "Resolve API-key auth through Principal (no behavior change)"
 - Modify: `api/middleware/auth.go` (add helper near `GetAuthKey`)
 - Test: `api/middleware/auth_test.go`
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```go
 func TestGetPrincipal(t *testing.T) {
@@ -249,9 +249,9 @@ func TestGetPrincipal(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run → FAIL** (`undefined: GetPrincipal`). `go test ./api/middleware/ -run TestGetPrincipal -v`
+- [x] **Step 2: Run → FAIL** (`undefined: GetPrincipal`). `go test ./api/middleware/ -run TestGetPrincipal -v`
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```go
 // GetPrincipal returns the unified authenticated identity, or nil if unauthenticated.
@@ -268,9 +268,9 @@ func GetPrincipal(c *echo.Context) *auth.Principal {
 }
 ```
 
-- [ ] **Step 4: Run → PASS.** `go test ./api/middleware/ -run TestGetPrincipal -v`
+- [x] **Step 4: Run → PASS.** `go test ./api/middleware/ -run TestGetPrincipal -v`
 
-- [ ] **Step 5: Commit** — `git commit` "Add GetPrincipal context helper"
+- [x] **Step 5: Commit** — `git commit` "Add GetPrincipal context helper"
 
 ---
 
@@ -282,7 +282,7 @@ func GetPrincipal(c *echo.Context) *auth.Principal {
 - Modify: `pkg/env/env.go` (Authentication & Authorization block, ~line 136)
 - Test: `pkg/env/env_test.go` (add a case if the file tests parsing; otherwise skip the test step)
 
-- [ ] **Step 1: Add fields** to the `Environment` struct after the existing `Auth*` fields:
+- [x] **Step 1: Add fields** to the `Environment` struct after the existing `Auth*` fields:
 
 ```go
 	// SSO / sessions (additive on top of AUTH_MODE)
@@ -298,7 +298,7 @@ func GetPrincipal(c *echo.Context) *auth.Principal {
 	AuthLDAPEnabled bool `envconfig:"AUTH_LDAP_ENABLED" default:"false"`
 ```
 
-- [ ] **Step 2: Helper to report whether any SSO provider is enabled** (same file):
+- [x] **Step 2: Helper to report whether any SSO provider is enabled** (same file):
 
 ```go
 // SSOEnabled reports whether any SSO provider is configured.
@@ -307,12 +307,12 @@ func (e Environment) SSOEnabled() bool {
 }
 ```
 
-- [ ] **Step 3: Verify it compiles & parses**
+- [x] **Step 3: Verify it compiles & parses**
 
 Run: `go build ./pkg/env/ && go test ./pkg/env/ -v`
 Expected: PASS (no behavior change to existing vars).
 
-- [ ] **Step 4: Commit** — "Add SSO/session environment configuration"
+- [x] **Step 4: Commit** — "Add SSO/session environment configuration"
 
 ### Task 1.2: `User` and `Session` models + migration registration
 
@@ -322,7 +322,7 @@ Expected: PASS (no behavior change to existing vars).
 - Modify: `internal/auth/principal.go` (add `PrincipalFromUser`), `internal/auth/principal_test.go` (add `TestPrincipalFromUser` from Task 0.1)
 - Test: `internal/models/user_test.go`
 
-- [ ] **Step 1: Write `internal/models/user.go`**
+- [x] **Step 1: Write `internal/models/user.go`**
 
 ```go
 package models
@@ -352,7 +352,7 @@ type User struct {
 func (u *User) IsDisabled() bool { return u.DisabledAt != nil }
 ```
 
-- [ ] **Step 2: Write `internal/models/session.go`**
+- [x] **Step 2: Write `internal/models/session.go`**
 
 ```go
 package models
@@ -384,7 +384,7 @@ type Session struct {
 func (s *Session) IsRevoked() bool { return s.RevokedAt != nil }
 ```
 
-- [ ] **Step 3: Register in `internal/models/models.go`** — add after `&AuditLog{}` (User before Session for FK ordering):
+- [x] **Step 3: Register in `internal/models/models.go`** — add after `&AuditLog{}` (User before Session for FK ordering):
 
 ```go
 	&AuditLog{},
@@ -392,7 +392,7 @@ func (s *Session) IsRevoked() bool { return s.RevokedAt != nil }
 	&Session{},
 ```
 
-- [ ] **Step 4: Add `PrincipalFromUser`** to `internal/auth/principal.go`:
+- [x] **Step 4: Add `PrincipalFromUser`** to `internal/auth/principal.go`:
 
 ```go
 // PrincipalFromUser builds a Principal from an authenticated user. SSO users are
@@ -410,7 +410,7 @@ func PrincipalFromUser(u *models.User) *Principal {
 
 Add `TestPrincipalFromUser` (from Task 0.1 Step 1) to `internal/auth/principal_test.go`.
 
-- [ ] **Step 5: Write `internal/models/user_test.go`** (round-trip + AutoMigrate smoke):
+- [x] **Step 5: Write `internal/models/user_test.go`** (round-trip + AutoMigrate smoke):
 
 ```go
 package models
@@ -444,12 +444,12 @@ func TestUserSessionMigrate(t *testing.T) {
 
 > Note: if `gorm.io/driver/sqlite` is not already a dependency, use the project's existing in-memory test DB helper instead (grep `service_test.go` for how `internal/auth` opens its test DB) and mirror that. Do not add a new driver dependency just for tests.
 
-- [ ] **Step 6: Run → PASS, then gate**
+- [x] **Step 6: Run → PASS, then gate**
 
 Run: `go test ./internal/models/ ./internal/auth/ -run 'User|Principal' -v` then `just unit-test`
 Expected: PASS.
 
-- [ ] **Step 7: Commit** — "Add User and Session models with migration registration"
+- [x] **Step 7: Commit** — "Add User and Session models with migration registration"
 
 ### Task 1.3: Session token generation
 
@@ -457,7 +457,7 @@ Expected: PASS.
 - Modify: `internal/auth/keygen.go`
 - Test: `internal/auth/keygen_test.go`
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 ```go
 func TestGenerateToken(t *testing.T) {
@@ -471,9 +471,9 @@ func TestGenerateToken(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestGenerateToken -v`
+- [x] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestGenerateToken -v`
 
-- [ ] **Step 3: Implement** (append to `internal/auth/keygen.go`):
+- [x] **Step 3: Implement** (append to `internal/auth/keygen.go`):
 
 ```go
 // SessionTokenPrefix marks opaque session tokens (distinct from API keys).
@@ -490,7 +490,7 @@ func GenerateToken() (string, error) {
 }
 ```
 
-- [ ] **Step 4: Run → PASS.** **Step 5: Commit** — "Add session token generator"
+- [x] **Step 4: Run → PASS.** **Step 5: Commit** — "Add session token generator"
 
 ### Task 1.4: `SessionStore` — create / validate / revoke
 
@@ -498,7 +498,7 @@ func GenerateToken() (string, error) {
 - Create: `internal/auth/session.go`
 - Test: `internal/auth/session_test.go`
 
-- [ ] **Step 1: Failing test** (introduce `newTestDB` helper reused by later tasks):
+- [x] **Step 1: Failing test** (introduce `newTestDB` helper reused by later tasks):
 
 ```go
 package auth
@@ -550,9 +550,9 @@ func TestSessionStoreRevoke(t *testing.T) {
 
 > `newTestDB(t)`: grep `internal/auth/service_test.go` for the existing helper that opens the in-memory test DB and reuse/extract it into a shared `testhelpers_test.go` so both files use one helper (DRY). Match whatever driver the existing auth tests already use.
 
-- [ ] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestSessionStore -v`
+- [x] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestSessionStore -v`
 
-- [ ] **Step 3: Implement `internal/auth/session.go`**
+- [x] **Step 3: Implement `internal/auth/session.go`**
 
 ```go
 package auth
@@ -717,8 +717,8 @@ func (s *SessionStore) recordSeen(id uuid.UUID) {
 }
 ```
 
-- [ ] **Step 4: Run → PASS.** `go test ./internal/auth/ -run TestSessionStore -v`
-- [ ] **Step 5: Commit** — "Add SessionStore create/validate/revoke"
+- [x] **Step 4: Run → PASS.** `go test ./internal/auth/ -run TestSessionStore -v`
+- [x] **Step 5: Commit** — "Add SessionStore create/validate/revoke"
 
 ### Task 1.5: Session reaper + coalesced last-seen flusher
 
@@ -726,7 +726,7 @@ func (s *SessionStore) recordSeen(id uuid.UUID) {
 - Modify: `internal/auth/session.go`
 - Test: `internal/auth/session_test.go`
 
-- [ ] **Step 1: Failing tests**
+- [x] **Step 1: Failing tests**
 
 ```go
 func TestSessionFlushSeen(t *testing.T) {
@@ -763,9 +763,9 @@ func TestSessionReap(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run 'TestSessionFlushSeen|TestSessionReap' -v`
+- [x] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run 'TestSessionFlushSeen|TestSessionReap' -v`
 
-- [ ] **Step 3: Implement** (append to `internal/auth/session.go`)
+- [x] **Step 3: Implement** (append to `internal/auth/session.go`)
 
 ```go
 // flushSeen writes buffered last-seen timestamps and bumps idle expiry. Mirrors
@@ -832,7 +832,7 @@ func (s *SessionStore) RunReaper(ctx context.Context) {
 }
 ```
 
-- [ ] **Step 4: Run → PASS.** **Step 5: Commit** — "Add session reaper and coalesced last-seen flusher"
+- [x] **Step 4: Run → PASS.** **Step 5: Commit** — "Add session reaper and coalesced last-seen flusher"
 
 ### Task 1.6: `RoleMapper` — group→role resolution
 
@@ -840,7 +840,7 @@ func (s *SessionStore) RunReaper(ctx context.Context) {
 - Create: `internal/auth/rolemap.go`
 - Test: `internal/auth/rolemap_test.go`
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 ```go
 func TestRoleMapperResolve(t *testing.T) {
@@ -875,9 +875,9 @@ func TestRoleMapperRejectsBadRole(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestRoleMapper -v`
+- [x] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestRoleMapper -v`
 
-- [ ] **Step 3: Implement `internal/auth/rolemap.go`**
+- [x] **Step 3: Implement `internal/auth/rolemap.go`**
 
 ```go
 package auth
@@ -957,7 +957,7 @@ func (m *RoleMapper) Resolve(groups []string) (models.Role, bool) {
 }
 ```
 
-- [ ] **Step 4: Run → PASS.** **Step 5: Commit** — "Add group-to-role mapper"
+- [x] **Step 4: Run → PASS.** **Step 5: Commit** — "Add group-to-role mapper"
 
 ### Task 1.7: `UserStore.Upsert` — JIT provisioning
 
@@ -965,7 +965,7 @@ func (m *RoleMapper) Resolve(groups []string) (models.Role, bool) {
 - Create: `internal/auth/users.go`
 - Test: `internal/auth/users_test.go`
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 ```go
 func TestUserStoreUpsert(t *testing.T) {
@@ -991,9 +991,9 @@ func TestUserStoreUpsert(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run → FAIL.** (`ExternalIdentity` is defined in Task 1.8; if writing 1.7 first, add the struct stub now and the interfaces in 1.8 — recommended order: do Task 1.8 Step 3's `ExternalIdentity` definition first, then this task.)
+- [x] **Step 2: Run → FAIL.** (`ExternalIdentity` is defined in Task 1.8; if writing 1.7 first, add the struct stub now and the interfaces in 1.8 — recommended order: do Task 1.8 Step 3's `ExternalIdentity` definition first, then this task.)
 
-- [ ] **Step 3: Implement `internal/auth/users.go`**
+- [x] **Step 3: Implement `internal/auth/users.go`**
 
 ```go
 package auth
@@ -1054,7 +1054,7 @@ func (us *UserStore) Upsert(ctx context.Context, ext *ExternalIdentity, role mod
 
 > Add `import "time"` to the block. Place `ExternalIdentity` (Task 1.8) before this file compiles.
 
-- [ ] **Step 4: Run → PASS.** **Step 5: Commit** — "Add JIT user provisioning"
+- [x] **Step 4: Run → PASS.** **Step 5: Commit** — "Add JIT user provisioning"
 
 ### Task 1.8: Provider interfaces + shared login pipeline
 
@@ -1062,7 +1062,7 @@ func (us *UserStore) Upsert(ctx context.Context, ext *ExternalIdentity, role mod
 - Create: `internal/auth/provider.go`
 - Test: `internal/auth/provider_test.go`
 
-- [ ] **Step 1: Failing test** (a fake identity exercises the full provision→map→mint tail)
+- [x] **Step 1: Failing test** (a fake identity exercises the full provision→map→mint tail)
 
 ```go
 func TestSSOServiceComplete(t *testing.T) {
@@ -1084,9 +1084,9 @@ func TestSSOServiceComplete(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestSSOServiceComplete -v`
+- [x] **Step 2: Run → FAIL.** `go test ./internal/auth/ -run TestSSOServiceComplete -v`
 
-- [ ] **Step 3: Implement `internal/auth/provider.go`**
+- [x] **Step 3: Implement `internal/auth/provider.go`**
 
 ```go
 package auth
@@ -1152,7 +1152,7 @@ func (s *SSOService) Complete(ctx context.Context, ext *ExternalIdentity, method
 }
 ```
 
-- [ ] **Step 4: Run → PASS.** **Step 5: Commit** — "Add provider interfaces and shared SSO login pipeline"
+- [x] **Step 4: Run → PASS.** **Step 5: Commit** — "Add provider interfaces and shared SSO login pipeline"
 
 ### Task 1.9: Session-bound CSRF (synchronizer token)
 
@@ -1167,7 +1167,7 @@ resolved, comparing against server-side state — there is **no readable CSRF co
 cookie injection cannot forge it. This file provides the check helper, method classification, and
 the context plumbing that `/auth/whoami` uses to surface the token.
 
-- [ ] **Step 1: Failing test**
+- [x] **Step 1: Failing test**
 
 ```go
 func TestEnforceSessionCSRF(t *testing.T) {
@@ -1194,9 +1194,9 @@ func TestEnforceSessionCSRF(t *testing.T) {
 
 > `newCtx` helper: build an Echo context from method/path/headers (mirror the setup already used in `api/middleware/auth_test.go`; extract a shared helper if convenient).
 
-- [ ] **Step 2: Run → FAIL.** `go test ./api/middleware/ -run TestEnforceSessionCSRF -v`
+- [x] **Step 2: Run → FAIL.** `go test ./api/middleware/ -run TestEnforceSessionCSRF -v`
 
-- [ ] **Step 3: Implement `api/middleware/csrf.go`**
+- [x] **Step 3: Implement `api/middleware/csrf.go`**
 
 ```go
 package middleware
@@ -1252,7 +1252,7 @@ func hasBearer(c *echo.Context) bool {
 
 (`hasBearer` is used by the Task 1.10 auth middleware to take the API-key branch.)
 
-- [ ] **Step 4: Run → PASS.** **Step 5: Commit** — "Add session-bound CSRF synchronizer check"
+- [x] **Step 4: Run → PASS.** **Step 5: Commit** — "Add session-bound CSRF synchronizer check"
 
 ### Task 1.10: Resolve session-cookie principals in the auth middleware
 
@@ -1261,7 +1261,7 @@ func hasBearer(c *echo.Context) bool {
 - Modify: `api/rest/bind/bind.go` (pass new deps; gate on auth-enabled)
 - Test: `api/middleware/auth_test.go`
 
-- [ ] **Step 1: Failing test** — a valid session cookie authenticates a `GET /v1/jobs` as its user's role
+- [x] **Step 1: Failing test** — a valid session cookie authenticates a `GET /v1/jobs` as its user's role
 
 ```go
 func TestAuthAcceptsSessionCookie(t *testing.T) {
@@ -1275,9 +1275,9 @@ func TestAuthAcceptsSessionCookie(t *testing.T) {
 
 Flesh this out following the existing API-key test's harness in the same file (reuse its DB/echo setup; add a session via `SessionStore.Create`).
 
-- [ ] **Step 2: Run → FAIL.**
+- [x] **Step 2: Run → FAIL.**
 
-- [ ] **Step 3: Implement.** Introduce a deps struct so the signature doesn't grow unbounded:
+- [x] **Step 3: Implement.** Introduce a deps struct so the signature doesn't grow unbounded:
 
 ```go
 // AuthDeps bundles the dependencies the auth middleware needs.
@@ -1353,9 +1353,9 @@ Keep the existing rate-limit, failure-audit, RBAC, and scope blocks — only the
 
 This requires `All(...)` to receive `sessions *auth.SessionStore`. Add it to the `bind.All` signature and thread it from `api.Start`.
 
-- [ ] **Step 4: Run the full middleware + auth suites + gate.** Update every existing `authmw.Auth(svc, auditor, limiter)` call site (tests + `api.go` metrics) to the new `AuthDeps` form. `go test ./api/... ./internal/auth/ -v && just unit-test`.
+- [x] **Step 4: Run the full middleware + auth suites + gate.** Update every existing `authmw.Auth(svc, auditor, limiter)` call site (tests + `api.go` metrics) to the new `AuthDeps` form. `go test ./api/... ./internal/auth/ -v && just unit-test`.
 
-- [ ] **Step 5: Commit** — "Resolve session-cookie principals in auth middleware"
+- [x] **Step 5: Commit** — "Resolve session-cookie principals in auth middleware"
 
 ### Task 1.11: `/auth/whoami`, `/auth/logout`, extended `/auth/status`
 
@@ -1364,7 +1364,7 @@ This requires `All(...)` to receive `sessions *auth.SessionStore`. Add it to the
 - Modify: `api/api.go` (`authStatus`; mount public SSO routes), `api/rest/bind/bind.go` (`bindAuth` adds whoami/logout)
 - Test: `api/rest/controller/auth/sso_test.go`
 
-- [ ] **Step 1: Failing test** — whoami returns 401 without a session and the principal's identity with one; logout revokes.
+- [x] **Step 1: Failing test** — whoami returns 401 without a session and the principal's identity with one; logout revokes.
 
 ```go
 func TestWhoamiLogout(t *testing.T) {
@@ -1374,9 +1374,9 @@ func TestWhoamiLogout(t *testing.T) {
 }
 ```
 
-- [ ] **Step 2: Run → FAIL.**
+- [x] **Step 2: Run → FAIL.**
 
-- [ ] **Step 3: Implement `api/rest/controller/auth/sso.go`**
+- [x] **Step 3: Implement `api/rest/controller/auth/sso.go`**
 
 ```go
 package auth
@@ -1426,7 +1426,7 @@ func (s *SSOController) Logout(c *echo.Context) error {
 
 (`Whoami` is mounted behind the protected group so `GetPrincipal` is populated; `Logout` does its own cookie read so it works regardless.)
 
-- [ ] **Step 4: Extend `authStatus` in `api/api.go`:**
+- [x] **Step 4: Extend `authStatus` in `api/api.go`:**
 
 ```go
 func authStatus(vars env.Environment) echo.HandlerFunc {
@@ -1454,7 +1454,7 @@ func authStatus(vars env.Environment) echo.HandlerFunc {
 
 Add `g.GET("/auth/whoami", ssoCtrl.Whoami)` to `bindAuth` (protected) and `e.POST("/auth/logout", ssoCtrl.Logout)` near `/auth/status` in `api.Start` (public — reads cookie directly).
 
-- [ ] **Step 5: Run → PASS, gate, commit** — "Add whoami/logout endpoints and method-aware auth status"
+- [x] **Step 5: Run → PASS, gate, commit** — "Add whoami/logout endpoints and method-aware auth status"
 
 ### Task 1.12: Wire session services into startup
 
@@ -1462,7 +1462,7 @@ Add `g.GET("/auth/whoami", ssoCtrl.Whoami)` to `bindAuth` (protected) and `e.POS
 - Modify: `cmd/start/start.go` (`initAuth` + its return/threading), `api/api.go` (`Start` signature), `api/rest/bind/bind.go` (`All` signature)
 - Test: covered by an integration smoke (server boots with SSO env) — add to `test/` if a server-boot harness exists; otherwise verify via `just unit-test` compile + a manual boot.
 
-- [ ] **Step 1:** In `initAuth`, after building `authSvc/auditor/limiter`, when `vars.AuthMode == "api-key" || vars.SSOEnabled()` build the session stack and return it (extend the return tuple or, preferably, return an `auth.Deps`-style bundle):
+- [x] **Step 1:** In `initAuth`, after building `authSvc/auditor/limiter`, when `vars.AuthMode == "api-key" || vars.SSOEnabled()` build the session stack and return it (extend the return tuple or, preferably, return an `auth.Deps`-style bundle):
 
 ```go
 	sessions := auth.NewSessionStore(conn,
@@ -1483,11 +1483,11 @@ Add `g.GET("/auth/whoami", ssoCtrl.Whoami)` to `bindAuth` (protected) and `e.POS
 	}
 ```
 
-- [ ] **Step 2:** Thread `sessions` (and later the SSO service + providers) through `api.Start(...)` → `bind.All(...)`. Update both signatures and the call site at `cmd/start/start.go:527`.
+- [x] **Step 2:** Thread `sessions` (and later the SSO service + providers) through `api.Start(...)` → `bind.All(...)`. Update both signatures and the call site at `cmd/start/start.go:527`.
 
-- [ ] **Step 3:** `go build ./... ` (via the project toolchain) and `just unit-test`.
+- [x] **Step 3:** `go build ./... ` (via the project toolchain) and `just unit-test`.
 
-- [ ] **Step 4: Manual boot smoke** (document the command in the PR):
+- [x] **Step 4: Manual boot smoke** (document the command in the PR):
 
 ```bash
 CAESIUM_AUTH_MODE=api-key CAESIUM_AUTH_KEY_HASH_SECRET=$(openssl rand -hex 32) \
@@ -1495,7 +1495,7 @@ CAESIUM_AUTH_REQUIRE_TLS=false CAESIUM_AUTH_OIDC_ENABLED=true \
 CAESIUM_AUTH_ROLE_MAPPING='*=viewer' just run   # expect: boots, /auth/status lists oidc
 ```
 
-- [ ] **Step 5: Commit** — "Wire session store, reaper, and flusher into startup"
+- [x] **Step 5: Commit** — "Wire session store, reaper, and flusher into startup"
 
 ### Task 1.13: UI session (cookie) mode
 
@@ -1503,11 +1503,11 @@ CAESIUM_AUTH_ROLE_MAPPING='*=viewer' just run   # expect: boots, /auth/status li
 - Modify: `ui/src/lib/auth.ts`, `ui/src/features/auth/AuthGate.tsx`
 - Test: `ui/src/lib/__tests__/auth.test.ts`, `ui/src/features/auth/__tests__/AuthGate.test.tsx`
 
-- [ ] **Step 1: Failing test** — `AuthGate` treats an established session (`/auth/whoami` 200) as authed without the API-key box; `withAuthHeaders` adds `X-CSRF-Token` from the token cached from `/auth/whoami`.
+- [x] **Step 1: Failing test** — `AuthGate` treats an established session (`/auth/whoami` 200) as authed without the API-key box; `withAuthHeaders` adds `X-CSRF-Token` from the token cached from `/auth/whoami`.
 
-- [ ] **Step 2: Run → FAIL.** `cd ui && npx vitest run src/lib/__tests__/auth.test.ts`
+- [x] **Step 2: Run → FAIL.** `cd ui && npx vitest run src/lib/__tests__/auth.test.ts`
 
-- [ ] **Step 3: Implement.** In `auth.ts`, add session detection + CSRF header (from the in-memory token `checkSession()` captures from `/auth/whoami`, not a cookie) and a `checkSession()` that calls `/auth/whoami` with `credentials: "include"`. In `AuthGate.tsx`, after the `/auth/status` probe, also call `/auth/whoami`; if it returns 200, render children (cookie session active). Keep the in-memory API-key path intact. SSO "Sign in with…" buttons + LDAP form are added in the provider plans (they need login URLs from `/auth/status.methods`).
+- [x] **Step 3: Implement.** In `auth.ts`, add session detection + CSRF header (from the in-memory token `checkSession()` captures from `/auth/whoami`, not a cookie) and a `checkSession()` that calls `/auth/whoami` with `credentials: "include"`. In `AuthGate.tsx`, after the `/auth/status` probe, also call `/auth/whoami`; if it returns 200, render children (cookie session active). Keep the in-memory API-key path intact. SSO "Sign in with…" buttons + LDAP form are added in the provider plans (they need login URLs from `/auth/status.methods`).
 
 ```ts
 // auth.ts additions — CSRF token cached from /auth/whoami (synchronizer pattern; never a cookie)
@@ -1533,8 +1533,8 @@ export async function checkSession(): Promise<boolean> {
 
 Merge `csrfHeader()` into `withAuthHeaders` for unsafe requests, and include `credentials: "include"` on same-origin fetches in the API client.
 
-- [ ] **Step 4: Run → PASS.** `cd ui && npx vitest run`
-- [ ] **Step 5: Commit** — "Add UI cookie-session mode and CSRF header"
+- [x] **Step 4: Run → PASS.** `cd ui && npx vitest run`
+- [x] **Step 5: Commit** — "Add UI cookie-session mode and CSRF header"
 
 ---
 

--- a/internal/auth/keygen.go
+++ b/internal/auth/keygen.go
@@ -10,6 +10,9 @@ const (
 	// KeyPrefixLive is the scannable prefix for production API keys.
 	KeyPrefixLive = "csk_live_"
 
+	// SessionTokenPrefix marks opaque session tokens.
+	SessionTokenPrefix = "css_"
+
 	// randomBytes is the number of random bytes used in key generation (32 bytes = 256 bits).
 	randomBytes = 32
 
@@ -32,6 +35,16 @@ func GenerateKey() (plaintext, prefix string, err error) {
 	plaintext = KeyPrefixLive + random
 	prefix = plaintext[:displayPrefixLen]
 	return plaintext, prefix, nil
+}
+
+// GenerateToken produces a new opaque session token. The plaintext is shown to
+// the client once in the cookie; only its hash is stored.
+func GenerateToken() (string, error) {
+	random, err := base62Encode(randomBytes)
+	if err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	return SessionTokenPrefix + random, nil
 }
 
 // base62Encode generates n random bytes and encodes them in base62.

--- a/internal/auth/keygen_test.go
+++ b/internal/auth/keygen_test.go
@@ -32,6 +32,17 @@ func TestGenerateKeyUniqueness(t *testing.T) {
 	}
 }
 
+func TestGenerateToken(t *testing.T) {
+	a, err := GenerateToken()
+	require.NoError(t, err)
+	b, err := GenerateToken()
+	require.NoError(t, err)
+
+	require.NotEqual(t, a, b)
+	require.True(t, strings.HasPrefix(a, SessionTokenPrefix))
+	require.Greater(t, len(a), len(SessionTokenPrefix)+20)
+}
+
 func TestHashKeyDeterministicWithoutSecret(t *testing.T) {
 	key := "csk_live_testkey123"
 	h1, err := HashKey(key, "")
@@ -47,4 +58,3 @@ func TestHashKeyUsesHMACWhenSecretConfigured(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "hmac-sha256:99620ba47041b7576ac9c72874fc81913345ce1f3aa2cbeec28c5aa65d79e20c", h)
 }
-

--- a/internal/auth/principal.go
+++ b/internal/auth/principal.go
@@ -1,0 +1,49 @@
+package auth
+
+import (
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+// PrincipalKind distinguishes the credential type behind an authenticated request.
+type PrincipalKind string
+
+const (
+	PrincipalAPIKey PrincipalKind = "api_key"
+	PrincipalUser   PrincipalKind = "user"
+)
+
+// Principal is the unified authenticated identity used by RBAC, scope checks,
+// and audit. It is produced from either an API key or a user session.
+type Principal struct {
+	Kind    PrincipalKind
+	Role    models.Role
+	Scope   []byte // raw KeyScope JSON; nil/empty == unrestricted.
+	Subject string // audit actor: key prefix or user email.
+	UserID  *uuid.UUID
+	KeyID   *uuid.UUID
+}
+
+// PrincipalFromKey builds a Principal from a validated API key.
+func PrincipalFromKey(k *models.APIKey) *Principal {
+	id := k.ID
+	return &Principal{
+		Kind:    PrincipalAPIKey,
+		Role:    k.Role,
+		Scope:   k.Scope,
+		Subject: k.KeyPrefix,
+		KeyID:   &id,
+	}
+}
+
+// PrincipalFromUser builds a Principal from an authenticated user. SSO users are
+// unscoped (nil Scope) in v1.
+func PrincipalFromUser(u *models.User) *Principal {
+	id := u.ID
+	return &Principal{
+		Kind:    PrincipalUser,
+		Role:    u.Role,
+		Subject: u.Email,
+		UserID:  &id,
+	}
+}

--- a/internal/auth/principal_test.go
+++ b/internal/auth/principal_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrincipalFromKey(t *testing.T) {
+	id := uuid.New()
+	key := &models.APIKey{
+		ID:        id,
+		KeyPrefix: "csk_live_ab",
+		Role:      models.RoleOperator,
+		Scope:     []byte(`{"jobs":["x"]}`),
+	}
+	p := PrincipalFromKey(key)
+	assert.Equal(t, PrincipalAPIKey, p.Kind)
+	assert.Equal(t, models.RoleOperator, p.Role)
+	assert.Equal(t, "csk_live_ab", p.Subject)
+	assert.Equal(t, []byte(`{"jobs":["x"]}`), p.Scope)
+	assert.Equal(t, &id, p.KeyID)
+	assert.Nil(t, p.UserID)
+}
+
+func TestPrincipalFromUser(t *testing.T) {
+	id := uuid.New()
+	u := &models.User{ID: id, Email: "a@b.com", Role: models.RoleViewer}
+	p := PrincipalFromUser(u)
+	assert.Equal(t, PrincipalUser, p.Kind)
+	assert.Equal(t, models.RoleViewer, p.Role)
+	assert.Equal(t, "a@b.com", p.Subject)
+	assert.Equal(t, &id, p.UserID)
+	assert.Nil(t, p.Scope)
+	assert.Nil(t, p.KeyID)
+}

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -1,0 +1,64 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+// ErrLoginDenied is returned when an external identity maps to no role.
+var ErrLoginDenied = errors.New("login denied: no role mapping")
+
+// ExternalIdentity is the normalized identity every provider produces.
+type ExternalIdentity struct {
+	Issuer      string
+	Subject     string
+	Email       string
+	DisplayName string
+	Groups      []string
+}
+
+// RedirectAuthenticator is implemented by browser-redirect providers.
+type RedirectAuthenticator interface {
+	Name() string
+	Begin(w http.ResponseWriter, r *http.Request, returnTo string) (redirectURL string, err error)
+	Complete(r *http.Request) (*ExternalIdentity, error)
+}
+
+// CredentialAuthenticator is implemented by credential providers.
+type CredentialAuthenticator interface {
+	Name() string
+	Authenticate(ctx context.Context, username, password string) (*ExternalIdentity, error)
+}
+
+// SSOService is the shared tail: provision the user, map a role, mint a session.
+type SSOService struct {
+	users    *UserStore
+	sessions *SessionStore
+	roles    *RoleMapper
+}
+
+// NewSSOService creates a shared SSO login pipeline.
+func NewSSOService(users *UserStore, sessions *SessionStore, roles *RoleMapper) *SSOService {
+	return &SSOService{users: users, sessions: sessions, roles: roles}
+}
+
+// Complete turns an authenticated ExternalIdentity into a server-side session.
+func (s *SSOService) Complete(ctx context.Context, ext *ExternalIdentity, method, ip, ua string) (string, *models.Session, error) {
+	role, ok := s.roles.Resolve(ext.Groups)
+	if !ok {
+		return "", nil, ErrLoginDenied
+	}
+	user, err := s.users.Upsert(ctx, ext, role)
+	if err != nil {
+		return "", nil, err
+	}
+	return s.sessions.Create(ctx, CreateSessionRequest{
+		UserID:     user.ID,
+		AuthMethod: method,
+		SourceIP:   ip,
+		UserAgent:  ua,
+	})
+}

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -8,8 +8,8 @@ import (
 	"github.com/caesium-cloud/caesium/internal/models"
 )
 
-// ErrLoginDenied is returned when an external identity maps to no role.
-var ErrLoginDenied = errors.New("login denied: no role mapping")
+// ErrLoginDenied is returned when an external identity is not allowed to log in.
+var ErrLoginDenied = errors.New("login denied")
 
 // ExternalIdentity is the normalized identity every provider produces.
 type ExternalIdentity struct {
@@ -54,6 +54,9 @@ func (s *SSOService) Complete(ctx context.Context, ext *ExternalIdentity, method
 	user, err := s.users.Upsert(ctx, ext, role)
 	if err != nil {
 		return "", nil, err
+	}
+	if user.IsDisabled() {
+		return "", nil, ErrLoginDenied
 	}
 	return s.sessions.Create(ctx, CreateSessionRequest{
 		UserID:     user.ID,

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -3,9 +3,11 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,4 +38,42 @@ func TestSSOServiceComplete(t *testing.T) {
 		Groups:  []string{"none"},
 	}, "oidc", "", "")
 	require.ErrorIs(t, err, ErrLoginDenied)
+}
+
+func TestSSOServiceCompleteRejectsDisabledUser(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	mapper, err := NewRoleMapper("eng=operator", "")
+	require.NoError(t, err)
+	sso := NewSSOService(NewUserStore(db), NewSessionStore(db), mapper)
+
+	disabledAt := time.Now().UTC()
+	user := &models.User{
+		ID:         uuid.New(),
+		Issuer:     "oidc",
+		Subject:    "disabled-sub",
+		Email:      "old@example.com",
+		Role:       models.RoleViewer,
+		CreatedAt:  disabledAt,
+		DisabledAt: &disabledAt,
+	}
+	require.NoError(t, db.Create(user).Error)
+
+	_, _, err = sso.Complete(context.Background(), &ExternalIdentity{
+		Issuer:  "oidc",
+		Subject: "disabled-sub",
+		Email:   "new@example.com",
+		Groups:  []string{"eng"},
+	}, "oidc", "1.2.3.4", "agent")
+	require.ErrorIs(t, err, ErrLoginDenied)
+
+	var got models.User
+	require.NoError(t, db.First(&got, "id = ?", user.ID).Error)
+	require.Equal(t, "old@example.com", got.Email)
+	require.Equal(t, models.RoleViewer, got.Role)
+	require.Nil(t, got.LastLoginAt)
+
+	var sessions int64
+	require.NoError(t, db.Model(&models.Session{}).Where("user_id = ?", user.ID).Count(&sessions).Error)
+	require.Zero(t, sessions)
 }

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSOServiceComplete(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	mapper, err := NewRoleMapper("eng=operator", "")
+	require.NoError(t, err)
+	sso := NewSSOService(NewUserStore(db), NewSessionStore(db), mapper)
+
+	cookie, sess, err := sso.Complete(context.Background(), &ExternalIdentity{
+		Issuer:  "oidc",
+		Subject: "s1",
+		Email:   "a@b.com",
+		Groups:  []string{"eng"},
+	}, "oidc", "1.2.3.4", "agent")
+	require.NoError(t, err)
+	require.NotEmpty(t, cookie)
+	require.Equal(t, "oidc", sess.AuthMethod)
+
+	var user models.User
+	require.NoError(t, db.First(&user, "subject = ?", "s1").Error)
+	require.Equal(t, models.RoleOperator, user.Role)
+
+	_, _, err = sso.Complete(context.Background(), &ExternalIdentity{
+		Issuer:  "oidc",
+		Subject: "s2",
+		Groups:  []string{"none"},
+	}, "oidc", "", "")
+	require.ErrorIs(t, err, ErrLoginDenied)
+}

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -34,6 +34,7 @@ var endpointPolicy = map[string]models.Role{
 	// Viewer
 	"GET /metrics":                   models.RoleViewer,
 	"GET /auth/whoami":               models.RoleViewer,
+	"POST /auth/logout":              models.RoleViewer,
 	"GET /v1/jobs":                   models.RoleViewer,
 	"GET /v1/jobs/:id":               models.RoleViewer,
 	"GET /v1/jobs/:id/tasks":         models.RoleViewer,
@@ -51,8 +52,6 @@ var endpointPolicy = map[string]models.Role{
 	"GET /v1/atoms":                  models.RoleViewer,
 	"GET /v1/atoms/:id":              models.RoleViewer,
 	"GET /v1/nodes/:id/workers":      models.RoleViewer,
-	"GET /v1/auth/whoami":            models.RoleViewer,
-	"POST /v1/auth/logout":           models.RoleViewer,
 
 	// Runner
 	"POST /v1/jobs/:id/run":                      models.RoleRunner,

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -33,6 +33,7 @@ var endpointPolicy = map[string]models.Role{
 
 	// Viewer
 	"GET /metrics":                   models.RoleViewer,
+	"GET /auth/whoami":               models.RoleViewer,
 	"GET /v1/jobs":                   models.RoleViewer,
 	"GET /v1/jobs/:id":               models.RoleViewer,
 	"GET /v1/jobs/:id/tasks":         models.RoleViewer,
@@ -50,6 +51,8 @@ var endpointPolicy = map[string]models.Role{
 	"GET /v1/atoms":                  models.RoleViewer,
 	"GET /v1/atoms/:id":              models.RoleViewer,
 	"GET /v1/nodes/:id/workers":      models.RoleViewer,
+	"GET /v1/auth/whoami":            models.RoleViewer,
+	"POST /v1/auth/logout":           models.RoleViewer,
 
 	// Runner
 	"POST /v1/jobs/:id/run":                      models.RoleRunner,

--- a/internal/auth/rolemap.go
+++ b/internal/auth/rolemap.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+// RoleMapper resolves IdP groups to Caesium roles. Highest matched role wins.
+type RoleMapper struct {
+	byGroup     map[string]models.Role
+	wildcard    *models.Role
+	defaultRole *models.Role
+}
+
+// NewRoleMapper parses a semicolon-separated group=role mapping and optional
+// default role. Entries split on the last '=' so LDAP DNs can be used as keys.
+func NewRoleMapper(mapping, defaultRole string) (*RoleMapper, error) {
+	m := &RoleMapper{byGroup: map[string]models.Role{}}
+	for _, entry := range strings.Split(mapping, ";") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		eq := strings.LastIndex(entry, "=")
+		if eq <= 0 || eq == len(entry)-1 {
+			return nil, fmt.Errorf("invalid role mapping entry %q (want group=role)", entry)
+		}
+		group := strings.TrimSpace(entry[:eq])
+		role := models.Role(strings.TrimSpace(entry[eq+1:]))
+		if !models.ValidRole(string(role)) {
+			return nil, fmt.Errorf("invalid role %q in mapping", role)
+		}
+		if group == "*" {
+			r := role
+			m.wildcard = &r
+			continue
+		}
+		m.byGroup[group] = role
+	}
+
+	if dr := strings.TrimSpace(defaultRole); dr != "" {
+		if !models.ValidRole(dr) {
+			return nil, fmt.Errorf("invalid default role %q", dr)
+		}
+		r := models.Role(dr)
+		m.defaultRole = &r
+	}
+	return m, nil
+}
+
+// Resolve returns the effective role for groups and whether login is allowed.
+func (m *RoleMapper) Resolve(groups []string) (models.Role, bool) {
+	var best models.Role
+	matched := false
+	for _, g := range groups {
+		role, ok := m.byGroup[strings.TrimSpace(g)]
+		if !ok {
+			continue
+		}
+		if !matched || models.RoleLevel(role) > models.RoleLevel(best) {
+			best = role
+			matched = true
+		}
+	}
+	if matched {
+		return best, true
+	}
+	if m.wildcard != nil {
+		return *m.wildcard, true
+	}
+	if m.defaultRole != nil {
+		return *m.defaultRole, true
+	}
+	return "", false
+}

--- a/internal/auth/rolemap.go
+++ b/internal/auth/rolemap.go
@@ -8,6 +8,8 @@ import (
 )
 
 // RoleMapper resolves IdP groups to Caesium roles. Highest matched role wins.
+// The wildcard entry "*" matches every login; defaultRole is only a fallback
+// when no explicit or wildcard mapping applies.
 type RoleMapper struct {
 	byGroup     map[string]models.Role
 	wildcard    *models.Role
@@ -64,11 +66,12 @@ func (m *RoleMapper) Resolve(groups []string) (models.Role, bool) {
 			matched = true
 		}
 	}
+	if m.wildcard != nil && (!matched || models.RoleLevel(*m.wildcard) > models.RoleLevel(best)) {
+		best = *m.wildcard
+		matched = true
+	}
 	if matched {
 		return best, true
-	}
-	if m.wildcard != nil {
-		return *m.wildcard, true
 	}
 	if m.defaultRole != nil {
 		return *m.defaultRole, true

--- a/internal/auth/rolemap_test.go
+++ b/internal/auth/rolemap_test.go
@@ -39,6 +39,14 @@ func TestRoleMapperDefaultRole(t *testing.T) {
 	require.Equal(t, models.RoleViewer, r)
 }
 
+func TestRoleMapperWildcardParticipatesInHighestRole(t *testing.T) {
+	m, err := NewRoleMapper("admins=viewer;*=operator", "")
+	require.NoError(t, err)
+	r, ok := m.Resolve([]string{"admins"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleOperator, r)
+}
+
 func TestRoleMapperDNWithEquals(t *testing.T) {
 	m, err := NewRoleMapper("CN=Caesium Admins,OU=Groups,DC=example,DC=com=admin", "")
 	require.NoError(t, err)

--- a/internal/auth/rolemap_test.go
+++ b/internal/auth/rolemap_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoleMapperResolve(t *testing.T) {
+	m, err := NewRoleMapper("caesium-admins=admin;data-eng=operator;*=viewer", "")
+	require.NoError(t, err)
+
+	r, ok := m.Resolve([]string{"data-eng"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleOperator, r)
+
+	r, ok = m.Resolve([]string{"data-eng", "caesium-admins"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleAdmin, r)
+
+	r, ok = m.Resolve([]string{"unknown"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleViewer, r)
+}
+
+func TestRoleMapperDenyByDefault(t *testing.T) {
+	m, err := NewRoleMapper("admins=admin", "")
+	require.NoError(t, err)
+	_, ok := m.Resolve([]string{"nobody"})
+	require.False(t, ok)
+}
+
+func TestRoleMapperDefaultRole(t *testing.T) {
+	m, err := NewRoleMapper("admins=admin", "viewer")
+	require.NoError(t, err)
+	r, ok := m.Resolve([]string{"nobody"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleViewer, r)
+}
+
+func TestRoleMapperDNWithEquals(t *testing.T) {
+	m, err := NewRoleMapper("CN=Caesium Admins,OU=Groups,DC=example,DC=com=admin", "")
+	require.NoError(t, err)
+	r, ok := m.Resolve([]string{"CN=Caesium Admins,OU=Groups,DC=example,DC=com"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleAdmin, r)
+}
+
+func TestRoleMapperRejectsBadRole(t *testing.T) {
+	_, err := NewRoleMapper("g=superuser", "")
+	require.Error(t, err)
+}

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -20,6 +20,8 @@ var (
 	ErrUserDisabled   = errors.New("user disabled")
 )
 
+const sessionFlushBatchSize = 900
+
 // SessionStore manages server-side login sessions in the catalog DB. Tokens
 // are hashed at rest and last-seen updates are coalesced.
 type SessionStore struct {
@@ -182,10 +184,10 @@ func (s *SessionStore) RunLastSeenFlusher(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			s.flushSeen()
+			s.flushSeen(context.Background())
 			return
 		case <-ticker.C:
-			s.flushSeen()
+			s.flushSeen(ctx)
 		}
 	}
 }
@@ -223,7 +225,7 @@ func (s *SessionStore) RunReaper(ctx context.Context) {
 	}
 }
 
-func (s *SessionStore) flushSeen() {
+func (s *SessionStore) flushSeen(ctx context.Context) {
 	s.seenMu.Lock()
 	pending := s.seen
 	s.seen = make(map[uuid.UUID]time.Time, len(pending))
@@ -237,11 +239,17 @@ func (s *SessionStore) flushSeen() {
 		ids = append(ids, id)
 	}
 	now := s.nowUTC()
-	if err := s.db.Model(&models.Session{}).Where("id IN ?", ids).Updates(map[string]any{
-		"last_seen_at":    now,
-		"idle_expires_at": now.Add(s.idleTTL),
-	}).Error; err != nil {
-		log.Warn("failed to flush session last_seen", "error", err)
+	for start := 0; start < len(ids); start += sessionFlushBatchSize {
+		end := start + sessionFlushBatchSize
+		if end > len(ids) {
+			end = len(ids)
+		}
+		if err := s.db.WithContext(ctx).Model(&models.Session{}).Where("id IN ?", ids[start:end]).Updates(map[string]any{
+			"last_seen_at":    now,
+			"idle_expires_at": now.Add(s.idleTTL),
+		}).Error; err != nil {
+			log.Warn("failed to flush session last_seen batch", "error", err)
+		}
 	}
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -1,0 +1,256 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrSessionInvalid = errors.New("session not found")
+	ErrSessionRevoked = errors.New("session revoked")
+	ErrSessionExpired = errors.New("session expired")
+	ErrUserDisabled   = errors.New("user disabled")
+)
+
+// SessionStore manages server-side login sessions in the catalog DB. Tokens
+// are hashed at rest and last-seen updates are coalesced.
+type SessionStore struct {
+	db              *gorm.DB
+	tokenHashSecret string
+	idleTTL         time.Duration
+	absoluteTTL     time.Duration
+	now             func() time.Time
+
+	seenMu sync.Mutex
+	seen   map[uuid.UUID]time.Time
+}
+
+// SessionStoreOption customizes session-store behavior.
+type SessionStoreOption func(*SessionStore)
+
+// WithSessionHashSecret configures the server-side secret for session-token hashes.
+func WithSessionHashSecret(secret string) SessionStoreOption {
+	return func(s *SessionStore) {
+		s.tokenHashSecret = secret
+	}
+}
+
+// WithSessionTTLs configures idle and absolute session lifetimes.
+func WithSessionTTLs(idle, absolute time.Duration) SessionStoreOption {
+	return func(s *SessionStore) {
+		s.idleTTL = idle
+		s.absoluteTTL = absolute
+	}
+}
+
+// WithSessionNow overrides the session-store clock. Intended for tests.
+func WithSessionNow(now func() time.Time) SessionStoreOption {
+	return func(s *SessionStore) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+// NewSessionStore creates a new session store backed by the given database.
+func NewSessionStore(db *gorm.DB, opts ...SessionStoreOption) *SessionStore {
+	s := &SessionStore{
+		db:          db,
+		idleTTL:     8 * time.Hour,
+		absoluteTTL: 24 * time.Hour,
+		now:         time.Now,
+		seen:        make(map[uuid.UUID]time.Time),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// CreateSessionRequest holds parameters for minting a session.
+type CreateSessionRequest struct {
+	UserID     uuid.UUID
+	AuthMethod string
+	SourceIP   string
+	UserAgent  string
+}
+
+// Create mints a new session and returns the plaintext token for the cookie.
+func (s *SessionStore) Create(ctx context.Context, req CreateSessionRequest) (string, *models.Session, error) {
+	plaintext, err := GenerateToken()
+	if err != nil {
+		return "", nil, err
+	}
+	hash, err := HashKey(plaintext, s.tokenHashSecret)
+	if err != nil {
+		return "", nil, fmt.Errorf("hash session token: %w", err)
+	}
+	csrf, err := base62Encode(randomBytes)
+	if err != nil {
+		return "", nil, fmt.Errorf("generate csrf token: %w", err)
+	}
+
+	now := s.nowUTC()
+	sess := &models.Session{
+		ID:                uuid.New(),
+		UserID:            req.UserID,
+		TokenHash:         hash,
+		CSRFToken:         csrf,
+		AuthMethod:        req.AuthMethod,
+		CreatedAt:         now,
+		IdleExpiresAt:     now.Add(s.idleTTL),
+		AbsoluteExpiresAt: now.Add(s.absoluteTTL),
+		SourceIP:          req.SourceIP,
+		UserAgent:         req.UserAgent,
+	}
+	if err := s.db.WithContext(ctx).Create(sess).Error; err != nil {
+		return "", nil, fmt.Errorf("create session: %w", err)
+	}
+	return plaintext, sess, nil
+}
+
+// Validate resolves a plaintext token to its live session and user.
+func (s *SessionStore) Validate(ctx context.Context, plaintext string) (*models.Session, *models.User, error) {
+	hash, err := HashKey(plaintext, s.tokenHashSecret)
+	if err != nil {
+		return nil, nil, fmt.Errorf("hash session token: %w", err)
+	}
+
+	var sess models.Session
+	if err := s.db.WithContext(ctx).Where("token_hash = ?", hash).First(&sess).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, ErrSessionInvalid
+		}
+		return nil, nil, fmt.Errorf("lookup session: %w", err)
+	}
+	if sess.IsRevoked() {
+		return nil, nil, ErrSessionRevoked
+	}
+	now := s.nowUTC()
+	if now.After(sess.AbsoluteExpiresAt) || now.After(sess.IdleExpiresAt) {
+		return nil, nil, ErrSessionExpired
+	}
+
+	var user models.User
+	if err := s.db.WithContext(ctx).First(&user, "id = ?", sess.UserID).Error; err != nil {
+		return nil, nil, fmt.Errorf("load session user: %w", err)
+	}
+	if user.IsDisabled() {
+		return nil, nil, ErrUserDisabled
+	}
+
+	s.recordSeen(sess.ID)
+	return &sess, &user, nil
+}
+
+// Revoke marks a single session revoked.
+func (s *SessionStore) Revoke(ctx context.Context, id uuid.UUID) error {
+	res := s.db.WithContext(ctx).Model(&models.Session{}).
+		Where("id = ? AND revoked_at IS NULL", id).
+		Update("revoked_at", s.nowUTC())
+	if res.Error != nil {
+		return fmt.Errorf("revoke session: %w", res.Error)
+	}
+	if res.RowsAffected == 0 {
+		return ErrSessionInvalid
+	}
+	return nil
+}
+
+// RevokeAllForUser revokes every live session for a user.
+func (s *SessionStore) RevokeAllForUser(ctx context.Context, userID uuid.UUID) error {
+	if err := s.db.WithContext(ctx).Model(&models.Session{}).
+		Where("user_id = ? AND revoked_at IS NULL", userID).
+		Update("revoked_at", s.nowUTC()).Error; err != nil {
+		return fmt.Errorf("revoke user sessions: %w", err)
+	}
+	return nil
+}
+
+// RunLastSeenFlusher periodically flushes buffered session activity.
+func (s *SessionStore) RunLastSeenFlusher(ctx context.Context) {
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			s.flushSeen()
+			return
+		case <-ticker.C:
+			s.flushSeen()
+		}
+	}
+}
+
+// Reap deletes expired sessions and sessions revoked more than an hour ago.
+func (s *SessionStore) Reap(ctx context.Context) (int64, error) {
+	now := s.nowUTC()
+	res := s.db.WithContext(ctx).
+		Where(
+			"absolute_expires_at < ? OR idle_expires_at < ? OR (revoked_at IS NOT NULL AND revoked_at < ?)",
+			now,
+			now,
+			now.Add(-time.Hour),
+		).
+		Delete(&models.Session{})
+	if res.Error != nil {
+		return 0, fmt.Errorf("reap sessions: %w", res.Error)
+	}
+	return res.RowsAffected, nil
+}
+
+// RunReaper sweeps expired sessions until ctx is cancelled.
+func (s *SessionStore) RunReaper(ctx context.Context) {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := s.Reap(ctx); err != nil {
+				log.Warn("session reap failed", "error", err)
+			}
+		}
+	}
+}
+
+func (s *SessionStore) flushSeen() {
+	s.seenMu.Lock()
+	pending := s.seen
+	s.seen = make(map[uuid.UUID]time.Time, len(pending))
+	s.seenMu.Unlock()
+	if len(pending) == 0 {
+		return
+	}
+
+	ids := make([]uuid.UUID, 0, len(pending))
+	for id := range pending {
+		ids = append(ids, id)
+	}
+	now := s.nowUTC()
+	if err := s.db.Model(&models.Session{}).Where("id IN ?", ids).Updates(map[string]any{
+		"last_seen_at":    now,
+		"idle_expires_at": now.Add(s.idleTTL),
+	}).Error; err != nil {
+		log.Warn("failed to flush session last_seen", "error", err)
+	}
+}
+
+func (s *SessionStore) recordSeen(id uuid.UUID) {
+	s.seenMu.Lock()
+	s.seen[id] = s.nowUTC()
+	s.seenMu.Unlock()
+}
+
+func (s *SessionStore) nowUTC() time.Time {
+	return s.now().UTC()
+}

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -1,0 +1,130 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSessionStoreCreateValidate(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleOperator}
+	require.NoError(t, db.Create(u).Error)
+
+	store := NewSessionStore(db, WithSessionTTLs(8*time.Hour, 24*time.Hour))
+	plaintext, sess, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID, AuthMethod: "oidc"})
+	require.NoError(t, err)
+	require.NotEmpty(t, plaintext)
+	require.NotEmpty(t, sess.TokenHash)
+	require.NotEqual(t, plaintext, sess.TokenHash)
+	require.NotEmpty(t, sess.CSRFToken)
+
+	gotSess, gotUser, err := store.Validate(context.Background(), plaintext)
+	require.NoError(t, err)
+	require.Equal(t, sess.ID, gotSess.ID)
+	require.Equal(t, u.Email, gotUser.Email)
+
+	_, _, err = store.Validate(context.Background(), "css_wrong")
+	require.ErrorIs(t, err, ErrSessionInvalid)
+}
+
+func TestSessionStoreRevoke(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+	store := NewSessionStore(db, WithSessionTTLs(time.Hour, time.Hour))
+	plaintext, sess, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+	require.NoError(t, store.Revoke(context.Background(), sess.ID))
+	_, _, err = store.Validate(context.Background(), plaintext)
+	require.ErrorIs(t, err, ErrSessionRevoked)
+}
+
+func TestSessionStoreValidateExpired(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	past := time.Now().UTC().Add(-2 * time.Hour)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+	store := NewSessionStore(
+		db,
+		WithSessionNow(func() time.Time { return past }),
+		WithSessionTTLs(time.Minute, time.Minute),
+	)
+	plaintext, _, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+
+	store.now = time.Now
+	_, _, err = store.Validate(context.Background(), plaintext)
+	require.ErrorIs(t, err, ErrSessionExpired)
+}
+
+func TestSessionStoreValidateDisabledUser(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	disabledAt := time.Now().UTC()
+	u := &models.User{
+		ID:         uuid.New(),
+		Issuer:     "oidc",
+		Subject:    "s",
+		Email:      "a@b.com",
+		Role:       models.RoleViewer,
+		DisabledAt: &disabledAt,
+	}
+	require.NoError(t, db.Create(u).Error)
+	store := NewSessionStore(db)
+	plaintext, _, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+
+	_, _, err = store.Validate(context.Background(), plaintext)
+	require.ErrorIs(t, err, ErrUserDisabled)
+}
+
+func TestSessionFlushSeen(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+	store := NewSessionStore(db, WithSessionTTLs(time.Hour, 24*time.Hour))
+	_, sess, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+	before := sess.IdleExpiresAt
+
+	store.recordSeen(sess.ID)
+	store.flushSeen()
+
+	var got models.Session
+	require.NoError(t, db.First(&got, "id = ?", sess.ID).Error)
+	require.NotNil(t, got.LastSeenAt)
+	require.False(t, got.IdleExpiresAt.Before(before))
+}
+
+func TestSessionReap(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+	past := time.Now().UTC().Add(-time.Hour)
+	store := NewSessionStore(
+		db,
+		WithSessionNow(func() time.Time { return past }),
+		WithSessionTTLs(time.Minute, time.Minute),
+	)
+	_, sess, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+
+	store.now = time.Now
+	n, err := store.Reap(context.Background())
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, n, int64(1))
+	var count int64
+	require.NoError(t, db.Model(&models.Session{}).Where("id = ?", sess.ID).Count(&count).Error)
+	require.Equal(t, int64(0), count)
+}

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -98,12 +98,43 @@ func TestSessionFlushSeen(t *testing.T) {
 	before := sess.IdleExpiresAt
 
 	store.recordSeen(sess.ID)
-	store.flushSeen()
+	store.flushSeen(context.Background())
 
 	var got models.Session
 	require.NoError(t, db.First(&got, "id = ?", sess.ID).Error)
 	require.NotNil(t, got.LastSeenAt)
 	require.False(t, got.IdleExpiresAt.Before(before))
+}
+
+func TestSessionFlushSeenBatchesLargeUpdates(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+
+	now := time.Now().UTC()
+	sessions := make([]models.Session, 0, sessionFlushBatchSize+5)
+	store := NewSessionStore(db, WithSessionTTLs(time.Hour, 24*time.Hour))
+	for i := 0; i < sessionFlushBatchSize+5; i++ {
+		id := uuid.New()
+		sessions = append(sessions, models.Session{
+			ID:                id,
+			UserID:            u.ID,
+			TokenHash:         id.String(),
+			CSRFToken:         "csrf-" + id.String(),
+			CreatedAt:         now,
+			IdleExpiresAt:     now.Add(time.Hour),
+			AbsoluteExpiresAt: now.Add(24 * time.Hour),
+		})
+		store.recordSeen(id)
+	}
+	require.NoError(t, db.Create(&sessions).Error)
+
+	store.flushSeen(context.Background())
+
+	var count int64
+	require.NoError(t, db.Model(&models.Session{}).Where("last_seen_at IS NOT NULL").Count(&count).Error)
+	require.Equal(t, int64(len(sessions)), count)
 }
 
 func TestSessionReap(t *testing.T) {

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -48,27 +49,57 @@ func (us *UserStore) Upsert(ctx context.Context, ext *ExternalIdentity, role mod
 			LastLoginAt: &now,
 		}
 		if err := us.db.WithContext(ctx).Create(&user).Error; err != nil {
+			if isUniqueConstraintError(err) {
+				if existing, lookupErr := us.lookupByIdentity(ctx, ext); lookupErr == nil {
+					return us.updateExisting(ctx, &existing, ext, role, groupsJSON, now)
+				}
+			}
 			return nil, fmt.Errorf("create user: %w", err)
 		}
 	case err != nil:
 		return nil, fmt.Errorf("lookup user: %w", err)
 	default:
-		updates := map[string]any{
-			"email":         ext.Email,
-			"display_name":  ext.DisplayName,
-			"groups":        groupsJSON,
-			"role":          role,
-			"last_login_at": now,
-		}
-		if err := us.db.WithContext(ctx).Model(&user).Updates(updates).Error; err != nil {
-			return nil, fmt.Errorf("update user: %w", err)
-		}
-		user.Email = ext.Email
-		user.DisplayName = ext.DisplayName
-		user.Groups = groupsJSON
-		user.Role = role
-		user.LastLoginAt = &now
+		return us.updateExisting(ctx, &user, ext, role, groupsJSON, now)
 	}
 
 	return &user, nil
+}
+
+func (us *UserStore) lookupByIdentity(ctx context.Context, ext *ExternalIdentity) (models.User, error) {
+	var user models.User
+	err := us.db.WithContext(ctx).Where("issuer = ? AND subject = ?", ext.Issuer, ext.Subject).First(&user).Error
+	return user, err
+}
+
+func (us *UserStore) updateExisting(ctx context.Context, user *models.User, ext *ExternalIdentity, role models.Role, groupsJSON []byte, now time.Time) (*models.User, error) {
+	if user.IsDisabled() {
+		return user, nil
+	}
+
+	updates := map[string]any{
+		"email":         ext.Email,
+		"display_name":  ext.DisplayName,
+		"groups":        groupsJSON,
+		"role":          role,
+		"last_login_at": now,
+	}
+	if err := us.db.WithContext(ctx).Model(user).Updates(updates).Error; err != nil {
+		return nil, fmt.Errorf("update user: %w", err)
+	}
+	user.Email = ext.Email
+	user.DisplayName = ext.DisplayName
+	user.Groups = groupsJSON
+	user.Role = role
+	user.LastLoginAt = &now
+	return user, nil
+}
+
+func isUniqueConstraintError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "constraint failed") ||
+		strings.Contains(msg, "duplicate")
 }

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -1,0 +1,74 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// UserStore provisions and updates user identities.
+type UserStore struct {
+	db  *gorm.DB
+	now func() time.Time
+}
+
+// NewUserStore creates a user store backed by the given database.
+func NewUserStore(db *gorm.DB) *UserStore {
+	return &UserStore{db: db, now: time.Now}
+}
+
+// Upsert provisions a user on first login and refreshes profile, role, and
+// last-login fields on subsequent logins, keyed on (issuer, subject).
+func (us *UserStore) Upsert(ctx context.Context, ext *ExternalIdentity, role models.Role) (*models.User, error) {
+	now := us.now().UTC()
+	groupsJSON, err := json.Marshal(ext.Groups)
+	if err != nil {
+		return nil, fmt.Errorf("marshal groups: %w", err)
+	}
+
+	var user models.User
+	err = us.db.WithContext(ctx).Where("issuer = ? AND subject = ?", ext.Issuer, ext.Subject).First(&user).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		user = models.User{
+			ID:          uuid.New(),
+			Issuer:      ext.Issuer,
+			Subject:     ext.Subject,
+			Email:       ext.Email,
+			DisplayName: ext.DisplayName,
+			Groups:      groupsJSON,
+			Role:        role,
+			CreatedAt:   now,
+			LastLoginAt: &now,
+		}
+		if err := us.db.WithContext(ctx).Create(&user).Error; err != nil {
+			return nil, fmt.Errorf("create user: %w", err)
+		}
+	case err != nil:
+		return nil, fmt.Errorf("lookup user: %w", err)
+	default:
+		updates := map[string]any{
+			"email":         ext.Email,
+			"display_name":  ext.DisplayName,
+			"groups":        groupsJSON,
+			"role":          role,
+			"last_login_at": now,
+		}
+		if err := us.db.WithContext(ctx).Model(&user).Updates(updates).Error; err != nil {
+			return nil, fmt.Errorf("update user: %w", err)
+		}
+		user.Email = ext.Email
+		user.DisplayName = ext.DisplayName
+		user.Groups = groupsJSON
+		user.Role = role
+		user.LastLoginAt = &now
+	}
+
+	return &user, nil
+}

--- a/internal/auth/users_test.go
+++ b/internal/auth/users_test.go
@@ -3,10 +3,13 @@ package auth
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
 )
 
 func TestUserStoreUpsert(t *testing.T) {
@@ -35,4 +38,39 @@ func TestUserStoreUpsert(t *testing.T) {
 	require.Equal(t, u1.ID, u2.ID)
 	require.Equal(t, "a2@b.com", u2.Email)
 	require.Equal(t, models.RoleOperator, u2.Role)
+}
+
+func TestUserStoreUpsertHandlesConcurrentCreateConflict(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	us := NewUserStore(db.Session(&gorm.Session{SkipDefaultTransaction: true}))
+
+	const callbackName = "test:insert_racing_user"
+	inserted := false
+	require.NoError(t, db.Callback().Create().Before("gorm:create").Register(callbackName, func(tx *gorm.DB) {
+		if inserted || tx.Statement.Schema == nil || tx.Statement.Schema.Name != "User" {
+			return
+		}
+		inserted = true
+		now := time.Now().UTC()
+		tx.Exec(
+			"INSERT INTO users (id, issuer, subject, email, role, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+			uuid.New(), "oidc", "sub-race", "raced@example.com", string(models.RoleViewer), now,
+		)
+	}))
+
+	u, err := us.Upsert(context.Background(), &ExternalIdentity{
+		Issuer:  "oidc",
+		Subject: "sub-race",
+		Email:   "winner@example.com",
+		Groups:  []string{"eng"},
+	}, models.RoleOperator)
+	require.NoError(t, err)
+	require.True(t, inserted)
+	require.Equal(t, "winner@example.com", u.Email)
+	require.Equal(t, models.RoleOperator, u.Role)
+
+	var count int64
+	require.NoError(t, db.Model(&models.User{}).Where("issuer = ? AND subject = ?", "oidc", "sub-race").Count(&count).Error)
+	require.Equal(t, int64(1), count)
 }

--- a/internal/auth/users_test.go
+++ b/internal/auth/users_test.go
@@ -1,0 +1,38 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserStoreUpsert(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	us := NewUserStore(db)
+
+	u1, err := us.Upsert(context.Background(), &ExternalIdentity{
+		Issuer:      "oidc",
+		Subject:     "sub-1",
+		Email:       "a@b.com",
+		DisplayName: "A",
+		Groups:      []string{"x"},
+	}, models.RoleViewer)
+	require.NoError(t, err)
+	require.Equal(t, models.RoleViewer, u1.Role)
+	require.NotNil(t, u1.LastLoginAt)
+
+	u2, err := us.Upsert(context.Background(), &ExternalIdentity{
+		Issuer:  "oidc",
+		Subject: "sub-1",
+		Email:   "a2@b.com",
+		Groups:  []string{"y"},
+	}, models.RoleOperator)
+	require.NoError(t, err)
+	require.Equal(t, u1.ID, u2.ID)
+	require.Equal(t, "a2@b.com", u2.Email)
+	require.Equal(t, models.RoleOperator, u2.Role)
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -18,6 +18,8 @@ var All = []interface{}{
 	&ExecutionEvent{},
 	&APIKey{},
 	&AuditLog{},
+	&User{},
+	&Session{},
 	&NotificationChannel{},
 	&NotificationPolicy{},
 	// Phase 2 run-owner coordination tables (catalog DB, cross-run, low-volume).

--- a/internal/models/session.go
+++ b/internal/models/session.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Session is a server-side login session. The opaque token is never stored;
+// only its keyed hash (TokenHash) is persisted.
+type Session struct {
+	ID                uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	UserID            uuid.UUID  `gorm:"type:uuid;not null;index" json:"user_id"`
+	TokenHash         string     `gorm:"type:text;not null;uniqueIndex" json:"-"`
+	CSRFToken         string     `gorm:"type:text;not null" json:"-"`
+	AuthMethod        string     `gorm:"type:text" json:"auth_method"`
+	CreatedAt         time.Time  `gorm:"not null" json:"created_at"`
+	IdleExpiresAt     time.Time  `gorm:"not null" json:"idle_expires_at"`
+	AbsoluteExpiresAt time.Time  `gorm:"not null" json:"absolute_expires_at"`
+	LastSeenAt        *time.Time `json:"last_seen_at,omitempty"`
+	RevokedAt         *time.Time `json:"revoked_at,omitempty"`
+	SourceIP          string     `gorm:"type:text" json:"source_ip,omitempty"`
+	UserAgent         string     `gorm:"type:text" json:"user_agent,omitempty"`
+}
+
+// IsRevoked reports whether the session was explicitly revoked.
+func (s *Session) IsRevoked() bool {
+	return s.RevokedAt != nil
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -1,0 +1,27 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// User is a human identity provisioned just-in-time from an external IdP.
+type User struct {
+	ID          uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Issuer      string         `gorm:"type:text;not null;uniqueIndex:idx_users_identity" json:"issuer"`
+	Subject     string         `gorm:"type:text;not null;uniqueIndex:idx_users_identity" json:"subject"`
+	Email       string         `gorm:"type:text;index" json:"email"`
+	DisplayName string         `gorm:"type:text" json:"display_name,omitempty"`
+	Groups      datatypes.JSON `gorm:"type:json" json:"groups,omitempty"`
+	Role        Role           `gorm:"type:text;not null" json:"role"`
+	CreatedAt   time.Time      `gorm:"not null" json:"created_at"`
+	LastLoginAt *time.Time     `json:"last_login_at,omitempty"`
+	DisabledAt  *time.Time     `json:"disabled_at,omitempty"`
+}
+
+// IsDisabled reports whether the user account has been disabled.
+func (u *User) IsDisabled() bool {
+	return u.DisabledAt != nil
+}

--- a/internal/models/user_test.go
+++ b/internal/models/user_test.go
@@ -1,0 +1,66 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestUserSessionMigrate(t *testing.T) {
+	db := openModelTestDB(t)
+
+	u := &User{
+		ID:      uuid.New(),
+		Issuer:  "oidc",
+		Subject: "sub-1",
+		Email:   "a@b.com",
+		Role:    RoleViewer,
+	}
+	require.NoError(t, db.Create(u).Error)
+
+	s := &Session{
+		ID:         uuid.New(),
+		UserID:     u.ID,
+		TokenHash:  "h",
+		CSRFToken:  "csrf",
+		AuthMethod: "oidc",
+	}
+	require.NoError(t, db.Create(s).Error)
+
+	var got User
+	require.NoError(t, db.First(&got, "id = ?", u.ID).Error)
+	require.Equal(t, "a@b.com", got.Email)
+	require.False(t, got.IsDisabled())
+}
+
+func TestSessionIsRevoked(t *testing.T) {
+	s := &Session{}
+	require.False(t, s.IsRevoked())
+	now := time.Now()
+	s.RevokedAt = &now
+	require.True(t, s.IsRevoked())
+}
+
+func openModelTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared&_busy_timeout=5000"), &gorm.Config{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		sqlDB, err := db.DB()
+		require.NoError(t, err)
+		require.NoError(t, sqlDB.Close())
+	})
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+
+	require.NoError(t, db.AutoMigrate(&User{}, &Session{}))
+	return db
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -134,14 +134,23 @@ type Environment struct {
 	NotificationWatcherInterval time.Duration `envconfig:"NOTIFICATION_WATCHER_INTERVAL" default:"15s"`
 
 	// Authentication & Authorization
-	AuthMode                string `envconfig:"AUTH_MODE" default:"none"` // none, api-key
-	AuthKeyHashSecret       string `envconfig:"AUTH_KEY_HASH_SECRET" default:""`
-	AuthRequireTLS          bool   `envconfig:"AUTH_REQUIRE_TLS" default:"true"`
-	TLSCert                 string `envconfig:"TLS_CERT" default:""`
-	TLSKey                  string `envconfig:"TLS_KEY" default:""`
-	TrustedProxies          string `envconfig:"TRUSTED_PROXIES" default:""`
-	AuthRateLimitPerMinute  int    `envconfig:"AUTH_RATE_LIMIT_PER_MINUTE" default:"10"`
-	AuthRateLimitBurstAlert int    `envconfig:"AUTH_RATE_LIMIT_BURST_ALERT" default:"100"`
+	AuthMode                string        `envconfig:"AUTH_MODE" default:"none"` // none, api-key
+	AuthKeyHashSecret       string        `envconfig:"AUTH_KEY_HASH_SECRET" default:""`
+	AuthRequireTLS          bool          `envconfig:"AUTH_REQUIRE_TLS" default:"true"`
+	TLSCert                 string        `envconfig:"TLS_CERT" default:""`
+	TLSKey                  string        `envconfig:"TLS_KEY" default:""`
+	TrustedProxies          string        `envconfig:"TRUSTED_PROXIES" default:""`
+	AuthRateLimitPerMinute  int           `envconfig:"AUTH_RATE_LIMIT_PER_MINUTE" default:"10"`
+	AuthRateLimitBurstAlert int           `envconfig:"AUTH_RATE_LIMIT_BURST_ALERT" default:"100"`
+	AuthPublicBaseURL       string        `envconfig:"AUTH_PUBLIC_BASE_URL" default:""`
+	AuthSessionIdleTTL      time.Duration `envconfig:"AUTH_SESSION_IDLE_TTL" default:"8h"`
+	AuthSessionAbsoluteTTL  time.Duration `envconfig:"AUTH_SESSION_ABSOLUTE_TTL" default:"24h"`
+	AuthSessionCookieName   string        `envconfig:"AUTH_SESSION_COOKIE_NAME" default:"caesium_session"`
+	AuthRoleMapping         string        `envconfig:"AUTH_ROLE_MAPPING" default:""`
+	AuthDefaultRole         string        `envconfig:"AUTH_DEFAULT_ROLE" default:""`
+	AuthOIDCEnabled         bool          `envconfig:"AUTH_OIDC_ENABLED" default:"false"`
+	AuthSAMLEnabled         bool          `envconfig:"AUTH_SAML_ENABLED" default:"false"`
+	AuthLDAPEnabled         bool          `envconfig:"AUTH_LDAP_ENABLED" default:"false"`
 
 	// Run-owner coordination (Phase 2).
 	// CAESIUM_RUN_OWNER_ENABLED enables the run-owner coordination mode.
@@ -207,4 +216,9 @@ type Environment struct {
 	// fast failover.  Default false — when off, completions take the proven
 	// SQL-advancement path (B2), byte-identical.  Requires RUN_OWNER_ENABLED.
 	RunOwnerInMemory bool `envconfig:"RUN_OWNER_IN_MEMORY" default:"false"`
+}
+
+// SSOEnabled reports whether any SSO provider is configured.
+func (e Environment) SSOEnabled() bool {
+	return e.AuthOIDCEnabled || e.AuthSAMLEnabled || e.AuthLDAPEnabled
 }

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -24,6 +24,20 @@ func (s *EnvTestSuite) TestProcess() {
 	assert.Equal(s.T(), 3, Variables().DatabaseStandbys)
 	assert.Equal(s.T(), 15*time.Second, Variables().WorkerPollInterval)
 	assert.Equal(s.T(), "full", Variables().WakeupFanoutMode)
+	assert.Equal(s.T(), 8*time.Hour, Variables().AuthSessionIdleTTL)
+	assert.Equal(s.T(), 24*time.Hour, Variables().AuthSessionAbsoluteTTL)
+	assert.Equal(s.T(), "caesium_session", Variables().AuthSessionCookieName)
+	assert.False(s.T(), Variables().SSOEnabled())
+}
+
+func (s *EnvTestSuite) TestSSOEnabled() {
+	env := Environment{AuthOIDCEnabled: true}
+	assert.True(s.T(), env.SSOEnabled())
+	env = Environment{AuthSAMLEnabled: true}
+	assert.True(s.T(), env.SSOEnabled())
+	env = Environment{AuthLDAPEnabled: true}
+	assert.True(s.T(), env.SSOEnabled())
+	assert.False(s.T(), Environment{}.SSOEnabled())
 }
 
 func (s *EnvTestSuite) TestProcessInvalidTypeFailure() {

--- a/ui/src/features/auth/AuthGate.tsx
+++ b/ui/src/features/auth/AuthGate.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { isAuthenticated, onAuthChange } from "@/lib/auth";
+import { checkSession, isAuthenticated, onAuthChange } from "@/lib/auth";
 import { LoginPage } from "./LoginPage";
 
 interface AuthGateProps {
@@ -31,8 +31,13 @@ export function AuthGate({ children }: AuthGateProps) {
         }
 
         const body = (await resp.json()) as { enabled?: boolean };
+        const enabled = Boolean(body.enabled);
+        const hasSession = enabled && !isAuthenticated() ? await checkSession() : false;
         if (!cancelled) {
-          setAuthRequired(Boolean(body.enabled));
+          setAuthRequired(enabled);
+          if (hasSession) {
+            setAuthed(true);
+          }
         }
       } catch {
         // Network error — assume auth not required, let real errors surface later.

--- a/ui/src/features/auth/__tests__/AuthGate.test.tsx
+++ b/ui/src/features/auth/__tests__/AuthGate.test.tsx
@@ -13,10 +13,15 @@ describe("AuthGate", () => {
   });
 
   it("renders the login page when the auth status endpoint says auth is enabled", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ enabled: true }),
-    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      });
 
     render(
       <AuthGate>
@@ -27,7 +32,8 @@ describe("AuthGate", () => {
     await waitFor(() => {
       expect(screen.getByText("Enter your API key to continue")).toBeInTheDocument();
     });
-    expect(mockFetch).toHaveBeenCalledWith("/auth/status");
+    expect(mockFetch).toHaveBeenNthCalledWith(1, "/auth/status");
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "/auth/whoami", { credentials: "include" });
   });
 
   it("renders children when auth is not required", async () => {
@@ -48,10 +54,15 @@ describe("AuthGate", () => {
   });
 
   it("reacts to auth state changes after an enabled auth probe", async () => {
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({ enabled: true }),
-    });
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({}),
+      });
 
     render(
       <AuthGate>
@@ -70,5 +81,29 @@ describe("AuthGate", () => {
     await waitFor(() => {
       expect(screen.getByText("protected")).toBeInTheDocument();
     });
+  });
+
+  it("renders children when an existing cookie session is valid", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ kind: "user", email: "ops@example.com", csrf_token: "csrf-secret" }),
+      });
+
+    render(
+      <AuthGate>
+        <div>protected</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("protected")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Enter your API key to continue")).not.toBeInTheDocument();
+    expect(mockFetch).toHaveBeenNthCalledWith(2, "/auth/whoami", { credentials: "include" });
   });
 });

--- a/ui/src/lib/__tests__/auth.test.ts
+++ b/ui/src/lib/__tests__/auth.test.ts
@@ -1,10 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { clearApiKey, isAuthenticated, onAuthChange, setApiKey, withAuthHeaders } from "@/lib/auth";
+import {
+  checkSession,
+  clearApiKey,
+  isAuthenticated,
+  onAuthChange,
+  setApiKey,
+  withAuthHeaders,
+} from "@/lib/auth";
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
 
 describe("auth", () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     clearApiKey();
-    vi.restoreAllMocks();
   });
 
   it("stores and clears the api key in memory", () => {
@@ -33,5 +43,33 @@ describe("auth", () => {
     unsubscribe();
     setApiKey("csk_live_other");
     expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("checks cookie sessions with credentials and caches the csrf token", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ csrf_token: "csrf-secret" }),
+    });
+
+    await expect(checkSession()).resolves.toBe(true);
+
+    expect(mockFetch).toHaveBeenCalledWith("/auth/whoami", { credentials: "include" });
+    expect(isAuthenticated()).toBe(true);
+    expect(withAuthHeaders()).toMatchObject({
+      "X-CSRF-Token": "csrf-secret",
+    });
+    expect(withAuthHeaders()).not.toHaveProperty("Authorization");
+  });
+
+  it("does not mark failed cookie session checks as authenticated", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    });
+
+    await expect(checkSession()).resolves.toBe(false);
+
+    expect(isAuthenticated()).toBe(false);
+    expect(withAuthHeaders()).not.toHaveProperty("X-CSRF-Token");
   });
 });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -378,6 +378,7 @@ async function requestURL<T>(url: string, options?: RequestInit): Promise<T> {
   });
 
   const response = await fetch(url, {
+    credentials: "include",
     ...options,
     headers,
   });
@@ -479,7 +480,7 @@ export const api = {
    */
   getHealthStatus: async (): Promise<HealthResponse> => {
     const headers = withAuthHeaders({ "Content-Type": "application/json" });
-    const response = await fetch("/health", { headers });
+    const response = await fetch("/health", { credentials: "include", headers });
     if (response.status === 401) {
       clearApiKey();
       throw new ApiError(401, "Authentication required");

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -9,7 +9,13 @@
 type AuthChangeListener = () => void;
 
 let apiKey: string | null = null;
+let cookieSession = false;
+let csrfToken: string | null = null;
 const listeners: Set<AuthChangeListener> = new Set();
+
+function notifyAuthChange(): void {
+  listeners.forEach((fn) => fn());
+}
 
 function cloneHeaders(headers?: HeadersInit): Record<string, string> {
   if (!headers) {
@@ -27,18 +33,58 @@ function cloneHeaders(headers?: HeadersInit): Record<string, string> {
 /** Store the API key in memory (never persisted to disk). */
 export function setApiKey(key: string): void {
   apiKey = key;
-  listeners.forEach((fn) => fn());
+  notifyAuthChange();
 }
 
 /** Clear the API key (logout). */
 export function clearApiKey(): void {
   apiKey = null;
-  listeners.forEach((fn) => fn());
+  cookieSession = false;
+  csrfToken = null;
+  notifyAuthChange();
 }
 
 /** Returns true if an API key is currently set. */
 export function isAuthenticated(): boolean {
-  return apiKey !== null;
+  return apiKey !== null || cookieSession;
+}
+
+/** Return the cached CSRF header for cookie-session requests. */
+export function csrfHeader(): Record<string, string> {
+  return csrfToken ? { "X-CSRF-Token": csrfToken } : {};
+}
+
+/**
+ * Checks whether the browser has a valid cookie session and caches the
+ * session-bound CSRF token returned by the server.
+ */
+export async function checkSession(): Promise<boolean> {
+  try {
+    const response = await fetch("/auth/whoami", { credentials: "include" });
+    if (!response.ok) {
+      if (cookieSession || csrfToken) {
+        cookieSession = false;
+        csrfToken = null;
+        notifyAuthChange();
+      }
+      return false;
+    }
+
+    const body = (await response.json()) as { csrf_token?: string };
+    csrfToken = body.csrf_token ?? null;
+    if (!cookieSession) {
+      cookieSession = true;
+      notifyAuthChange();
+    }
+    return true;
+  } catch {
+    if (cookieSession || csrfToken) {
+      cookieSession = false;
+      csrfToken = null;
+      notifyAuthChange();
+    }
+    return false;
+  }
 }
 
 /**
@@ -49,6 +95,8 @@ export function withAuthHeaders(headers?: HeadersInit): Record<string, string> {
   const nextHeaders = cloneHeaders(headers);
   if (apiKey) {
     nextHeaders.Authorization = `Bearer ${apiKey}`;
+  } else {
+    Object.assign(nextHeaders, csrfHeader());
   }
   return nextHeaders;
 }


### PR DESCRIPTION
## Summary
- add the shared `Principal` abstraction and route API-key auth through it
- add dqlite-backed users/sessions, session token hashing, CSRF, role mapping, JIT provisioning, and shared SSO completion plumbing
- add session-cookie auth middleware, `/auth/whoami`, `/auth/logout`, method-aware `/auth/status`, startup wiring, and UI cookie-session support

## Impact
This lands the P0/P1 SSO foundation from `docs/superpowers/plans/2026-05-27-sso-foundation.md`. No OIDC/SAML/LDAP provider login is implemented yet; follow-on provider plans can now produce an `ExternalIdentity` and use the shared completion path. API-key behavior is preserved while session cookies can authenticate protected routes.

## Validation
- `go test -count=1 ./internal/auth/ ./internal/models/ ./pkg/env/ -v`
- `go test -count=1 ./api/middleware ./api/rest/controller/auth -v`
- `cd ui && npx vitest run`
- `just unit-test`
- `just lint`
- builder-image SSO boot smoke with `CAESIUM_AUTH_OIDC_ENABLED=true` and `CAESIUM_AUTH_ROLE_MAPPING=*=viewer`; `/auth/status` returned `api-key` and `oidc` methods

## Notes
Local host-only `go test ./api` and `go test ./api/rest/bind` are blocked outside the builder image by missing `dqlite.h`; the same packages pass under `just unit-test`.
