### PR TITLE
Add differentiation strategy and data-plane memory design docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ This directory separates current-source operator documentation from forward-look
 
 ## Strategy & Roadmap
 
+- [differentiation-strategy.md](differentiation-strategy.md): Positioning thesis — the sovereignty-led funnel, why Caesium wins by constraint not comparison, and the kill-conditions that test it.
 - [roadmap.md](roadmap.md): Strategic vision, design principles, and the prioritized feature plan.
 
 ## Active Design Records
@@ -32,6 +33,7 @@ Forward-looking or partially-shipped designs with open work. Each carries a `> S
 - [design-incremental-execution.md](design-incremental-execution.md): Smart incremental execution and task caching (Phase 1 shipped; follow-on phases planned).
 - [design-sla-management.md](design-sla-management.md): SLA deadline tracking, predictive completion estimates, and escalation chains (proposed).
 - [design-task-templates.md](design-task-templates.md): Reusable, parameterized step templates (proposed).
+- [design-data-plane-memory.md](design-data-plane-memory.md): The second-act substrate (digest pinning, decomposed-hash persistence, DAG versioning, lineage datasets, large-object passing) that makes the data-plane queryable — explain/reproduce/skip (proposed).
 
 ## Load Testing
 

--- a/docs/design-data-plane-memory.md
+++ b/docs/design-data-plane-memory.md
@@ -1,0 +1,118 @@
+# Design: Data-Plane Memory (the second-act substrate)
+
+> Status: Proposed (2026-06-19). This is the **retention / differentiation layer**, not the lead positioning — see [`differentiation-strategy.md`](differentiation-strategy.md). It turns Caesium's already-shipped content-addressed cache, event store, and OpenLineage pipeline into a *queryable memory of what data flowed and why each task ran*. It is sequenced **after** sovereignty positioning and built in a **correctness-first order**. Do not market the features here until the components they depend on have shipped — a reproducibility claim on an unpinned image tag is worse than no claim.
+
+## Thesis (scoped)
+
+Caesium uniquely computes a transitive content hash that folds in the **typed data that flowed between steps** (`PredecessorOutputs`), and records an event-sourced history of every run on embedded dqlite. That substrate makes three queries possible that a pure container scheduler structurally cannot answer and that the open-core incumbents will not commoditize:
+
+- **EXPLAIN** — `caesium why`: why did this task run / skip / re-run?
+- **REPRODUCE** — a digest-pinned, git-committable run receipt + a cache-backed quarantined what-if replay.
+- **SKIP** — value-verified content-addressed incremental execution ("Bazel for data pipelines").
+
+**The honest gap:** today the substrate is ~60% built, and each query above depends on persistence that does not exist yet. This spec closes that gap in dependency order. Until it lands, scope claims to what the event store can answer today (cache hit/miss, predecessor-hash change, param change).
+
+## Goals
+
+1. Make the data-plane memory **queryable**, not just computed-and-discarded.
+2. Preserve every architectural constraint: zero external dependencies, single binary, container-only (no SDK), GitOps determinism, dqlite write characteristics, and the cache-correctness invariant (*a miss is always safe; a false hit is a bug*).
+3. Each component is independently shippable and independently valuable; later components are strictly additive.
+
+## Non-goals
+
+- A managed lineage/observability backend, a hosted control plane, or any phone-home. Everything stays self-hosted.
+- Competing with Datafold/dbt audit_helper on full row/column value diffing. We attribute *which step/output changed and why a task re-ran*; we hand off to those tools for value-level dataset diffs.
+- Reconstructing source data that has been overwritten. We store task identity and structured contract values, **not** the datasets a task reads. Replay re-executes identical code against the same typed inputs and pinned digests — it does not resurrect deleted data.
+
+---
+
+## Components, in correctness-first build order
+
+> Verified current state is cited with file:line. The house migration pattern is GORM `AutoMigrate(models.All...)` (`internal/models/models.go`); new columns are added as struct fields with GORM tags and created at startup — additive, nullable, backward-compatible. The house pattern for getting per-task context to distributed workers is scheduler-propagated fields on `TaskRun` (e.g. `PredecessorCacheHashes`/`PredecessorCacheOutputs`, per [`design-incremental-execution.md`](design-incremental-execution.md)); any new per-task field must follow that pattern so local and distributed modes behave identically.
+
+### Component 1 — Image digest resolution (FIRST: correctness gate)
+
+**Current state.** Image digest pinning does **not exist**. `HashInput.Image` (`internal/cache/hash.go:21`) hashes the literal tag (`alpine:3.23`, `foo:latest`); `Compute()` (`hash.go:33`) writes `image:%s` as-is. `internal/imagecheck/check.go` only checks local availability via `ImageInspectWithRaw`; it never resolves or stores a digest. No `RepoDigest`/`@sha256` handling anywhere in `internal/` or `pkg/`.
+
+**Why first.** A reproducibility receipt or a content-addressed skip built on a mutable tag is unsound: a `:latest` that changes underneath leaves the hash unchanged, so the cache serves a stale result and the "receipt" attests to the wrong image. **Shipping REPRODUCE before this is a silent correctness failure** (see the kill-conditions in the strategy doc).
+
+**Proposed change.** Resolve each step's image tag to its content digest (`sha256:…`) at task-spec construction time and (a) record the resolved digest on `TaskRun` and the cache `Entry`, and (b) **fold the digest, not the tag, into `HashInput`** so the cache key itself becomes tamper-evident. Resolution reuses the engine abstraction (`internal/atom` Docker/Podman/k8s); for k8s, prefer the digest already present in the pull status. Respect the constraint that tags were *deliberately* hashed literally to avoid per-check network latency: make digest resolution **opt-in per job** (e.g. `cache.pinDigests: true`) and cache the tag→digest mapping with a short TTL so steady-state runs pay no network cost.
+
+**Effort:** M. **Risk:** added pull-time latency on first resolution; registry auth for private images (reuse the existing secret providers). **Unlocks:** the integrity of REPRODUCE and the correctness of SKIP across tag drift.
+
+### Component 2 — Persist the decomposed `HashInput`
+
+**Current state.** `HashInput` (`hash.go:16-30`) is rich (image, command, env, mounts, k8s spec, predecessor hashes, **predecessor outputs**, run params, cache version), but `Compute()` returns only the final hex SHA-256. Persistence keeps **only that opaque digest**: `TaskRun.Hash` (`internal/models/run.go:49`), written by `SetTaskHash` (`internal/run/store.go:276`). The cache `TaskCache` entry (`run.go:92-103`) persists `{Hash, Result, Output, BranchSelections, RunID, TaskRunID, ExpiresAt}` — **no decomposed inputs.** So today the system can only conclude *"the hashes differ,"* which is no better than Argo's "the string differed."
+
+**Proposed change.** At hash-compute time, serialize the decomposed `HashInput` to a canonical JSON blob and store it as one new **nullable** JSON column on `TaskRun` (and on the cache `Entry`, so a cache hit can also be explained). This is additive (`AutoMigrate`), written on the existing write path, and gated behind cache being enabled. **Guardrails:** redact/whitelist env values before persisting (secrets resolve through `internal/jobdef/secret` and are already excluded from the hash — keep them out of the blob too); bound blob size and prune with the existing cache TTL/LRU.
+
+**Effort:** M. **Risk:** dqlite write volume (mitigated: one bounded blob per task, not per log line); secret leakage (mitigated by redaction). **Unlocks:** `caesium why` at **field granularity** — a pure read-side, field-by-field diff of two stored blobs ("CACHE MISS — predecessor `extract.row_count` changed 1.2M→1.4M; image, command, env identical; had it been unchanged this would have skipped"), joined to the `ExecutionEvent` store for trigger-side causation. Also makes `caesium run diff` causal (data-delta and re-run-cause become the *same* computation, because the hash already contains predecessor outputs).
+
+### Component 3 — Version DAG topology (stop destroying history)
+
+**Current state.** On every apply, `reconcileEdgesTx` hard-deletes all edges: `tx.Unscoped().Where("job_id = ?", …).Delete(&models.TaskEdge{})` (`internal/jobdef/importer.go:602`), then recreates them. `provenance_commit` is overwritten in place on update (`importer.go:~390-401`). There is **no** `*_version` / `*_snapshot` / `*_history` table in `internal/models`. `RunCheckpoint` snapshots *run* state, not *job-definition* topology. So "the pipeline as of commit X" is reconstructable only by `git checkout` + re-apply — which means any "bisect/time-travel over pipeline behavior" claim is really a git feature, not a Caesium one.
+
+**Proposed change.** Add an **append-only** `dag_snapshot` (or `job_version`) table that records, per apply, the full topology (tasks + edges) and per-edge `provenance_commit`, keyed by content hash of the manifest + git SHA. Reconciliation continues to maintain the *live* graph for execution, but no longer destroys history. This is the prerequisite for any "why did the graph change between these two runs" or commit-range analysis, reconstructable from dqlite alone.
+
+**Effort:** M–L. **Risk:** snapshot growth (bound with retention/dedup on unchanged topology — most applies don't change the DAG). **Unlocks:** version-aware EXPLAIN ("this edge was added in commit `3f2a1c` by alice@"), and a future `caesium blame` over commit ranges without `git checkout`.
+
+### Component 4 — Populate OpenLineage datasets
+
+**Current state.** The emission pipeline is production-grade and **shipped** — facets (Execution, DAG, Provenance, SourceCodeLocation, JobType, ParentRun, ErrorMessage), namespace handling, composite/console/file/http/retry transports — but **every mapper emits empty datasets**: `Inputs: []Dataset{}` / `Outputs: []Dataset{}` across all seven mappers in `internal/lineage/mapper.go` (e.g. lines 128-130, 255-257, 324-326). So OpenLineage consumers receive runs with no data graph. *This is the highest leverage-to-effort gap in the repo: ~80% built.*
+
+**Proposed change.** Derive datasets from (a) declared step I/O and (b) structured outputs that already carry file paths / table names, and attach a dataset + schema facet in the task mappers (after metadata load, before the `RunEvent` return). Keep only references/digests + small facet summaries in dqlite; emit full facets out via the existing http transport to a BYO consumer (respects the bounded-storage constraint). This is the foundation for cross-job impact analysis ("what breaks if this table changes") — but note that **cross-job blast-radius requires this component to exist first**; do not pitch it as already-leveraged. (This closes the gap previously tracked as the lineage "Component 0" spec-drop.)
+
+**Effort:** M. **Risk:** dataset identity/naming consistency across heterogeneous containers. **Unlocks:** a real, self-hosted, SDK-free lineage + change-impact catalog — the un-paywalled answer to Dagster's catalog.
+
+### Component 5 — Raise the 64 KB cap / large-object reference passing
+
+**Current state.** `MaxOutputBytes = 65536` (`pkg/task/output.go:28`); exceeding it **errors the task** (`output.go:87-94`). Outputs flow downstream as `CAESIUM_OUTPUT_<STEP>_<KEY>` env via `BuildOutputEnv` (`output.go:297-315`). There is **no** large-object / reference-passing path — values are strings in memory and in dqlite. So "value-verified skip" and any data-level diff cannot see a dataframe or a file the way Flyte's auto-offload or Datafold can.
+
+**Proposed change.** Add a `##caesium::output` variant that offloads a large payload to a **BYO** volume/object store (reuse the volumes abstraction) and passes only a **content-addressed reference** (path + digest) between containers — keeping dqlite to bounded references, never blobs. Hash the *reference digest* into `HashInput` so a step that emits byte-identical output produces a cache hit, enabling a **value-verified short-circuit**: replay a changed step, and if its output digest matches the last successful run's, **stop** — downstream stays green, proven not heuristic.
+
+**Effort:** L. **Risk:** BYO storage credentials/availability (opt-in, via existing secret providers); must never become a *mandatory* dependency. **Unlocks:** value-verified SKIP across heterogeneous containers (Spark/bash/dbt), and large-object passing that closes the most-cited expressiveness gap vs. Flyte/Mage.
+
+---
+
+## What each feature needs (don't ship ahead of its substrate)
+
+| Feature | Requires | Honest scope until then |
+|---|---|---|
+| `caesium why` (field-level) | C2 (+ C3 for graph-change causation) | Scope to cache hit/miss, predecessor-hash change, param change — call it that, not "data causality" |
+| Reproducibility receipt / `verify` | **C1 first**, then C2 | Do not ship — an unpinned-tag receipt is a silent correctness failure |
+| Quarantined what-if replay | C1, C2 (+ C5 for data-diff) | Re-run only hash-changed tasks; unchanged = provably-identical cache hits |
+| `caesium run diff` (causal) | C2 | Cache-bust attribution only; hand off value diffs to dbt/Datafold |
+| Value-verified skip ("Bazel for data") | C5 (+ C1) | Metadata-only skip exists today (shipped cache); value-verification needs C5 |
+| Cross-job impact analysis | C4 (+ C3) | Intra-DAG only until lineage datasets are populated |
+
+## Constraints this spec must honor
+
+- **Zero mandatory dependencies.** Everything stateful fits in dqlite, or is strictly opt-in/BYO (digest cache, artifact CAS). No Postgres/Redis/Kafka/object-store-by-default.
+- **dqlite write characteristics.** Writes serialize through Raft (`busy_timeout` is a no-op). Persist bounded, batched, pruned state — one blob per task, not per log line; reuse the cache TTL/LRU and checkpoint cadence.
+- **Cache-correctness invariant.** Any change to `HashInput` (digests in C1, reference digests in C5) must keep hashing conservative and all-inputs-inclusive; a miss must remain always safe.
+- **Distributed parity.** New per-task context must propagate via `TaskRun` fields the way `PredecessorCacheHashes`/`PredecessorCacheOutputs` do — never reconstructed independently per worker.
+- **GitOps determinism.** All behavior expressible in YAML and reproducible from the manifest + params.
+- **No SDK.** The only contract with user code stays: image + command + env + stdout markers + exit code + mounted volumes.
+
+## Sequencing & acceptance
+
+1. **C1 digest resolution** → acceptance: a job with `cache.pinDigests: true` records `sha256:…` on `TaskRun`/`Entry`; a moving `:latest` produces a cache **miss** (verified by a harness scenario asserting `cacheHit: false`).
+2. **C2 decomposed-input persistence** → acceptance: `caesium why <run> --task <t>` prints the single discriminating field between two runs; machine-readable JSON assertable in the harness.
+3. **C3 DAG versioning** → acceptance: applying a topology change creates a new `dag_snapshot`; the prior topology is still queryable.
+4. **C4 lineage datasets** → acceptance: emitted OpenLineage events carry non-empty `Inputs`/`Outputs`; impact query returns downstream datasets for a changed step.
+5. **C5 large-object refs** → acceptance: a step emitting a >64 KB payload via the reference protocol succeeds; a byte-identical re-run short-circuits with downstream staying green.
+
+Each ships behind the existing opt-in cache/lineage config and is independently revertible.
+
+## Open questions
+
+- Digest resolution for air-gapped registries (the sovereignty buyer): resolve at apply-time against the local mirror, or at first run? Likely apply-time with a recorded digest so runs are reproducible offline.
+- Retention policy for `dag_snapshot` and decomposed-input blobs under high apply/run frequency — dedup-on-unchanged + TTL, surfaced via the existing cache-prune machinery.
+- Whether `caesium why`'s trigger-side causation should read the `ExecutionEvent` payload directly or a derived index (write-amplification vs. query latency).
+
+## Related documents
+
+- [`differentiation-strategy.md`](differentiation-strategy.md) — why this is the second act, not the headline.
+- [`design-incremental-execution.md`](design-incremental-execution.md) — the shipped content-addressed cache and its distributed propagation pattern.
+- [`open_lineage.md`](open_lineage.md) — the shipped OpenLineage emission pipeline this populates.
+- [`roadmap.md`](roadmap.md) — `caesium why` / run-diff overlap with the "live DAG debugging" item (3.4), reimagined here as *causal* rather than a visual state-viewer.

--- a/docs/design-data-plane-memory.md
+++ b/docs/design-data-plane-memory.md
@@ -32,7 +32,7 @@ Caesium uniquely computes a transitive content hash that folds in the **typed da
 
 ### Component 1 — Image digest resolution (FIRST: correctness gate)
 
-**Current state.** Image digest pinning does **not exist**. `HashInput.Image` (`internal/cache/hash.go:21`) hashes the literal tag (`alpine:3.23`, `foo:latest`); `Compute()` (`hash.go:33`) writes `image:%s` as-is. `internal/imagecheck/check.go` only checks local availability via `ImageInspectWithRaw`; it never resolves or stores a digest. No `RepoDigest`/`@sha256` handling anywhere in `internal/` or `pkg/`.
+**Current state.** Image digest pinning does **not exist**. `HashInput.Image` (`internal/cache/hash.go:19`) hashes the literal tag (`alpine:3.23`, `foo:latest`); `Compute()` (`hash.go:33`) writes `image:%s` as-is. `internal/imagecheck/check.go` only checks local availability via `ImageInspectWithRaw`; it never resolves or stores a digest. No `RepoDigest`/`@sha256` handling anywhere in `internal/` or `pkg/`.
 
 **Why first.** A reproducibility receipt or a content-addressed skip built on a mutable tag is unsound: a `:latest` that changes underneath leaves the hash unchanged, so the cache serves a stale result and the "receipt" attests to the wrong image. **Shipping REPRODUCE before this is a silent correctness failure** (see the kill-conditions in the strategy doc).
 

--- a/docs/differentiation-strategy.md
+++ b/docs/differentiation-strategy.md
@@ -1,0 +1,104 @@
+# Differentiation Strategy: Where Caesium Wins
+
+> Status: Proposed positioning (2026-06-19). This document reframes how Caesium is positioned and prioritized. It is the output of a structured competitive analysis + a six-angle adversarial red-team of the resulting thesis. It does not change shipped behavior; it changes what we lead with, what we build next, and why. Supersedes the implicit "better Airflow" framing of the feature roadmap. The companion build spec is [`design-data-plane-memory.md`](design-data-plane-memory.md).
+
+## The problem this document solves
+
+Caesium can feel *placeless*. It is a container-first, dependency-free Airflow alternative with a great UI and many quality-of-life features — but most of the current roadmap (event triggers, concurrency strategies, SLAs, cost tracking, approval gates, live debugging) answers the question *"why not Airflow?"* It does **not** answer the harder question a platform engineer actually asks:
+
+> *"Why wouldn't I just define this natively in Kubernetes Jobs + Kueue + Argo Workflows?"*
+
+Nearly every roadmap item is something a competent platform team can approximate on Kubernetes in a sprint. That is the source of the placeless feeling. A durable identity has to rest on something competitors **structurally cannot or will not** copy — not on a longer feature list.
+
+## The market actually has two camps, and we were straddling both
+
+- **Camp 1 — pure container schedulers** (raw k8s Jobs + Kueue, Argo Workflows/Events). *Data-blind by design.* Kueue is a quota cop (hierarchical cohort borrowing, weighted fair-share, preemption, gang admission) with no DAG, no data, no lineage — and it never will, by scope. Argo adds a DAG but bolts a NATS/Kafka EventBus + external Postgres back on; its "cache" is string-keyed memoization, blind to whether *data* changed.
+- **Camp 2 — data-aware orchestrators** (Dagster, Flyte, Airflow 3, Prefect, Kestra, Mage). They own data semantics — but every serious one carries at least one of: **Python/SDK lock-in**, a **mandatory heavy backend** (Postgres, often + Redis/Kafka/ES), or an **open-core paywall** on the parts that make the demo shine (Dagster+ Insights/Catalog/Branch-Deploys; Kestra paywalls k8s/SSO/RBAC/audit). Kestra is the most dangerous lookalike (OSS, YAML-first, no-SDK) but is a fat 5-process JVM platform that mandates a DB.
+
+The roadmap aimed Caesium at Camp 2's *feature axis* (data-awareness) while quietly depending on Camp 1's *operational simplicity*. That is backwards.
+
+## The honest correction
+
+A first attempt at a north-star — *"Caesium is the only orchestrator with a content-addressed memory of the data plane"* — was put through a six-angle adversarial red-team (streetlight/overfitting, category-design, incumbent-durability, real-demand, rival-wedge, go-to-market). **All six attacks landed "serious," and they independently converged on the same structural facts**, which were then code-verified:
+
+1. The "memory" is **~60% built, and the unbuilt 40% is the product**. The decomposed hash inputs are thrown away (only the SHA-256 digest is persisted); OpenLineage datasets are emitted empty; image tags are never resolved to digests; the 64 KB scalar output cap means we cannot diff real data. So the flagship queries (`caesium why`, reproducibility receipts, value-verified skip) cannot run over today's substrate.
+2. Each flagship verb is **individually beaten by a free incumbent already in the data team's stack**: dbt `state:modified+`, Dagster `data_version` staleness + Asset Checks, Flyte cross-workflow DataCatalog memoization, Datafold/dbt audit_helper value diffs.
+3. The hash trick is ~150 LOC, **cloneable in a sprint**; a "why is this stale" panel is a one-quarter feature for a funded incumbent. The head start on that axis is *negative*.
+4. **No team has ever switched orchestrators** because "why did this re-run last night" was too hard to answer. It is a vitamin, not a painkiller.
+
+The verdict was **survives-with-pivot (high confidence)**. The thesis was real but mis-scoped on three axes simultaneously: **wrong lead axis** (data-memory vs. sovereignty), **wrong buyer** (regulated-vendor vs. self-hosting engineer), and **wrong claim type** (inventing a category vs. entering an existing one). The data-plane work is a great *second act* and a suicidal *first act*.
+
+## The load-bearing insight: constraint sells, comparison doesn't
+
+> **A sovereignty wedge sells by _constraint_. A data-awareness wedge sells by _comparison_.**
+
+This distinction is decisive *specifically because Caesium has renounced marketing, sales, and a revenue motive*:
+
+- *"Our content-addressed cache beats Flyte's memoization"* is a **comparison**. You win comparisons with benchmarks, docs, conference talks, and a sales motion — exactly the GTM engine this project will never build.
+- *"You literally cannot run Dagster/Airflow/Flyte in this air-gapped SCIF / factory floor / regulated bank"* is a **constraint**. The buyer's own compliance and network reality does the selling, for free.
+
+A project with no demand-generation must pick the wedge that **propagates by necessity, not persuasion.**
+
+## The real moat was never the hash
+
+It is two asymmetries competitors cannot unwind:
+
+1. **Deployment asymmetry.** Dagster needs Postgres; Airflow needs a metadata DB + broker + executor; Flyte needs Kubernetes + a control plane + an object store + an RDBMS; Prefect's good parts are cloud; Kestra is a 5-process JVM platform. **None can become "`scp` one binary to an air-gapped node and it just runs"** without detonating their own dependency graph. Caesium is a single zero-dependency Go binary with embedded dqlite — *today, shipped, best-in-class on this axis.*
+2. **Business-model asymmetry.** The open-core incumbents **will not commoditize their own paid lineage/observability/RBAC tiers.** Everything they paywall (HA, RBAC, SSO, audit, k8s execution, lineage) Caesium already ships free. "They won't" is as durable as "they can't."
+
+## The corrected positioning — a funnel, not a single bet
+
+The pivot is **invert the ranking**, not discard the data work. All three differentiation vectors compose into one funnel, and each answers a *different* competitor's "why not":
+
+| Layer | Vector | Answers… | Status |
+|---|---|---|---|
+| **Hook** — reason to clone | DX over raw k8s | *"Why not hand-roll Argo/Kueue?"* | Strong, but a taste argument; needs marketing to win |
+| **Close** — reason to adopt | **Operational sovereignty** | *"Why not Airflow/Dagster/Flyte?"* | **100% built, un-copyable, sells by constraint** |
+| **Retain** — reason to stay | Content-addressed data-plane memory | *"Why not the other zero-dep schedulers (Argo/Kueue/Cronicle)?"* | Second act; ~40% to build (see spec) |
+
+**Lead with sovereignty. Hook with DX. Retain with data-plane memory** — explicitly demoted from north-star to *"the killer differentiator within sovereignty"*: it is what makes Caesium more than "Argo with a nicer binary," once a user is already inside.
+
+### The coherent buyer (one, not three)
+
+The self-hosting platform/data engineer who refuses a control plane. Sovereignty is their *acquisition* reason; data-engineering-first DAG semantics are *what they are sovereign about*. This sharpens — rather than contradicts — the roadmap's "data engineering first" principle. Critically, **reframe REPRODUCE** from compliance-attestation (a buyer the no-vendor charter forbids — an auditor cannot cite a community Discord in a 21 CFR Part 11 binding) to **developer-grade "trust my own re-run"** for that same engineer. That collapses three incompatible buyers into one.
+
+## Positioning statement
+
+> *Kubernetes + Kueue + Argo schedule your containers but understand nothing about your data, and every serious data-aware orchestrator makes you stand up Postgres, Redis, or Kafka — or pay for the parts that matter. Caesium is the data-pipeline orchestrator that ships as a **single zero-dependency self-hosted binary**: it runs where Dagster, Airflow, and Flyte architecturally cannot — air-gapped, edge, regulated on-prem, sovereign — with HA, RBAC, SSO, and lineage free. And once you're inside, it remembers what data flowed and why each task ran, so it can explain, reproduce, and provably skip work — the data-plane memory that separates it from the other zero-dependency schedulers.*
+
+Use the words a frustrated engineer actually types into a search bar: *"lightweight Airflow alternative no database," "self-hosted orchestrator no Postgres," "air-gapped pipeline scheduler."* Retire *"content-addressed memory of the data plane"* as a category name — it is vendor-internal vocabulary.
+
+## What this means for the roadmap
+
+- **No code required first.** The highest-leverage move is a positioning rewrite (README/landing) to lead with sovereignty. The asset is already built.
+- **Delegate scheduling to Kueue; never bin-pack.** Emit the `kueue.x-k8s.io/queue-name` label so a Caesium DAG inherits quota/fair-share for free. A shallow Caesium "priority field" reads as a toy.
+- **The data-plane memory is the second act**, built in a correctness-first order (see [`design-data-plane-memory.md`](design-data-plane-memory.md)): digest-pin images → persist decomposed hash inputs → version DAG topology → populate lineage datasets → raise the 64 KB cap.
+- **Scope `caesium why` honestly** until the substrate lands: what the event store answers *today* is cache hit/miss, predecessor-hash change, and param change — not field-level data causality.
+
+## Do NOT build (protect the wedge)
+
+- **Generic priority / quotas / fair-share / preemption / GPU / gang / topology scheduling** — Kueue owns this on every axis a single binary structurally loses. Delegate, don't compete.
+- **Out-UI-ing Kestra** — its in-browser editor is its product and years ahead. Win on a different axis.
+- **Connector / plugin breadth** — Airflow has 1,500+ providers, Kestra 1,200+ plugins. "The image *is* the integration." Any connector-catalog framing loses instantly.
+- **Generic caching / cost dashboards / dataset-event triggers as headlines** — me-too unless tied to *data* (cost-per-dataset, cost wasted on cold re-runs the cache would have skipped).
+- **Container-native + YAML as *the* pitch** — table stakes (Argo, Kestra). Always lead with what runs on top.
+
+## Kill-conditions (watch these; the pivot can be wrong too)
+
+- 3–6 months of sovereignty-led positioning yields **zero inbound** from air-gapped/edge/regulated/on-prem users → the constraint isn't real and the pivot's premise fails.
+- An incumbent ships a field-level "why is this stale / why did this run" panel **before** Caesium ships a working `caesium why` → confirms the data-axis head start is negative.
+- Sovereignty adopters install but **never touch** skip/why/receipt features → data-plane memory is a slide, not a retention hook; cut the roadmap's back half.
+- A reproducibility receipt is treated as authoritative **while image tags are still unpinned** → a silent correctness failure (stale `:latest` served from cache); REPRODUCE is actively harmful until digest-pinning lands.
+- A funded zero-dep competitor (e.g. Kestra adding richer caching) closes the deployment-simplicity gap **and** offers data-awareness → both asymmetries collapse; reassess.
+- Engineering effort keeps flowing to `internal/cache/hash.go` (the built, replicable 60%) instead of digest-pinning + decomposed-input persistence (the unbuilt, differentiating 40%) → polishing the streetlight instead of searching the dark.
+
+## How we got here (methodology)
+
+This thesis was not authored top-down. It came from: (1) a structured competitive deep-dive of k8s/Kueue, Argo, Airflow, Dagster, Prefect, Temporal, Kestra, and Flyte/Windmill/Hatchet/Mage, grounded against the Caesium codebase; (2) multi-lens ideation of ~33 candidate differentiators; (3) an adversarial stress-test of each (skeptics instructed to kill ideas by proving them me-too, easy-on-k8s, or principle-violating — verified against real code); and (4) a six-angle red-team of the surviving north-star itself. The pivot above is the red-team's verdict, recorded honestly including where the first synthesis overfit to existing code. Future readers should treat the kill-conditions as the live test of whether this positioning still holds.
+
+## Related documents
+
+- [`design-data-plane-memory.md`](design-data-plane-memory.md) — the second-act substrate build, in correctness-first order.
+- [`roadmap.md`](roadmap.md) — feature roadmap (to be re-ranked behind this positioning).
+- [`design-incremental-execution.md`](design-incremental-execution.md) — the shipped content-addressed cache this builds on.
+- [`archive/brainstorm-differentiators.md`](archive/brainstorm-differentiators.md) — the original (pre-pivot) idea backlog.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -238,6 +238,8 @@ Features that were previously on the roadmap and are now shipped:
 
 ## Related Documents
 
+- [Differentiation Strategy: Where Caesium Wins](differentiation-strategy.md) — positioning thesis; re-ranks this roadmap behind a sovereignty-led funnel
+- [Design: Data-Plane Memory](design-data-plane-memory.md) — the second-act substrate enabling explain/reproduce/skip
 - [Brainstorm: Killer Features Beyond Airflow Parity](archive/brainstorm-differentiators.md) — original idea backlog
 - [Design: Smart Incremental Execution](design-incremental-execution.md) — shipped cache system
 - [Design: Event-Driven Triggers](design-event-triggers.md) — P0 trigger overhaul

--- a/internal/guardrails/guardrails_test.go
+++ b/internal/guardrails/guardrails_test.go
@@ -338,12 +338,14 @@ func TestPlanningAndHistoricalDocsCarryStatusBanner(t *testing.T) {
 	files := []string{
 		"docs/design-airflow-parity.md",
 		"docs/design-concurrency-priority.md",
+		"docs/design-data-plane-memory.md",
 		"docs/design-database-locking-fix.md",
 		"docs/design-event-triggers.md",
 		"docs/design-incremental-execution.md",
 		"docs/design-scaling-job-execution.md",
 		"docs/design-sla-management.md",
 		"docs/design-task-templates.md",
+		"docs/differentiation-strategy.md",
 	}
 
 	for _, rel := range files {


### PR DESCRIPTION
## Summary

Captures the outcome of a structured competitive analysis + a six-angle adversarial red-team of Caesium's positioning, as two durable docs plus an index/roadmap wire-up.

**The shift:** the current roadmap answers "why not Airflow?" but not "why not just use k8s + Kueue + Argo?" — most of it is reproducible on Kubernetes in a sprint. The red-team (verdict: _survives-with-pivot_, high confidence; all six attacks landed "serious" and converged on the same facts) found the first _"content-addressed memory of the data plane"_ north-star was overfit to existing code. The corrected positioning **leads with operational sovereignty** — the zero-dependency single binary incumbents structurally cannot copy, which sells by _constraint_ not _comparison_ — uses DX-over-k8s as the hook, and demotes the data-plane memory to the _retention_ layer.

## What's here

- **`docs/differentiation-strategy.md`** — positioning thesis: the two-camp market map, the constraint-vs-comparison insight, the real moat (deployment + business-model asymmetry, not the hash), the sovereignty-led funnel, the do-not-build list, and the kill-conditions. Includes an honest methodology note (records where the first synthesis overfit).
- **`docs/design-data-plane-memory.md`** — the second-act substrate spec in **correctness-first order**, grounded in current code (file:line verified):
  1. image digest resolution (correctness gate — receipts on an unpinned tag are a silent failure),
  2. persist the decomposed `HashInput` (unlocks field-level `caesium why`),
  3. version DAG topology (stop the `Unscoped().Delete` of `TaskEdge` on every apply),
  4. populate OpenLineage datasets (~80% built today),
  5. large-object reference passing (replace the 64 KB error cap).
- **`docs/README.md` / `docs/roadmap.md`** — index + cross-links.
- **`internal/guardrails/guardrails_test.go`** — adds both docs to the `> Status:` banner allowlist.

## Test evidence

Docs-only behavior change; the single Go change is the guardrails allowlist.

```
$ go test ./internal/guardrails/ -run 'TestDocsREADMEIndexesEveryTopLevelDoc|TestPlanningAndHistoricalDocsCarryStatusBanner' -count=1
ok  github.com/caesium-cloud/caesium/internal/guardrails
```

## Note

Strategy/design only — no implementation. Natural follow-up is Component 1 (image digest resolution), the correctness gate everything else depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvA6zFvnhXRHHHVccZy1em
