### PR TITLE
Fix flaky OIDC state-cookie tamper test (base64 last-char malleability)

### DIFF
--- a/internal/auth/oidc/provider_test.go
+++ b/internal/auth/oidc/provider_test.go
@@ -435,11 +435,19 @@ func tamperCookieValue(value string) string {
 	if len(value) == 0 {
 		return "tampered"
 	}
+	// Mutate the FIRST base64 character rather than the last. The state cookie is
+	// base64.RawURLEncoding(payload) + "." + base64.RawURLEncoding(sig); a 32-byte
+	// HMAC encodes to 43 chars whose final character carries only 4 significant
+	// bits — the decoder discards the trailing 2. So replacing the last character
+	// ('A'->'B' when already 'A') can decode to identical bytes, leaving the
+	// signature valid ~1/16 of runs and making this test flaky. The first
+	// character's six bits are all significant, so changing it always alters the
+	// decoded payload and is reliably rejected as a signature mismatch.
 	replacement := byte('A')
-	if value[len(value)-1] == replacement {
+	if value[0] == replacement {
 		replacement = 'B'
 	}
-	return value[:len(value)-1] + string(replacement)
+	return string(replacement) + value[1:]
 }
 
 type mockIssuer struct {


### PR DESCRIPTION
## Summary

`TestCompleteRejectsInvalidStateCookieBeforeExchange/tampered_cookie` (`internal/auth/oidc`) flakes **~1/16 of runs**, architecture-independent. It surfaced intermittently on CI — most recently the `unit-test-arm64` and `unit-test` jobs — failing with `invalid oidc nonce` where `invalid oidc state` was expected. (Spotted while chasing CI flakes on an unrelated docs PR; this is the real root cause, fixed here on its own branch.)

## Root cause

The state cookie is `base64.RawURLEncoding(payload) + "." + base64.RawURLEncoding(sig)`. A 32-byte HMAC-SHA256 encodes to **43** base64 chars, and the **final character carries only 4 significant bits** — `base64.RawURLEncoding` discards the trailing 2 bits on decode.

`tamperCookieValue` replaced the **last** character (`'A'`→`'B'` when it was already `'A'`). `'A'`(0) and `'B'`(1) differ only in one of those discarded low bits, so whenever the signature's final byte had a zero low nibble (~1/16), the "tampered" cookie decoded to **identical bytes** — the HMAC still verified, `decodeStateCookie` succeeded, and `Complete` proceeded past the state check to fail later on the nonce. Hence the wrong error.

## Fix

Mutate the **first** base64 character instead. Its six bits are all significant, so the change always alters the decoded payload and is reliably rejected as a signature mismatch — preserving the test's intent (`ErrInvalidState` / "signature mismatch").

## Verification

- **Before:** ~19 failures per 300 iterations (`-count=300`).
- **After:** 1000 iterations + `-race` pass clean; full `internal/auth/oidc` package passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)