### PR TITLE
[codex] Add SSO sign-out affordance

### DIFF
--- a/docs/sso-authentication.md
+++ b/docs/sso-authentication.md
@@ -56,6 +56,52 @@ IP addresses or CIDR ranges; invalid entries fail the auth startup TLS guard.
 | `CAESIUM_AUTH_SESSION_ABSOLUTE_TTL` | `24h` | Hard session expiry. |
 | `CAESIUM_TRUSTED_PROXIES` | empty | Comma-separated trusted proxy IPs/CIDRs for forwarded-proto handling. |
 
+## Browser Auth Endpoint Contract
+
+Browser clients discover available auth paths with `GET /auth/status`. The
+response is:
+
+```json
+{
+  "enabled": true,
+  "methods": [
+    { "type": "api-key" },
+    {
+      "type": "oidc",
+      "id": "oidc",
+      "label": "Sign in with OIDC",
+      "loginUrl": "/auth/sso/oidc/login",
+      "mode": "redirect"
+    }
+  ]
+}
+```
+
+SSO method objects include `type`, stable `id`, display `label`, same-origin
+`loginUrl`, and `mode`. `mode` is `redirect` for OIDC and SAML, and
+`credential` for LDAP. API-key auth is advertised as `{ "type": "api-key" }`
+when `CAESIUM_AUTH_MODE=api-key` is enabled.
+
+`GET /auth/whoami` requires a valid API key or session cookie. Cookie-session
+responses include `csrf_token` alongside the principal fields (`kind`,
+`subject`, `email`, and `role`). Browser clients should keep that token in
+memory and send it as `X-CSRF-Token` on unsafe cookie-session requests.
+
+`POST /auth/logout` revokes the current cookie session and clears the session
+cookie. Because logout is an unsafe cookie-session request, browser callers
+must include `X-CSRF-Token` with the value returned by `/auth/whoami`.
+Bearer API-key requests do not require CSRF, and logout does not revoke API
+keys; use the API-key revoke endpoints for key lifecycle.
+
+The operator console sign-out control uses this endpoint and clears local
+in-memory auth state even if the server cannot be reached.
+
+API keys and browser SSO can coexist. When both are enabled, `/auth/status`
+lists both the API-key method and the configured SSO methods. Requests with an
+`Authorization: Bearer ...` header are evaluated as API-key requests before any
+session cookie; an invalid or malformed bearer header fails instead of falling
+back to the cookie session.
+
 ## OIDC
 
 ```sh

--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -1657,6 +1657,10 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   required OIDC `azp` for multi-audience ID tokens, rejected invalid trusted
   proxy entries in the auth TLS startup guard, and corrected SSO role-mapping
   docs/tests to include the supported `runner` role.
+- [x] **Wave 11 status:** Documented the visible browser-auth endpoint
+  contract for `/auth/status` method objects, `/auth/whoami` session CSRF
+  surfacing, `/auth/logout` CSRF requirements, API-key/SSO coexistence, and
+  the operator-console sign-out affordance.
 - **Files:** `docs/sso-authentication.md` (operator setup for all three + role mapping + session tuning + TLS), README/roadmap updates.
 - **Key work:** end-to-end security pass; verify cookie flags/CSRF/open-redirect guards across providers; finalize metrics + audit actions (`auth.login`, `auth.logout`, `auth.session_revoked`, `user.provisioned`, `auth.login_denied`).
 

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Bell, ChevronRight, LogOut } from "lucide-react";
+import { useState } from "react";
 import { ModeToggle } from "../mode-toggle";
 import { CommandMenu } from "../command-menu";
 import { Button } from "@/components/ui/button";
@@ -75,6 +76,21 @@ function Breadcrumb() {
 }
 
 export function Header() {
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const handleSignOut = async () => {
+    if (isSigningOut) {
+      return;
+    }
+
+    setIsSigningOut(true);
+    try {
+      await logout();
+    } finally {
+      setIsSigningOut(false);
+    }
+  };
+
   return (
     <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-border/70 bg-background/70 px-6 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="flex items-center gap-4">
@@ -101,8 +117,10 @@ export function Header() {
           variant="ghost"
           size="icon"
           aria-label="Sign out"
+          aria-busy={isSigningOut}
           className="text-text-2 hover:text-text-1"
-          onClick={() => void logout()}
+          disabled={isSigningOut}
+          onClick={() => void handleSignOut()}
         >
           <LogOut className="h-4 w-4" />
         </Button>

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,9 +1,10 @@
 import { Link, useRouterState } from "@tanstack/react-router";
-import { Bell, ChevronRight } from "lucide-react";
+import { Bell, ChevronRight, LogOut } from "lucide-react";
 import { ModeToggle } from "../mode-toggle";
 import { CommandMenu } from "../command-menu";
 import { Button } from "@/components/ui/button";
 import { UTCClock } from "@/components/ui/utc-clock";
+import { logout } from "@/lib/auth";
 
 interface Crumb {
   label: string;
@@ -95,6 +96,15 @@ export function Header() {
           className="text-text-2 hover:text-text-1"
         >
           <Bell className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Sign out"
+          className="text-text-2 hover:text-text-1"
+          onClick={() => void logout()}
+        >
+          <LogOut className="h-4 w-4" />
         </Button>
         <ModeToggle />
       </div>

--- a/ui/src/components/layout/__tests__/Header.test.tsx
+++ b/ui/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Header } from "../Header";
+
+const { logoutMock } = vi.hoisted(() => ({
+  logoutMock: vi.fn(() => Promise.resolve()),
+}));
+
+type MockRouterState = {
+  location: {
+    pathname: string;
+  };
+};
+
+type MockLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  children: ReactNode;
+  to: string;
+};
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, to, ...props }: MockLinkProps) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+  useRouterState: ({ select }: { select: (state: MockRouterState) => string }) =>
+    select({ location: { pathname: "/jobs" } }),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  logout: logoutMock,
+}));
+
+vi.mock("../../command-menu", () => ({
+  CommandMenu: () => <button type="button">Search...</button>,
+}));
+
+vi.mock("../../mode-toggle", () => ({
+  ModeToggle: () => <button type="button">Toggle theme</button>,
+}));
+
+describe("Header", () => {
+  beforeEach(() => {
+    logoutMock.mockClear();
+  });
+
+  it("calls logout from the sign-out control", () => {
+    render(<Header />);
+
+    const signOut = screen.getByRole("button", { name: "Sign out" });
+    expect(signOut).toBeVisible();
+
+    fireEvent.click(signOut);
+
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/components/layout/__tests__/Header.test.tsx
+++ b/ui/src/components/layout/__tests__/Header.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Header } from "../Header";
@@ -42,7 +42,8 @@ vi.mock("../../mode-toggle", () => ({
 
 describe("Header", () => {
   beforeEach(() => {
-    logoutMock.mockClear();
+    logoutMock.mockReset();
+    logoutMock.mockResolvedValue(undefined);
   });
 
   it("calls logout from the sign-out control", () => {
@@ -54,5 +55,31 @@ describe("Header", () => {
     fireEvent.click(signOut);
 
     expect(logoutMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables sign-out while logout is pending", async () => {
+    let resolveLogout!: () => void;
+    logoutMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveLogout = resolve;
+      }),
+    );
+    render(<Header />);
+
+    const signOut = screen.getByRole("button", { name: "Sign out" });
+
+    fireEvent.click(signOut);
+
+    expect(signOut).toBeDisabled();
+    expect(signOut).toHaveAttribute("aria-busy", "true");
+
+    fireEvent.click(signOut);
+    expect(logoutMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveLogout();
+    });
+
+    await waitFor(() => expect(signOut).not.toBeDisabled());
   });
 });


### PR DESCRIPTION
## Summary
- add a header sign-out control that calls the existing UI logout flow
- cover the control with a focused Header component test
- document the browser auth endpoint contract and update the SSO plan Wave 11 status

## Validation
- npm test -- src/components/layout/__tests__/Header.test.tsx src/features/auth/__tests__/AuthGate.test.tsx src/lib/__tests__/auth.test.ts
- npm run lint
- npm run build
- git diff --check -- docs/sso-authentication.md docs/superpowers/plans/2026-05-27-sso-foundation.md ui/src/components/layout/Header.tsx ui/src/components/layout/__tests__/Header.test.tsx
- just unit-test
- just lint