### PR TITLE
[codex] Close SSO logout coexistence gaps

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -183,6 +183,65 @@ func TestRegisterSSORoutesProtectsLogoutWithCSRF(t *testing.T) {
 	require.ErrorIs(t, err, iauth.ErrSessionRevoked)
 }
 
+func TestRegisterSSORoutesBearerLogoutSkipsCSRFAndKeepsCredentials(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	svc := iauth.NewService(db)
+	auditor := iauth.NewAuditLogger(db)
+	limiter := iauth.NewRateLimiter(5, time.Minute)
+	sessions := iauth.NewSessionStore(db)
+	user := &models.User{
+		ID:        uuid.New(),
+		Issuer:    "oidc",
+		Subject:   "sub-1",
+		Email:     "viewer@example.com",
+		Role:      models.RoleViewer,
+		CreatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create(user).Error)
+	sessionToken, sess, err := sessions.Create(t.Context(), iauth.CreateSessionRequest{UserID: user.ID})
+	require.NoError(t, err)
+	apiKey, err := svc.CreateKey(&iauth.CreateKeyRequest{
+		Role:      models.RoleViewer,
+		CreatedBy: "seed",
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	registerSSORoutes(e, env.Environment{AuthSessionCookieName: "caesium_session"}, svc, auditor, limiter, sessions, nil, SSOProviders{})
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey.Plaintext)
+	req.AddCookie(&http.Cookie{Name: "caesium_session", Value: sessionToken})
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+	require.Empty(t, rec.Result().Cookies())
+
+	storedKey, err := svc.ValidateKey(apiKey.Plaintext)
+	require.NoError(t, err)
+	require.Equal(t, apiKey.Key.ID, storedKey.ID)
+	require.Nil(t, storedKey.RevokedAt)
+
+	storedSession, _, err := sessions.Validate(t.Context(), sessionToken)
+	require.NoError(t, err)
+	require.Equal(t, sess.ID, storedSession.ID)
+	require.Nil(t, storedSession.RevokedAt)
+
+	entries, err := auditor.Query(&iauth.AuditQueryRequest{Action: iauth.ActionAuthLogout, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, apiKey.Key.KeyPrefix, entries[0].Actor)
+	require.Equal(t, "api_key", entries[0].ResourceType)
+	require.Equal(t, apiKey.Key.ID.String(), entries[0].ResourceID)
+	require.Equal(t, iauth.OutcomeSuccess, entries[0].Outcome)
+
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal(entries[0].Metadata, &metadata))
+	require.Equal(t, true, metadata["noop"])
+}
+
 func TestRegisterSSORoutesWhoamiReturnsSessionCSRF(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })

--- a/api/rest/controller/auth/sso.go
+++ b/api/rest/controller/auth/sso.go
@@ -117,6 +117,11 @@ func (s *SSOController) LDAPLogin(c *echo.Context) error {
 }
 
 func (s *SSOController) Logout(c *echo.Context) error {
+	if principal := authmw.GetPrincipal(c); principal != nil && principal.Kind == iauth.PrincipalAPIKey {
+		s.recordAPIKeyLogoutNoop(c, principal)
+		return c.NoContent(http.StatusNoContent)
+	}
+
 	var sess *models.Session
 	var user *models.User
 	recordLogout := false
@@ -309,6 +314,28 @@ func (s *SSOController) recordLogout(c *echo.Context, outcome string, sess *mode
 		entry.ResourceType = "session"
 		entry.ResourceID = sess.ID.String()
 		entry.Metadata["provider"] = sess.AuthMethod
+	}
+	logAuditFailure(s.auditor.Log(entry))
+}
+
+func (s *SSOController) recordAPIKeyLogoutNoop(c *echo.Context, principal *iauth.Principal) {
+	if s.auditor == nil || principal == nil {
+		return
+	}
+	entry := iauth.AuditEntry{
+		Actor:        principal.Subject,
+		Action:       iauth.ActionAuthLogout,
+		ResourceType: "api_key",
+		SourceIP:     c.RealIP(),
+		Outcome:      iauth.OutcomeSuccess,
+		Metadata: map[string]interface{}{
+			"method": c.Request().Method,
+			"path":   c.Request().URL.Path,
+			"noop":   true,
+		},
+	}
+	if principal.KeyID != nil {
+		entry.ResourceID = principal.KeyID.String()
 	}
 	logAuditFailure(s.auditor.Log(entry))
 }

--- a/docs/superpowers/plans/2026-05-27-sso-foundation.md
+++ b/docs/superpowers/plans/2026-05-27-sso-foundation.md
@@ -33,11 +33,15 @@
   negative fixtures for OIDC, SAML, and LDAP. `codex/sso-p5-hardening-wave`
   then covered fail-closed state-cookie callbacks, LDAP malformed search
   results, trusted-proxy same-origin redirects, and secure-cookie checks for
-  redirect callbacks. Wave 9 on `codex/sso-remaining-foundation-wave` is scoped
-  to remaining foundation hardening and docs cleanup. Wave 10 on
-  `codex/sso-post-foundation-hardening` clears one-time OIDC/SAML state cookies
-  after redirect callbacks, tightens OIDC multi-audience `azp` checks, validates
-  trusted-proxy TLS-guard config, and corrects role-mapping docs/tests.
+  redirect callbacks. Wave 9 on `codex/sso-remaining-foundation-wave` covered
+  remaining foundation hardening and docs cleanup. Wave 10 on
+  `codex/sso-post-foundation-hardening` cleared one-time OIDC/SAML state cookies
+  after redirect callbacks, tightened OIDC multi-audience `azp` checks,
+  validated trusted-proxy TLS-guard config, and corrected role-mapping
+  docs/tests. Wave 11 on `codex/sso-ui-logout-contract` (PR #202) documented
+  the browser-auth status, whoami, logout, coexistence, and operator-console
+  sign-out contract. Wave 12 on `codex/sso-plan-closure-coverage` closed stale
+  plan metadata and added route-level API-key logout coexistence coverage.
 
 ## File structure
 
@@ -1661,6 +1665,9 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
   contract for `/auth/status` method objects, `/auth/whoami` session CSRF
   surfacing, `/auth/logout` CSRF requirements, API-key/SSO coexistence, and
   the operator-console sign-out affordance.
+- [x] **Wave 12 status:** Closed stale plan metadata and added route-level
+  coverage proving bearer API-key logout does not require CSRF and does not
+  revoke API keys or cookie sessions when both credentials are present.
 - **Files:** `docs/sso-authentication.md` (operator setup for all three + role mapping + session tuning + TLS), README/roadmap updates.
 - **Key work:** end-to-end security pass; verify cookie flags/CSRF/open-redirect guards across providers; finalize metrics + audit actions (`auth.login`, `auth.logout`, `auth.session_revoked`, `user.provisioned`, `auth.login_denied`).
 
@@ -1670,4 +1677,4 @@ Each becomes its own `docs/superpowers/plans/2026-…-sso-<phase>.md`, written j
 
 - **Spec coverage:** §5.1 Principal → Tasks 0.1–0.3, 1.10; §6 data model → 1.2; §7 config → 1.1; §9 role mapping → 1.6; §10 sessions → 1.4/1.5; §11 middleware/CSRF/endpoints → 1.9–1.11; §5.2 provider interface + login tail → 1.8; UI → 1.13; providers §8 → P2–P4 plans; docs §17 → P5.
 - **Type consistency:** `Principal.Scope` is `[]byte` (matches `auth.ScopeJobs`/`CheckScope` and `models.APIKey.Scope` = `datatypes.JSON`); `SSOService.Complete` returns `(cookieValue string, *models.Session, error)` consistent with `SessionStore.Create`; `RoleMapper.Resolve` returns `(models.Role, bool)` consumed by `Complete`.
-- **Open follow-through for the executor:** `ExternalIdentity` (Task 1.8) must exist before Tasks 1.7/1.8 tests compile — do Task 1.8's struct first if ordering causes a compile gap. Reuse one `newTestDB`/`newCtx` helper across `internal/auth` and `api/middleware` tests rather than duplicating.
+- **Test helper note:** Reuse one `newTestDB`/`newCtx` helper across `internal/auth` and `api/middleware` tests rather than duplicating.


### PR DESCRIPTION
## Summary
- make bearer-authenticated `/auth/logout` a no-op for cookie-session state
- add route-level coverage for bearer + cookie coexistence without CSRF
- close stale SSO plan metadata and record Wave 12 status

## Validation
- docker run --rm --platform linux/arm64 -v /Users/cryan/dev/caesium:/bld/caesium -w /bld/caesium caesiumcloud/caesium-builder:latest-full sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test -count=1 -run TestRegisterSSORoutesBearerLogoutSkipsCSRFAndKeepsCredentials ./api -v'\n- just unit-test\n- just lint\n- git diff --check -- api/api_test.go api/rest/controller/auth/sso.go docs/superpowers/plans/2026-05-27-sso-foundation.md