### PR TITLE
[codex] Complete SSO P5 hardening coverage

### DIFF
--- a/api/rest/controller/auth/sso_test.go
+++ b/api/rest/controller/auth/sso_test.go
@@ -99,6 +99,49 @@ func TestOIDCLoginSanitizesExternalReturnTo(t *testing.T) {
 	require.Equal(t, "/", provider.beginReturnTo)
 }
 
+func TestRedirectLoginReturnToHonorsTrustedProxyOrigin(t *testing.T) {
+	_, trustedProxy, err := net.ParseCIDR("127.0.0.1/32")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		want       string
+	}{
+		{
+			name:       "trusted proxy allows forwarded https same origin",
+			remoteAddr: "127.0.0.1:1234",
+			want:       "/runs?status=mine#latest",
+		},
+		{
+			name:       "untrusted peer cannot upgrade origin with forwarded proto",
+			remoteAddr: "203.0.113.10:1234",
+			want:       "/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &fakeRedirectAuthenticator{
+				name:     "oidc",
+				beginURL: "https://idp.example/authorize",
+			}
+			ctrl := NewSSO(nil, nil, "caesium_session", trustedProxy)
+			ctrl.SetOIDCProvider(provider)
+			target := "/auth/sso/oidc/login?returnTo=https%3A%2F%2Fexample.com%2Fruns%3Fstatus%3Dmine%23latest"
+			c, _ := newAuthContext(t, http.MethodGet, target, "")
+			c.Request().RemoteAddr = tt.remoteAddr
+			c.Request().Header.Set("X-Forwarded-Proto", "https")
+
+			err := ctrl.OIDCLogin(c)
+			require.NoError(t, err)
+
+			require.True(t, provider.beginCalled)
+			require.Equal(t, tt.want, provider.beginReturnTo)
+		})
+	}
+}
+
 func TestSAMLLoginRedirectsThroughProvider(t *testing.T) {
 	provider := &fakeRedirectAuthenticator{
 		name:     "saml",
@@ -248,6 +291,62 @@ func TestRedirectCallbacksAllowSameOriginAbsoluteReturnTo(t *testing.T) {
 
 			require.Equal(t, http.StatusFound, rec.Code)
 			require.Equal(t, "/runs?status=mine#latest", rec.Header().Get("Location"))
+		})
+	}
+}
+
+func TestRedirectCallbacksSetSecureSessionCookieBehindTrustedHTTPSProxy(t *testing.T) {
+	_, trustedProxy, err := net.ParseCIDR("127.0.0.1/32")
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		provider string
+		method   string
+		target   string
+		call     func(*SSOController, *echo.Context) error
+	}{
+		{
+			name:     "oidc",
+			provider: "oidc",
+			method:   http.MethodGet,
+			target:   "/auth/sso/oidc/callback?code=abc&state=xyz",
+			call:     func(ctrl *SSOController, c *echo.Context) error { return ctrl.OIDCCallback(c) },
+		},
+		{
+			name:     "saml",
+			provider: "saml",
+			method:   http.MethodPost,
+			target:   "/auth/sso/saml/acs",
+			call:     func(ctrl *SSOController, c *echo.Context) error { return ctrl.SAMLACS(c) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessions, sso := newTestSSOService(t)
+			provider := &fakeRedirectAuthenticator{
+				name:     tt.provider,
+				returnTo: "/runs",
+				identity: testExternalIdentity(tt.provider),
+			}
+			ctrl := NewSSO(sessions, sso, "caesium_session", trustedProxy)
+			if tt.provider == "oidc" {
+				ctrl.SetOIDCProvider(provider)
+			} else {
+				ctrl.SetSAMLProvider(provider)
+			}
+			c, rec := newAuthContext(t, tt.method, tt.target, "")
+			c.Request().RemoteAddr = "127.0.0.1:1234"
+			c.Request().Header.Set("X-Forwarded-Proto", "https")
+
+			err := tt.call(ctrl, c)
+			require.NoError(t, err)
+
+			sessionCookie := requireResponseCookie(t, rec.Result().Cookies(), "caesium_session")
+			require.True(t, sessionCookie.HttpOnly)
+			require.True(t, sessionCookie.Secure)
+			require.Equal(t, http.SameSiteLaxMode, sessionCookie.SameSite)
 		})
 	}
 }

--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -29,9 +29,12 @@
   `codex/sso-fixtures-wave` branch continued P5 after
   `codex/sso-hardening-wave` (PR #196) with signed SAML response fixtures, a
   self-contained containerized OpenLDAP fixture, and `user.provisioned` audit
-  events. The current `codex/sso-negative-fixtures-wave` branch adds deeper
-  provider-specific negative fixtures for OIDC, SAML, and LDAP. The remaining
-  full hardening pass is still outstanding.
+  events. `codex/sso-negative-fixtures-wave` (PR #198) added deeper
+  provider-specific negative fixtures for OIDC, SAML, and LDAP. The current
+  `codex/sso-p5-hardening-wave` branch closes the remaining P5 provider and
+  security coverage with fail-closed state-cookie callbacks, LDAP malformed
+  search results, trusted-proxy same-origin redirects, and secure-cookie checks
+  for redirect callbacks.
 
 ## File structure
 
@@ -1565,10 +1568,14 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   affordance, and focused mock-provider tests.
 - [x] **Wave 7 status:** Added OIDC ID-token audience mismatch coverage,
   asserting callbacks fail with `ErrInvalidIDToken`.
+- [x] **Wave 8 status:** Added OIDC callback hardening for tampered and
+  expired pre-login state cookies plus early authorization-error/missing-code
+  returns, asserting no token exchange occurs on fail-closed paths.
 - **Files:** `internal/auth/oidc/provider.go` (implements `RedirectAuthenticator`), provider config in `pkg/env/env.go` (`AUTH_OIDC_*`), login/callback handlers in `api/rest/controller/auth/sso.go`, route mounts in `api.Start`, UI "Sign in with OIDC" button.
 - **Key work:** discovery; Authorization Code + PKCE; `state`/`nonce` in a short-lived signed pre-login cookie; ID-token signature + `iss`/`aud`/`exp`/`nonce` verification; groups from `AUTH_OIDC_GROUPS_CLAIM` → `ExternalIdentity` → `SSOService.Complete` (mints session + per-session CSRF token) → set session cookie → redirect to validated `returnTo`.
 - **Tests:** against a mock OIDC provider (in-process JWKS); negative cases
-  (bad state, bad nonce, expired token, audience mismatch).
+  (bad state, tampered/expired state cookie, early callback errors, bad nonce,
+  expired token, audience mismatch).
 
 ### P3 — SAML provider (`crewjam/saml`)  *(highest risk)*
 - [x] **Wave 3 status (PR #194):** Implemented the SAML redirect provider foundation:
@@ -1583,10 +1590,13 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
 - [x] **Wave 7 status:** Added signed SAMLResponse negative fixture coverage
   for wrong audience restrictions, asserting the response is rejected before
   replay state is recorded.
+- [x] **Wave 8 status:** Added SAML callback hardening for tampered and
+  expired pre-login state cookies, asserting invalid state is rejected before
+  SAMLResponse validation.
 - **Files:** `internal/auth/saml/provider.go`, `AUTH_SAML_*` config, ACS + metadata routes.
 - **Key work:** SP metadata; IdP metadata fetched **HTTPS-only with TLS certificate verification**; XML-dsig verification; `Audience`/`Recipient`/`NotOnOrAfter` with clock-skew leeway; **dqlite-backed** assertion replay cache (`saml_assertion_ids`, not per-node in-memory); RelayState = validated `returnTo`; groups from attribute → shared tail.
 - **Tests:** signed assertion fixtures incl. tampered/expired/replayed/wrong
-  audience; SP metadata round-trip.
+  audience; tampered/expired state cookies; SP metadata round-trip.
 
 ### P4 — LDAP provider (`go-ldap/ldap/v3`)
 - [x] **Wave 4 status:** Implemented the LDAP `CredentialAuthenticator`,
@@ -1605,8 +1615,8 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   and role mapping; it skips cleanly when Docker is unavailable.
 - [x] **Wave 7 status:** Added fail-closed LDAP negative coverage for group
   search failures after successful user credential verification.
-- [ ] **Hardening still required:** the broader dedicated P5 security pass and
-  remaining provider edge-case expansion are still outstanding.
+- [x] **Wave 8 status:** Added fail-closed LDAP edge coverage for nil user
+  search results and user entries with missing DNs before any user bind.
 - **Files:** `internal/auth/ldap/provider.go` (implements `CredentialAuthenticator`), `AUTH_LDAP_*` config, `POST /auth/sso/ldap/login` handler (rate-limited), UI username/password form.
 - **Key work:** LDAPS/StartTLS; service bind → user search (`USER_FILTER`) → rebind to verify; group query (`GROUP_FILTER`); **escape all user-supplied input with `ldap.EscapeFilter` before substitution** (LDAP-injection guard); reject empty-password/anonymous bind.
 - **Tests:** real-directory LDAP integration assertions (skipped unless
@@ -1629,8 +1639,11 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
 - [x] **Wave 7 status:** Added provider-specific negative fixtures for OIDC
   audience mismatch, SAML wrong audience restrictions, and LDAP group-search
   fail-closed behavior.
-- [ ] **Hardening status:** Not complete in this wave. The remaining full P5
-  pass and any additional provider edge-case expansion are still outstanding.
+- [x] **Wave 8 status:** Completed the remaining P5 hardening pass by covering
+  fail-closed OIDC/SAML pre-login state handling, malformed LDAP search results,
+  trusted-proxy same-origin return targets, and secure session-cookie flags for
+  redirect-provider callbacks. Prior P5 waves covered CSRF, audit, metrics, and
+  operator docs.
 - **Files:** `docs/sso-authentication.md` (operator setup for all three + role mapping + session tuning + TLS), README/roadmap updates.
 - **Key work:** end-to-end security pass; verify cookie flags/CSRF/open-redirect guards across providers; finalize metrics + audit actions (`auth.login`, `auth.logout`, `auth.session_revoked`, `user.provisioned`, `auth.login_denied`).
 

--- a/internal/auth/ldap/provider_test.go
+++ b/internal/auth/ldap/provider_test.go
@@ -175,6 +175,43 @@ func TestAuthenticateRejectsEmptyPasswordBeforeDial(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidCredentials)
 }
 
+func TestAuthenticateFailsClosedWhenUserSearchReturnsNilResult(t *testing.T) {
+	fake := &fakeConn{nilUserResult: true}
+	cfg := baseConfig()
+	cfg.Dial = func(_ context.Context, _ Config) (Conn, error) { return fake, nil }
+	provider, err := New(cfg)
+	require.NoError(t, err)
+
+	identity, err := provider.Authenticate(context.Background(), "alice", "secret")
+	require.Nil(t, identity)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.ErrorContains(t, err, "user search returned nil result")
+	require.Equal(t, []bindCall{{dn: cfg.BindDN, password: cfg.BindPassword}}, fake.binds)
+	require.Len(t, fake.searches, 1)
+	require.Equal(t, "ou=People,dc=example,dc=com", fake.searches[0].BaseDN)
+	require.True(t, fake.closed)
+}
+
+func TestAuthenticateFailsClosedWhenUserEntryMissingDN(t *testing.T) {
+	fake := &fakeConn{
+		userResult: &gldap.SearchResult{Entries: []*gldap.Entry{
+			{DN: "   "},
+		}},
+	}
+	cfg := baseConfig()
+	cfg.Dial = func(_ context.Context, _ Config) (Conn, error) { return fake, nil }
+	provider, err := New(cfg)
+	require.NoError(t, err)
+
+	identity, err := provider.Authenticate(context.Background(), "alice", "secret")
+	require.Nil(t, identity)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	require.ErrorContains(t, err, "user entry is missing DN")
+	require.Equal(t, []bindCall{{dn: cfg.BindDN, password: cfg.BindPassword}}, fake.binds)
+	require.Len(t, fake.searches, 1)
+	require.True(t, fake.closed)
+}
+
 func TestAuthenticateRejectsDuplicateUserSearchResults(t *testing.T) {
 	fake := &fakeConn{
 		userResult: &gldap.SearchResult{Entries: []*gldap.Entry{
@@ -218,6 +255,7 @@ type fakeConn struct {
 	timeout        time.Duration
 	closed         bool
 	userResult     *gldap.SearchResult
+	nilUserResult  bool
 	groupResult    *gldap.SearchResult
 	userBindErr    error
 	groupSearchErr error
@@ -235,6 +273,9 @@ func (f *fakeConn) Search(req *gldap.SearchRequest) (*gldap.SearchResult, error)
 	f.searches = append(f.searches, req)
 	switch req.BaseDN {
 	case baseConfig().UserBaseDN:
+		if f.nilUserResult {
+			return nil, nil
+		}
 		if f.userResult != nil {
 			return f.userResult, nil
 		}

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -307,6 +307,9 @@ func cloneCookieWithValue(cookie *http.Cookie, value string) *http.Cookie {
 }
 
 func tamperCookieValue(value string) string {
+	if len(value) == 0 {
+		return "tampered"
+	}
 	replacement := byte('A')
 	if value[len(value)-1] == replacement {
 		replacement = 'B'

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -109,6 +109,89 @@ func TestCompleteRejectsStateMismatch(t *testing.T) {
 	assert.Nil(t, issuer.lastTokenForm)
 }
 
+func TestCompleteRejectsInvalidStateCookieBeforeExchange(t *testing.T) {
+	tests := []struct {
+		name       string
+		prepare    func(*Provider, *http.Cookie, loginState) *http.Cookie
+		wantErr    error
+		wantErrMsg string
+	}{
+		{
+			name: "tampered cookie",
+			prepare: func(_ *Provider, cookie *http.Cookie, _ loginState) *http.Cookie {
+				return cloneCookieWithValue(cookie, tamperCookieValue(cookie.Value))
+			},
+			wantErr:    ErrInvalidState,
+			wantErrMsg: "signature mismatch",
+		},
+		{
+			name: "expired cookie",
+			prepare: func(provider *Provider, cookie *http.Cookie, state loginState) *http.Cookie {
+				provider.now = func() time.Time {
+					return time.Unix(state.ExpiresAt, 0).Add(time.Second)
+				}
+				return cookie
+			},
+			wantErr:    ErrInvalidState,
+			wantErrMsg: "expired state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := newMockIssuer(t, "groups")
+			provider := newTestProvider(t, issuer, "groups")
+
+			stateCookie, state := beginForCallback(t, provider, "/")
+			stateCookie = tt.prepare(provider, stateCookie, state)
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"https://app.example.com/auth/sso/oidc/callback?code=good-code&state="+url.QueryEscape(state.State),
+				nil,
+			)
+			req.AddCookie(stateCookie)
+
+			_, _, err := provider.CompleteWithReturnTo(req)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Contains(t, err.Error(), tt.wantErrMsg)
+			assert.Nil(t, issuer.lastTokenForm)
+		})
+	}
+}
+
+func TestCompleteRejectsEarlyCallbackErrorsBeforeStateCookie(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		wantErr error
+	}{
+		{
+			name:    "authorization error",
+			rawURL:  "https://app.example.com/auth/sso/oidc/callback?error=access_denied&error_description=user+canceled",
+			wantErr: ErrAuthorizationFailed,
+		},
+		{
+			name:    "missing code",
+			rawURL:  "https://app.example.com/auth/sso/oidc/callback?state=ignored",
+			wantErr: ErrMissingCode,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := newMockIssuer(t, "groups")
+			provider := newTestProvider(t, issuer, "groups")
+
+			req := httptest.NewRequest(http.MethodGet, tt.rawURL, nil)
+			req.AddCookie(&http.Cookie{Name: DefaultStateCookieName, Value: "not-a-valid-state-cookie"})
+
+			_, _, err := provider.CompleteWithReturnTo(req)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Nil(t, issuer.lastTokenForm)
+		})
+	}
+}
+
 func TestCompleteRejectsNonceMismatch(t *testing.T) {
 	issuer := newMockIssuer(t, "groups")
 	provider := newTestProvider(t, issuer, "groups")
@@ -215,6 +298,20 @@ func requireCookie(t *testing.T, res *http.Response, name string) *http.Cookie {
 	}
 	t.Fatalf("cookie %q not found", name)
 	return nil
+}
+
+func cloneCookieWithValue(cookie *http.Cookie, value string) *http.Cookie {
+	clone := *cookie
+	clone.Value = value
+	return &clone
+}
+
+func tamperCookieValue(value string) string {
+	replacement := byte('A')
+	if value[len(value)-1] == replacement {
+		replacement = 'B'
+	}
+	return value[:len(value)-1] + string(replacement)
 }
 
 type mockIssuer struct {

--- a/internal/auth/saml/provider_test.go
+++ b/internal/auth/saml/provider_test.go
@@ -104,7 +104,9 @@ func TestCompleteRejectsTamperedStateCookieBeforeParsingResponse(t *testing.T) {
 	_, err = provider.Begin(rec, req, "/")
 	require.NoError(t, err)
 
-	cookie := rec.Result().Cookies()[0]
+	cookies := rec.Result().Cookies()
+	require.NotEmpty(t, cookies)
+	cookie := cookies[0]
 	stateReq := httptest.NewRequest(http.MethodGet, "/auth/sso/saml/acs", nil)
 	stateReq.AddCookie(cookie)
 	state, err := provider.readStateCookie(stateReq)
@@ -118,6 +120,7 @@ func TestCompleteRejectsTamperedStateCookieBeforeParsingResponse(t *testing.T) {
 
 	_, _, err = provider.CompleteWithReturnTo(acsReq)
 	require.ErrorIs(t, err, ErrInvalidState)
+	require.Contains(t, err.Error(), "signature mismatch")
 	require.NotContains(t, err.Error(), "validate saml response")
 }
 
@@ -138,7 +141,9 @@ func TestCompleteRejectsExpiredStateCookieBeforeParsingResponse(t *testing.T) {
 	_, err = provider.Begin(rec, req, "/")
 	require.NoError(t, err)
 
-	cookie := rec.Result().Cookies()[0]
+	cookies := rec.Result().Cookies()
+	require.NotEmpty(t, cookies)
+	cookie := cookies[0]
 	stateReq := httptest.NewRequest(http.MethodGet, "/auth/sso/saml/acs", nil)
 	stateReq.AddCookie(cookie)
 	state, err := provider.readStateCookie(stateReq)
@@ -152,6 +157,7 @@ func TestCompleteRejectsExpiredStateCookieBeforeParsingResponse(t *testing.T) {
 
 	_, _, err = provider.CompleteWithReturnTo(acsReq)
 	require.ErrorIs(t, err, ErrInvalidState)
+	require.Contains(t, err.Error(), "expired state")
 	require.NotContains(t, err.Error(), "validate saml response")
 }
 

--- a/internal/auth/saml/provider_test.go
+++ b/internal/auth/saml/provider_test.go
@@ -90,6 +90,71 @@ func TestCompleteRejectsRelayStateMismatchBeforeParsingResponse(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidState)
 }
 
+func TestCompleteRejectsTamperedStateCookieBeforeParsingResponse(t *testing.T) {
+	provider, err := New(t.Context(), Config{
+		IDPMetadataXML: minimalIDPMetadata,
+		PublicBaseURL:  "https://app.example.com",
+		CookieSecret:   []byte(strings.Repeat("x", 32)),
+		ReplayCache:    fakeReplayCache{},
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/sso/saml/login", nil)
+	_, err = provider.Begin(rec, req, "/")
+	require.NoError(t, err)
+
+	cookie := rec.Result().Cookies()[0]
+	stateReq := httptest.NewRequest(http.MethodGet, "/auth/sso/saml/acs", nil)
+	stateReq.AddCookie(cookie)
+	state, err := provider.readStateCookie(stateReq)
+	require.NoError(t, err)
+
+	cookie.Value += "tampered"
+	body := "RelayState=" + state.RelayState + "&SAMLResponse=not-a-real-response"
+	acsReq := httptest.NewRequest(http.MethodPost, "/auth/sso/saml/acs", strings.NewReader(body))
+	acsReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	acsReq.AddCookie(cookie)
+
+	_, _, err = provider.CompleteWithReturnTo(acsReq)
+	require.ErrorIs(t, err, ErrInvalidState)
+	require.NotContains(t, err.Error(), "validate saml response")
+}
+
+func TestCompleteRejectsExpiredStateCookieBeforeParsingResponse(t *testing.T) {
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	provider, err := New(t.Context(), Config{
+		IDPMetadataXML: minimalIDPMetadata,
+		PublicBaseURL:  "https://app.example.com",
+		StateTTL:       time.Minute,
+		CookieSecret:   []byte(strings.Repeat("x", 32)),
+		ReplayCache:    fakeReplayCache{},
+	})
+	require.NoError(t, err)
+	provider.now = func() time.Time { return now }
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/sso/saml/login", nil)
+	_, err = provider.Begin(rec, req, "/")
+	require.NoError(t, err)
+
+	cookie := rec.Result().Cookies()[0]
+	stateReq := httptest.NewRequest(http.MethodGet, "/auth/sso/saml/acs", nil)
+	stateReq.AddCookie(cookie)
+	state, err := provider.readStateCookie(stateReq)
+	require.NoError(t, err)
+
+	provider.now = func() time.Time { return now.Add(time.Minute + time.Second) }
+	body := "RelayState=" + state.RelayState + "&SAMLResponse=not-a-real-response"
+	acsReq := httptest.NewRequest(http.MethodPost, "/auth/sso/saml/acs", strings.NewReader(body))
+	acsReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	acsReq.AddCookie(cookie)
+
+	_, _, err = provider.CompleteWithReturnTo(acsReq)
+	require.ErrorIs(t, err, ErrInvalidState)
+	require.NotContains(t, err.Error(), "validate saml response")
+}
+
 func TestIdentityFromAssertion(t *testing.T) {
 	assertion := &crewsaml.Assertion{
 		ID:     "assertion-1",


### PR DESCRIPTION
## Summary
- add fail-closed OIDC callback coverage for tampered/expired pre-login state cookies and early callback errors before token exchange
- add SAML invalid-state callback coverage and LDAP malformed user-search fail-closed coverage
- verify trusted-proxy same-origin returnTo handling and Secure session-cookie flags for OIDC/SAML callbacks
- update the SSO foundation plan to record Wave 8 P5 closeout

## Tests
- `docker run --rm --platform linux/arm64 -v /Users/cryan/dev/caesium:/bld/caesium -w /bld/caesium caesiumcloud/caesium-builder:latest-full sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test ./api/rest/controller/auth ./internal/auth/oidc ./internal/auth/saml ./internal/auth/ldap -count=1 -v'`
- `just unit-test`
- `just lint`
- `git diff --check`
