### PR TITLE
[codex] Harden remaining SSO foundation edge cases

### DIFF
--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -63,7 +63,15 @@ func Auth(d AuthDeps) echo.MiddlewareFunc {
 			var key *models.APIKey
 			var principal *auth.Principal
 
-			if token := extractBearerToken(c); token != "" {
+			token, malformedAuthorization := extractBearerToken(c)
+			if malformedAuthorization {
+				if recordCredentialFailure(c, d, ip, "authorization", "malformed_authorization") {
+					return rateLimitError(c, d.Limiter, ip)
+				}
+				return echo.NewHTTPError(http.StatusUnauthorized, "invalid authorization header")
+			}
+
+			if token != "" {
 				validKey, err := d.Service.ValidateKey(token)
 				if err != nil {
 					reason := classifyAuthError(err)
@@ -137,17 +145,22 @@ func Auth(d AuthDeps) echo.MiddlewareFunc {
 	}
 }
 
-// extractBearerToken extracts the token from the Authorization header.
-func extractBearerToken(c *echo.Context) string {
+// extractBearerToken extracts a Bearer token and reports malformed
+// Authorization headers so cookie auth cannot silently mask them.
+func extractBearerToken(c *echo.Context) (string, bool) {
 	header := c.Request().Header.Get("Authorization")
 	if header == "" {
-		return ""
+		return "", false
 	}
 	parts := strings.SplitN(header, " ", 2)
 	if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
-		return ""
+		return "", true
 	}
-	return strings.TrimSpace(parts[1])
+	token := strings.TrimSpace(parts[1])
+	if token == "" {
+		return "", true
+	}
+	return token, false
 }
 
 // normalisePath returns the Echo route pattern (with :param placeholders)

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -334,6 +334,55 @@ func TestAuthBearerPrecedenceExemptsSessionCSRF(t *testing.T) {
 	require.Equal(t, http.StatusOK, rec.Code)
 }
 
+func TestAuthRejectsMalformedAuthorizationEvenWithSessionCookie(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := auth.NewService(db)
+	auditor := auth.NewAuditLogger(db)
+	limiter := auth.NewRateLimiter(10, time.Minute)
+	sessions := auth.NewSessionStore(db)
+	user := &models.User{
+		ID:        uuid.New(),
+		Issuer:    "oidc",
+		Subject:   "sub-1",
+		Email:     "viewer@example.com",
+		Role:      models.RoleViewer,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(user).Error)
+	token, _, err := sessions.Create(t.Context(), auth.CreateSessionRequest{UserID: user.ID})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/jobs", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: token})
+
+	called := false
+	_, err = callMiddlewareWithDeps(t, authmw.AuthDeps{
+		Service:    svc,
+		Auditor:    auditor,
+		Limiter:    limiter,
+		Sessions:   sessions,
+		CookieName: "caesium_session",
+	}, req, &echo.RouteInfo{Path: "/v1/jobs", Method: http.MethodGet}, nil, func(c *echo.Context) error {
+		called = true
+		return c.NoContent(http.StatusOK)
+	})
+	require.Error(t, err)
+	require.False(t, called)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, he.Code)
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Action: auth.ActionAuthDenied, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, "authorization", entries[0].Actor)
+	requireAuditReason(t, entries[0], "malformed_authorization")
+}
+
 func TestAuthRejectsInvalidSessionCookieRecordsFailureAndAudit(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -232,6 +232,7 @@ Features that were previously on the roadmap and are now shipped:
 | Task retries with exponential backoff | [`airflow-parity.md`](airflow-parity.md) | Shipped |
 | Trigger rules (all_success, all_done, etc.) | [`airflow-parity.md`](airflow-parity.md) | Shipped |
 | Embedded web UI with DAG visualization | [`ui_implementation_plan.md`](ui_implementation_plan.md) | Shipped |
+| Native SSO authentication | [`sso-authentication.md`](sso-authentication.md) | Shipped (OIDC, SAML, LDAP) |
 
 ---
 

--- a/docs/sso-authentication.md
+++ b/docs/sso-authentication.md
@@ -19,6 +19,8 @@ CAESIUM_AUTH_PUBLIC_BASE_URL=https://caesium.example.com
 CAESIUM_AUTH_ROLE_MAPPING='CN=Caesium Admins,OU=Groups,DC=example,DC=com=admin;data-eng=operator;*=viewer'
 CAESIUM_AUTH_SESSION_IDLE_TTL=8h
 CAESIUM_AUTH_SESSION_ABSOLUTE_TTL=24h
+CAESIUM_AUTH_SESSION_COOKIE_NAME=caesium_session
+CAESIUM_AUTH_DEFAULT_ROLE=
 ```
 
 `CAESIUM_AUTH_ROLE_MAPPING` is a semicolon-separated list of `group=role`
@@ -26,13 +28,32 @@ entries. Caesium chooses the highest mapped role when a user belongs to several
 groups. Valid roles are `viewer`, `operator`, and `admin`. Use `*` only when a
 catch-all login policy is intended.
 
+If no group mapping matches, an empty `CAESIUM_AUTH_DEFAULT_ROLE` denies login.
+Set it to `viewer`, `operator`, or `admin` only when unmapped SSO users should
+receive that fallback role.
+
 The browser session cookie is HTTP-only and `SameSite=Lax`. Unsafe requests from
 cookie sessions must include the CSRF token surfaced by `GET /auth/whoami`.
+`CAESIUM_AUTH_SESSION_COOKIE_NAME` changes the cookie name; use it when multiple
+Caesium deployments share a parent domain.
 
 If Caesium is served behind a TLS-terminating proxy, set
-`CAESIUM_TRUSTED_PROXIES` so session cookies are marked `Secure` when the
-trusted proxy forwards `X-Forwarded-Proto: https`. Leave
-`CAESIUM_AUTH_REQUIRE_TLS=true` in production.
+`CAESIUM_TRUSTED_PROXIES` to a comma-separated list of immediate proxy IPs or
+CIDRs. Caesium trusts `X-Forwarded-Proto: https` only from those peers; that
+controls both `Secure` session cookies and same-origin redirect checks. Leave
+`CAESIUM_AUTH_REQUIRE_TLS=true` in production so auth startup requires either
+direct TLS certs or a trusted proxy path.
+
+### Common Operator Reference
+
+| Env | Default | Operator note |
+| --- | --- | --- |
+| `CAESIUM_AUTH_PUBLIC_BASE_URL` | unset | External base URL used to derive OIDC redirect and SAML ACS/metadata URLs. |
+| `CAESIUM_AUTH_DEFAULT_ROLE` | empty | Fallback role when no group mapping matches; empty denies login. |
+| `CAESIUM_AUTH_SESSION_COOKIE_NAME` | `caesium_session` | Browser session cookie name for SSO callbacks, `/auth/whoami`, and logout. |
+| `CAESIUM_AUTH_SESSION_IDLE_TTL` | `8h` | Sliding idle timeout refreshed by valid session use. |
+| `CAESIUM_AUTH_SESSION_ABSOLUTE_TTL` | `24h` | Hard session expiry. |
+| `CAESIUM_TRUSTED_PROXIES` | empty | Comma-separated trusted proxy IPs/CIDRs for forwarded-proto handling. |
 
 ## OIDC
 
@@ -55,12 +76,21 @@ CAESIUM_AUTH_SAML_ENABLED=true
 CAESIUM_AUTH_SAML_IDP_METADATA_URL=https://idp.example.com/metadata
 CAESIUM_AUTH_SAML_SP_CERT=/etc/caesium/saml/sp.crt
 CAESIUM_AUTH_SAML_SP_KEY=/etc/caesium/saml/sp.key
+CAESIUM_AUTH_SAML_SP_ENTITY_ID=https://caesium.example.com/auth/sso/saml/metadata
+CAESIUM_AUTH_SAML_ACS_URL=https://caesium.example.com/auth/sso/saml/acs
+CAESIUM_AUTH_SAML_METADATA_URL=https://caesium.example.com/auth/sso/saml/metadata
 CAESIUM_AUTH_SAML_GROUPS_ATTRIBUTE=groups
 ```
 
 Configure exactly one IdP metadata source:
 `CAESIUM_AUTH_SAML_IDP_METADATA_URL`, `CAESIUM_AUTH_SAML_IDP_METADATA_XML`, or
 `CAESIUM_AUTH_SAML_IDP_METADATA_FILE`. Metadata URLs must use HTTPS.
+
+If `CAESIUM_AUTH_SAML_ACS_URL` or `CAESIUM_AUTH_SAML_METADATA_URL` is unset,
+Caesium derives `/auth/sso/saml/acs` and `/auth/sso/saml/metadata` from
+`CAESIUM_AUTH_PUBLIC_BASE_URL`. If `CAESIUM_AUTH_SAML_SP_ENTITY_ID` is unset,
+it defaults to the metadata URL. Configure those same SP values in the IdP so
+audience, recipient, and metadata checks match.
 
 ## LDAP
 
@@ -78,6 +108,10 @@ CAESIUM_AUTH_LDAP_USER_FILTER='(uid={username})'
 CAESIUM_AUTH_LDAP_GROUP_BASE_DN='ou=groups,dc=example,dc=com'
 CAESIUM_AUTH_LDAP_GROUP_FILTER='(member={dn})'
 CAESIUM_AUTH_LDAP_GROUP_ATTRIBUTE=cn
+CAESIUM_AUTH_LDAP_TIMEOUT=10s
+CAESIUM_AUTH_LDAP_USERNAME_ATTRIBUTE=uid
+CAESIUM_AUTH_LDAP_EMAIL_ATTRIBUTE=mail
+CAESIUM_AUTH_LDAP_DISPLAY_NAME_ATTRIBUTE=displayName
 ```
 
 Use `ldaps://` where possible. To use StartTLS on `ldap://`, set
@@ -99,6 +133,16 @@ CAESIUM_AUTH_LDAP_USERNAME_ATTRIBUTE=sAMAccountName
 CAESIUM_AUTH_LDAP_EMAIL_ATTRIBUTE=userPrincipalName
 CAESIUM_AUTH_LDAP_DISPLAY_NAME_ATTRIBUTE=cn
 ```
+
+LDAP attribute and timeout reference:
+
+| Env | Default | Operator note |
+| --- | --- | --- |
+| `CAESIUM_AUTH_LDAP_TIMEOUT` | `10s` | Dial, bind, and search timeout; keep below your load balancer timeout. |
+| `CAESIUM_AUTH_LDAP_USERNAME_ATTRIBUTE` | `uid` | Attribute used as the external username when present. |
+| `CAESIUM_AUTH_LDAP_EMAIL_ATTRIBUTE` | `mail` | Attribute used for the Caesium user email. |
+| `CAESIUM_AUTH_LDAP_DISPLAY_NAME_ATTRIBUTE` | `displayName` | Attribute used for the display name. |
+| `CAESIUM_AUTH_LDAP_GROUP_ATTRIBUTE` | `cn` | Values mapped through `CAESIUM_AUTH_ROLE_MAPPING`; use `dn` for full-DN mappings. |
 
 Empty passwords are rejected before any LDAP bind so directories that permit
 anonymous binds cannot accidentally authenticate a user.

--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -25,16 +25,16 @@
 - **Commit messages:** concise imperative subject (repo style, e.g. "Add Principal abstraction to auth middleware"); end every commit message with the trailer `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`.
 - **Progress:** Foundation P0/P1 merged in PR #192. OIDC continued on
   `sso-oidc-provider` (PR #193). SAML continued on `sso-saml-provider`
-  (PR #194). LDAP continued on `codex/ldap-sso-provider` (PR #195). The current
-  `codex/sso-fixtures-wave` branch continued P5 after
-  `codex/sso-hardening-wave` (PR #196) with signed SAML response fixtures, a
-  self-contained containerized OpenLDAP fixture, and `user.provisioned` audit
-  events. `codex/sso-negative-fixtures-wave` (PR #198) added deeper
-  provider-specific negative fixtures for OIDC, SAML, and LDAP. The current
-  `codex/sso-p5-hardening-wave` branch closes the remaining P5 provider and
-  security coverage with fail-closed state-cookie callbacks, LDAP malformed
-  search results, trusted-proxy same-origin redirects, and secure-cookie checks
-  for redirect callbacks.
+  (PR #194). LDAP continued on `codex/ldap-sso-provider` (PR #195).
+  `codex/sso-hardening-wave` (PR #196) and `codex/sso-fixtures-wave` added P5
+  hardening with signed SAML response fixtures, a self-contained containerized
+  OpenLDAP fixture, and `user.provisioned` audit events.
+  `codex/sso-negative-fixtures-wave` (PR #198) added deeper provider-specific
+  negative fixtures for OIDC, SAML, and LDAP. `codex/sso-p5-hardening-wave`
+  then covered fail-closed state-cookie callbacks, LDAP malformed search
+  results, trusted-proxy same-origin redirects, and secure-cookie checks for
+  redirect callbacks. Wave 9 on `codex/sso-remaining-foundation-wave` is scoped
+  to remaining foundation hardening and docs cleanup.
 
 ## File structure
 
@@ -1644,6 +1644,11 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   trusted-proxy same-origin return targets, and secure session-cookie flags for
   redirect-provider callbacks. Prior P5 waves covered CSRF, audit, metrics, and
   operator docs.
+- [x] **Wave 9 status:** Covered remaining foundation hardening: fail-closed
+  shared identity validation, session idle-refresh correctness, malformed
+  `Authorization` header rejection before cookie-session fallback, OIDC/SAML
+  provider identity and state-cookie checks, UI cookie-session fail-closed/logout
+  handling, and operator docs/roadmap cleanup.
 - **Files:** `docs/sso-authentication.md` (operator setup for all three + role mapping + session tuning + TLS), README/roadmap updates.
 - **Key work:** end-to-end security pass; verify cookie flags/CSRF/open-redirect guards across providers; finalize metrics + audit actions (`auth.login`, `auth.logout`, `auth.session_revoked`, `user.provisioned`, `auth.login_denied`).
 

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -220,9 +220,6 @@ func validateIdentityShape(idToken *gooidc.IDToken, claims map[string]json.RawMe
 	if strings.TrimSpace(idToken.Subject) == "" {
 		return fmt.Errorf("%w: missing subject", ErrInvalidIDToken)
 	}
-	if len(idToken.Audience) <= 1 {
-		return nil
-	}
 
 	rawAuthorizedParty, ok := claims["azp"]
 	if !ok {

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	authpkg "github.com/caesium-cloud/caesium/internal/auth"
@@ -190,6 +191,9 @@ func (p *Provider) identityFromIDToken(idToken *gooidc.IDToken) (*authpkg.Extern
 	if err := idToken.Claims(&allClaims); err != nil {
 		return nil, fmt.Errorf("%w: decode claims: %v", ErrInvalidIDToken, err)
 	}
+	if err := validateIdentityShape(idToken, allClaims, p.oauth2Config.ClientID); err != nil {
+		return nil, err
+	}
 	groups, err := extractGroups(allClaims[p.groupsClaim])
 	if err != nil {
 		return nil, err
@@ -210,6 +214,28 @@ func (p *Provider) identityFromIDToken(idToken *gooidc.IDToken) (*authpkg.Extern
 		DisplayName: displayName,
 		Groups:      groups,
 	}, nil
+}
+
+func validateIdentityShape(idToken *gooidc.IDToken, claims map[string]json.RawMessage, clientID string) error {
+	if strings.TrimSpace(idToken.Subject) == "" {
+		return fmt.Errorf("%w: missing subject", ErrInvalidIDToken)
+	}
+	if len(idToken.Audience) <= 1 {
+		return nil
+	}
+
+	rawAuthorizedParty, ok := claims["azp"]
+	if !ok {
+		return nil
+	}
+	var authorizedParty string
+	if err := json.Unmarshal(rawAuthorizedParty, &authorizedParty); err != nil {
+		return fmt.Errorf("%w: decode authorized party: %v", ErrInvalidIDToken, err)
+	}
+	if authorizedParty != clientID {
+		return fmt.Errorf("%w: authorized party mismatch", ErrInvalidIDToken)
+	}
+	return nil
 }
 
 func extractGroups(raw json.RawMessage) ([]string, error) {

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -308,6 +308,25 @@ func TestCompleteRejectsAuthorizedPartyMismatchForMultipleAudiences(t *testing.T
 	require.NotNil(t, issuer.lastTokenForm)
 }
 
+func TestCompleteRejectsAuthorizedPartyMismatchForSingleAudience(t *testing.T) {
+	issuer := newMockIssuer(t, "groups")
+	provider := newTestProvider(t, issuer, "groups")
+
+	stateCookie, state := beginForCallback(t, provider, "/")
+	issuer.nextNonce = state.Nonce
+	issuer.nextAuthorizedParty = "different-client"
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"https://app.example.com/auth/sso/oidc/callback?code=good-code&state="+url.QueryEscape(state.State),
+		nil,
+	)
+	req.AddCookie(stateCookie)
+
+	_, _, err := provider.CompleteWithReturnTo(req)
+	require.ErrorIs(t, err, ErrInvalidIDToken)
+	require.NotNil(t, issuer.lastTokenForm)
+}
+
 func TestExtractGroupsClaim(t *testing.T) {
 	groups, err := extractGroups(json.RawMessage(`"one"`))
 	require.NoError(t, err)

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -246,6 +246,68 @@ func TestCompleteRejectsAudienceMismatch(t *testing.T) {
 	require.NotNil(t, issuer.lastTokenForm)
 }
 
+func TestCompleteRejectsMissingOrBlankSubject(t *testing.T) {
+	tests := []struct {
+		name    string
+		prepare func(*mockIssuer)
+	}{
+		{
+			name: "missing subject",
+			prepare: func(issuer *mockIssuer) {
+				issuer.omitSubject = true
+			},
+		},
+		{
+			name: "blank subject",
+			prepare: func(issuer *mockIssuer) {
+				subject := " \t "
+				issuer.nextSubject = &subject
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issuer := newMockIssuer(t, "groups")
+			provider := newTestProvider(t, issuer, "groups")
+
+			stateCookie, state := beginForCallback(t, provider, "/")
+			issuer.nextNonce = state.Nonce
+			tt.prepare(issuer)
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"https://app.example.com/auth/sso/oidc/callback?code=good-code&state="+url.QueryEscape(state.State),
+				nil,
+			)
+			req.AddCookie(stateCookie)
+
+			_, _, err := provider.CompleteWithReturnTo(req)
+			require.ErrorIs(t, err, ErrInvalidIDToken)
+			require.NotNil(t, issuer.lastTokenForm)
+		})
+	}
+}
+
+func TestCompleteRejectsAuthorizedPartyMismatchForMultipleAudiences(t *testing.T) {
+	issuer := newMockIssuer(t, "groups")
+	provider := newTestProvider(t, issuer, "groups")
+
+	stateCookie, state := beginForCallback(t, provider, "/")
+	issuer.nextNonce = state.Nonce
+	issuer.nextAudiences = []string{"caesium", "api-client"}
+	issuer.nextAuthorizedParty = "different-client"
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"https://app.example.com/auth/sso/oidc/callback?code=good-code&state="+url.QueryEscape(state.State),
+		nil,
+	)
+	req.AddCookie(stateCookie)
+
+	_, _, err := provider.CompleteWithReturnTo(req)
+	require.ErrorIs(t, err, ErrInvalidIDToken)
+	require.NotNil(t, issuer.lastTokenForm)
+}
+
 func TestExtractGroupsClaim(t *testing.T) {
 	groups, err := extractGroups(json.RawMessage(`"one"`))
 	require.NoError(t, err)
@@ -318,13 +380,17 @@ func tamperCookieValue(value string) string {
 }
 
 type mockIssuer struct {
-	server        *httptest.Server
-	key           *rsa.PrivateKey
-	groupsClaim   string
-	nextNonce     string
-	nextAudience  string
-	nextExpiry    time.Time
-	lastTokenForm url.Values
+	server              *httptest.Server
+	key                 *rsa.PrivateKey
+	groupsClaim         string
+	nextNonce           string
+	nextSubject         *string
+	omitSubject         bool
+	nextAudience        string
+	nextAudiences       []string
+	nextAuthorizedParty string
+	nextExpiry          time.Time
+	lastTokenForm       url.Values
 }
 
 func newMockIssuer(t *testing.T, groupsClaim string) *mockIssuer {
@@ -381,21 +447,35 @@ func (m *mockIssuer) token(w http.ResponseWriter, r *http.Request) {
 	if audience == "" {
 		audience = "caesium"
 	}
+	var audienceClaim any = audience
+	if len(m.nextAudiences) > 0 {
+		audienceClaim = append([]string(nil), m.nextAudiences...)
+	}
 	expiresAt := m.nextExpiry
 	if expiresAt.IsZero() {
 		expiresAt = time.Now().Add(time.Hour)
 	}
-	idToken := m.signIDToken(map[string]any{
+	claims := map[string]any{
 		"iss":         m.URL(),
-		"sub":         "subject-123",
-		"aud":         audience,
+		"aud":         audienceClaim,
 		"exp":         expiresAt.Unix(),
 		"iat":         time.Now().Add(-time.Minute).Unix(),
 		"nonce":       nonce,
 		"email":       "ada@example.com",
 		"name":        "Ada Lovelace",
 		m.groupsClaim: []string{"caesium-admins", "data-eng"},
-	})
+	}
+	if !m.omitSubject {
+		subject := "subject-123"
+		if m.nextSubject != nil {
+			subject = *m.nextSubject
+		}
+		claims["sub"] = subject
+	}
+	if m.nextAuthorizedParty != "" {
+		claims["azp"] = m.nextAuthorizedParty
+	}
+	idToken := m.signIDToken(claims)
 	writeJSON(w, map[string]any{
 		"access_token": "access-token",
 		"token_type":   "Bearer",

--- a/internal/auth/provider.go
+++ b/internal/auth/provider.go
@@ -15,6 +15,9 @@ import (
 // ErrLoginDenied is returned when an external identity is not allowed to log in.
 var ErrLoginDenied = errors.New("login denied")
 
+// ErrInvalidExternalIdentity is returned when a provider returns an unusable identity.
+var ErrInvalidExternalIdentity = errors.New("invalid external identity")
+
 // ExternalIdentity is the normalized identity every provider produces.
 type ExternalIdentity struct {
 	Issuer      string
@@ -73,6 +76,11 @@ func (s *SSOService) Complete(ctx context.Context, ext *ExternalIdentity, method
 		metrics.SSOLoginsTotal.WithLabelValues(provider, outcome).Inc()
 		metrics.SSOLoginDurationSeconds.WithLabelValues(provider).Observe(time.Since(start).Seconds())
 	}()
+
+	if ext == nil || strings.TrimSpace(ext.Issuer) == "" || strings.TrimSpace(ext.Subject) == "" {
+		s.auditLoginError(ext, method, ip, "invalid_external_identity")
+		return "", nil, ErrInvalidExternalIdentity
+	}
 
 	role, ok := s.roles.Resolve(ext.Groups)
 	if !ok {

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -43,6 +43,73 @@ func TestSSOServiceComplete(t *testing.T) {
 	require.ErrorIs(t, err, ErrLoginDenied)
 }
 
+func TestSSOServiceCompleteRejectsInvalidExternalIdentity(t *testing.T) {
+	tests := []struct {
+		name string
+		ext  *ExternalIdentity
+	}{
+		{
+			name: "nil",
+			ext:  nil,
+		},
+		{
+			name: "blank issuer",
+			ext: &ExternalIdentity{
+				Issuer:  "",
+				Subject: "sub",
+				Groups:  []string{"eng"},
+			},
+		},
+		{
+			name: "whitespace issuer",
+			ext: &ExternalIdentity{
+				Issuer:  " \t\n",
+				Subject: "sub",
+				Groups:  []string{"eng"},
+			},
+		},
+		{
+			name: "blank subject",
+			ext: &ExternalIdentity{
+				Issuer:  "oidc",
+				Subject: "",
+				Groups:  []string{"eng"},
+			},
+		},
+		{
+			name: "whitespace subject",
+			ext: &ExternalIdentity{
+				Issuer:  "oidc",
+				Subject: " \t\n",
+				Groups:  []string{"eng"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db := testutil.OpenTestDB(t)
+			defer testutil.CloseDB(db)
+			mapper, err := NewRoleMapper("eng=operator", "")
+			require.NoError(t, err)
+			sso := NewSSOService(NewUserStore(db), NewSessionStore(db), mapper)
+
+			cookie, sess, err := sso.Complete(context.Background(), tt.ext, "oidc", "1.2.3.4", "agent")
+			require.ErrorIs(t, err, ErrInvalidExternalIdentity)
+			require.Empty(t, cookie)
+			require.Nil(t, sess)
+
+			var users int64
+			require.NoError(t, db.Model(&models.User{}).Count(&users).Error)
+			require.Zero(t, users)
+
+			var sessions int64
+			require.NoError(t, db.Model(&models.Session{}).Count(&sessions).Error)
+			require.Zero(t, sessions)
+		})
+	}
+}
+
 func TestSSOServiceCompleteRejectsDisabledUser(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	defer testutil.CloseDB(db)

--- a/internal/auth/saml/provider.go
+++ b/internal/auth/saml/provider.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	authpkg "github.com/caesium-cloud/caesium/internal/auth"
@@ -46,6 +47,9 @@ func New(ctx context.Context, cfg Config) (*Provider, error) {
 	if err != nil {
 		return nil, err
 	}
+	if !hasRedirectSSOBinding(idpMetadata) {
+		return nil, ErrNoRedirectBinding
+	}
 	cert, key, err := loadKeyPair(cfg.SPCertPath, cfg.SPKeyPath)
 	if err != nil {
 		return nil, err
@@ -83,6 +87,20 @@ func New(ctx context.Context, cfg Config) (*Provider, error) {
 		replayCache:     cfg.ReplayCache,
 		now:             time.Now,
 	}, nil
+}
+
+func hasRedirectSSOBinding(metadata *crewsaml.EntityDescriptor) bool {
+	if metadata == nil {
+		return false
+	}
+	for _, descriptor := range metadata.IDPSSODescriptors {
+		for _, service := range descriptor.SingleSignOnServices {
+			if service.Binding == crewsaml.HTTPRedirectBinding && strings.TrimSpace(service.Location) != "" {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // Name reports the provider id used by the shared SSO completion path.

--- a/internal/auth/saml/provider_test.go
+++ b/internal/auth/saml/provider_test.go
@@ -19,6 +19,13 @@ const minimalIDPMetadata = `
   </IDPSSODescriptor>
 </EntityDescriptor>`
 
+const postOnlyIDPMetadata = `
+<EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.example.com/metadata">
+  <IDPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">
+    <SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://idp.example.com/sso"/>
+  </IDPSSODescriptor>
+</EntityDescriptor>`
+
 func TestBeginCreatesTrackedRedirect(t *testing.T) {
 	provider, err := New(t.Context(), Config{
 		IDPMetadataXML: minimalIDPMetadata,
@@ -50,6 +57,28 @@ func TestBeginCreatesTrackedRedirect(t *testing.T) {
 	require.Equal(t, "/runs?status=failed#latest", state.ReturnTo)
 }
 
+func TestBeginSetsSecurePostStateCookieSameSiteNone(t *testing.T) {
+	provider, err := New(t.Context(), Config{
+		IDPMetadataXML: minimalIDPMetadata,
+		PublicBaseURL:  "https://app.example.com",
+		CookieSecure:   true,
+		CookieSecret:   []byte(strings.Repeat("x", 32)),
+		ReplayCache:    fakeReplayCache{},
+	})
+	require.NoError(t, err)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/auth/sso/saml/login", nil)
+	_, err = provider.Begin(rec, req, "/")
+	require.NoError(t, err)
+
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1)
+	require.True(t, cookies[0].HttpOnly)
+	require.True(t, cookies[0].Secure)
+	require.Equal(t, http.SameSiteNoneMode, cookies[0].SameSite)
+}
+
 func TestBeginRejectsCrossOriginReturnTo(t *testing.T) {
 	provider, err := New(t.Context(), Config{
 		IDPMetadataXML: minimalIDPMetadata,
@@ -65,6 +94,17 @@ func TestBeginRejectsCrossOriginReturnTo(t *testing.T) {
 
 	require.ErrorIs(t, err, ErrInvalidReturnTo)
 	require.Empty(t, rec.Result().Cookies())
+}
+
+func TestNewRejectsMetadataWithoutRedirectSSOBinding(t *testing.T) {
+	_, err := New(t.Context(), Config{
+		IDPMetadataXML: postOnlyIDPMetadata,
+		PublicBaseURL:  "https://app.example.com",
+		CookieSecret:   []byte(strings.Repeat("x", 32)),
+		ReplayCache:    fakeReplayCache{},
+	})
+
+	require.ErrorIs(t, err, ErrNoRedirectBinding)
 }
 
 func TestCompleteRejectsRelayStateMismatchBeforeParsingResponse(t *testing.T) {

--- a/internal/auth/saml/state.go
+++ b/internal/auth/saml/state.go
@@ -46,6 +46,10 @@ func (p *Provider) setStateCookie(w http.ResponseWriter, state loginState) error
 		return err
 	}
 	expires := time.Unix(state.ExpiresAt, 0).UTC()
+	sameSite := http.SameSiteLaxMode
+	if p.cookieSecure {
+		sameSite = http.SameSiteNoneMode
+	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     p.stateCookieName,
 		Value:    value,
@@ -54,7 +58,7 @@ func (p *Provider) setStateCookie(w http.ResponseWriter, state loginState) error
 		MaxAge:   int(p.stateTTL.Seconds()),
 		HttpOnly: true,
 		Secure:   p.cookieSecure,
-		SameSite: http.SameSiteLaxMode,
+		SameSite: sameSite,
 	})
 	return nil
 }

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -31,7 +31,7 @@ type SessionStore struct {
 	absoluteTTL     time.Duration
 	now             func() time.Time
 
-	seenMu sync.Mutex
+	seenMu sync.RWMutex
 	seen   map[uuid.UUID]time.Time
 }
 
@@ -205,6 +205,8 @@ func (s *SessionStore) RunLastSeenFlusher(ctx context.Context) {
 
 // Reap deletes expired sessions and sessions revoked more than an hour ago.
 func (s *SessionStore) Reap(ctx context.Context) (int64, error) {
+	s.flushSeen(ctx)
+
 	now := s.nowUTC()
 	res := s.db.WithContext(ctx).
 		Where(
@@ -271,9 +273,9 @@ func (s *SessionStore) recordSeen(id uuid.UUID) {
 }
 
 func (s *SessionStore) pendingSeen(id uuid.UUID) (time.Time, bool) {
-	s.seenMu.Lock()
+	s.seenMu.RLock()
 	seenAt, ok := s.seen[id]
-	s.seenMu.Unlock()
+	s.seenMu.RUnlock()
 	return seenAt, ok
 }
 

--- a/internal/auth/session.go
+++ b/internal/auth/session.go
@@ -137,7 +137,18 @@ func (s *SessionStore) Validate(ctx context.Context, plaintext string) (*models.
 		return nil, nil, ErrSessionRevoked
 	}
 	now := s.nowUTC()
-	if now.After(sess.AbsoluteExpiresAt) || now.After(sess.IdleExpiresAt) {
+	if now.After(sess.AbsoluteExpiresAt) {
+		return nil, nil, ErrSessionExpired
+	}
+	idleExpiresAt := sess.IdleExpiresAt
+	if seenAt, ok := s.pendingSeen(sess.ID); ok {
+		pendingIdleExpiresAt := seenAt.Add(s.idleTTL)
+		if pendingIdleExpiresAt.After(idleExpiresAt) {
+			idleExpiresAt = pendingIdleExpiresAt
+			sess.IdleExpiresAt = idleExpiresAt
+		}
+	}
+	if now.After(idleExpiresAt) {
 		return nil, nil, ErrSessionExpired
 	}
 
@@ -257,6 +268,13 @@ func (s *SessionStore) recordSeen(id uuid.UUID) {
 	s.seenMu.Lock()
 	s.seen[id] = s.nowUTC()
 	s.seenMu.Unlock()
+}
+
+func (s *SessionStore) pendingSeen(id uuid.UUID) (time.Time, bool) {
+	s.seenMu.Lock()
+	seenAt, ok := s.seen[id]
+	s.seenMu.Unlock()
+	return seenAt, ok
 }
 
 func (s *SessionStore) nowUTC() time.Time {

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -223,3 +223,35 @@ func TestSessionReap(t *testing.T) {
 	require.NoError(t, db.Model(&models.Session{}).Where("id = ?", sess.ID).Count(&count).Error)
 	require.Equal(t, int64(0), count)
 }
+
+func TestSessionReapFlushesPendingIdleRefreshBeforeDeleting(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := base
+	store := NewSessionStore(
+		db,
+		WithSessionNow(func() time.Time { return now }),
+		WithSessionTTLs(10*time.Second, time.Minute),
+	)
+	plaintext, sess, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+
+	now = base.Add(9 * time.Second)
+	_, _, err = store.Validate(context.Background(), plaintext)
+	require.NoError(t, err)
+
+	now = base.Add(11 * time.Second)
+	n, err := store.Reap(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, n)
+
+	var got models.Session
+	require.NoError(t, db.First(&got, "id = ?", sess.ID).Error)
+	require.NotNil(t, got.LastSeenAt)
+	require.WithinDuration(t, base.Add(11*time.Second), *got.LastSeenAt, time.Millisecond)
+	require.WithinDuration(t, base.Add(21*time.Second), got.IdleExpiresAt, time.Millisecond)
+}

--- a/internal/auth/session_test.go
+++ b/internal/auth/session_test.go
@@ -66,6 +66,70 @@ func TestSessionStoreValidateExpired(t *testing.T) {
 	require.ErrorIs(t, err, ErrSessionExpired)
 }
 
+func TestSessionStoreValidateHonorsPendingIdleRefresh(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := base
+	store := NewSessionStore(
+		db,
+		WithSessionNow(func() time.Time { return now }),
+		WithSessionTTLs(10*time.Second, time.Minute),
+	)
+	plaintext, sess, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+	require.WithinDuration(t, base.Add(10*time.Second), sess.IdleExpiresAt, time.Millisecond)
+
+	now = base.Add(9 * time.Second)
+	_, _, err = store.Validate(context.Background(), plaintext)
+	require.NoError(t, err)
+
+	var stale models.Session
+	require.NoError(t, db.First(&stale, "id = ?", sess.ID).Error)
+	require.WithinDuration(t, base.Add(10*time.Second), stale.IdleExpiresAt, time.Millisecond)
+
+	now = base.Add(11 * time.Second)
+	gotSess, _, err := store.Validate(context.Background(), plaintext)
+	require.NoError(t, err)
+	require.WithinDuration(t, base.Add(19*time.Second), gotSess.IdleExpiresAt, time.Millisecond)
+
+	store.flushSeen(context.Background())
+
+	var flushed models.Session
+	require.NoError(t, db.First(&flushed, "id = ?", sess.ID).Error)
+	require.NotNil(t, flushed.LastSeenAt)
+	require.WithinDuration(t, base.Add(11*time.Second), *flushed.LastSeenAt, time.Millisecond)
+	require.WithinDuration(t, base.Add(21*time.Second), flushed.IdleExpiresAt, time.Millisecond)
+}
+
+func TestSessionStoreValidatePendingIdleRefreshDoesNotExtendAbsoluteExpiry(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	defer testutil.CloseDB(db)
+	u := &models.User{ID: uuid.New(), Issuer: "oidc", Subject: "s", Email: "a@b.com", Role: models.RoleViewer}
+	require.NoError(t, db.Create(u).Error)
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := base
+	store := NewSessionStore(
+		db,
+		WithSessionNow(func() time.Time { return now }),
+		WithSessionTTLs(10*time.Second, 10*time.Second),
+	)
+	plaintext, _, err := store.Create(context.Background(), CreateSessionRequest{UserID: u.ID})
+	require.NoError(t, err)
+
+	now = base.Add(9 * time.Second)
+	_, _, err = store.Validate(context.Background(), plaintext)
+	require.NoError(t, err)
+
+	now = base.Add(11 * time.Second)
+	_, _, err = store.Validate(context.Background(), plaintext)
+	require.ErrorIs(t, err, ErrSessionExpired)
+}
+
 func TestSessionStoreValidateDisabledUser(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	defer testutil.CloseDB(db)

--- a/ui/src/features/auth/AuthGate.tsx
+++ b/ui/src/features/auth/AuthGate.tsx
@@ -20,6 +20,7 @@ interface AuthGateProps {
 export function AuthGate({ children }: AuthGateProps) {
   const [authRequired, setAuthRequired] = useState<boolean | null>(null);
   const [authMethods, setAuthMethods] = useState<AuthMethod[]>([]);
+  const [authUnavailable, setAuthUnavailable] = useState(false);
   const [authed, setAuthed] = useState(isAuthenticated);
 
   // Subscribe to auth state changes.
@@ -33,7 +34,7 @@ export function AuthGate({ children }: AuthGateProps) {
       try {
         const resp = await fetch("/auth/status");
         if (!resp.ok) {
-          if (!cancelled) setAuthRequired(false);
+          if (!cancelled) setAuthUnavailable(true);
           return;
         }
 
@@ -49,8 +50,7 @@ export function AuthGate({ children }: AuthGateProps) {
           }
         }
       } catch {
-        // Network error — assume auth not required, let real errors surface later.
-        if (!cancelled) setAuthRequired(false);
+        if (!cancelled) setAuthUnavailable(true);
       }
     }
 
@@ -63,6 +63,16 @@ export function AuthGate({ children }: AuthGateProps) {
   const handleLogin = useCallback(() => {
     setAuthed(true);
   }, []);
+
+  if (authUnavailable) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background text-foreground">
+        <p role="alert" className="text-sm text-muted-foreground">
+          Authentication unavailable
+        </p>
+      </div>
+    );
+  }
 
   // Still probing.
   if (authRequired === null) return null;

--- a/ui/src/features/auth/__tests__/AuthGate.test.tsx
+++ b/ui/src/features/auth/__tests__/AuthGate.test.tsx
@@ -36,6 +36,65 @@ describe("AuthGate", () => {
     expect(mockFetch).toHaveBeenNthCalledWith(2, "/auth/whoami", { credentials: "include" });
   });
 
+  it("renders the login page when whoami omits csrf for an enabled cookie session", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ enabled: true }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ kind: "user", email: "ops@example.com" }),
+      });
+
+    render(
+      <AuthGate>
+        <div>protected</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Enter your API key to continue")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+  });
+
+  it("does not render protected children when auth status is non-OK", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({}),
+    });
+
+    render(
+      <AuthGate>
+        <div>protected</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Authentication unavailable");
+    });
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not render protected children when auth status is unreachable", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+
+    render(
+      <AuthGate>
+        <div>protected</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Authentication unavailable");
+    });
+    expect(screen.queryByText("protected")).not.toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   it("renders advertised browser redirect methods on the login page", async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/ui/src/lib/__tests__/auth.test.ts
+++ b/ui/src/lib/__tests__/auth.test.ts
@@ -9,6 +9,7 @@ import {
   isCredentialAuthMethod,
   isRedirectAuthMethod,
   isAuthenticated,
+  logout,
   onAuthChange,
   type RedirectAuthMethod,
   setApiKey,
@@ -67,6 +68,24 @@ describe("auth", () => {
       "X-CSRF-Token": "csrf-secret",
     });
     expect(withAuthHeaders()).not.toHaveProperty("Authorization");
+  });
+
+  it("fails closed when a cookie session response omits the csrf token", async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrf_token: "csrf-secret" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ kind: "user", email: "ops@example.com" }),
+      });
+
+    await expect(checkSession()).resolves.toBe(true);
+    await expect(checkSession()).resolves.toBe(false);
+
+    expect(isAuthenticated()).toBe(false);
+    expect(withAuthHeaders()).not.toHaveProperty("X-CSRF-Token");
   });
 
   it("builds a same-page return target for SSO callbacks", () => {
@@ -138,6 +157,54 @@ describe("auth", () => {
     expect(withAuthHeaders()).toMatchObject({
       "X-CSRF-Token": "csrf-secret",
     });
+  });
+
+  it("posts logout with the csrf header and clears local state on 401", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ csrf_token: "csrf-secret" }),
+    });
+
+    await expect(checkSession()).resolves.toBe(true);
+
+    const listener = vi.fn();
+    const unsubscribe = onAuthChange(listener);
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValueOnce({ status: 401, ok: false });
+
+    await expect(logout()).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledWith("/auth/logout", {
+      method: "POST",
+      credentials: "include",
+      headers: { "X-CSRF-Token": "csrf-secret" },
+    });
+    expect(isAuthenticated()).toBe(false);
+    expect(withAuthHeaders()).not.toHaveProperty("X-CSRF-Token");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  it("clears local auth state when logout cannot reach the server", async () => {
+    setApiKey("csk_live_secret");
+
+    const listener = vi.fn();
+    const unsubscribe = onAuthChange(listener);
+    mockFetch.mockRejectedValueOnce(new Error("offline"));
+
+    await expect(logout()).resolves.toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledWith("/auth/logout", {
+      method: "POST",
+      credentials: "include",
+      headers: {},
+    });
+    expect(isAuthenticated()).toBe(false);
+    expect(withAuthHeaders()).not.toHaveProperty("Authorization");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
   });
 
   it("maps credential login denial statuses without caching a session", async () => {

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -66,6 +66,14 @@ export function clearApiKey(): void {
   notifyAuthChange();
 }
 
+function clearCookieSession(): void {
+  if (cookieSession || csrfToken) {
+    cookieSession = false;
+    csrfToken = null;
+    notifyAuthChange();
+  }
+}
+
 /** Returns true if an API key is currently set. */
 export function isAuthenticated(): boolean {
   return apiKey !== null || cookieSession;
@@ -157,28 +165,40 @@ export async function checkSession(): Promise<boolean> {
   try {
     const response = await fetch("/auth/whoami", { credentials: "include" });
     if (!response.ok) {
-      if (cookieSession || csrfToken) {
-        cookieSession = false;
-        csrfToken = null;
-        notifyAuthChange();
-      }
+      clearCookieSession();
       return false;
     }
 
-    const body = (await response.json()) as { csrf_token?: string };
-    csrfToken = body.csrf_token ?? null;
+    const body = (await response.json()) as { csrf_token?: unknown };
+    if (typeof body.csrf_token !== "string" || body.csrf_token.length === 0) {
+      clearCookieSession();
+      return false;
+    }
+
+    csrfToken = body.csrf_token;
     if (!cookieSession) {
       cookieSession = true;
       notifyAuthChange();
     }
     return true;
   } catch {
-    if (cookieSession || csrfToken) {
-      cookieSession = false;
-      csrfToken = null;
-      notifyAuthChange();
-    }
+    clearCookieSession();
     return false;
+  }
+}
+
+/** Revoke the browser session if reachable, then always clear local auth state. */
+export async function logout(): Promise<void> {
+  try {
+    await fetch("/auth/logout", {
+      method: "POST",
+      credentials: "include",
+      headers: csrfHeader(),
+    });
+  } catch {
+    // Local logout must still complete if the server is unreachable.
+  } finally {
+    clearApiKey();
   }
 }
 


### PR DESCRIPTION
Summary
- Fail closed on malformed shared SSO identities, malformed Authorization headers, OIDC subject/authorized-party mismatches, and SAML metadata without redirect SSO binding.
- Preserve active sessions across coalesced idle-refresh windows while keeping absolute expiry authoritative; make secure SAML POST state cookies SameSite=None.
- Harden UI cookie-session handling, add logout revocation flow, and update SSO operator docs, roadmap, and the plan progress entry.

Validation
- just unit-test
- just lint
- just ui-lint
- just ui-test
- git diff --check

Docs
- Updated docs/superpowers/plans/2026-05-27-sso-foundation.md with Wave 9 status.
- Expanded docs/sso-authentication.md operator env reference.
- Marked native SSO shipped in docs/roadmap.md.