### PR TITLE
Add UI support for volumes and workload identity

### DIFF
--- a/docs/examples/k8s-workload-identity-volume.job.yaml
+++ b/docs/examples/k8s-workload-identity-volume.job.yaml
@@ -1,0 +1,65 @@
+# Demonstrates Kubernetes workload identity and BYO PVC-backed volumes.
+# Hydrate-safe: this job uses an HTTP trigger, so it is visible in the UI
+# after `just hydrate` but only runs when explicitly triggered.
+#
+# To run this on Kubernetes, create the referenced ServiceAccounts and PVC
+# first, then fire the HTTP trigger.
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: k8s-workload-identity-volume-demo
+  labels:
+    team: platform
+    feature: workload-identity
+    runtime: kubernetes
+  annotations:
+    purpose: "Show Kubernetes serviceAccountName, pod annotations, and PVC mounts"
+  serviceAccountName: caesium-report-reader
+  podAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/caesium-report-reader
+  automountServiceAccountToken: false
+trigger:
+  type: http
+  configuration:
+    path: "/hooks/examples/k8s-workload-identity-volume"
+volumes:
+  - name: cloud-workspace
+    sources:
+      kubernetes:
+        pvc: caesium-cloud-workspace-rwx
+steps:
+  - name: plan-access
+    engine: kubernetes
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        mkdir -p /workspace/plans
+        echo "Plan cloud access using metadata-level ServiceAccount defaults."
+        echo '##caesium::output {"plan": "/workspace/plans/access-plan.txt"}'
+    volumeMounts:
+      - volume: cloud-workspace
+        path: /workspace
+    next:
+      - write-cloud-report
+
+  - name: write-cloud-report
+    engine: kubernetes
+    image: alpine:3.23
+    dependsOn: [plan-access]
+    serviceAccountName: caesium-cloud-writer
+    podAnnotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/caesium-cloud-writer
+    automountServiceAccountToken: true
+    command:
+      - sh
+      - -c
+      - |
+        echo "Use the step-level ServiceAccount override for cloud writes."
+        echo "Would write cloud report into /workspace/reports."
+    volumeMounts:
+      - volume: cloud-workspace
+        path: /workspace
+        subPath: reports

--- a/docs/examples/k8s-workload-identity-volume.job.yaml
+++ b/docs/examples/k8s-workload-identity-volume.job.yaml
@@ -42,8 +42,6 @@ steps:
     volumeMounts:
       - volume: cloud-workspace
         path: /workspace
-    next:
-      - write-cloud-report
 
   - name: write-cloud-report
     engine: kubernetes

--- a/docs/examples/volume-artifacts.job.yaml
+++ b/docs/examples/volume-artifacts.job.yaml
@@ -1,0 +1,76 @@
+# Demonstrates named job volumes with Docker/Podman-compatible sources.
+# Hydrate-safe: this job uses an HTTP trigger, so it is visible in the UI
+# after `just hydrate` but only runs when explicitly triggered.
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: volume-artifacts-demo
+  labels:
+    team: platform
+    feature: volumes
+  annotations:
+    purpose: "Show named volumes and read-only mounts in the DAG and atom spec"
+trigger:
+  type: http
+  configuration:
+    path: "/hooks/examples/volume-artifacts"
+volumes:
+  - name: workspace
+    sources:
+      docker:
+        volume: caesium-example-workspace
+      podman:
+        volume: caesium-example-workspace
+      kubernetes:
+        pvc: caesium-example-workspace-rwx
+steps:
+  - name: prepare-artifact
+    engine: docker
+    image: alpine:3.23
+    command:
+      - sh
+      - -c
+      - |
+        mkdir -p /workspace/reports
+        printf 'status=prepared\nfeature=volumes\n' > /workspace/reports/summary.txt
+        echo '##caesium::output {"artifact_path": "/workspace/reports/summary.txt"}'
+    volumeMounts:
+      - volume: workspace
+        path: /workspace
+    next:
+      - verify-artifact
+
+  - name: verify-artifact
+    engine: docker
+    image: alpine:3.23
+    dependsOn: [prepare-artifact]
+    command:
+      - sh
+      - -c
+      - |
+        test -s /workspace/reports/summary.txt
+        echo "Verified shared artifact:"
+        cat /workspace/reports/summary.txt
+        echo '##caesium::output {"verified": "true"}'
+    volumeMounts:
+      - volume: workspace
+        path: /workspace
+        readOnly: true
+    next:
+      - publish-manifest
+
+  - name: publish-manifest
+    engine: docker
+    image: alpine:3.23
+    dependsOn: [verify-artifact]
+    command:
+      - sh
+      - -c
+      - |
+        cat /workspace/reports/summary.txt
+        echo "Would publish manifest metadata from shared storage."
+    volumeMounts:
+      - volume: workspace
+        path: /workspace
+        readOnly: true

--- a/docs/examples/volume-artifacts.job.yaml
+++ b/docs/examples/volume-artifacts.job.yaml
@@ -38,8 +38,6 @@ steps:
     volumeMounts:
       - volume: workspace
         path: /workspace
-    next:
-      - verify-artifact
 
   - name: verify-artifact
     engine: docker
@@ -57,8 +55,6 @@ steps:
       - volume: workspace
         path: /workspace
         readOnly: true
-    next:
-      - publish-manifest
 
   - name: publish-manifest
     engine: docker

--- a/docs/job-definitions.md
+++ b/docs/job-definitions.md
@@ -324,6 +324,8 @@ In this manifest, `fetch-data` inherits the job-level 24-hour TTL, `transform` o
   - Explicit edge wiring (`explicit-links.job.yaml`).
   - Fan-out/fan-in DAG (`fanout-join.job.yaml`).
   - Data contract validation across producer and consumer steps (`data-contracts.job.yaml`).
+  - Artifact handoff through shared task volumes (`volume-artifacts.job.yaml`).
+  - Kubernetes workload identity with projected credentials and volume mounts (`k8s-workload-identity-volume.job.yaml`).
   - HTTP-triggered debugging workflow (`http-ops-debug.job.yaml`).
   - Incremental execution and cache reuse (`incremental-cache.job.yaml`).
   - HTTP-triggered log streaming showcase with ANSI color and sustained output (`log-streaming.job.yaml`).

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -2,6 +2,9 @@ package jobdef
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/caesium-cloud/caesium/pkg/container"
@@ -129,6 +132,30 @@ func TestParseValidDefinitions(t *testing.T) {
 			if len(start.Next) != 2 {
 				t.Fatalf("branchy job should have two successors, got %d", len(start.Next))
 			}
+		}
+	}
+}
+
+func TestParseRepositoryExamples(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+
+	for _, dir := range []string{"docs/examples", "docs/examples-k8s"} {
+		pattern := filepath.Join(repoRoot, filepath.FromSlash(dir), "*.job.yaml")
+		matches, err := filepath.Glob(pattern)
+		require.NoError(t, err)
+		require.NotEmpty(t, matches, "expected example manifests in %s", dir)
+
+		for _, path := range matches {
+			t.Run(filepath.ToSlash(path[len(repoRoot)+1:]), func(t *testing.T) {
+				data, err := os.ReadFile(path)
+				require.NoError(t, err)
+				def, err := Parse(data)
+				require.NoError(t, err)
+				require.NotEmpty(t, def.Metadata.Alias)
+				require.NotEmpty(t, def.Steps)
+			})
 		}
 	}
 }

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -148,6 +148,7 @@ func TestParseRepositoryExamples(t *testing.T) {
 		require.NotEmpty(t, matches, "expected example manifests in %s", dir)
 
 		for _, path := range matches {
+			path := path
 			t.Run(filepath.ToSlash(path[len(repoRoot)+1:]), func(t *testing.T) {
 				data, err := os.ReadFile(path)
 				require.NoError(t, err)

--- a/test/jobdef_runtime_test.go
+++ b/test/jobdef_runtime_test.go
@@ -1,0 +1,186 @@
+//go:build integration
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/caesium-cloud/caesium/pkg/container"
+	"github.com/stretchr/testify/require"
+)
+
+func (s *IntegrationTestSuite) TestJobApplyPersistsVolumeAndWorkloadIdentityRuntimeSpecs() {
+	suffix := time.Now().UnixNano()
+	volumeAlias := fmt.Sprintf("integration-volume-runtime-%d", suffix)
+	identityAlias := fmt.Sprintf("integration-identity-runtime-%d", suffix)
+	manifest := fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %[1]s
+trigger:
+  type: http
+  configuration:
+    path: "/hooks/integration/%[1]s"
+volumes:
+  - name: workspace
+    sources:
+      docker:
+        volume: caesium-integration-workspace
+      podman:
+        volume: caesium-integration-workspace
+      kubernetes:
+        pvc: caesium-integration-workspace-rwx
+steps:
+  - name: prepare-artifact
+    engine: docker
+    image: alpine:3.23
+    command: ["sh", "-c", "echo prepared > /workspace/result.txt"]
+    volumeMounts:
+      - {volume: workspace, path: /workspace}
+    next: verify-artifact
+  - name: verify-artifact
+    engine: docker
+    image: alpine:3.23
+    dependsOn: [prepare-artifact]
+    command: ["sh", "-c", "test -s /workspace/result.txt"]
+    volumeMounts:
+      - {volume: workspace, path: /workspace, readOnly: true}
+---
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %[2]s
+  serviceAccountName: caesium-report-reader
+  podAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/caesium-report-reader
+  automountServiceAccountToken: false
+trigger:
+  type: http
+  configuration:
+    path: "/hooks/integration/%[2]s"
+volumes:
+  - name: cloud-workspace
+    sources:
+      kubernetes:
+        pvc: caesium-cloud-workspace-rwx
+steps:
+  - name: plan-access
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo plan"]
+    volumeMounts:
+      - {volume: cloud-workspace, path: /workspace}
+    next: write-cloud-report
+  - name: write-cloud-report
+    engine: kubernetes
+    image: alpine:3.23
+    dependsOn: [plan-access]
+    serviceAccountName: caesium-cloud-writer
+    podAnnotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/caesium-cloud-writer
+    automountServiceAccountToken: true
+    command: ["sh", "-c", "echo write"]
+    volumeMounts:
+      - {volume: cloud-workspace, path: /workspace, readOnly: true, subPath: reports}
+`, volumeAlias, identityAlias)
+
+	dir := s.writeRawJobManifest(manifest)
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	volumeJob := s.requireJobByAlias(volumeAlias)
+	volumeSpecs := s.fetchAtomSpecsByTaskName(volumeJob.ID)
+	require.Len(s.T(), volumeSpecs, 2)
+
+	prepareMount := requireSingleResolvedMount(s.T(), volumeSpecs["prepare-artifact"])
+	require.Equal(s.T(), container.VolumeMountTypeVolume, prepareMount.Type)
+	require.Equal(s.T(), "workspace", prepareMount.Name)
+	require.Equal(s.T(), "caesium-integration-workspace", prepareMount.Source)
+	require.Equal(s.T(), "/workspace", prepareMount.Target)
+	require.False(s.T(), prepareMount.ReadOnly)
+
+	verifyMount := requireSingleResolvedMount(s.T(), volumeSpecs["verify-artifact"])
+	require.Equal(s.T(), container.VolumeMountTypeVolume, verifyMount.Type)
+	require.Equal(s.T(), "caesium-integration-workspace", verifyMount.Source)
+	require.Equal(s.T(), "/workspace", verifyMount.Target)
+	require.True(s.T(), verifyMount.ReadOnly)
+
+	identityJob := s.requireJobByAlias(identityAlias)
+	identitySpecs := s.fetchAtomSpecsByTaskName(identityJob.ID)
+	require.Len(s.T(), identitySpecs, 2)
+
+	planSpec := identitySpecs["plan-access"]
+	planMount := requireSingleResolvedMount(s.T(), planSpec)
+	require.Equal(s.T(), container.VolumeMountTypePVC, planMount.Type)
+	require.Equal(s.T(), "caesium-cloud-workspace-rwx", planMount.Source)
+	require.Equal(s.T(), "/workspace", planMount.Target)
+	require.NotNil(s.T(), planSpec.Kubernetes)
+	require.Equal(s.T(), "caesium-report-reader", planSpec.Kubernetes.ServiceAccountName)
+	require.Equal(
+		s.T(),
+		map[string]string{"eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/caesium-report-reader"},
+		planSpec.Kubernetes.PodAnnotations,
+	)
+	require.NotNil(s.T(), planSpec.Kubernetes.AutomountServiceAccountToken)
+	require.False(s.T(), *planSpec.Kubernetes.AutomountServiceAccountToken)
+
+	writeSpec := identitySpecs["write-cloud-report"]
+	writeMount := requireSingleResolvedMount(s.T(), writeSpec)
+	require.Equal(s.T(), container.VolumeMountTypePVC, writeMount.Type)
+	require.Equal(s.T(), "caesium-cloud-workspace-rwx", writeMount.Source)
+	require.Equal(s.T(), "/workspace", writeMount.Target)
+	require.True(s.T(), writeMount.ReadOnly)
+	require.Equal(s.T(), "reports", writeMount.SubPath)
+	require.NotNil(s.T(), writeSpec.Kubernetes)
+	require.Equal(s.T(), "caesium-cloud-writer", writeSpec.Kubernetes.ServiceAccountName)
+	require.Equal(
+		s.T(),
+		map[string]string{"eks.amazonaws.com/role-arn": "arn:aws:iam::123456789012:role/caesium-cloud-writer"},
+		writeSpec.Kubernetes.PodAnnotations,
+	)
+	require.NotNil(s.T(), writeSpec.Kubernetes.AutomountServiceAccountToken)
+	require.True(s.T(), *writeSpec.Kubernetes.AutomountServiceAccountToken)
+}
+
+func (s *IntegrationTestSuite) writeRawJobManifest(contents string) string {
+	dir, err := os.MkdirTemp("", "caesium-runtime-job-*")
+	require.NoError(s.T(), err)
+
+	path := filepath.Join(dir, "runtime.job.yaml")
+	require.NoError(s.T(), os.WriteFile(path, []byte(contents), 0o644))
+	return dir
+}
+
+func (s *IntegrationTestSuite) fetchAtomSpecsByTaskName(jobID string) map[string]container.Spec {
+	tasks := s.jobTasks(jobID)
+	specs := make(map[string]container.Spec, len(tasks))
+	for _, task := range tasks {
+		name := taskString(task, "name")
+		atomID := taskString(task, "AtomID", "atom_id")
+		require.NotEmptyf(s.T(), name, "task response missing name: %#v", task)
+		require.NotEmptyf(s.T(), atomID, "task response missing atom id: %#v", task)
+		specs[name] = s.fetchAtomSpec(atomID)
+	}
+	return specs
+}
+
+func taskString(task map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value := valueFromMap(task, key); value != nil {
+			if str, ok := value.(string); ok {
+				return str
+			}
+		}
+	}
+	return ""
+}
+
+func requireSingleResolvedMount(t require.TestingT, spec container.Spec) container.VolumeMount {
+	require.Len(t, spec.ResolvedVolumeMounts, 1)
+	return spec.ResolvedVolumeMounts[0]
+}

--- a/ui/e2e/runtime-hints.spec.ts
+++ b/ui/e2e/runtime-hints.spec.ts
@@ -1,0 +1,38 @@
+import { expect, type Page, test } from "@playwright/test";
+import { applyDefinitions, loadFixtureDefinition } from "./helpers/fixtures";
+
+test("DAG view surfaces volume mounts and workload identity from applied job definitions", async ({ page, request }) => {
+  const volumeDefinition = await loadFixtureDefinition("volume-artifacts.job.yaml");
+  const identityDefinition = await loadFixtureDefinition("k8s-workload-identity-volume.job.yaml");
+  const volumeAlias = String(volumeDefinition.metadata?.alias);
+  const identityAlias = String(identityDefinition.metadata?.alias);
+
+  await applyDefinitions(request, volumeDefinition, identityDefinition);
+
+  await openJobDetail(page, volumeAlias);
+  const volumeBadges = page.getByTestId("runtime-volume-badge");
+  await expect(volumeBadges).toHaveCount(3);
+  await expect(volumeBadges).toHaveText(["1", "1", "1"]);
+  await expect(page.getByTestId("runtime-identity-badge")).toHaveCount(0);
+
+  await openJobDetail(page, identityAlias);
+  const identityVolumeBadges = page.getByTestId("runtime-volume-badge");
+  await expect(identityVolumeBadges).toHaveCount(2);
+  await expect(identityVolumeBadges).toHaveText(["1", "1"]);
+
+  const identityBadges = page.getByTestId("runtime-identity-badge");
+  await expect(identityBadges).toHaveCount(2);
+  await expect(identityBadges).toHaveText(["SA", "SA"]);
+  await expect(page.locator('[data-testid="runtime-identity-badge"][title="ServiceAccount caesium-report-reader"]')).toHaveCount(1);
+  await expect(page.locator('[data-testid="runtime-identity-badge"][title="ServiceAccount caesium-cloud-writer"]')).toHaveCount(1);
+});
+
+async function openJobDetail(page: Page, alias: string) {
+  await page.goto("/jobs");
+  const row = page.locator('[data-testid="job-row"]', { hasText: alias }).first();
+  await expect(row).toBeVisible();
+  await row.getByRole("link", { name: alias }).click();
+  await page.waitForURL(/\/jobs\/[^/]+$/);
+  await expect(page.getByRole("heading", { name: alias })).toBeVisible();
+  await expect(page.locator(".react-flow__node").first()).toBeVisible();
+}

--- a/ui/src/features/jobdefs/JobDefsPage.tsx
+++ b/ui/src/features/jobdefs/JobDefsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -171,7 +171,8 @@ export function JobDefsPage() {
   const lineCount = yaml.split("\n").length;
   const diffCount = diffResult ? (diffResult.added?.length || 0) + (diffResult.removed?.length || 0) + (diffResult.modified?.length || 0) : 0;
   const hasErrors = lintResult.errors && lintResult.errors.length > 0;
-  const runtimeHints = getJobDefRuntimeHints(yaml);
+  const deferredYaml = useDeferredValue(yaml);
+  const runtimeHints = useMemo(() => getJobDefRuntimeHints(deferredYaml), [deferredYaml]);
 
   return (
     <div className="space-y-6 pb-12">

--- a/ui/src/features/jobdefs/JobDefsPage.tsx
+++ b/ui/src/features/jobdefs/JobDefsPage.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
+import type { ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, type DiffResponse, type LintResponse } from "@/lib/api";
-import { FileCode2, Play, CheckCircle2, XCircle, Upload, GitBranch, FileWarning, Info } from "lucide-react";
+import { FileCode2, Play, CheckCircle2, XCircle, Upload, GitBranch, FileWarning, Info, HardDrive, ShieldCheck } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import CodeMirror from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
@@ -10,38 +11,47 @@ import { linter, type Diagnostic } from "@codemirror/lint";
 import { EditorView } from "@codemirror/view";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card } from "@/components/ui/card";
+import { getJobDefRuntimeHints, type JobDefRuntimeHints } from "./runtimeHints";
 
-const EXAMPLE_YAML = `apiVersion: v1
+export const EXAMPLE_YAML = `apiVersion: v1
 kind: Job
 metadata:
-  alias: nightly-etl-warehouse
+  alias: infra-plan-apply
   labels:
-    team: data-platform
+    team: platform
     tier: critical
+  serviceAccountName: caesium-planner
+  podAnnotations:
+    iam.gke.io/gcp-service-account: terraform-planner@example.iam.gserviceaccount.com
+  automountServiceAccountToken: true
 trigger:
-  type: cron
+  type: http
   configuration:
-    cron: "0 2 * * *"
-    timezone: "UTC"
+    path: "/hooks/infra/apply"
+volumes:
+  - name: work
+    sources:
+      docker:
+        bind: /mnt/nfs/caesium-work
+      podman:
+        bind: /mnt/nfs/caesium-work
+      kubernetes:
+        pvc: ci-shared-rwx
 steps:
-  - name: extract.users
-    image: ghcr.io/cs/postgres-extractor:1.4
-    command: ["python", "/app/extract.py", "--table=users"]
-  - name: extract.orders
-    image: ghcr.io/cs/postgres-extractor:1.4
-    command: ["python", "/app/extract.py", "--table=orders"]
-  - name: transform.users
-    image: ghcr.io/cs/dbt:1.7
-    dependsOn: [extract.users]
-    command: ["dbt", "run", "--select", "users"]
-  - name: transform.orders
-    image: ghcr.io/cs/dbt:1.7
-    dependsOn: [extract.orders]
-    command: ["dbt", "run", "--select", "orders"]
-  - name: load.warehouse
-    image: snowflake/snowsql
-    dependsOn: [transform.users, transform.orders]
-    command: ["snowsql", "-f", "/sql/load.sql"]
+  - name: plan
+    engine: kubernetes
+    image: hashicorp/terraform:1.9
+    command: ["terraform", "plan", "-out=/work/tf.plan"]
+    volumeMounts:
+      - {volume: work, path: /work}
+  - name: apply
+    engine: kubernetes
+    image: hashicorp/terraform:1.9
+    dependsOn: [plan]
+    serviceAccountName: caesium-deployer
+    volumeMounts:
+      - {volume: work, path: /work, readOnly: true, subPath: plans}
+    command: ["terraform", "apply", "/work/tf.plan"]
 `;
 
 // Simple custom theme for the editor to match our brand
@@ -161,6 +171,7 @@ export function JobDefsPage() {
   const lineCount = yaml.split("\n").length;
   const diffCount = diffResult ? (diffResult.added?.length || 0) + (diffResult.removed?.length || 0) + (diffResult.modified?.length || 0) : 0;
   const hasErrors = lintResult.errors && lintResult.errors.length > 0;
+  const runtimeHints = getJobDefRuntimeHints(yaml);
 
   return (
     <div className="space-y-6 pb-12">
@@ -328,6 +339,24 @@ export function JobDefsPage() {
         {/* Right rail */}
         <div className="flex flex-col gap-3 sticky top-4">
           <Card className="bg-midnight/30 border-graphite/50 p-4 shadow-md">
+            <div className="text-[10px] font-bold uppercase tracking-widest text-text-3 mb-3">Runtime support</div>
+            <div className="flex flex-col gap-3">
+              <RuntimeHint
+                icon={<HardDrive className="h-3.5 w-3.5" />}
+                label="Volumes"
+                value={formatVolumeHint(runtimeHints)}
+                detail={formatVolumeDetail(runtimeHints)}
+              />
+              <RuntimeHint
+                icon={<ShieldCheck className="h-3.5 w-3.5" />}
+                label="Kubernetes identity"
+                value={formatIdentityHint(runtimeHints)}
+                detail={formatIdentityDetail(runtimeHints)}
+              />
+            </div>
+          </Card>
+
+          <Card className="bg-midnight/30 border-graphite/50 p-4 shadow-md">
             <div className="text-[10px] font-bold uppercase tracking-widest text-text-3 mb-3">Schema reference</div>
             <RefBlock title="Top-level fields" code={`apiVersion: v1
 kind: Job
@@ -341,6 +370,21 @@ dependsOn: [extract.users]
 
 # Or explicit successors
 next: [transform.users]`} />
+            <RefBlock title="Volumes" code={`volumes:
+  - name: work
+    sources:
+      docker: {bind: /mnt/nfs/work}
+      kubernetes: {pvc: ci-shared-rwx}
+
+volumeMounts:
+  - {volume: work, path: /work}`} />
+            <RefBlock title="Kubernetes identity" code={`metadata:
+  serviceAccountName: caesium-runner
+  podAnnotations: {...}
+
+steps:
+  - engine: kubernetes
+    serviceAccountName: caesium-deployer`} />
             <RefBlock title="Callbacks" code={`callbacks:
   - type: notification
     configuration:
@@ -367,12 +411,68 @@ next: [transform.users]`} />
                 <span className="text-cyan-glow mt-0.5">·</span> 
                 <span>Without edges, steps run sequentially.</span>
               </li>
+              <li className="flex gap-2">
+                <span className="text-cyan-glow mt-0.5">·</span>
+                <span>Use a shared <code className="font-mono bg-obsidian px-1 py-0.5 rounded text-[11px] text-cyan-glow border border-graphite/50">bind</code> path or RWX <code className="font-mono bg-obsidian px-1 py-0.5 rounded text-[11px] text-cyan-glow border border-graphite/50">pvc</code> for cross-step files.</span>
+              </li>
             </ul>
           </Card>
         </div>
       </div>
     </div>
   );
+}
+
+function RuntimeHint({
+  icon,
+  label,
+  value,
+  detail,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  detail: string;
+}) {
+  return (
+    <div className="flex items-start gap-2.5 text-xs">
+      <div className="mt-0.5 text-cyan-glow shrink-0">{icon}</div>
+      <div className="min-w-0">
+        <div className="font-medium text-text-1">{label}</div>
+        <div className="font-mono text-[11px] text-text-2 break-all">{value}</div>
+        <div className="text-[11px] text-text-4 leading-relaxed">{detail}</div>
+      </div>
+    </div>
+  );
+}
+
+function formatVolumeHint(hints: JobDefRuntimeHints) {
+  if (hints.parseError) return "Waiting for valid YAML";
+  if (hints.volumeCount === 0) return "No volumes declared";
+  return `${hints.volumeCount} declared`;
+}
+
+function formatVolumeDetail(hints: JobDefRuntimeHints) {
+  if (hints.parseError) return "Live lint will show parser details.";
+  if (hints.volumeMountCount === 0) return "No step mounts a declared volume.";
+  const steps = `${hints.volumeMountedStepCount} ${hints.volumeMountedStepCount === 1 ? "step" : "steps"}`;
+  const mounts = `${hints.volumeMountCount} ${hints.volumeMountCount === 1 ? "mount" : "mounts"}`;
+  return `${mounts} across ${steps}.`;
+}
+
+function formatIdentityHint(hints: JobDefRuntimeHints) {
+  if (hints.parseError) return "Waiting for valid YAML";
+  if (hints.serviceAccountNames.length === 0) return "No service account";
+  return hints.serviceAccountNames.join(", ");
+}
+
+function formatIdentityDetail(hints: JobDefRuntimeHints) {
+  if (hints.parseError) return "Live lint will show parser details.";
+  const extras = [];
+  if (hints.hasPodAnnotations) extras.push("pod annotations");
+  if (hints.hasAutomountTokenSetting) extras.push("token setting");
+  if (extras.length === 0) return "Step-level values override metadata defaults.";
+  return `Includes ${extras.join(" and ")}.`;
 }
 
 function DiffView({ diff }: { diff: DiffResponse | null }) {

--- a/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
+++ b/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { JobDefsPage } from "../JobDefsPage";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    lintJobDef: vi.fn(),
+    diffJobDef: vi.fn(),
+    applyJobDef: vi.fn(),
+  },
+}));
+
+vi.mock("@uiw/react-codemirror", () => ({
+  default: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange?: (value: string) => void;
+  }) => (
+    <textarea
+      aria-label="job.yaml editor"
+      value={value}
+      onChange={(event) => onChange?.(event.currentTarget.value)}
+    />
+  ),
+}));
+
+vi.mock("@codemirror/lang-yaml", () => ({
+  yaml: () => [],
+}));
+
+vi.mock("@codemirror/lint", () => ({
+  linter: () => [],
+}));
+
+vi.mock("@codemirror/view", () => ({
+  EditorView: {
+    theme: () => [],
+  },
+}));
+
+import { api } from "@/lib/api";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("JobDefsPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.mocked(api.lintJobDef).mockResolvedValue({
+      errors: [],
+      warnings: [],
+      summary: { steps: "2 steps" },
+    });
+    vi.mocked(api.diffJobDef).mockResolvedValue({
+      added: [],
+      removed: [],
+      modified: [],
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders volume and workload identity authoring support", () => {
+    render(<JobDefsPage />, { wrapper: createWrapper() });
+
+    expect(screen.getByText("Runtime support")).toBeInTheDocument();
+    expect(screen.getByText("1 declared")).toBeInTheDocument();
+    expect(screen.getByText("2 mounts across 2 steps.")).toBeInTheDocument();
+    expect(screen.getByText("caesium-planner, caesium-deployer")).toBeInTheDocument();
+    expect(screen.getByText("Includes pod annotations and token setting.")).toBeInTheDocument();
+    expect(screen.getAllByText("Volumes").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Kubernetes identity").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("ships a starter manifest with volumes and Kubernetes identity fields", () => {
+    render(<JobDefsPage />, { wrapper: createWrapper() });
+
+    const editor = screen.getByLabelText("job.yaml editor") as HTMLTextAreaElement;
+    expect(editor.value).toContain("volumes:");
+    expect(editor.value).toContain("volumeMounts:");
+    expect(editor.value).toContain("serviceAccountName: caesium-deployer");
+    expect(editor.value).toContain("automountServiceAccountToken: true");
+    expect(editor.value).toContain("kubernetes:");
+    expect(editor.value).toContain("pvc: ci-shared-rwx");
+  });
+
+  it("updates runtime hints as the manifest changes", () => {
+    render(<JobDefsPage />, { wrapper: createWrapper() });
+
+    fireEvent.change(screen.getByLabelText("job.yaml editor"), {
+      target: {
+        value: `apiVersion: v1
+kind: Job
+metadata:
+  alias: simple
+trigger:
+  type: cron
+  configuration:
+    cron: "0 * * * *"
+steps:
+  - name: run
+    image: alpine:3.23
+`,
+      },
+    });
+
+    expect(screen.getByText("No volumes declared")).toBeInTheDocument();
+    expect(screen.getByText("No service account")).toBeInTheDocument();
+  });
+});

--- a/ui/src/features/jobdefs/__tests__/runtimeHints.test.ts
+++ b/ui/src/features/jobdefs/__tests__/runtimeHints.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { getJobDefRuntimeHints } from "../runtimeHints";
+
+describe("getJobDefRuntimeHints", () => {
+  it("summarizes volumes and Kubernetes identity fields", () => {
+    const hints = getJobDefRuntimeHints(`apiVersion: v1
+kind: Job
+metadata:
+  alias: volume-identity
+  serviceAccountName: default-runner
+  podAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/caesium-runner
+  automountServiceAccountToken: false
+volumes:
+  - name: work
+    sources:
+      kubernetes:
+        pvc: ci-shared-rwx
+steps:
+  - name: plan
+    engine: kubernetes
+    image: hashicorp/terraform:1.9
+    volumeMounts:
+      - {volume: work, path: /work}
+  - name: apply
+    engine: kubernetes
+    image: hashicorp/terraform:1.9
+    serviceAccountName: deployer
+    volumeMounts:
+      - {volume: work, path: /work, readOnly: true}
+`);
+
+    expect(hints).toMatchObject({
+      volumeCount: 1,
+      volumeMountCount: 2,
+      volumeMountedStepCount: 2,
+      hasPodAnnotations: true,
+      hasAutomountTokenSetting: true,
+    });
+    expect(hints.serviceAccountNames).toEqual(["default-runner", "deployer"]);
+  });
+
+  it("accumulates hints across multi-document manifests", () => {
+    const hints = getJobDefRuntimeHints(`apiVersion: v1
+kind: Job
+metadata:
+  alias: first
+volumes:
+  - name: scratch
+    source:
+      tmpfs: {sizeBytes: 1048576}
+steps:
+  - name: test
+    image: alpine:3.23
+    volumeMounts:
+      - {volume: scratch, path: /tmp/scratch}
+---
+apiVersion: v1
+kind: Job
+metadata:
+  alias: second
+  serviceAccountName: batch-runner
+steps:
+  - name: run
+    engine: kubernetes
+    image: alpine:3.23
+`);
+
+    expect(hints.volumeCount).toBe(1);
+    expect(hints.volumeMountCount).toBe(1);
+    expect(hints.volumeMountedStepCount).toBe(1);
+    expect(hints.serviceAccountNames).toEqual(["batch-runner"]);
+  });
+
+  it("reports parse errors without throwing", () => {
+    const hints = getJobDefRuntimeHints("apiVersion: v1\nmetadata: [");
+
+    expect(hints.parseError).toBeTruthy();
+    expect(hints.volumeCount).toBe(0);
+    expect(hints.serviceAccountNames).toEqual([]);
+  });
+});

--- a/ui/src/features/jobdefs/runtimeHints.ts
+++ b/ui/src/features/jobdefs/runtimeHints.ts
@@ -1,4 +1,5 @@
 import { parseAllDocuments } from "yaml";
+import { isRecord } from "@/lib/typeGuards";
 
 export interface JobDefRuntimeHints {
   volumeCount: number;
@@ -75,20 +76,19 @@ function collectIdentityHints(
 ) {
   if (!isRecord(value)) return;
 
-  if (typeof value.serviceAccountName === "string") {
-    const serviceAccountName = value.serviceAccountName.trim();
+  const rawServiceAccountName = value.serviceAccountName;
+  if (typeof rawServiceAccountName === "string") {
+    const serviceAccountName = rawServiceAccountName.trim();
     if (serviceAccountName) serviceAccounts.add(serviceAccountName);
   }
 
-  if (isRecord(value.podAnnotations) && Object.keys(value.podAnnotations).length > 0) {
+  const rawPodAnnotations = value.podAnnotations;
+  if (isRecord(rawPodAnnotations) && Object.keys(rawPodAnnotations).length > 0) {
     hints.hasPodAnnotations = true;
   }
 
-  if (typeof value.automountServiceAccountToken === "boolean") {
+  const rawAutomountServiceAccountToken = value.automountServiceAccountToken;
+  if (typeof rawAutomountServiceAccountToken === "boolean") {
     hints.hasAutomountTokenSetting = true;
   }
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === "object" && !Array.isArray(value);
 }

--- a/ui/src/features/jobdefs/runtimeHints.ts
+++ b/ui/src/features/jobdefs/runtimeHints.ts
@@ -1,0 +1,94 @@
+import { parseAllDocuments } from "yaml";
+
+export interface JobDefRuntimeHints {
+  volumeCount: number;
+  volumeMountCount: number;
+  volumeMountedStepCount: number;
+  serviceAccountNames: string[];
+  hasPodAnnotations: boolean;
+  hasAutomountTokenSetting: boolean;
+  parseError?: string;
+}
+
+export function getJobDefRuntimeHints(yamlSource: string): JobDefRuntimeHints {
+  const hints: JobDefRuntimeHints = {
+    volumeCount: 0,
+    volumeMountCount: 0,
+    volumeMountedStepCount: 0,
+    serviceAccountNames: [],
+    hasPodAnnotations: false,
+    hasAutomountTokenSetting: false,
+  };
+  const serviceAccounts = new Set<string>();
+
+  try {
+    const docs = parseAllDocuments(yamlSource);
+    for (const doc of docs) {
+      if (doc.errors.length > 0) {
+        hints.parseError = doc.errors[0]?.message || "Invalid YAML";
+        continue;
+      }
+
+      collectDocumentHints(doc.toJS(), hints, serviceAccounts);
+    }
+  } catch (err) {
+    hints.parseError = err instanceof Error ? err.message : "Invalid YAML";
+  }
+
+  hints.serviceAccountNames = [...serviceAccounts];
+  return hints;
+}
+
+function collectDocumentHints(
+  value: unknown,
+  hints: JobDefRuntimeHints,
+  serviceAccounts: Set<string>,
+) {
+  if (!isRecord(value)) return;
+
+  const volumes = value.volumes;
+  if (Array.isArray(volumes)) {
+    hints.volumeCount += volumes.length;
+  }
+
+  collectIdentityHints(value.metadata, hints, serviceAccounts);
+
+  const steps = value.steps;
+  if (!Array.isArray(steps)) return;
+
+  for (const step of steps) {
+    if (!isRecord(step)) continue;
+    collectIdentityHints(step, hints, serviceAccounts);
+
+    const mounts = step.volumeMounts;
+    if (Array.isArray(mounts) && mounts.length > 0) {
+      hints.volumeMountCount += mounts.length;
+      hints.volumeMountedStepCount += 1;
+    }
+  }
+}
+
+function collectIdentityHints(
+  value: unknown,
+  hints: JobDefRuntimeHints,
+  serviceAccounts: Set<string>,
+) {
+  if (!isRecord(value)) return;
+
+  if (typeof value.serviceAccountName === "string") {
+    const serviceAccountName = value.serviceAccountName.trim();
+    if (serviceAccountName) serviceAccounts.add(serviceAccountName);
+  }
+
+  if (isRecord(value.podAnnotations) && Object.keys(value.podAnnotations).length > 0) {
+    hints.hasPodAnnotations = true;
+  }
+
+  if (typeof value.automountServiceAccountToken === "boolean") {
+    hints.hasAutomountTokenSetting = true;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}

--- a/ui/src/features/jobs/JobDAG.tsx
+++ b/ui/src/features/jobs/JobDAG.tsx
@@ -11,6 +11,7 @@ import 'reactflow/dist/style.css';
 import dagre from 'dagre';
 import { ShieldCheck } from 'lucide-react';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { isRecord } from '@/lib/typeGuards';
 import type { JobDAGResponse, Atom, JobTask, TaskRun } from '@/lib/api';
 import { TaskNode } from './components/TaskNode';
 import { BranchNode } from './components/BranchNode';
@@ -401,8 +402,4 @@ function EmptyState({ message }: { message: string }) {
             {message}
         </div>
     );
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/ui/src/features/jobs/components/TaskNode.tsx
+++ b/ui/src/features/jobs/components/TaskNode.tsx
@@ -1,5 +1,6 @@
 import { memo } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
+import { isRecord } from '@/lib/typeGuards';
 import { cn, shortId } from '@/lib/utils';
 import {
   Activity,
@@ -246,19 +247,18 @@ function getRuntimeHints(spec: unknown) {
     ? spec.resolvedVolumeMounts
     : [];
   const kubernetes = isRecord(spec.kubernetes) ? spec.kubernetes : null;
-  const serviceAccountName = typeof kubernetes?.serviceAccountName === 'string'
-    ? kubernetes.serviceAccountName.trim()
+  const rawServiceAccountName = kubernetes?.serviceAccountName;
+  const serviceAccountName = typeof rawServiceAccountName === 'string'
+    ? rawServiceAccountName.trim()
     : '';
-  const hasPodAnnotations = isRecord(kubernetes?.podAnnotations) && Object.keys(kubernetes.podAnnotations).length > 0;
-  const hasAutomountSetting = typeof kubernetes?.automountServiceAccountToken === 'boolean';
+  const rawPodAnnotations = kubernetes?.podAnnotations;
+  const hasPodAnnotations = isRecord(rawPodAnnotations) && Object.keys(rawPodAnnotations).length > 0;
+  const rawAutomountServiceAccountToken = kubernetes?.automountServiceAccountToken;
+  const hasAutomountSetting = typeof rawAutomountServiceAccountToken === 'boolean';
 
   return {
     volumeCount: resolvedVolumeMounts.length,
     hasKubernetesIdentity: serviceAccountName !== '' || hasPodAnnotations || hasAutomountSetting,
     serviceAccountName,
   };
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value);
 }

--- a/ui/src/features/jobs/components/TaskNode.tsx
+++ b/ui/src/features/jobs/components/TaskNode.tsx
@@ -15,12 +15,15 @@ import {
   AlertTriangle,
   Archive,
   SkipForward,
+  HardDrive,
+  ShieldCheck,
 } from 'lucide-react';
 import { Duration } from '@/components/duration';
 
 export const TaskNode = memo(({ data }: NodeProps) => {
   const { label, atom, status, isSelected, startedAt, completedAt, engine, command, error } = data;
   const taskLabel = typeof label === 'string' ? label : '';
+  const runtimeHints = getRuntimeHints(atom?.spec);
 
   const getStatusIcon = () => {
     switch (status) {
@@ -124,6 +127,26 @@ export const TaskNode = memo(({ data }: NodeProps) => {
                     SHELL
                   </span>
                 )}
+                {runtimeHints.volumeCount > 0 && (
+                  <span
+                    data-testid="runtime-volume-badge"
+                    title={`${runtimeHints.volumeCount} resolved volume ${runtimeHints.volumeCount === 1 ? 'mount' : 'mounts'}`}
+                    className="inline-flex items-center gap-0.5 rounded border border-caesium-cyan/30 bg-caesium-cyan/10 px-1 text-[8px] font-black text-caesium-cyan"
+                  >
+                    <HardDrive className="h-2.5 w-2.5" />
+                    {runtimeHints.volumeCount}
+                  </span>
+                )}
+                {runtimeHints.hasKubernetesIdentity && (
+                  <span
+                    data-testid="runtime-identity-badge"
+                    title={runtimeHints.serviceAccountName ? `ServiceAccount ${runtimeHints.serviceAccountName}` : 'Kubernetes pod identity settings'}
+                    className="inline-flex items-center gap-0.5 rounded border border-gold/35 bg-gold/10 px-1 text-[8px] font-black text-gold"
+                  >
+                    <ShieldCheck className="h-2.5 w-2.5" />
+                    SA
+                  </span>
+                )}
                 <span className="truncate text-[9px] font-mono text-muted-foreground">
                   {shortId(taskLabel)}
                 </span>
@@ -209,3 +232,33 @@ export const TaskNode = memo(({ data }: NodeProps) => {
 });
 
 TaskNode.displayName = 'TaskNode';
+
+function getRuntimeHints(spec: unknown) {
+  if (!isRecord(spec)) {
+    return {
+      volumeCount: 0,
+      hasKubernetesIdentity: false,
+      serviceAccountName: '',
+    };
+  }
+
+  const resolvedVolumeMounts = Array.isArray(spec.resolvedVolumeMounts)
+    ? spec.resolvedVolumeMounts
+    : [];
+  const kubernetes = isRecord(spec.kubernetes) ? spec.kubernetes : null;
+  const serviceAccountName = typeof kubernetes?.serviceAccountName === 'string'
+    ? kubernetes.serviceAccountName.trim()
+    : '';
+  const hasPodAnnotations = isRecord(kubernetes?.podAnnotations) && Object.keys(kubernetes.podAnnotations).length > 0;
+  const hasAutomountSetting = typeof kubernetes?.automountServiceAccountToken === 'boolean';
+
+  return {
+    volumeCount: resolvedVolumeMounts.length,
+    hasKubernetesIdentity: serviceAccountName !== '' || hasPodAnnotations || hasAutomountSetting,
+    serviceAccountName,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/ui/src/features/jobs/components/__tests__/TaskNode.test.tsx
+++ b/ui/src/features/jobs/components/__tests__/TaskNode.test.tsx
@@ -122,4 +122,31 @@ describe('TaskNode', () => {
     expect(screen.queryByText('IN')).not.toBeInTheDocument();
     expect(screen.queryByText('OUT')).not.toBeInTheDocument();
   });
+
+  it('renders runtime badges for resolved volumes and Kubernetes identity', () => {
+    renderTaskNode({
+      label: 'task-runtime',
+      status: 'pending',
+      atom: {
+        image: 'alpine:3.23',
+        engine: 'kubernetes',
+        command: ['echo', 'runtime'],
+        spec: {
+          resolvedVolumeMounts: [
+            { type: 'pvc', source: 'shared-work', target: '/work' },
+            { type: 'pvc', source: 'shared-cache', target: '/cache' },
+          ],
+          kubernetes: {
+            serviceAccountName: 'caesium-writer',
+          },
+        },
+      },
+      engine: 'kubernetes',
+      command: ['echo', 'runtime'],
+    });
+
+    expect(screen.getByTestId('runtime-volume-badge')).toHaveTextContent('2');
+    expect(screen.getByTestId('runtime-identity-badge')).toHaveTextContent('SA');
+    expect(screen.getByTitle('ServiceAccount caesium-writer')).toBeInTheDocument();
+  });
 });

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -74,6 +74,68 @@ describe('api', () => {
     expect(mockFetch).toHaveBeenCalledWith('/v1/jobs/job-42/cache', expect.anything());
   });
 
+  it('applyJobDef preserves volume and workload identity fields in the request payload', async () => {
+    mockFetch.mockResolvedValue(okResponse({ applied: 1 }));
+
+    await api.applyJobDef(`apiVersion: v1
+kind: Job
+metadata:
+  alias: runtime-contract
+  serviceAccountName: caesium-reader
+  podAnnotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/caesium-reader
+  automountServiceAccountToken: false
+trigger:
+  type: http
+  configuration:
+    path: /hooks/runtime-contract
+volumes:
+  - name: workspace
+    sources:
+      kubernetes:
+        pvc: caesium-workspace-rwx
+steps:
+  - name: run
+    engine: kubernetes
+    image: alpine:3.23
+    serviceAccountName: caesium-writer
+    volumeMounts:
+      - {volume: workspace, path: /workspace, readOnly: true}
+`);
+
+    const [, init] = mockFetch.mock.calls[0];
+    const payload = JSON.parse(String(init?.body));
+    expect(payload.definitions).toHaveLength(1);
+    expect(payload.definitions[0]).toMatchObject({
+      metadata: {
+        alias: 'runtime-contract',
+        serviceAccountName: 'caesium-reader',
+        podAnnotations: {
+          'eks.amazonaws.com/role-arn': 'arn:aws:iam::123456789012:role/caesium-reader',
+        },
+        automountServiceAccountToken: false,
+      },
+      volumes: [
+        {
+          name: 'workspace',
+          sources: {
+            kubernetes: { pvc: 'caesium-workspace-rwx' },
+          },
+        },
+      ],
+      steps: [
+        expect.objectContaining({
+          name: 'run',
+          engine: 'kubernetes',
+          serviceAccountName: 'caesium-writer',
+          volumeMounts: [
+            { volume: 'workspace', path: '/workspace', readOnly: true },
+          ],
+        }),
+      ],
+    });
+  });
+
   it('deleteTaskCache encodes the task name in the URL', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/ui/src/lib/typeGuards.ts
+++ b/ui/src/lib/typeGuards.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -56,6 +56,14 @@ export default defineConfig({
       '/v1': {
         target: 'http://localhost:8080',
         changeOrigin: true,
+      },
+      '/auth': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+      '/health': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
       }
     }
   },


### PR DESCRIPTION
## Summary
- add Job Definitions authoring hints for volumes and Kubernetes workload identity
- show resolved volume and ServiceAccount badges in the DAG nodes
- add hydrate-safe example manifests and backend/UI coverage for the new runtime fields

## Tests
- go test ./pkg/jobdef
- npm test -- --run
- npm run lint
- npm run build:ci
- npx playwright test --list
- git diff --check

## Notes
- The `/auth` and `/health` Vite proxy entries are dev-server-only wiring so the local UI can reach the same backend auth/status endpoints as `/v1`; they do not add production routes or expose new server behavior.
- Tagged integration package compile is blocked on this host outside the containerized build environment: dqlite headers are unavailable (fatal error: 'dqlite.h' file not found).