### PR TITLE
[codex] Harden SSO callback state cleanup

### DIFF
--- a/api/middleware/proxy.go
+++ b/api/middleware/proxy.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"fmt"
 	"net"
 	"net/http"
 	"strings"
@@ -11,8 +12,27 @@ import (
 // ParseTrustedProxyRanges parses a comma-separated proxy allowlist into IP
 // ranges. Entries may be CIDR ranges or individual IP addresses.
 func ParseTrustedProxyRanges(raw string) []*net.IPNet {
+	ranges, invalid := parseTrustedProxyRanges(raw)
+	for _, entry := range invalid {
+		log.Warn("ignoring invalid trusted proxy entry", "value", entry)
+	}
+	return ranges
+}
+
+// ParseTrustedProxyRangesStrict parses a proxy allowlist and rejects invalid
+// entries. Use it when a proxy list is part of startup security validation.
+func ParseTrustedProxyRangesStrict(raw string) ([]*net.IPNet, error) {
+	ranges, invalid := parseTrustedProxyRanges(raw)
+	if len(invalid) > 0 {
+		return nil, fmt.Errorf("invalid trusted proxy entry %q", invalid[0])
+	}
+	return ranges, nil
+}
+
+func parseTrustedProxyRanges(raw string) ([]*net.IPNet, []string) {
 	parts := strings.Split(raw, ",")
 	ranges := make([]*net.IPNet, 0, len(parts))
+	invalid := make([]string, 0)
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 		if part == "" {
@@ -33,9 +53,9 @@ func ParseTrustedProxyRanges(raw string) []*net.IPNet {
 			continue
 		}
 
-		log.Warn("ignoring invalid trusted proxy entry", "value", part)
+		invalid = append(invalid, part)
 	}
-	return ranges
+	return ranges, invalid
 }
 
 // RequestIsSecure reports whether the original request is HTTPS. Forwarded

--- a/api/middleware/proxy_test.go
+++ b/api/middleware/proxy_test.go
@@ -1,0 +1,31 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTrustedProxyRangesStrict(t *testing.T) {
+	ranges, err := ParseTrustedProxyRangesStrict("127.0.0.1, 10.0.0.0/24")
+	require.NoError(t, err)
+	require.Len(t, ranges, 2)
+}
+
+func TestParseTrustedProxyRangesStrictRejectsInvalidEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "invalid only", raw: "not-a-cidr"},
+		{name: "mixed valid and invalid", raw: "127.0.0.1, not-a-cidr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ranges, err := ParseTrustedProxyRangesStrict(tt.raw)
+			require.Error(t, err)
+			require.Nil(t, ranges)
+		})
+	}
+}

--- a/api/rest/controller/auth/sso.go
+++ b/api/rest/controller/auth/sso.go
@@ -177,6 +177,8 @@ func (s *SSOController) completeRedirectLogin(c *echo.Context, provider iauth.Re
 	}
 
 	ext, returnTo, err := completeRedirectProvider(provider, c.Request())
+	clearRedirectStateCookie(provider, c.Response(), c.Request())
+
 	providerName := providerMethod(provider, fallbackName)
 	if err != nil {
 		s.recordProviderLoginFailure(c, providerName, "unknown", "callback_failed", iauth.OutcomeError)
@@ -401,12 +403,22 @@ type redirectAuthenticatorWithReturnTo interface {
 	CompleteWithReturnTo(r *http.Request) (*iauth.ExternalIdentity, string, error)
 }
 
+type redirectAuthenticatorStateClearer interface {
+	ClearStateCookie(w http.ResponseWriter, r *http.Request)
+}
+
 func completeRedirectProvider(provider iauth.RedirectAuthenticator, r *http.Request) (*iauth.ExternalIdentity, string, error) {
 	if withReturnTo, ok := provider.(redirectAuthenticatorWithReturnTo); ok {
 		return withReturnTo.CompleteWithReturnTo(r)
 	}
 	ext, err := provider.Complete(r)
 	return ext, "/", err
+}
+
+func clearRedirectStateCookie(provider iauth.RedirectAuthenticator, w http.ResponseWriter, r *http.Request) {
+	if clearer, ok := provider.(redirectAuthenticatorStateClearer); ok {
+		clearer.ClearStateCookie(w, r)
+	}
 }
 
 func safeReturnTo(r *http.Request, raw string, trustedProxies []*net.IPNet) string {

--- a/api/rest/controller/auth/sso_test.go
+++ b/api/rest/controller/auth/sso_test.go
@@ -639,6 +639,110 @@ func TestOIDCCallbackRecordsProviderErrorsAsErrors(t *testing.T) {
 	require.Empty(t, deniedEntries)
 }
 
+func TestRedirectCallbacksClearProviderStateCookieOnSuccess(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		method   string
+		target   string
+		call     func(*SSOController, *echo.Context) error
+	}{
+		{
+			name:     "oidc",
+			provider: "oidc",
+			method:   http.MethodGet,
+			target:   "/auth/sso/oidc/callback?code=abc&state=xyz",
+			call:     func(ctrl *SSOController, c *echo.Context) error { return ctrl.OIDCCallback(c) },
+		},
+		{
+			name:     "saml",
+			provider: "saml",
+			method:   http.MethodPost,
+			target:   "/auth/sso/saml/acs",
+			call:     func(ctrl *SSOController, c *echo.Context) error { return ctrl.SAMLACS(c) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessions, sso := newTestSSOService(t)
+			provider := &fakeRedirectAuthenticator{
+				name:     tt.provider,
+				returnTo: "/runs",
+				identity: testExternalIdentity(tt.provider),
+			}
+			ctrl := NewSSO(sessions, sso, "caesium_session")
+			if tt.provider == "oidc" {
+				ctrl.SetOIDCProvider(provider)
+			} else {
+				ctrl.SetSAMLProvider(provider)
+			}
+			c, rec := newAuthContext(t, tt.method, tt.target, "")
+
+			err := tt.call(ctrl, c)
+			require.NoError(t, err)
+
+			require.True(t, provider.clearStateCalled)
+			clearCookie := requireResponseCookie(t, rec.Result().Cookies(), provider.stateCookieName())
+			require.Empty(t, clearCookie.Value)
+			require.Equal(t, "/auth/sso/"+tt.provider, clearCookie.Path)
+			require.LessOrEqual(t, clearCookie.MaxAge, 0)
+			require.Equal(t, time.Unix(0, 0).UTC(), clearCookie.Expires)
+		})
+	}
+}
+
+func TestRedirectCallbacksClearProviderStateCookieOnProviderError(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		method   string
+		target   string
+		call     func(*SSOController, *echo.Context) error
+	}{
+		{
+			name:     "oidc",
+			provider: "oidc",
+			method:   http.MethodGet,
+			target:   "/auth/sso/oidc/callback?code=abc&state=xyz",
+			call:     func(ctrl *SSOController, c *echo.Context) error { return ctrl.OIDCCallback(c) },
+		},
+		{
+			name:     "saml",
+			provider: "saml",
+			method:   http.MethodPost,
+			target:   "/auth/sso/saml/acs",
+			call:     func(ctrl *SSOController, c *echo.Context) error { return ctrl.SAMLACS(c) },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := NewSSO(nil, iauth.NewSSOService(nil, nil, nil), "caesium_session")
+			provider := &fakeRedirectAuthenticator{
+				name:        tt.provider,
+				completeErr: errors.New("provider callback failed"),
+			}
+			if tt.provider == "oidc" {
+				ctrl.SetOIDCProvider(provider)
+			} else {
+				ctrl.SetSAMLProvider(provider)
+			}
+			c, rec := newAuthContext(t, tt.method, tt.target, "")
+
+			err := tt.call(ctrl, c)
+			require.Error(t, err)
+
+			require.True(t, provider.clearStateCalled)
+			clearCookie := requireResponseCookie(t, rec.Result().Cookies(), provider.stateCookieName())
+			require.Empty(t, clearCookie.Value)
+			require.Equal(t, "/auth/sso/"+tt.provider, clearCookie.Path)
+			require.LessOrEqual(t, clearCookie.MaxAge, 0)
+			require.Equal(t, time.Unix(0, 0).UTC(), clearCookie.Expires)
+		})
+	}
+}
+
 func TestOIDCCallbackRejectsDeniedLogin(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })
@@ -851,16 +955,17 @@ func TestLogoutIgnoresForwardedProtoFromUntrustedPeer(t *testing.T) {
 }
 
 type fakeRedirectAuthenticator struct {
-	name           string
-	beginURL       string
-	beginErr       error
-	returnTo       string
-	identity       *iauth.ExternalIdentity
-	completeErr    error
-	beginCalled    bool
-	beginReturnTo  string
-	completeCalled bool
-	metadataBody   string
+	name             string
+	beginURL         string
+	beginErr         error
+	returnTo         string
+	identity         *iauth.ExternalIdentity
+	completeErr      error
+	beginCalled      bool
+	beginReturnTo    string
+	completeCalled   bool
+	clearStateCalled bool
+	metadataBody     string
 }
 
 func (f *fakeRedirectAuthenticator) Name() string {
@@ -881,6 +986,23 @@ func (f *fakeRedirectAuthenticator) Complete(_ *http.Request) (*iauth.ExternalId
 func (f *fakeRedirectAuthenticator) CompleteWithReturnTo(_ *http.Request) (*iauth.ExternalIdentity, string, error) {
 	f.completeCalled = true
 	return f.identity, f.returnTo, f.completeErr
+}
+
+func (f *fakeRedirectAuthenticator) ClearStateCookie(w http.ResponseWriter, _ *http.Request) {
+	f.clearStateCalled = true
+	http.SetCookie(w, &http.Cookie{
+		Name:     f.stateCookieName(),
+		Value:    "",
+		Path:     "/auth/sso/" + f.name,
+		MaxAge:   -1,
+		Expires:  time.Unix(0, 0).UTC(),
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+func (f *fakeRedirectAuthenticator) stateCookieName() string {
+	return "caesium_" + f.name + "_state"
 }
 
 func (f *fakeRedirectAuthenticator) Metadata(w http.ResponseWriter, _ *http.Request) error {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/caesium-cloud/caesium/api"
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	runsvc "github.com/caesium-cloud/caesium/api/rest/service/run"
 	"github.com/caesium-cloud/caesium/internal/auth"
@@ -661,7 +662,10 @@ func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) 
 		// TLS requirement check.
 		if vars.AuthRequireTLS {
 			hasTLS := vars.TLSCert != "" && vars.TLSKey != ""
-			hasProxy := vars.TrustedProxies != ""
+			hasProxy, err := hasTrustedProxyTLSPath(vars.TrustedProxies)
+			if err != nil {
+				log.Fatal("invalid CAESIUM_TRUSTED_PROXIES", "error", err)
+			}
 			if !hasTLS && !hasProxy {
 				log.Fatal(
 					"TLS is required when authentication is enabled. " +
@@ -723,4 +727,15 @@ func initAuth(ctx context.Context, vars env.Environment, runAsync func(func())) 
 		log.Fatal("unknown CAESIUM_AUTH_MODE value", "mode", vars.AuthMode)
 		return nil, nil, nil, nil, nil // unreachable
 	}
+}
+
+func hasTrustedProxyTLSPath(raw string) (bool, error) {
+	if strings.TrimSpace(raw) == "" {
+		return false, nil
+	}
+	ranges, err := authmw.ParseTrustedProxyRangesStrict(raw)
+	if err != nil {
+		return false, err
+	}
+	return len(ranges) > 0, nil
 }

--- a/cmd/start/start_auth_test.go
+++ b/cmd/start/start_auth_test.go
@@ -1,0 +1,46 @@
+package start
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHasTrustedProxyTLSPath(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{name: "empty", raw: "", want: false},
+		{name: "blank entries", raw: " , ", want: false},
+		{name: "ip", raw: "127.0.0.1", want: true},
+		{name: "cidr", raw: "10.0.0.0/24", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hasTrustedProxyTLSPath(tt.raw)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestHasTrustedProxyTLSPathRejectsInvalidEntries(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "invalid only", raw: "not-a-cidr"},
+		{name: "mixed valid and invalid", raw: "127.0.0.1, not-a-cidr"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := hasTrustedProxyTLSPath(tt.raw)
+			require.Error(t, err)
+			require.False(t, got)
+		})
+	}
+}

--- a/docs/sso-authentication.md
+++ b/docs/sso-authentication.md
@@ -16,7 +16,7 @@ CAESIUM_AUTH_MODE=api-key
 CAESIUM_AUTH_KEY_HASH_SECRET=<32+ byte random secret>
 CAESIUM_AUTH_REQUIRE_TLS=true
 CAESIUM_AUTH_PUBLIC_BASE_URL=https://caesium.example.com
-CAESIUM_AUTH_ROLE_MAPPING='CN=Caesium Admins,OU=Groups,DC=example,DC=com=admin;data-eng=operator;*=viewer'
+CAESIUM_AUTH_ROLE_MAPPING='CN=Caesium Admins,OU=Groups,DC=example,DC=com=admin;data-eng=operator;job-runners=runner;*=viewer'
 CAESIUM_AUTH_SESSION_IDLE_TTL=8h
 CAESIUM_AUTH_SESSION_ABSOLUTE_TTL=24h
 CAESIUM_AUTH_SESSION_COOKIE_NAME=caesium_session
@@ -25,12 +25,12 @@ CAESIUM_AUTH_DEFAULT_ROLE=
 
 `CAESIUM_AUTH_ROLE_MAPPING` is a semicolon-separated list of `group=role`
 entries. Caesium chooses the highest mapped role when a user belongs to several
-groups. Valid roles are `viewer`, `operator`, and `admin`. Use `*` only when a
-catch-all login policy is intended.
+groups. Valid roles are `viewer`, `runner`, `operator`, and `admin`. Use `*`
+only when a catch-all login policy is intended.
 
 If no group mapping matches, an empty `CAESIUM_AUTH_DEFAULT_ROLE` denies login.
-Set it to `viewer`, `operator`, or `admin` only when unmapped SSO users should
-receive that fallback role.
+Set it to `viewer`, `runner`, `operator`, or `admin` only when unmapped SSO
+users should receive that fallback role.
 
 The browser session cookie is HTTP-only and `SameSite=Lax`. Unsafe requests from
 cookie sessions must include the CSRF token surfaced by `GET /auth/whoami`.
@@ -42,7 +42,8 @@ If Caesium is served behind a TLS-terminating proxy, set
 CIDRs. Caesium trusts `X-Forwarded-Proto: https` only from those peers; that
 controls both `Secure` session cookies and same-origin redirect checks. Leave
 `CAESIUM_AUTH_REQUIRE_TLS=true` in production so auth startup requires either
-direct TLS certs or a trusted proxy path.
+direct TLS certs or a trusted proxy path. Trusted proxy entries must be valid
+IP addresses or CIDR ranges; invalid entries fail the auth startup TLS guard.
 
 ### Common Operator Reference
 

--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -34,7 +34,10 @@
   then covered fail-closed state-cookie callbacks, LDAP malformed search
   results, trusted-proxy same-origin redirects, and secure-cookie checks for
   redirect callbacks. Wave 9 on `codex/sso-remaining-foundation-wave` is scoped
-  to remaining foundation hardening and docs cleanup.
+  to remaining foundation hardening and docs cleanup. Wave 10 on
+  `codex/sso-post-foundation-hardening` clears one-time OIDC/SAML state cookies
+  after redirect callbacks, tightens OIDC multi-audience `azp` checks, validates
+  trusted-proxy TLS-guard config, and corrects role-mapping docs/tests.
 
 ## File structure
 
@@ -1649,6 +1652,11 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   `Authorization` header rejection before cookie-session fallback, OIDC/SAML
   provider identity and state-cookie checks, UI cookie-session fail-closed/logout
   handling, and operator docs/roadmap cleanup.
+- [x] **Wave 10 status:** Added one-time cleanup for OIDC/SAML pre-login state
+  cookies after redirect callbacks, preserving provider cookie policy on expiry,
+  required OIDC `azp` for multi-audience ID tokens, rejected invalid trusted
+  proxy entries in the auth TLS startup guard, and corrected SSO role-mapping
+  docs/tests to include the supported `runner` role.
 - **Files:** `docs/sso-authentication.md` (operator setup for all three + role mapping + session tuning + TLS), README/roadmap updates.
 - **Key work:** end-to-end security pass; verify cookie flags/CSRF/open-redirect guards across providers; finalize metrics + audit actions (`auth.login`, `auth.logout`, `auth.session_revoked`, `user.provisioned`, `auth.login_denied`).
 

--- a/internal/auth/oidc/provider.go
+++ b/internal/auth/oidc/provider.go
@@ -223,6 +223,9 @@ func validateIdentityShape(idToken *gooidc.IDToken, claims map[string]json.RawMe
 
 	rawAuthorizedParty, ok := claims["azp"]
 	if !ok {
+		if len(idToken.Audience) > 1 {
+			return fmt.Errorf("%w: missing authorized party", ErrInvalidIDToken)
+		}
 		return nil
 	}
 	var authorizedParty string

--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -57,6 +57,30 @@ func TestBeginBuildsAuthURLAndStateCookie(t *testing.T) {
 	assert.NotEmpty(t, state.CodeVerifier)
 }
 
+func TestClearStateCookiePreservesCookiePolicy(t *testing.T) {
+	issuer := newMockIssuer(t, "groups")
+	provider := newTestProvider(t, issuer, "groups")
+	provider.cookieSecure = true
+
+	setRec := httptest.NewRecorder()
+	_, err := provider.Begin(setRec, httptest.NewRequest(http.MethodGet, "https://app.example.com/auth/sso/oidc/login", nil), "/")
+	require.NoError(t, err)
+	setCookie := requireCookie(t, setRec.Result(), DefaultStateCookieName)
+
+	clearRec := httptest.NewRecorder()
+	provider.ClearStateCookie(clearRec, httptest.NewRequest(http.MethodGet, "https://app.example.com/auth/sso/oidc/callback", nil))
+	clearCookie := requireCookie(t, clearRec.Result(), DefaultStateCookieName)
+
+	assert.Equal(t, setCookie.Name, clearCookie.Name)
+	assert.Empty(t, clearCookie.Value)
+	assert.Equal(t, setCookie.Path, clearCookie.Path)
+	assert.Equal(t, setCookie.HttpOnly, clearCookie.HttpOnly)
+	assert.Equal(t, setCookie.Secure, clearCookie.Secure)
+	assert.Equal(t, setCookie.SameSite, clearCookie.SameSite)
+	assert.LessOrEqual(t, clearCookie.MaxAge, 0)
+	assert.Equal(t, time.Unix(0, 0).UTC(), clearCookie.Expires)
+}
+
 func TestBeginRejectsCrossOriginReturnTo(t *testing.T) {
 	issuer := newMockIssuer(t, "groups")
 	provider := newTestProvider(t, issuer, "groups")
@@ -305,6 +329,26 @@ func TestCompleteRejectsAuthorizedPartyMismatchForMultipleAudiences(t *testing.T
 
 	_, _, err := provider.CompleteWithReturnTo(req)
 	require.ErrorIs(t, err, ErrInvalidIDToken)
+	require.NotNil(t, issuer.lastTokenForm)
+}
+
+func TestCompleteRejectsMissingAuthorizedPartyForMultipleAudiences(t *testing.T) {
+	issuer := newMockIssuer(t, "groups")
+	provider := newTestProvider(t, issuer, "groups")
+
+	stateCookie, state := beginForCallback(t, provider, "/")
+	issuer.nextNonce = state.Nonce
+	issuer.nextAudiences = []string{"caesium", "api-client"}
+	req := httptest.NewRequest(
+		http.MethodGet,
+		"https://app.example.com/auth/sso/oidc/callback?code=good-code&state="+url.QueryEscape(state.State),
+		nil,
+	)
+	req.AddCookie(stateCookie)
+
+	_, _, err := provider.CompleteWithReturnTo(req)
+	require.ErrorIs(t, err, ErrInvalidIDToken)
+	require.ErrorContains(t, err, "missing authorized party")
 	require.NotNil(t, issuer.lastTokenForm)
 }
 

--- a/internal/auth/oidc/state.go
+++ b/internal/auth/oidc/state.go
@@ -20,6 +20,8 @@ var (
 	ErrInvalidState    = errors.New("invalid oidc state")
 )
 
+const stateCookiePath = "/auth/sso/oidc"
+
 type loginState struct {
 	State        string `json:"state"`
 	Nonce        string `json:"nonce"`
@@ -51,17 +53,26 @@ func (p *Provider) setStateCookie(w http.ResponseWriter, state loginState) error
 		return err
 	}
 	expires := time.Unix(state.ExpiresAt, 0).UTC()
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, p.stateCookie(value, expires, int(time.Until(expires).Seconds())))
+	return nil
+}
+
+// ClearStateCookie expires the one-time pre-login state cookie.
+func (p *Provider) ClearStateCookie(w http.ResponseWriter, _ *http.Request) {
+	http.SetCookie(w, p.stateCookie("", time.Unix(0, 0).UTC(), -1))
+}
+
+func (p *Provider) stateCookie(value string, expires time.Time, maxAge int) *http.Cookie {
+	return &http.Cookie{
 		Name:     p.stateCookieName,
 		Value:    value,
-		Path:     "/auth/sso/oidc",
+		Path:     stateCookiePath,
 		Expires:  expires,
-		MaxAge:   int(time.Until(expires).Seconds()),
+		MaxAge:   maxAge,
 		HttpOnly: true,
 		Secure:   p.cookieSecure,
 		SameSite: http.SameSiteLaxMode,
-	})
-	return nil
+	}
 }
 
 func (p *Provider) readStateCookie(r *http.Request) (loginState, error) {

--- a/internal/auth/rolemap_test.go
+++ b/internal/auth/rolemap_test.go
@@ -39,6 +39,19 @@ func TestRoleMapperDefaultRole(t *testing.T) {
 	require.Equal(t, models.RoleViewer, r)
 }
 
+func TestRoleMapperAcceptsRunnerRole(t *testing.T) {
+	m, err := NewRoleMapper("job-runners=runner", "runner")
+	require.NoError(t, err)
+
+	r, ok := m.Resolve([]string{"job-runners"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleRunner, r)
+
+	r, ok = m.Resolve([]string{"nobody"})
+	require.True(t, ok)
+	require.Equal(t, models.RoleRunner, r)
+}
+
 func TestRoleMapperWildcardParticipatesInHighestRole(t *testing.T) {
 	m, err := NewRoleMapper("admins=viewer;*=operator", "")
 	require.NoError(t, err)

--- a/internal/auth/saml/provider_test.go
+++ b/internal/auth/saml/provider_test.go
@@ -79,6 +79,52 @@ func TestBeginSetsSecurePostStateCookieSameSiteNone(t *testing.T) {
 	require.Equal(t, http.SameSiteNoneMode, cookies[0].SameSite)
 }
 
+func TestClearStateCookiePreservesCookiePolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		secure   bool
+		sameSite http.SameSite
+	}{
+		{name: "insecure lax", secure: false, sameSite: http.SameSiteLaxMode},
+		{name: "secure none", secure: true, sameSite: http.SameSiteNoneMode},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := New(t.Context(), Config{
+				IDPMetadataXML: minimalIDPMetadata,
+				PublicBaseURL:  "https://app.example.com",
+				CookieSecure:   tt.secure,
+				CookieSecret:   []byte(strings.Repeat("x", 32)),
+				ReplayCache:    fakeReplayCache{},
+			})
+			require.NoError(t, err)
+
+			setRec := httptest.NewRecorder()
+			_, err = provider.Begin(setRec, httptest.NewRequest(http.MethodGet, "/auth/sso/saml/login", nil), "/")
+			require.NoError(t, err)
+			setCookies := setRec.Result().Cookies()
+			require.Len(t, setCookies, 1)
+			require.Equal(t, tt.sameSite, setCookies[0].SameSite)
+
+			clearRec := httptest.NewRecorder()
+			provider.ClearStateCookie(clearRec, httptest.NewRequest(http.MethodPost, "/auth/sso/saml/acs", nil))
+			clearCookies := clearRec.Result().Cookies()
+			require.Len(t, clearCookies, 1)
+
+			clearCookie := clearCookies[0]
+			require.Equal(t, setCookies[0].Name, clearCookie.Name)
+			require.Empty(t, clearCookie.Value)
+			require.Equal(t, setCookies[0].Path, clearCookie.Path)
+			require.Equal(t, setCookies[0].HttpOnly, clearCookie.HttpOnly)
+			require.Equal(t, setCookies[0].Secure, clearCookie.Secure)
+			require.Equal(t, setCookies[0].SameSite, clearCookie.SameSite)
+			require.LessOrEqual(t, clearCookie.MaxAge, 0)
+			require.Equal(t, time.Unix(0, 0).UTC(), clearCookie.Expires)
+		})
+	}
+}
+
 func TestBeginRejectsCrossOriginReturnTo(t *testing.T) {
 	provider, err := New(t.Context(), Config{
 		IDPMetadataXML: minimalIDPMetadata,

--- a/internal/auth/saml/state.go
+++ b/internal/auth/saml/state.go
@@ -20,6 +20,8 @@ var (
 	ErrInvalidState    = errors.New("invalid saml state")
 )
 
+const stateCookiePath = "/auth/sso/saml"
+
 type loginState struct {
 	RelayState string `json:"relay_state"`
 	RequestID  string `json:"request_id"`
@@ -46,21 +48,33 @@ func (p *Provider) setStateCookie(w http.ResponseWriter, state loginState) error
 		return err
 	}
 	expires := time.Unix(state.ExpiresAt, 0).UTC()
-	sameSite := http.SameSiteLaxMode
-	if p.cookieSecure {
-		sameSite = http.SameSiteNoneMode
-	}
-	http.SetCookie(w, &http.Cookie{
+	http.SetCookie(w, p.stateCookie(value, expires, int(p.stateTTL.Seconds())))
+	return nil
+}
+
+// ClearStateCookie expires the one-time pre-login state cookie.
+func (p *Provider) ClearStateCookie(w http.ResponseWriter, _ *http.Request) {
+	http.SetCookie(w, p.stateCookie("", time.Unix(0, 0).UTC(), -1))
+}
+
+func (p *Provider) stateCookie(value string, expires time.Time, maxAge int) *http.Cookie {
+	return &http.Cookie{
 		Name:     p.stateCookieName,
 		Value:    value,
-		Path:     "/auth/sso/saml",
+		Path:     stateCookiePath,
 		Expires:  expires,
-		MaxAge:   int(p.stateTTL.Seconds()),
+		MaxAge:   maxAge,
 		HttpOnly: true,
 		Secure:   p.cookieSecure,
-		SameSite: sameSite,
-	})
-	return nil
+		SameSite: p.stateCookieSameSite(),
+	}
+}
+
+func (p *Provider) stateCookieSameSite() http.SameSite {
+	if p.cookieSecure {
+		return http.SameSiteNoneMode
+	}
+	return http.SameSiteLaxMode
 }
 
 func (p *Provider) readStateCookie(r *http.Request) (loginState, error) {


### PR DESCRIPTION
## Summary
- Clear one-time OIDC/SAML pre-login state cookies during redirect callbacks before the response is written, preserving each provider's cookie policy on expiry.
- Require `azp` to match the client ID when OIDC ID tokens contain multiple audiences, and reject invalid trusted-proxy entries in the auth TLS startup guard.
- Update SSO role-mapping docs/plan progress and add coverage for the supported `runner` role.

## Validation
- `docker run --rm --platform linux/arm64 -v /Users/cryan/dev/caesium:/bld/caesium -w /bld/caesium caesiumcloud/caesium-builder:latest-full sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test ./api/rest/controller/auth ./internal/auth/oidc ./internal/auth/saml ./internal/auth ./api/middleware ./cmd/start -run "TestRedirectCallbacksClearProviderStateCookie|TestClearStateCookiePreservesCookiePolicy|TestCompleteRejectsMissingAuthorizedPartyForMultipleAudiences|TestCompleteRejectsAuthorizedPartyMismatch|TestRoleMapper|TestParseTrustedProxyRangesStrict|TestHasTrustedProxyTLSPath" -count=1 -v'`
- `just unit-test`
- `just lint`
- `git diff --check`
