### PR TITLE
[codex] Harden SSO provider fixtures

### DIFF
--- a/docs/sso-authentication.md
+++ b/docs/sso-authentication.md
@@ -119,6 +119,19 @@ Set `CAESIUM_TEST_LDAP_EXPECTED_GROUPS`, `CAESIUM_TEST_LDAP_ROLE_MAPPING`, and
 `CAESIUM_TEST_LDAP_EXPECTED_ROLE` to make the test assert group extraction and
 role resolution against the seeded directory.
 
+The same package also includes a self-contained OpenLDAP fixture. It starts an
+`osixia/openldap:1.5.0` container seeded from
+`internal/auth/ldap/testdata/openldap/bootstrap.ldif`, skips cleanly when Docker
+is unavailable, and can be run with Docker socket access:
+
+```sh
+docker run --rm --platform linux/arm64 \
+  -v "$PWD":/bld/caesium \
+  -v "$HOME/.docker/run/docker.sock":/var/run/docker.sock \
+  -w /bld/caesium caesiumcloud/caesium-builder:latest-full \
+  sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test ./internal/auth/ldap -tags=integration -run TestProviderAuthenticateOpenLDAPFixture -v'
+```
+
 ## Security Checks
 
 All redirect `returnTo` and SAML RelayState values are constrained to same-origin
@@ -134,8 +147,9 @@ need a CSRF header because they are not ambient browser credentials.
 
 SSO login and logout lifecycle events are written to the audit log with actions
 `auth.login`, `auth.login_denied`, `auth.logout`, and
-`auth.session_revoked`. Audit metadata includes the provider and denial reason
-where applicable.
+`auth.session_revoked`. New SSO users also emit `user.provisioned` once when the
+shared login tail creates the local user record. Audit metadata includes the
+provider and denial reason where applicable.
 
 Prometheus exposes SSO counters and timing:
 

--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -26,10 +26,10 @@
 - **Progress:** Foundation P0/P1 merged in PR #192. OIDC continued on
   `sso-oidc-provider` (PR #193). SAML continued on `sso-saml-provider`
   (PR #194). LDAP continued on `codex/ldap-sso-provider` (PR #195). The current
-  `codex/sso-hardening-wave` branch starts P5 with LDAP real-directory assertion
-  hooks, cookie/CSRF/open-redirect regression coverage, and SSO login/logout
-  audit + metrics hooks. Self-contained OpenLDAP fixtures, static signed SAML
-  fixtures, and the remaining full hardening pass are still outstanding.
+  `codex/sso-fixtures-wave` branch continues P5 after `codex/sso-hardening-wave`
+  (PR #196) with signed SAML response fixtures, a self-contained
+  containerized OpenLDAP fixture, and `user.provisioned` audit events. The
+  remaining full hardening pass is still outstanding.
 
 ## File structure
 
@@ -1570,11 +1570,14 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   `AUTH_SAML_*` config, HTTPS-only IdP metadata loading, SP metadata, login/ACS
   route wiring, RelayState return targets, dqlite-backed assertion replay
   storage, group-attribute mapping into the shared SSO tail, and UI rendering
-  for advertised redirect methods. Static signed-assertion fixture coverage
-  remains for the P5 hardening pass.
+  for advertised redirect methods.
+- [x] **Wave 6 status:** Added self-contained signed SAMLResponse fixture
+  coverage through `Provider.CompleteWithReturnTo`, including accepted signed
+  assertions, tampered response rejection, replay rejection, and expired
+  assertion rejection.
 - **Files:** `internal/auth/saml/provider.go`, `AUTH_SAML_*` config, ACS + metadata routes.
 - **Key work:** SP metadata; IdP metadata fetched **HTTPS-only with TLS certificate verification**; XML-dsig verification; `Audience`/`Recipient`/`NotOnOrAfter` with clock-skew leeway; **dqlite-backed** assertion replay cache (`saml_assertion_ids`, not per-node in-memory); RelayState = validated `returnTo`; groups from attribute → shared tail.
-- **Tests:** static signed-assertion fixtures incl. tampered/expired/replayed; SP metadata round-trip.
+- **Tests:** signed assertion fixtures incl. tampered/expired/replayed; SP metadata round-trip.
 
 ### P4 — LDAP provider (`go-ldap/ldap/v3`)
 - [x] **Wave 4 status:** Implemented the LDAP `CredentialAuthenticator`,
@@ -1587,14 +1590,17 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   seeded real directory can assert profile fields, groups, and role resolution;
   added hermetic coverage for full-DN role mapping from LDAP group search
   results.
-- [ ] **Hardening still required:** self-contained containerized OpenLDAP
-  fixtures, the broader dedicated P5 security pass, and non-LDAP provider
-  fixture coverage remain outstanding.
+- [x] **Wave 6 status:** Added a self-contained OpenLDAP integration fixture
+  seeded from checked-in LDIF. It starts `osixia/openldap:1.5.0`, authenticates
+  through the real LDAP provider, and asserts profile fields, full-DN groups,
+  and role mapping; it skips cleanly when Docker is unavailable.
+- [ ] **Hardening still required:** the broader dedicated P5 security pass and
+  deeper provider-specific negative fixtures remain outstanding.
 - **Files:** `internal/auth/ldap/provider.go` (implements `CredentialAuthenticator`), `AUTH_LDAP_*` config, `POST /auth/sso/ldap/login` handler (rate-limited), UI username/password form.
 - **Key work:** LDAPS/StartTLS; service bind → user search (`USER_FILTER`) → rebind to verify; group query (`GROUP_FILTER`); **escape all user-supplied input with `ldap.EscapeFilter` before substitution** (LDAP-injection guard); reject empty-password/anonymous bind.
 - **Tests:** real-directory LDAP integration assertions (skipped unless
   `CAESIUM_TEST_LDAP_*` is set) plus hermetic group/role edge-case coverage;
-  self-contained OpenLDAP fixtures remain outstanding.
+  self-contained OpenLDAP fixture coverage.
 
 ### P5 — Docs + hardening
 - [x] **Docs draft status:** Created `docs/sso-authentication.md` for LDAP
@@ -1606,9 +1612,12 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   session cookies, `/auth/whoami` session CSRF surfacing, SSO audit actions
   (`auth.login`, `auth.login_denied`, `auth.logout`, `auth.session_revoked`),
   and Prometheus SSO login/logout metrics.
-- [ ] **Hardening status:** Not complete in this wave. Static signed SAML
-  fixtures, deeper provider-specific negative fixtures, and any follow-up
-  audit events such as `user.provisioned` still need the remaining P5 pass.
+- [x] **Wave 6 status:** Added signed SAML fixture coverage, a
+  self-contained OpenLDAP fixture, and the `user.provisioned` audit event for
+  first-time SSO user creation.
+- [ ] **Hardening status:** Not complete in this wave. Deeper
+  provider-specific negative fixtures and the remaining full P5 pass are still
+  outstanding.
 - **Files:** `docs/sso-authentication.md` (operator setup for all three + role mapping + session tuning + TLS), README/roadmap updates.
 - **Key work:** end-to-end security pass; verify cookie flags/CSRF/open-redirect guards across providers; finalize metrics + audit actions (`auth.login`, `auth.logout`, `auth.session_revoked`, `user.provisioned`, `auth.login_denied`).
 

--- a/internal/auth/audit.go
+++ b/internal/auth/audit.go
@@ -26,6 +26,7 @@ const (
 	ActionAuthLogout         = "auth.logout"
 	ActionAuthLoginDenied    = "auth.login_denied"
 	ActionAuthSessionRevoked = "auth.session_revoked"
+	ActionUserProvisioned    = "user.provisioned"
 	ActionKeyCreate          = "api_key.create"
 	ActionKeyRevoke          = "api_key.revoke"
 	ActionKeyRotate          = "api_key.rotate"

--- a/internal/auth/ldap/openldap_integration_test.go
+++ b/internal/auth/ldap/openldap_integration_test.go
@@ -1,0 +1,345 @@
+//go:build integration
+
+package ldap
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	authpkg "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/models"
+	cerrdefs "github.com/containerd/errdefs"
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	openLDAPImage      = "osixia/openldap:1.5.0"
+	openLDAPLDIFPath   = "testdata/openldap/bootstrap.ldif"
+	openLDAPAdminDN    = "cn=admin,dc=example,dc=org"
+	openLDAPAdminPass  = "admin-secret"
+	openLDAPUserDN     = "uid=alice,ou=people,dc=example,dc=org"
+	openLDAPUser       = "alice"
+	openLDAPUserPass   = "alice-secret"
+	openLDAPGroupBase  = "ou=groups,dc=example,dc=org"
+	openLDAPPeopleBase = "ou=people,dc=example,dc=org"
+)
+
+var openLDAPLDAPS = nat.Port("636/tcp")
+
+func TestProviderAuthenticateOpenLDAPFixture(t *testing.T) {
+	cli := dockerClientOrSkip(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	ensureOpenLDAPImage(t, ctx, cli)
+	containerID := createOpenLDAPContainer(t, ctx, cli)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cleanupCancel()
+		_ = cli.ContainerRemove(cleanupCtx, containerID, dockercontainer.RemoveOptions{
+			Force:         true,
+			RemoveVolumes: true,
+		})
+	})
+
+	require.NoError(t, cli.ContainerStart(ctx, containerID, dockercontainer.StartOptions{}))
+	endpoints := openLDAPEndpoints(t, ctx, cli, containerID)
+	identity := waitForOpenLDAPIdentity(t, ctx, cli, containerID, endpoints)
+
+	require.Equal(t, ProviderName, identity.Issuer)
+	require.Equal(t, openLDAPUserDN, identity.Subject)
+	require.Equal(t, "alice@example.org", identity.Email)
+	require.Equal(t, "Alice Fixture", identity.DisplayName)
+
+	viewersGroupDN := "cn=caesium-viewers," + openLDAPGroupBase
+	operatorsGroupDN := "cn=caesium-operators," + openLDAPGroupBase
+	require.ElementsMatch(t, []string{viewersGroupDN, operatorsGroupDN}, identity.Groups)
+
+	mapper, err := authpkg.NewRoleMapper(
+		viewersGroupDN+"=viewer;"+operatorsGroupDN+"=operator",
+		"",
+	)
+	require.NoError(t, err)
+	role, ok := mapper.Resolve(identity.Groups)
+	require.True(t, ok)
+	require.Equal(t, models.RoleOperator, role)
+}
+
+func dockerClientOrSkip(t *testing.T) *client.Client {
+	t.Helper()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		t.Skipf("Docker unavailable for OpenLDAP fixture: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cli.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	if _, err := cli.Ping(ctx); err != nil {
+		t.Skipf("Docker unavailable for OpenLDAP fixture: %v", err)
+	}
+	return cli
+}
+
+func ensureOpenLDAPImage(t *testing.T, ctx context.Context, cli *client.Client) {
+	t.Helper()
+
+	if _, err := cli.ImageInspect(ctx, openLDAPImage); err == nil {
+		return
+	} else if !cerrdefs.IsNotFound(err) {
+		require.NoError(t, err)
+	}
+
+	pulled, err := cli.ImagePull(ctx, openLDAPImage, image.PullOptions{})
+	require.NoError(t, err, "pull %s", openLDAPImage)
+	defer func() {
+		_ = pulled.Close()
+	}()
+	_, err = io.Copy(io.Discard, pulled)
+	require.NoError(t, err, "read %s pull stream", openLDAPImage)
+}
+
+func createOpenLDAPContainer(t *testing.T, ctx context.Context, cli *client.Client) string {
+	t.Helper()
+
+	ldifArchive := openLDAPLDIFArchive(t)
+	created, err := cli.ContainerCreate(
+		ctx,
+		&dockercontainer.Config{
+			Image: openLDAPImage,
+			Env: []string{
+				"LDAP_ORGANISATION=Caesium",
+				"LDAP_DOMAIN=example.org",
+				"LDAP_ADMIN_PASSWORD=" + openLDAPAdminPass,
+				"LDAP_TLS=true",
+				"LDAP_TLS_VERIFY_CLIENT=never",
+			},
+			ExposedPorts: nat.PortSet{openLDAPLDAPS: struct{}{}},
+		},
+		&dockercontainer.HostConfig{
+			PortBindings: nat.PortMap{
+				openLDAPLDAPS: []nat.PortBinding{{HostIP: "127.0.0.1"}},
+			},
+		},
+		nil,
+		nil,
+		"",
+	)
+	require.NoError(t, err)
+
+	err = cli.CopyToContainer(
+		ctx,
+		created.ID,
+		"/",
+		ldifArchive,
+		dockercontainer.CopyToContainerOptions{},
+	)
+	require.NoError(t, err)
+	return created.ID
+}
+
+func openLDAPLDIFArchive(t *testing.T) io.Reader {
+	t.Helper()
+
+	ldif, err := os.ReadFile(openLDAPLDIFPath)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, dir := range []string{
+		"container",
+		"container/service",
+		"container/service/slapd",
+		"container/service/slapd/assets",
+		"container/service/slapd/assets/config",
+		"container/service/slapd/assets/config/bootstrap",
+		"container/service/slapd/assets/config/bootstrap/ldif",
+		"container/service/slapd/assets/config/bootstrap/ldif/custom",
+	} {
+		err = tw.WriteHeader(&tar.Header{
+			Name:     dir + "/",
+			Mode:     0o755,
+			Typeflag: tar.TypeDir,
+		})
+		require.NoError(t, err)
+	}
+
+	err = tw.WriteHeader(&tar.Header{
+		Name: "container/service/slapd/assets/config/bootstrap/ldif/custom/50-caesium-users.ldif",
+		Mode: 0o644,
+		Size: int64(len(ldif)),
+	})
+	require.NoError(t, err)
+	_, err = tw.Write(ldif)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	return bytes.NewReader(buf.Bytes())
+}
+
+func openLDAPEndpoints(t *testing.T, ctx context.Context, cli *client.Client, containerID string) []string {
+	t.Helper()
+
+	inspect, err := cli.ContainerInspect(ctx, containerID)
+	require.NoError(t, err)
+
+	var endpoints []string
+	for _, binding := range inspect.NetworkSettings.Ports[openLDAPLDAPS] {
+		if binding.HostPort == "" {
+			continue
+		}
+		host := binding.HostIP
+		if host == "" || host == "0.0.0.0" || host == "::" {
+			host = "127.0.0.1"
+		}
+		endpoints = append(endpoints, net.JoinHostPort(host, binding.HostPort))
+		endpoints = append(endpoints, net.JoinHostPort("localhost", binding.HostPort))
+		endpoints = append(endpoints, net.JoinHostPort("host.docker.internal", binding.HostPort))
+	}
+
+	for _, network := range inspect.NetworkSettings.Networks {
+		if network == nil || network.IPAddress == "" {
+			continue
+		}
+		endpoints = append(endpoints, net.JoinHostPort(network.IPAddress, "636"))
+	}
+
+	endpoints = compactStrings(endpoints)
+	require.NotEmpty(t, endpoints, "OpenLDAP container has no reachable LDAPS endpoints")
+	return endpoints
+}
+
+func waitForOpenLDAPIdentity(t *testing.T, ctx context.Context, cli *client.Client, containerID string, endpoints []string) *authpkg.ExternalIdentity {
+	t.Helper()
+
+	deadline := time.Now().Add(45 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		for _, endpoint := range endpoints {
+			if err := probeTCP(ctx, endpoint); err != nil {
+				lastErr = err
+				continue
+			}
+
+			cfg := openLDAPProviderConfig(endpoint)
+			provider, err := New(cfg)
+			require.NoError(t, err)
+			identity, err := provider.Authenticate(ctx, openLDAPUser, openLDAPUserPass)
+			if err == nil {
+				return identity
+			}
+			lastErr = err
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	logs := openLDAPLogs(t, ctx, cli, containerID)
+	require.NoErrorf(t, lastErr, "OpenLDAP fixture did not become ready; endpoints=%s\nlogs:\n%s", strings.Join(endpoints, ", "), logs)
+	return nil
+}
+
+func openLDAPProviderConfig(endpoint string) Config {
+	return Config{
+		URL:                  "ldaps://" + endpoint,
+		TLSConfig:            &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // fixture cert is generated per container for a dynamic endpoint.
+		Timeout:              time.Second,
+		BindDN:               openLDAPAdminDN,
+		BindPassword:         openLDAPAdminPass,
+		UserBaseDN:           openLDAPPeopleBase,
+		UserFilter:           "(uid={username})",
+		GroupBaseDN:          openLDAPGroupBase,
+		GroupFilter:          "(member={dn})",
+		GroupAttribute:       "dn",
+		UsernameAttribute:    DefaultUsernameAttribute,
+		EmailAttribute:       DefaultEmailAttribute,
+		DisplayNameAttribute: DefaultDisplayNameAttribute,
+	}
+}
+
+func probeTCP(ctx context.Context, endpoint string) error {
+	probeCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(probeCtx, "tcp", endpoint)
+	if err != nil {
+		return fmt.Errorf("dial %s: %w", endpoint, err)
+	}
+	return conn.Close()
+}
+
+func openLDAPLogs(t *testing.T, ctx context.Context, cli *client.Client, containerID string) string {
+	t.Helper()
+
+	logs, err := cli.ContainerLogs(ctx, containerID, dockercontainer.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Tail:       "120",
+	})
+	if err != nil {
+		return "failed to read logs: " + err.Error()
+	}
+	defer func() {
+		_ = logs.Close()
+	}()
+	out, err := io.ReadAll(logs)
+	if err != nil {
+		return "failed to read logs: " + err.Error()
+	}
+	return string(out)
+}
+
+func compactStrings(values []string) []string {
+	out := values[:0]
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func TestOpenLDAPLDIFArchiveIncludesFixture(t *testing.T) {
+	archive := openLDAPLDIFArchive(t)
+	tr := tar.NewReader(archive)
+
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		require.NoError(t, err)
+		if filepath.Base(hdr.Name) != "50-caesium-users.ldif" {
+			continue
+		}
+		body, err := io.ReadAll(tr)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "uid=alice,ou=people,dc=example,dc=org")
+		return
+	}
+	t.Fatal("fixture LDIF missing from archive")
+}

--- a/internal/auth/ldap/openldap_integration_test.go
+++ b/internal/auth/ldap/openldap_integration_test.go
@@ -23,6 +23,7 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/docker/go-connections/nat"
 	"github.com/stretchr/testify/require"
 )
@@ -231,7 +232,15 @@ func waitForOpenLDAPIdentity(t *testing.T, ctx context.Context, cli *client.Clie
 
 	deadline := time.Now().Add(45 * time.Second)
 	var lastErr error
+OuterLoop:
 	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			lastErr = ctx.Err()
+			break OuterLoop
+		default:
+		}
+
 		for _, endpoint := range endpoints {
 			if err := probeTCP(ctx, endpoint); err != nil {
 				lastErr = err
@@ -247,7 +256,13 @@ func waitForOpenLDAPIdentity(t *testing.T, ctx context.Context, cli *client.Clie
 			}
 			lastErr = err
 		}
-		time.Sleep(500 * time.Millisecond)
+
+		select {
+		case <-ctx.Done():
+			lastErr = ctx.Err()
+			break OuterLoop
+		case <-time.After(500 * time.Millisecond):
+		}
 	}
 
 	logs := openLDAPLogs(t, ctx, cli, containerID)
@@ -299,11 +314,11 @@ func openLDAPLogs(t *testing.T, ctx context.Context, cli *client.Client, contain
 	defer func() {
 		_ = logs.Close()
 	}()
-	out, err := io.ReadAll(logs)
-	if err != nil {
-		return "failed to read logs: " + err.Error()
+	var stdout, stderr bytes.Buffer
+	if _, err := stdcopy.StdCopy(&stdout, &stderr, logs); err != nil {
+		return "failed to demultiplex logs: " + err.Error()
 	}
-	return string(out)
+	return stdout.String() + stderr.String()
 }
 
 func compactStrings(values []string) []string {

--- a/internal/auth/ldap/testdata/openldap/bootstrap.ldif
+++ b/internal/auth/ldap/testdata/openldap/bootstrap.ldif
@@ -1,0 +1,26 @@
+dn: ou=people,dc=example,dc=org
+objectClass: organizationalUnit
+ou: people
+
+dn: ou=groups,dc=example,dc=org
+objectClass: organizationalUnit
+ou: groups
+
+dn: uid=alice,ou=people,dc=example,dc=org
+objectClass: inetOrgPerson
+cn: Alice Fixture
+sn: Fixture
+uid: alice
+displayName: Alice Fixture
+mail: alice@example.org
+userPassword: alice-secret
+
+dn: cn=caesium-viewers,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: caesium-viewers
+member: uid=alice,ou=people,dc=example,dc=org
+
+dn: cn=caesium-operators,ou=groups,dc=example,dc=org
+objectClass: groupOfNames
+cn: caesium-operators
+member: uid=alice,ou=people,dc=example,dc=org

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -80,10 +80,13 @@ func (s *SSOService) Complete(ctx context.Context, ext *ExternalIdentity, method
 		s.auditLoginDenied(ext, method, ip, "no_role_mapping")
 		return "", nil, ErrLoginDenied
 	}
-	user, err := s.users.Upsert(ctx, ext, role)
+	user, created, err := s.users.upsert(ctx, ext, role)
 	if err != nil {
 		s.auditLoginError(ext, method, ip, "user_upsert_failed")
 		return "", nil, err
+	}
+	if created {
+		s.auditUserProvisioned(ext, method, ip, user)
 	}
 	if user.IsDisabled() {
 		outcome = OutcomeDenied
@@ -115,6 +118,25 @@ func (s *SSOService) Complete(ctx context.Context, ext *ExternalIdentity, method
 		},
 	})
 	return cookie, sess, nil
+}
+
+func (s *SSOService) auditUserProvisioned(ext *ExternalIdentity, method, ip string, user *models.User) {
+	if user == nil {
+		return
+	}
+	s.audit(AuditEntry{
+		Actor:        auditActor(ext),
+		Action:       ActionUserProvisioned,
+		ResourceType: "user",
+		ResourceID:   user.ID.String(),
+		SourceIP:     ip,
+		Outcome:      OutcomeSuccess,
+		Metadata: map[string]interface{}{
+			"provider": method,
+			"issuer":   ext.Issuer,
+			"role":     string(user.Role),
+		},
+	})
 }
 
 func (s *SSOService) auditLoginDenied(ext *ExternalIdentity, method, ip, reason string) {

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -129,3 +129,57 @@ func TestSSOServiceCompleteAuditsAndRecordsMetrics(t *testing.T) {
 	require.Equal(t, "no_role_mapping", metadata["reason"])
 	require.Equal(t, "oidc", metadata["provider"])
 }
+
+func TestSSOServiceCompleteAuditsUserProvisionedOnce(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	auditor := NewAuditLogger(db)
+	mapper, err := NewRoleMapper("eng=operator", "")
+	require.NoError(t, err)
+	sso := NewSSOService(NewUserStore(db), NewSessionStore(db), mapper, WithSSOAuditLogger(auditor))
+
+	identity := &ExternalIdentity{
+		Issuer:      "oidc",
+		Subject:     "sub-provisioned",
+		Email:       "first@example.com",
+		DisplayName: "First Login",
+		Groups:      []string{"eng"},
+	}
+	_, _, err = sso.Complete(context.Background(), identity, "oidc", "203.0.113.20", "agent")
+	require.NoError(t, err)
+
+	provisionedEntries, err := auditor.Query(&AuditQueryRequest{Action: ActionUserProvisioned, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, provisionedEntries, 1)
+	require.Equal(t, "first@example.com", provisionedEntries[0].Actor)
+	require.Equal(t, OutcomeSuccess, provisionedEntries[0].Outcome)
+	require.Equal(t, "user", provisionedEntries[0].ResourceType)
+	require.NotEmpty(t, provisionedEntries[0].ResourceID)
+
+	loginEntries, err := auditor.Query(&AuditQueryRequest{Action: ActionAuthLogin, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, loginEntries, 1)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(provisionedEntries[0].Metadata, &metadata))
+	require.Equal(t, "oidc", metadata["provider"])
+	require.Equal(t, "oidc", metadata["issuer"])
+	require.Equal(t, string(models.RoleOperator), metadata["role"])
+
+	_, _, err = sso.Complete(context.Background(), &ExternalIdentity{
+		Issuer:      identity.Issuer,
+		Subject:     identity.Subject,
+		Email:       "second@example.com",
+		DisplayName: "Second Login",
+		Groups:      []string{"eng"},
+	}, "oidc", "203.0.113.21", "agent")
+	require.NoError(t, err)
+
+	provisionedEntries, err = auditor.Query(&AuditQueryRequest{Action: ActionUserProvisioned, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, provisionedEntries, 1)
+
+	loginEntries, err = auditor.Query(&AuditQueryRequest{Action: ActionAuthLogin, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, loginEntries, 2)
+}

--- a/internal/auth/saml/provider_fixture_test.go
+++ b/internal/auth/saml/provider_fixture_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -49,7 +50,7 @@ func TestCompleteWithReturnToRejectsTamperedSignedSAMLResponseFixture(t *testing
 	_, _, err := fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, tamperedResponse))
 	require.Error(t, err)
 	require.ErrorContains(t, err, "validate saml response")
-	require.Empty(t, fixture.replay.records)
+	require.Zero(t, fixture.replay.recordCount())
 }
 
 func TestCompleteWithReturnToRejectsReplayOfSignedSAMLResponseFixture(t *testing.T) {
@@ -74,7 +75,7 @@ func TestCompleteWithReturnToRejectsExpiredSignedAssertionFixture(t *testing.T) 
 	_, _, err := fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, fixture.samlResponse))
 	require.Error(t, err)
 	require.ErrorContains(t, err, "validate saml response")
-	require.Empty(t, fixture.replay.records)
+	require.Zero(t, fixture.replay.recordCount())
 }
 
 type signedSAMLFixture struct {
@@ -333,16 +334,26 @@ func (r *samlFixtureRandReader) Read(p []byte) (int, error) {
 }
 
 type memoryReplayCache struct {
+	mu      sync.Mutex
 	records map[string]time.Time
 }
 
 func (m *memoryReplayCache) Record(_ context.Context, issuer, assertionID string, expiresAt time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	key := fmt.Sprintf("%s\x00%s", issuer, assertionID)
 	if _, ok := m.records[key]; ok {
 		return ErrAssertionReplay
 	}
 	m.records[key] = expiresAt
 	return nil
+}
+
+func (m *memoryReplayCache) recordCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.records)
 }
 
 var _ AssertionReplayCache = (*memoryReplayCache)(nil)

--- a/internal/auth/saml/provider_fixture_test.go
+++ b/internal/auth/saml/provider_fixture_test.go
@@ -1,0 +1,348 @@
+package saml
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	crewsaml "github.com/crewjam/saml"
+	dsig "github.com/russellhaering/goxmldsig"
+	"github.com/stretchr/testify/require"
+)
+
+const samlFixturePublicBaseURL = "https://app.example.com"
+
+var samlFixtureNow = time.Date(2026, 5, 28, 21, 0, 0, 0, time.UTC)
+
+func TestCompleteWithReturnToAcceptsSignedSAMLResponseFixture(t *testing.T) {
+	fixture := newSignedSAMLFixture(t, nil)
+
+	identity, returnTo, err := fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, fixture.samlResponse))
+	require.NoError(t, err)
+
+	require.Equal(t, "/runs?status=failed#latest", returnTo)
+	require.Equal(t, "https://idp.example.com/metadata", identity.Issuer)
+	require.Equal(t, "fixture-subject", identity.Subject)
+	require.Equal(t, "user@example.com", identity.Email)
+	require.Equal(t, "Fixture User", identity.DisplayName)
+	require.Equal(t, []string{"eng", "admins"}, identity.Groups)
+}
+
+func TestCompleteWithReturnToRejectsTamperedSignedSAMLResponseFixture(t *testing.T) {
+	fixture := newSignedSAMLFixture(t, nil)
+	tamperedResponse := tamperSAMLResponse(t, fixture.samlResponse, "user@example.com", "attacker@example.com")
+
+	_, _, err := fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, tamperedResponse))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "validate saml response")
+	require.Empty(t, fixture.replay.records)
+}
+
+func TestCompleteWithReturnToRejectsReplayOfSignedSAMLResponseFixture(t *testing.T) {
+	fixture := newSignedSAMLFixture(t, nil)
+
+	_, _, err := fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, fixture.samlResponse))
+	require.NoError(t, err)
+
+	_, _, err = fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, fixture.samlResponse))
+	require.ErrorIs(t, err, ErrAssertionReplay)
+}
+
+func TestCompleteWithReturnToRejectsExpiredSignedAssertionFixture(t *testing.T) {
+	expiredAt := samlFixtureNow.Add(-crewsaml.MaxClockSkew - time.Minute)
+	fixture := newSignedSAMLFixture(t, func(assertion *crewsaml.Assertion) {
+		assertion.Conditions.NotOnOrAfter = expiredAt
+		for i := range assertion.Subject.SubjectConfirmations {
+			assertion.Subject.SubjectConfirmations[i].SubjectConfirmationData.NotOnOrAfter = expiredAt
+		}
+	})
+
+	_, _, err := fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, fixture.samlResponse))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "validate saml response")
+	require.Empty(t, fixture.replay.records)
+}
+
+type signedSAMLFixture struct {
+	provider     *Provider
+	replay       *memoryReplayCache
+	cookie       *http.Cookie
+	relayState   string
+	samlResponse string
+}
+
+func newSignedSAMLFixture(t *testing.T, mutateAssertion func(*crewsaml.Assertion)) signedSAMLFixture {
+	t.Helper()
+	setSAMLFixtureGlobals(t)
+
+	idp := newFixtureIDP(t)
+	replay := &memoryReplayCache{records: map[string]time.Time{}}
+	provider, err := New(t.Context(), Config{
+		IDPMetadataXML: metadataXML(t, idp.Metadata()),
+		PublicBaseURL:  samlFixturePublicBaseURL,
+		CookieSecret:   []byte(strings.Repeat("x", 32)),
+		ReplayCache:    replay,
+	})
+	require.NoError(t, err)
+	provider.now = func() time.Time { return samlFixtureNow }
+
+	rec := httptest.NewRecorder()
+	beginReq := httptest.NewRequest(http.MethodGet, samlFixturePublicBaseURL+"/auth/sso/saml/login", nil)
+	_, err = provider.Begin(rec, beginReq, "/runs?status=failed#latest")
+	require.NoError(t, err)
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+
+	stateReq := httptest.NewRequest(http.MethodGet, samlFixturePublicBaseURL+"/auth/sso/saml/acs", nil)
+	stateReq.AddCookie(cookies[0])
+	state, err := provider.readStateCookie(stateReq)
+	require.NoError(t, err)
+
+	return signedSAMLFixture{
+		provider:     provider,
+		replay:       replay,
+		cookie:       cookies[0],
+		relayState:   state.RelayState,
+		samlResponse: makeSignedSAMLResponse(t, provider, idp, state, mutateAssertion),
+	}
+}
+
+func (f signedSAMLFixture) acsRequest(t *testing.T, samlResponse string) *http.Request {
+	t.Helper()
+	form := url.Values{
+		"RelayState":   {f.relayState},
+		"SAMLResponse": {samlResponse},
+	}
+	req := httptest.NewRequest(
+		http.MethodPost,
+		samlFixturePublicBaseURL+"/auth/sso/saml/acs",
+		strings.NewReader(form.Encode()),
+	)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(f.cookie)
+	return req
+}
+
+func makeSignedSAMLResponse(
+	t *testing.T,
+	provider *Provider,
+	idp *crewsaml.IdentityProvider,
+	state loginState,
+	mutateAssertion func(*crewsaml.Assertion),
+) string {
+	t.Helper()
+
+	spMetadata := provider.serviceProvider.Metadata()
+	require.NotEmpty(t, spMetadata.SPSSODescriptors)
+	spDescriptor := &spMetadata.SPSSODescriptors[0]
+	require.NotEmpty(t, spDescriptor.AssertionConsumerServices)
+	acsEndpoint := &spDescriptor.AssertionConsumerServices[0]
+
+	assertion := fixtureAssertion(provider, idp, state)
+	if mutateAssertion != nil {
+		mutateAssertion(assertion)
+	}
+
+	req := &crewsaml.IdpAuthnRequest{
+		Now:                     samlFixtureNow,
+		IDP:                     idp,
+		RelayState:              state.RelayState,
+		HTTPRequest:             httptest.NewRequest(http.MethodPost, idp.SSOURL.String(), nil),
+		Request:                 fixtureAuthnRequest(provider, state.RequestID),
+		ServiceProviderMetadata: spMetadata,
+		SPSSODescriptor:         spDescriptor,
+		ACSEndpoint:             acsEndpoint,
+		Assertion:               assertion,
+	}
+	require.NoError(t, req.MakeResponse())
+	form, err := req.PostBinding()
+	require.NoError(t, err)
+	require.Equal(t, provider.serviceProvider.AcsURL.String(), form.URL)
+	require.Equal(t, state.RelayState, form.RelayState)
+	return form.SAMLResponse
+}
+
+func fixtureAuthnRequest(provider *Provider, requestID string) crewsaml.AuthnRequest {
+	return crewsaml.AuthnRequest{
+		ID:                          requestID,
+		Version:                     "2.0",
+		IssueInstant:                samlFixtureNow,
+		Destination:                 "https://idp.example.com/sso",
+		Issuer:                      &crewsaml.Issuer{Value: provider.serviceProvider.EntityID},
+		AssertionConsumerServiceURL: provider.serviceProvider.AcsURL.String(),
+		ProtocolBinding:             crewsaml.HTTPPostBinding,
+	}
+}
+
+func fixtureAssertion(provider *Provider, idp *crewsaml.IdentityProvider, state loginState) *crewsaml.Assertion {
+	validUntil := samlFixtureNow.Add(2 * time.Minute)
+	return &crewsaml.Assertion{
+		ID:           "fixture-assertion",
+		IssueInstant: samlFixtureNow,
+		Version:      "2.0",
+		Issuer: crewsaml.Issuer{
+			Format: "urn:oasis:names:tc:SAML:2.0:nameid-format:entity",
+			Value:  idp.MetadataURL.String(),
+		},
+		Subject: &crewsaml.Subject{
+			NameID: &crewsaml.NameID{
+				Format:          string(crewsaml.PersistentNameIDFormat),
+				NameQualifier:   idp.MetadataURL.String(),
+				SPNameQualifier: provider.serviceProvider.EntityID,
+				Value:           "fixture-subject",
+			},
+			SubjectConfirmations: []crewsaml.SubjectConfirmation{{
+				Method: "urn:oasis:names:tc:SAML:2.0:cm:bearer",
+				SubjectConfirmationData: &crewsaml.SubjectConfirmationData{
+					InResponseTo: state.RequestID,
+					NotOnOrAfter: validUntil,
+					Recipient:    provider.serviceProvider.AcsURL.String(),
+				},
+			}},
+		},
+		Conditions: &crewsaml.Conditions{
+			NotBefore:    samlFixtureNow.Add(-time.Minute),
+			NotOnOrAfter: validUntil,
+			AudienceRestrictions: []crewsaml.AudienceRestriction{{
+				Audience: crewsaml.Audience{Value: provider.serviceProvider.EntityID},
+			}},
+		},
+		AuthnStatements: []crewsaml.AuthnStatement{{
+			AuthnInstant: samlFixtureNow.Add(-time.Minute),
+			SessionIndex: "fixture-session",
+			AuthnContext: crewsaml.AuthnContext{
+				AuthnContextClassRef: &crewsaml.AuthnContextClassRef{
+					Value: "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport",
+				},
+			},
+		}},
+		AttributeStatements: []crewsaml.AttributeStatement{{
+			Attributes: []crewsaml.Attribute{
+				{Name: "email", Values: []crewsaml.AttributeValue{{Type: "xs:string", Value: "user@example.com"}}},
+				{FriendlyName: "displayName", Values: []crewsaml.AttributeValue{{Type: "xs:string", Value: "Fixture User"}}},
+				{Name: "groups", Values: []crewsaml.AttributeValue{
+					{Type: "xs:string", Value: "eng"},
+					{Type: "xs:string", Value: "admins"},
+				}},
+			},
+		}},
+	}
+}
+
+func newFixtureIDP(t *testing.T) *crewsaml.IdentityProvider {
+	t.Helper()
+	cert, signer := fixtureKeyPair(t)
+	metadataURL := mustParseFixtureURL("https://idp.example.com/metadata")
+	return &crewsaml.IdentityProvider{
+		Signer:          signer,
+		Certificate:     cert,
+		MetadataURL:     metadataURL,
+		SSOURL:          mustParseFixtureURL("https://idp.example.com/sso"),
+		SignatureMethod: dsig.RSASHA256SignatureMethod,
+	}
+}
+
+func fixtureKeyPair(t *testing.T) (*x509.Certificate, crypto.Signer) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   "fixture-idp.example.com",
+			Organization: []string{"Caesium Test"},
+		},
+		NotBefore:             samlFixtureNow.Add(-time.Hour),
+		NotAfter:              samlFixtureNow.Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, key
+}
+
+func metadataXML(t *testing.T, descriptor *crewsaml.EntityDescriptor) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, xml.NewEncoder(&buf).Encode(descriptor))
+	return buf.String()
+}
+
+func mustParseFixtureURL(raw string) url.URL {
+	u, err := url.Parse(raw)
+	if err != nil {
+		panic(err)
+	}
+	return *u
+}
+
+func tamperSAMLResponse(t *testing.T, encoded, oldValue, newValue string) string {
+	t.Helper()
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	require.Contains(t, string(decoded), oldValue)
+	return base64.StdEncoding.EncodeToString(bytes.Replace(decoded, []byte(oldValue), []byte(newValue), 1))
+}
+
+func setSAMLFixtureGlobals(t *testing.T) {
+	t.Helper()
+	oldTimeNow := crewsaml.TimeNow
+	oldClock := crewsaml.Clock
+	oldRandReader := crewsaml.RandReader
+	crewsaml.TimeNow = func() time.Time { return samlFixtureNow }
+	crewsaml.Clock = dsig.NewFakeClockAt(samlFixtureNow)
+	crewsaml.RandReader = &samlFixtureRandReader{}
+	t.Cleanup(func() {
+		crewsaml.TimeNow = oldTimeNow
+		crewsaml.Clock = oldClock
+		crewsaml.RandReader = oldRandReader
+	})
+}
+
+type samlFixtureRandReader struct {
+	next byte
+}
+
+func (r *samlFixtureRandReader) Read(p []byte) (int, error) {
+	for i := range p {
+		r.next++
+		p[i] = r.next
+	}
+	return len(p), nil
+}
+
+type memoryReplayCache struct {
+	records map[string]time.Time
+}
+
+func (m *memoryReplayCache) Record(_ context.Context, issuer, assertionID string, expiresAt time.Time) error {
+	key := fmt.Sprintf("%s\x00%s", issuer, assertionID)
+	if _, ok := m.records[key]; ok {
+		return ErrAssertionReplay
+	}
+	m.records[key] = expiresAt
+	return nil
+}
+
+var _ AssertionReplayCache = (*memoryReplayCache)(nil)

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -27,10 +27,15 @@ func NewUserStore(db *gorm.DB) *UserStore {
 // Upsert provisions a user on first login and refreshes profile, role, and
 // last-login fields on subsequent logins, keyed on (issuer, subject).
 func (us *UserStore) Upsert(ctx context.Context, ext *ExternalIdentity, role models.Role) (*models.User, error) {
+	user, _, err := us.upsert(ctx, ext, role)
+	return user, err
+}
+
+func (us *UserStore) upsert(ctx context.Context, ext *ExternalIdentity, role models.Role) (*models.User, bool, error) {
 	now := us.now().UTC()
 	groupsJSON, err := json.Marshal(ext.Groups)
 	if err != nil {
-		return nil, fmt.Errorf("marshal groups: %w", err)
+		return nil, false, fmt.Errorf("marshal groups: %w", err)
 	}
 
 	var user models.User
@@ -51,18 +56,20 @@ func (us *UserStore) Upsert(ctx context.Context, ext *ExternalIdentity, role mod
 		if err := us.db.WithContext(ctx).Create(&user).Error; err != nil {
 			if isUniqueConstraintError(err) {
 				if existing, lookupErr := us.lookupByIdentity(ctx, ext); lookupErr == nil {
-					return us.updateExisting(ctx, &existing, ext, role, groupsJSON, now)
+					updated, err := us.updateExisting(ctx, &existing, ext, role, groupsJSON, now)
+					return updated, false, err
 				}
 			}
-			return nil, fmt.Errorf("create user: %w", err)
+			return nil, false, fmt.Errorf("create user: %w", err)
 		}
 	case err != nil:
-		return nil, fmt.Errorf("lookup user: %w", err)
+		return nil, false, fmt.Errorf("lookup user: %w", err)
 	default:
-		return us.updateExisting(ctx, &user, ext, role, groupsJSON, now)
+		updated, err := us.updateExisting(ctx, &user, ext, role, groupsJSON, now)
+		return updated, false, err
 	}
 
-	return &user, nil
+	return &user, true, nil
 }
 
 func (us *UserStore) lookupByIdentity(ctx context.Context, ext *ExternalIdentity) (models.User, error) {


### PR DESCRIPTION
## Summary

- Add signed SAMLResponse fixture coverage through `Provider.CompleteWithReturnTo`, including valid, tampered, replayed, and expired assertion paths.
- Add a self-contained OpenLDAP integration fixture seeded from checked-in LDIF, with real LDAP provider authentication and role-mapping assertions.
- Emit `user.provisioned` audit entries once for first-time SSO user creation, while preserving existing login audit/metric behavior.
- Update SSO docs and the plan progress for this wave.

## Validation

- `docker run --rm --platform linux/arm64 -v /Users/cryan/dev/caesium:/bld/caesium -w /bld/caesium caesiumcloud/caesium-builder:latest-full sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test ./internal/auth ./internal/auth/saml ./internal/auth/ldap -v'`
- `docker run --rm --platform linux/arm64 -v /Users/cryan/dev/caesium:/bld/caesium -v /Users/cryan/.docker/run/docker.sock:/var/run/docker.sock -w /bld/caesium caesiumcloud/caesium-builder:latest-full sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test -tags=integration ./internal/auth/ldap -run "TestProviderAuthenticateOpenLDAPFixture|TestOpenLDAPLDIFArchiveIncludesFixture" -count=1 -v'`
- `just unit-test`
- `just lint`
- `git diff --check`
