### PR TITLE
[codex] Add SSO provider negative fixtures

### DIFF
--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -26,10 +26,12 @@
 - **Progress:** Foundation P0/P1 merged in PR #192. OIDC continued on
   `sso-oidc-provider` (PR #193). SAML continued on `sso-saml-provider`
   (PR #194). LDAP continued on `codex/ldap-sso-provider` (PR #195). The current
-  `codex/sso-fixtures-wave` branch continues P5 after `codex/sso-hardening-wave`
-  (PR #196) with signed SAML response fixtures, a self-contained
-  containerized OpenLDAP fixture, and `user.provisioned` audit events. The
-  remaining full hardening pass is still outstanding.
+  `codex/sso-fixtures-wave` branch continued P5 after
+  `codex/sso-hardening-wave` (PR #196) with signed SAML response fixtures, a
+  self-contained containerized OpenLDAP fixture, and `user.provisioned` audit
+  events. The current `codex/sso-negative-fixtures-wave` branch adds deeper
+  provider-specific negative fixtures for OIDC, SAML, and LDAP. The remaining
+  full hardening pass is still outstanding.
 
 ## File structure
 
@@ -1561,9 +1563,12 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
 - [x] **Wave 2 status (PR #193):** Implemented the OIDC redirect provider, `AUTH_OIDC_*`
   config, login/callback route wiring, session-cookie completion, UI "Sign in with OIDC"
   affordance, and focused mock-provider tests.
+- [x] **Wave 7 status:** Added OIDC ID-token audience mismatch coverage,
+  asserting callbacks fail with `ErrInvalidIDToken`.
 - **Files:** `internal/auth/oidc/provider.go` (implements `RedirectAuthenticator`), provider config in `pkg/env/env.go` (`AUTH_OIDC_*`), login/callback handlers in `api/rest/controller/auth/sso.go`, route mounts in `api.Start`, UI "Sign in with OIDC" button.
 - **Key work:** discovery; Authorization Code + PKCE; `state`/`nonce` in a short-lived signed pre-login cookie; ID-token signature + `iss`/`aud`/`exp`/`nonce` verification; groups from `AUTH_OIDC_GROUPS_CLAIM` → `ExternalIdentity` → `SSOService.Complete` (mints session + per-session CSRF token) → set session cookie → redirect to validated `returnTo`.
-- **Tests:** against a mock OIDC provider (in-process JWKS); negative cases (bad state, bad nonce, expired token).
+- **Tests:** against a mock OIDC provider (in-process JWKS); negative cases
+  (bad state, bad nonce, expired token, audience mismatch).
 
 ### P3 — SAML provider (`crewjam/saml`)  *(highest risk)*
 - [x] **Wave 3 status (PR #194):** Implemented the SAML redirect provider foundation:
@@ -1575,9 +1580,13 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   coverage through `Provider.CompleteWithReturnTo`, including accepted signed
   assertions, tampered response rejection, replay rejection, and expired
   assertion rejection.
+- [x] **Wave 7 status:** Added signed SAMLResponse negative fixture coverage
+  for wrong audience restrictions, asserting the response is rejected before
+  replay state is recorded.
 - **Files:** `internal/auth/saml/provider.go`, `AUTH_SAML_*` config, ACS + metadata routes.
 - **Key work:** SP metadata; IdP metadata fetched **HTTPS-only with TLS certificate verification**; XML-dsig verification; `Audience`/`Recipient`/`NotOnOrAfter` with clock-skew leeway; **dqlite-backed** assertion replay cache (`saml_assertion_ids`, not per-node in-memory); RelayState = validated `returnTo`; groups from attribute → shared tail.
-- **Tests:** signed assertion fixtures incl. tampered/expired/replayed; SP metadata round-trip.
+- **Tests:** signed assertion fixtures incl. tampered/expired/replayed/wrong
+  audience; SP metadata round-trip.
 
 ### P4 — LDAP provider (`go-ldap/ldap/v3`)
 - [x] **Wave 4 status:** Implemented the LDAP `CredentialAuthenticator`,
@@ -1594,8 +1603,10 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   seeded from checked-in LDIF. It starts `osixia/openldap:1.5.0`, authenticates
   through the real LDAP provider, and asserts profile fields, full-DN groups,
   and role mapping; it skips cleanly when Docker is unavailable.
+- [x] **Wave 7 status:** Added fail-closed LDAP negative coverage for group
+  search failures after successful user credential verification.
 - [ ] **Hardening still required:** the broader dedicated P5 security pass and
-  deeper provider-specific negative fixtures remain outstanding.
+  remaining provider edge-case expansion are still outstanding.
 - **Files:** `internal/auth/ldap/provider.go` (implements `CredentialAuthenticator`), `AUTH_LDAP_*` config, `POST /auth/sso/ldap/login` handler (rate-limited), UI username/password form.
 - **Key work:** LDAPS/StartTLS; service bind → user search (`USER_FILTER`) → rebind to verify; group query (`GROUP_FILTER`); **escape all user-supplied input with `ldap.EscapeFilter` before substitution** (LDAP-injection guard); reject empty-password/anonymous bind.
 - **Tests:** real-directory LDAP integration assertions (skipped unless
@@ -1615,9 +1626,11 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
 - [x] **Wave 6 status:** Added signed SAML fixture coverage, a
   self-contained OpenLDAP fixture, and the `user.provisioned` audit event for
   first-time SSO user creation.
-- [ ] **Hardening status:** Not complete in this wave. Deeper
-  provider-specific negative fixtures and the remaining full P5 pass are still
-  outstanding.
+- [x] **Wave 7 status:** Added provider-specific negative fixtures for OIDC
+  audience mismatch, SAML wrong audience restrictions, and LDAP group-search
+  fail-closed behavior.
+- [ ] **Hardening status:** Not complete in this wave. The remaining full P5
+  pass and any additional provider edge-case expansion are still outstanding.
 - **Files:** `docs/sso-authentication.md` (operator setup for all three + role mapping + session tuning + TLS), README/roadmap updates.
 - **Key work:** end-to-end security pass; verify cookie flags/CSRF/open-redirect guards across providers; finalize metrics + audit actions (`auth.login`, `auth.logout`, `auth.session_revoked`, `user.provisioned`, `auth.login_denied`).
 

--- a/internal/auth/ldap/provider_test.go
+++ b/internal/auth/ldap/provider_test.go
@@ -111,7 +111,7 @@ func TestAuthenticateGroupDNsCanResolveRoleMappings(t *testing.T) {
 	cfg.GroupBaseDN = "ou=Groups,dc=example,dc=com"
 	cfg.GroupFilter = "(memberUid={username})"
 	cfg.GroupAttribute = "dn"
-	cfg.Dial = func(context.Context, Config) (Conn, error) { return fake, nil }
+	cfg.Dial = func(_ context.Context, _ Config) (Conn, error) { return fake, nil }
 	provider, err := New(cfg)
 	require.NoError(t, err)
 
@@ -142,7 +142,7 @@ func TestAuthenticateFailsClosedWhenGroupSearchFails(t *testing.T) {
 	cfg := baseConfig()
 	cfg.GroupBaseDN = "ou=Groups,dc=example,dc=com"
 	cfg.GroupFilter = "(member={dn})"
-	cfg.Dial = func(context.Context, Config) (Conn, error) { return fake, nil }
+	cfg.Dial = func(_ context.Context, _ Config) (Conn, error) { return fake, nil }
 	provider, err := New(cfg)
 	require.NoError(t, err)
 
@@ -153,6 +153,7 @@ func TestAuthenticateFailsClosedWhenGroupSearchFails(t *testing.T) {
 	require.Len(t, fake.searches, 2)
 	require.Equal(t, "ou=Groups,dc=example,dc=com", fake.searches[1].BaseDN)
 	require.Equal(t, `(member=uid=alice,ou=People,dc=example,dc=com)`, fake.searches[1].Filter)
+	require.Equal(t, []string{"cn"}, fake.searches[1].Attributes)
 	require.Equal(t, []bindCall{
 		{dn: cfg.BindDN, password: cfg.BindPassword},
 		{dn: "uid=alice,ou=People,dc=example,dc=com", password: "user-secret"},

--- a/internal/auth/ldap/provider_test.go
+++ b/internal/auth/ldap/provider_test.go
@@ -128,6 +128,39 @@ func TestAuthenticateGroupDNsCanResolveRoleMappings(t *testing.T) {
 	require.Equal(t, []string{"dn"}, fake.searches[1].Attributes)
 }
 
+func TestAuthenticateFailsClosedWhenGroupSearchFails(t *testing.T) {
+	groupSearchErr := errors.New("directory unavailable")
+	fake := &fakeConn{
+		userResult: &gldap.SearchResult{Entries: []*gldap.Entry{
+			gldap.NewEntry("uid=alice,ou=People,dc=example,dc=com", map[string][]string{
+				"uid":  {"alice"},
+				"mail": {"alice@example.com"},
+			}),
+		}},
+		groupSearchErr: groupSearchErr,
+	}
+	cfg := baseConfig()
+	cfg.GroupBaseDN = "ou=Groups,dc=example,dc=com"
+	cfg.GroupFilter = "(member={dn})"
+	cfg.Dial = func(context.Context, Config) (Conn, error) { return fake, nil }
+	provider, err := New(cfg)
+	require.NoError(t, err)
+
+	identity, err := provider.Authenticate(context.Background(), "alice", "user-secret")
+	require.Nil(t, identity)
+	require.ErrorContains(t, err, "search ldap groups")
+	require.ErrorIs(t, err, groupSearchErr)
+	require.Len(t, fake.searches, 2)
+	require.Equal(t, "ou=Groups,dc=example,dc=com", fake.searches[1].BaseDN)
+	require.Equal(t, `(member=uid=alice,ou=People,dc=example,dc=com)`, fake.searches[1].Filter)
+	require.Equal(t, []bindCall{
+		{dn: cfg.BindDN, password: cfg.BindPassword},
+		{dn: "uid=alice,ou=People,dc=example,dc=com", password: "user-secret"},
+		{dn: cfg.BindDN, password: cfg.BindPassword},
+	}, fake.binds)
+	require.True(t, fake.closed)
+}
+
 func TestAuthenticateRejectsEmptyPasswordBeforeDial(t *testing.T) {
 	cfg := baseConfig()
 	cfg.Dial = func(context.Context, Config) (Conn, error) {
@@ -179,13 +212,14 @@ type bindCall struct {
 }
 
 type fakeConn struct {
-	binds       []bindCall
-	searches    []*gldap.SearchRequest
-	timeout     time.Duration
-	closed      bool
-	userResult  *gldap.SearchResult
-	groupResult *gldap.SearchResult
-	userBindErr error
+	binds          []bindCall
+	searches       []*gldap.SearchRequest
+	timeout        time.Duration
+	closed         bool
+	userResult     *gldap.SearchResult
+	groupResult    *gldap.SearchResult
+	userBindErr    error
+	groupSearchErr error
 }
 
 func (f *fakeConn) Bind(username, password string) error {
@@ -204,6 +238,9 @@ func (f *fakeConn) Search(req *gldap.SearchRequest) (*gldap.SearchResult, error)
 			return f.userResult, nil
 		}
 	case "ou=Groups,dc=example,dc=com":
+		if f.groupSearchErr != nil {
+			return nil, f.groupSearchErr
+		}
 		if f.groupResult != nil {
 			return f.groupResult, nil
 		}

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -144,6 +144,25 @@ func TestCompleteRejectsExpiredIDToken(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidIDToken)
 }
 
+func TestCompleteRejectsAudienceMismatch(t *testing.T) {
+	issuer := newMockIssuer(t, "groups")
+	provider := newTestProvider(t, issuer, "groups")
+
+	stateCookie, state := beginForCallback(t, provider, "/")
+	issuer.nextNonce = state.Nonce
+	issuer.nextAudience = "different-client"
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"https://app.example.com/auth/sso/oidc/callback?code=good-code&state="+url.QueryEscape(state.State),
+		nil,
+	)
+	req.AddCookie(stateCookie)
+
+	_, _, err := provider.CompleteWithReturnTo(req)
+	require.ErrorIs(t, err, ErrInvalidIDToken)
+	require.NotNil(t, issuer.lastTokenForm)
+}
+
 func TestExtractGroupsClaim(t *testing.T) {
 	groups, err := extractGroups(json.RawMessage(`"one"`))
 	require.NoError(t, err)
@@ -203,6 +222,7 @@ type mockIssuer struct {
 	key           *rsa.PrivateKey
 	groupsClaim   string
 	nextNonce     string
+	nextAudience  string
 	nextExpiry    time.Time
 	lastTokenForm url.Values
 }
@@ -257,6 +277,10 @@ func (m *mockIssuer) token(w http.ResponseWriter, r *http.Request) {
 	if nonce == "" {
 		nonce = "nonce"
 	}
+	audience := m.nextAudience
+	if audience == "" {
+		audience = "caesium"
+	}
 	expiresAt := m.nextExpiry
 	if expiresAt.IsZero() {
 		expiresAt = time.Now().Add(time.Hour)
@@ -264,7 +288,7 @@ func (m *mockIssuer) token(w http.ResponseWriter, r *http.Request) {
 	idToken := m.signIDToken(map[string]any{
 		"iss":         m.URL(),
 		"sub":         "subject-123",
-		"aud":         "caesium",
+		"aud":         audience,
 		"exp":         expiresAt.Unix(),
 		"iat":         time.Now().Add(-time.Minute).Unix(),
 		"nonce":       nonce,

--- a/internal/auth/saml/provider_fixture_test.go
+++ b/internal/auth/saml/provider_fixture_test.go
@@ -78,6 +78,17 @@ func TestCompleteWithReturnToRejectsExpiredSignedAssertionFixture(t *testing.T) 
 	require.Zero(t, fixture.replay.recordCount())
 }
 
+func TestCompleteWithReturnToRejectsWrongAudienceSignedAssertionFixture(t *testing.T) {
+	fixture := newSignedSAMLFixture(t, func(assertion *crewsaml.Assertion) {
+		assertion.Conditions.AudienceRestrictions[0].Audience.Value = "https://other-sp.example.com/metadata"
+	})
+
+	_, _, err := fixture.provider.CompleteWithReturnTo(fixture.acsRequest(t, fixture.samlResponse))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "validate saml response")
+	require.Zero(t, fixture.replay.recordCount())
+}
+
 type signedSAMLFixture struct {
 	provider     *Provider
 	replay       *memoryReplayCache


### PR DESCRIPTION
## Summary
- add OIDC callback coverage for ID-token audience mismatch returning ErrInvalidIDToken
- add signed SAMLResponse fixture coverage for wrong audience restrictions before replay state is recorded
- add LDAP fail-closed coverage when group search fails after user credential verification
- update docs/superpowers/plans/2026-05-27-sso-foundation.md with Wave 7 progress and remaining hardening scope

## Validation
- docker run --rm --platform linux/arm64 -v /Users/cryan/dev/caesium:/bld/caesium -w /bld/caesium caesiumcloud/caesium-builder:latest-full sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test ./internal/auth/oidc ./internal/auth/saml ./internal/auth/ldap -count=1 -v'\n- just unit-test\n- just lint\n- git diff --check