### PR TITLE
Persist decomposed HashInput for caesium why (data-plane-memory W2-α)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory.md
+++ b/docs/exec-plans/active/data-plane-memory.md
@@ -133,7 +133,7 @@ from a tamper-prone opaque digest into a tamper-evident, explainable record.
       `docs/caesium-job-llm-reference.md` + `docs/job-schema-reference.md`,
       new `test/dataplane_test.go` harness scenario asserting `cacheHit: false` on a re-pushed tag.
       Done (W1-α): added `HashInput.ResolvedImageDigest` (empty preserves the legacy tag-only hash); `imagecheck.Resolver` with a TTL tag→digest cache (Docker via `ImageInspect` RepoDigests + pull-if-absent, Podman/k8s fall back to the tag); `cache.pinDigests` threaded through `ResolveCacheConfig` + `CAESIUM_CACHE_PIN_DIGESTS`/`CAESIUM_CACHE_DIGEST_TTL`; nullable `resolved_image_digest` recorded on `TaskRun` + `TaskCache`; `test/dataplane_test.go` asserts a moved tag misses and a stable tag still hits.
-- [ ] A2. Persist the decomposed `HashInput` as a canonical, secret-redacted JSON
+- [x] A2. Persist the decomposed `HashInput` as a canonical, secret-redacted JSON
       blob on `TaskRun` and the cache `Entry`, written on the existing hash
       write-path, gated on cache being enabled and bounded/pruned with the cache
       TTL/LRU. Propagate to distributed workers via `TaskRun` fields the way
@@ -143,6 +143,7 @@ from a tamper-prone opaque digest into a tamper-evident, explainable record.
       `internal/run/store.go` (write alongside `SetTaskHash`),
       `internal/dispatch/`, `internal/worker/` (distributed propagation).
       Depends on: A1.
+      Done (W2-α): `HashInput.CanonicalJSON()` serializes a versioned, secret-redacted, field-by-field blob (env values redacted to a `sha256:` digest, `secret://` references kept verbatim; bounded at 64 KB with a graceful oversized-marker fallback). Nullable `hash_input_blob` JSON column added to `TaskRun` and `TaskCache` (additive AutoMigrate). `SetTaskHashWithBlob` writes it alongside the hash on the existing write-path (`SetTaskHashWithDigest` retained as a shim). Threaded through `cache.Entry` → `TaskCache`. Wired into both hash sites — `internal/job/job.go` (local/scheduler) and `internal/worker/runtime_executor.go` (distributed): the worker rebuilds the identical `HashInput` from the scheduler-propagated `TaskRun` + predecessor data, so no new dispatch-time field was needed.
 - [ ] A3. Add `caesium why <run> --task <t>`: a read-side, field-by-field diff of
       two stored `HashInput` blobs ("CACHE MISS — predecessor `extract.row_count`
       changed 1.2M→1.4M; image, command, env identical"), joined to the

--- a/internal/cache/hash.go
+++ b/internal/cache/hash.go
@@ -12,6 +12,199 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/container"
 )
 
+// HashInputBlobVersion is the schema version of the persisted decomposed
+// HashInput blob (see CanonicalJSON). Bump it whenever the on-disk shape
+// changes so a reader (e.g. `caesium why`) can tell two blobs were produced by
+// different serializers and avoid diffing incompatible layouts. It is
+// independent of CacheVersion, which keys the cache itself.
+const HashInputBlobVersion = 1
+
+// maxHashInputBlobBytes bounds the size of a single persisted blob. dqlite
+// writes serialize through Raft, so an unbounded blob (e.g. a task with
+// thousands of predecessor outputs) would amplify write pressure. When the
+// canonical encoding exceeds this, CanonicalJSON returns a compact "oversized"
+// marker carrying only the digest + counts instead of the full decomposition —
+// the field-level explanation degrades gracefully rather than bloating dqlite.
+const maxHashInputBlobBytes = 64 * 1024
+
+// redactedEnvValue is the placeholder stored in place of a non-secret-reference
+// env value. The value is replaced by a digest so `caesium why` can still
+// detect that an env var changed (the digest differs) without ever persisting
+// the plaintext value, which may contain a credential that was injected as a
+// literal rather than through a secret:// reference.
+type redactedEnvValue struct {
+	// Digest is "sha256:" + the hex SHA-256 of the raw value. A changed value
+	// yields a changed digest, so two blobs remain diffable field-by-field.
+	Digest string `json:"digest"`
+	// Redacted is always true; it documents in the persisted JSON that the
+	// literal value was intentionally withheld.
+	Redacted bool `json:"redacted"`
+}
+
+// envBlobValue is one entry in the persisted env map. Exactly one of Secret or
+// Redacted is set: a secret:// reference is stored verbatim (it is a non-secret
+// pointer and is the informative thing to show), and every other value is
+// redacted to a digest.
+type envBlobValue struct {
+	// Secret holds the literal secret:// URI when the value is a secret
+	// reference. Secret references resolve through internal/jobdef/secret and
+	// are excluded from the hash; they are safe to store and carry no
+	// credential material.
+	Secret string `json:"secret,omitempty"`
+	// Redacted holds the digest of a non-reference value. nil when Secret is
+	// set.
+	Redacted *redactedEnvValue `json:"redacted,omitempty"`
+}
+
+// HashInputBlob is the canonical, secret-redacted, field-by-field
+// representation of a HashInput that is persisted alongside the opaque digest.
+// It exists so the system can answer *which* input changed between two runs
+// (the basis of `caesium why`), not merely that "the hashes differ". Every
+// field that contributes to Compute() is represented here; env values are
+// redacted (see envBlobValue) but all other fields — including predecessor
+// outputs, which are typed data-contract values, not secrets — are stored
+// verbatim so a reader can show the before/after.
+type HashInputBlob struct {
+	// BlobVersion is HashInputBlobVersion at serialization time.
+	BlobVersion int `json:"blobVersion"`
+	// Hash is the Compute() digest this blob decomposes. Storing it inline lets
+	// a reader confirm the blob matches the persisted TaskRun.Hash before
+	// trusting the decomposition.
+	Hash string `json:"hash"`
+
+	JobAlias             string                       `json:"jobAlias,omitempty"`
+	TaskName             string                       `json:"taskName,omitempty"`
+	Image                string                       `json:"image,omitempty"`
+	ResolvedImageDigest  string                       `json:"resolvedImageDigest,omitempty"`
+	Command              []string                     `json:"command,omitempty"`
+	Env                  map[string]envBlobValue      `json:"env,omitempty"`
+	WorkDir              string                       `json:"workDir,omitempty"`
+	Mounts               []container.Mount            `json:"mounts,omitempty"`
+	ResolvedVolumeMounts []container.VolumeMount      `json:"resolvedVolumeMounts,omitempty"`
+	Kubernetes           *container.KubernetesSpec    `json:"kubernetes,omitempty"`
+	PredecessorHashes    []string                     `json:"predecessorHashes,omitempty"`
+	PredecessorOutputs   map[string]map[string]string `json:"predecessorOutputs,omitempty"`
+	RunParams            map[string]string            `json:"runParams,omitempty"`
+	CacheVersion         int                          `json:"cacheVersion"`
+
+	// Oversized is set (with Digest/EnvCount/PredecessorOutputCount populated
+	// and the verbatim fields cleared) when the full decomposition exceeded
+	// maxHashInputBlobBytes. A reader can still report "inputs changed" via the
+	// digest but cannot diff field-by-field.
+	Oversized *oversizedBlob `json:"oversized,omitempty"`
+}
+
+// oversizedBlob is the degraded representation stored when a full HashInputBlob
+// would exceed maxHashInputBlobBytes.
+type oversizedBlob struct {
+	EnvCount               int `json:"envCount"`
+	PredecessorCount       int `json:"predecessorCount"`
+	PredecessorOutputCount int `json:"predecessorOutputCount"`
+}
+
+// secretRefPrefix is the scheme prefix identifying a secret:// reference. It
+// must match internal/jobdef/secret's scheme; an env value with this prefix is
+// a non-secret pointer (resolved at container-create time, after hashing) and
+// is stored verbatim, while every other value is redacted.
+const secretRefPrefix = "secret://"
+
+// redactEnv produces the persisted env map: secret:// references verbatim, all
+// other values replaced by a digest. The map is built deterministically by the
+// caller's JSON encoder (encoding/json sorts map keys), so the result is
+// canonical.
+func redactEnv(env map[string]string) map[string]envBlobValue {
+	if len(env) == 0 {
+		return nil
+	}
+	out := make(map[string]envBlobValue, len(env))
+	for k, v := range env {
+		if strings.HasPrefix(v, secretRefPrefix) {
+			out[k] = envBlobValue{Secret: v}
+			continue
+		}
+		sum := sha256.Sum256([]byte(v))
+		out[k] = envBlobValue{Redacted: &redactedEnvValue{
+			Digest:   "sha256:" + hex.EncodeToString(sum[:]),
+			Redacted: true,
+		}}
+	}
+	return out
+}
+
+// CanonicalJSON serializes the decomposed HashInput to a canonical,
+// secret-redacted JSON blob suitable for persistence and later field-by-field
+// diffing (`caesium why`). It is deterministic: encoding/json emits object keys
+// in sorted order and every slice is hashed/copied in the same order Compute()
+// uses. The returned bytes are bounded by maxHashInputBlobBytes; if the full
+// decomposition would exceed that, a compact oversized marker is returned
+// instead so dqlite write pressure stays bounded.
+//
+// Env values are never stored verbatim: secret:// references are kept as-is
+// (they are safe pointers) and all other values are reduced to a digest, so a
+// credential injected as a literal env value never lands in the blob.
+func (h HashInput) CanonicalJSON() ([]byte, error) {
+	blob := HashInputBlob{
+		BlobVersion:          HashInputBlobVersion,
+		Hash:                 h.Compute(),
+		JobAlias:             h.JobAlias,
+		TaskName:             h.TaskName,
+		Image:                h.Image,
+		ResolvedImageDigest:  h.ResolvedImageDigest,
+		Command:              h.Command,
+		Env:                  redactEnv(h.Env),
+		WorkDir:              h.WorkDir,
+		Mounts:               h.Mounts,
+		ResolvedVolumeMounts: h.ResolvedVolumeMounts,
+		Kubernetes:           h.Kubernetes,
+		PredecessorHashes:    sortedCopy(h.PredecessorHashes),
+		PredecessorOutputs:   h.PredecessorOutputs,
+		RunParams:            h.RunParams,
+		CacheVersion:         h.CacheVersion,
+	}
+
+	data, err := json.Marshal(blob)
+	if err != nil {
+		return nil, fmt.Errorf("cache: marshal hash-input blob: %w", err)
+	}
+	if len(data) <= maxHashInputBlobBytes {
+		return data, nil
+	}
+
+	// Degrade gracefully: keep identity + a digest, drop the verbatim fields.
+	oversized := HashInputBlob{
+		BlobVersion:         HashInputBlobVersion,
+		Hash:                blob.Hash,
+		JobAlias:            h.JobAlias,
+		TaskName:            h.TaskName,
+		Image:               h.Image,
+		ResolvedImageDigest: h.ResolvedImageDigest,
+		CacheVersion:        h.CacheVersion,
+		Oversized: &oversizedBlob{
+			EnvCount:               len(h.Env),
+			PredecessorCount:       len(h.PredecessorHashes),
+			PredecessorOutputCount: len(h.PredecessorOutputs),
+		},
+	}
+	data, err = json.Marshal(oversized)
+	if err != nil {
+		return nil, fmt.Errorf("cache: marshal oversized hash-input blob: %w", err)
+	}
+	return data, nil
+}
+
+// sortedCopy returns a sorted copy of s without mutating the input, so the
+// persisted blob lists predecessor hashes in the same deterministic order
+// Compute() folds them in.
+func sortedCopy(s []string) []string {
+	if len(s) == 0 {
+		return nil
+	}
+	out := make([]string, len(s))
+	copy(out, s)
+	sort.Strings(out)
+	return out
+}
+
 // HashInput contains all fields that contribute to a task's identity hash.
 type HashInput struct {
 	JobAlias string

--- a/internal/cache/hash.go
+++ b/internal/cache/hash.go
@@ -47,9 +47,13 @@ type redactedEnvValue struct {
 // redacted to a digest.
 type envBlobValue struct {
 	// Secret holds the literal secret:// URI when the value is a secret
-	// reference. Secret references resolve through internal/jobdef/secret and
-	// are excluded from the hash; they are safe to store and carry no
-	// credential material.
+	// reference. The URI itself IS included in the hash — a changed URI
+	// (secret://vault/db/pass -> .../pass-v2) changes the key. What is NOT
+	// hashed is the resolved secret value, which is substituted at
+	// container-create time, after hashing (see
+	// jobdefruntime.ResolveContainerSpecSecrets). The URI carries no credential
+	// material and is safe to store verbatim, so `caesium why` can show it in a
+	// diff.
 	Secret string `json:"secret,omitempty"`
 	// Redacted holds the digest of a non-reference value. nil when Secret is
 	// set.
@@ -103,9 +107,10 @@ type oversizedBlob struct {
 }
 
 // secretRefPrefix is the scheme prefix identifying a secret:// reference. It
-// must match internal/jobdef/secret's scheme; an env value with this prefix is
-// a non-secret pointer (resolved at container-create time, after hashing) and
-// is stored verbatim, while every other value is redacted.
+// must match internal/jobdef/secret's scheme. An env value with this prefix is
+// a non-secret pointer whose URI is hashed verbatim but whose resolved value is
+// substituted only at container-create time (after hashing); it is stored
+// verbatim in the blob, while every other value is redacted.
 const secretRefPrefix = "secret://"
 
 // redactEnv produces the persisted env map: secret:// references verbatim, all
@@ -134,18 +139,26 @@ func redactEnv(env map[string]string) map[string]envBlobValue {
 // CanonicalJSON serializes the decomposed HashInput to a canonical,
 // secret-redacted JSON blob suitable for persistence and later field-by-field
 // diffing (`caesium why`). It is deterministic: encoding/json emits object keys
-// in sorted order and every slice is hashed/copied in the same order Compute()
-// uses. The returned bytes are bounded by maxHashInputBlobBytes; if the full
-// decomposition would exceed that, a compact oversized marker is returned
-// instead so dqlite write pressure stays bounded.
+// in sorted order and every slice is stored in the same canonical order
+// Compute() hashes it (predecessor hashes sorted; mounts and volume mounts
+// sorted by their Compute() sort key), so the blob faithfully represents the
+// hashed inputs and a diff never reports a spurious reorder. The returned bytes
+// are bounded by maxHashInputBlobBytes; if the full decomposition would exceed
+// that, a compact oversized marker is returned instead so dqlite write pressure
+// stays bounded.
+//
+// precomputed is the digest Compute() already produced on the hash write-path;
+// it is embedded inline (so a reader can confirm the blob matches the persisted
+// Hash) and reused rather than recomputed, avoiding a second full SHA-256 pass.
 //
 // Env values are never stored verbatim: secret:// references are kept as-is
-// (they are safe pointers) and all other values are reduced to a digest, so a
-// credential injected as a literal env value never lands in the blob.
-func (h HashInput) CanonicalJSON() ([]byte, error) {
+// (the URI itself is hashed but carries no credential material) and all other
+// values are reduced to a digest, so a credential injected as a literal env
+// value never lands in the blob.
+func (h HashInput) CanonicalJSON(precomputed string) ([]byte, error) {
 	blob := HashInputBlob{
 		BlobVersion:          HashInputBlobVersion,
-		Hash:                 h.Compute(),
+		Hash:                 precomputed,
 		JobAlias:             h.JobAlias,
 		TaskName:             h.TaskName,
 		Image:                h.Image,
@@ -153,8 +166,8 @@ func (h HashInput) CanonicalJSON() ([]byte, error) {
 		Command:              h.Command,
 		Env:                  redactEnv(h.Env),
 		WorkDir:              h.WorkDir,
-		Mounts:               h.Mounts,
-		ResolvedVolumeMounts: h.ResolvedVolumeMounts,
+		Mounts:               sortedMounts(h.Mounts),
+		ResolvedVolumeMounts: sortedVolumeMounts(h.ResolvedVolumeMounts),
 		Kubernetes:           h.Kubernetes,
 		PredecessorHashes:    sortedCopy(h.PredecessorHashes),
 		PredecessorOutputs:   h.PredecessorOutputs,
@@ -202,6 +215,48 @@ func sortedCopy(s []string) []string {
 	out := make([]string, len(s))
 	copy(out, s)
 	sort.Strings(out)
+	return out
+}
+
+// mountSortKey is the canonical string a Mount is sorted by. Compute() and
+// CanonicalJSON() both order mounts by this key so the hash and the persisted
+// blob agree on order — otherwise `caesium why` could report a spurious
+// mount-reorder that had no effect on the hash.
+func mountSortKey(m container.Mount) string {
+	return fmt.Sprintf("%s:%s:%s:%t", m.Source, m.Target, m.Type, m.ReadOnly)
+}
+
+// volumeMountSortKey is the canonical string a VolumeMount is sorted by, shared
+// by Compute() and CanonicalJSON() for the same reason as mountSortKey.
+func volumeMountSortKey(m container.VolumeMount) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%t:%s:%s:%s:%s", m.Name, m.Type, m.Source, m.Target, m.ReadOnly, m.SubPath, canonicalJSON(m.Tmpfs), canonicalJSON(m.ClaimTemplate), canonicalJSON(m.VolumeSource))
+}
+
+// sortedMounts returns a copy of mounts ordered by mountSortKey without
+// mutating the input.
+func sortedMounts(mounts []container.Mount) []container.Mount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]container.Mount, len(mounts))
+	copy(out, mounts)
+	sort.Slice(out, func(i, j int) bool {
+		return mountSortKey(out[i]) < mountSortKey(out[j])
+	})
+	return out
+}
+
+// sortedVolumeMounts returns a copy of mounts ordered by volumeMountSortKey
+// without mutating the input.
+func sortedVolumeMounts(mounts []container.VolumeMount) []container.VolumeMount {
+	if len(mounts) == 0 {
+		return nil
+	}
+	out := make([]container.VolumeMount, len(mounts))
+	copy(out, mounts)
+	sort.Slice(out, func(i, j int) bool {
+		return volumeMountSortKey(out[i]) < volumeMountSortKey(out[j])
+	})
 	return out
 }
 
@@ -258,23 +313,15 @@ func (h HashInput) Compute() string {
 
 	w(digest, "workdir:%s\n", h.WorkDir)
 
-	// Sorted mounts (serialize each mount deterministically)
-	mountStrs := make([]string, 0, len(h.Mounts))
-	for _, m := range h.Mounts {
-		mountStrs = append(mountStrs, fmt.Sprintf("%s:%s:%s:%t", m.Source, m.Target, m.Type, m.ReadOnly))
-	}
-	sort.Strings(mountStrs)
-	for _, m := range mountStrs {
-		w(digest, "mount:%s\n", m)
+	// Sorted mounts (serialize each mount deterministically). The same sort
+	// keys are reused by CanonicalJSON so the persisted blob lists mounts in the
+	// identical order they were hashed.
+	for _, m := range sortedMounts(h.Mounts) {
+		w(digest, "mount:%s\n", mountSortKey(m))
 	}
 
-	volumeMountStrs := make([]string, 0, len(h.ResolvedVolumeMounts))
-	for _, m := range h.ResolvedVolumeMounts {
-		volumeMountStrs = append(volumeMountStrs, fmt.Sprintf("%s:%s:%s:%s:%t:%s:%s:%s:%s", m.Name, m.Type, m.Source, m.Target, m.ReadOnly, m.SubPath, canonicalJSON(m.Tmpfs), canonicalJSON(m.ClaimTemplate), canonicalJSON(m.VolumeSource)))
-	}
-	sort.Strings(volumeMountStrs)
-	for _, m := range volumeMountStrs {
-		w(digest, "volume_mount:%s\n", m)
+	for _, m := range sortedVolumeMounts(h.ResolvedVolumeMounts) {
+		w(digest, "volume_mount:%s\n", volumeMountSortKey(m))
 	}
 
 	if h.Kubernetes != nil {

--- a/internal/cache/hash_test.go
+++ b/internal/cache/hash_test.go
@@ -224,13 +224,20 @@ func unmarshalBlob(t *testing.T, data []byte) HashInputBlob {
 	return blob
 }
 
+// canonicalBlob serializes in, supplying its own Compute() digest the way the
+// production write-path does (Compute is called once, then reused).
+func canonicalBlob(t *testing.T, in HashInput) ([]byte, error) {
+	t.Helper()
+	return in.CanonicalJSON(in.Compute())
+}
+
 // TestCanonicalJSON_Deterministic asserts the serialization is stable: the same
 // input (including unordered maps) yields byte-identical blobs, so two runs are
 // comparable and dedup/diff logic is sound.
 func TestCanonicalJSON_Deterministic(t *testing.T) {
-	a, err := baseInput().CanonicalJSON()
+	a, err := canonicalBlob(t, baseInput())
 	require.NoError(t, err)
-	b, err := baseInput().CanonicalJSON()
+	b, err := canonicalBlob(t, baseInput())
 	require.NoError(t, err)
 	assert.Equal(t, a, b, "same input must serialize to byte-identical blobs")
 
@@ -238,7 +245,7 @@ func TestCanonicalJSON_Deterministic(t *testing.T) {
 	reordered := baseInput()
 	reordered.Env = map[string]string{"BAZ": "qux", "FOO": "bar"}
 	reordered.RunParams = map[string]string{"param1": "value1"}
-	c, err := reordered.CanonicalJSON()
+	c, err := canonicalBlob(t, reordered)
 	require.NoError(t, err)
 	assert.Equal(t, a, c, "map ordering must not affect the canonical blob")
 }
@@ -248,7 +255,7 @@ func TestCanonicalJSON_Deterministic(t *testing.T) {
 // persisted TaskRun.Hash before trusting it.
 func TestCanonicalJSON_BlobHashMatchesCompute(t *testing.T) {
 	in := baseInput()
-	data, err := in.CanonicalJSON()
+	data, err := canonicalBlob(t, in)
 	require.NoError(t, err)
 	blob := unmarshalBlob(t, data)
 	assert.Equal(t, in.Compute(), blob.Hash)
@@ -261,7 +268,7 @@ func TestCanonicalJSON_FieldsRoundTrip(t *testing.T) {
 	in := baseInput()
 	in.ResolvedImageDigest = "sha256:abc"
 	in.WorkDir = "/app"
-	data, err := in.CanonicalJSON()
+	data, err := canonicalBlob(t, in)
 	require.NoError(t, err)
 	blob := unmarshalBlob(t, data)
 
@@ -280,13 +287,60 @@ func TestCanonicalJSON_FieldsRoundTrip(t *testing.T) {
 	assert.Equal(t, []string{"abc123", "def456"}, blob.PredecessorHashes)
 }
 
+// TestCanonicalJSON_MountOrderMatchesHash is the P1 correctness invariant: the
+// blob must list mounts and volume mounts in the SAME canonical (sorted) order
+// Compute() hashes them, so two runs whose mounts differ only by insertion
+// order produce identical blobs — `caesium why` must never report a spurious
+// mount-reorder that had no effect on the hash.
+func TestCanonicalJSON_MountOrderMatchesHash(t *testing.T) {
+	mountsA := []container.Mount{
+		{Type: container.MountTypeBind, Source: "/a", Target: "/x", ReadOnly: true},
+		{Type: container.MountTypeBind, Source: "/b", Target: "/y", ReadOnly: false},
+	}
+	mountsB := []container.Mount{ // same set, reversed insertion order
+		{Type: container.MountTypeBind, Source: "/b", Target: "/y", ReadOnly: false},
+		{Type: container.MountTypeBind, Source: "/a", Target: "/x", ReadOnly: true},
+	}
+	volA := []container.VolumeMount{
+		{Name: "v1", Type: container.VolumeMountTypeVolume, Target: "/d1"},
+		{Name: "v2", Type: container.VolumeMountTypeVolume, Target: "/d2"},
+	}
+	volB := []container.VolumeMount{
+		{Name: "v2", Type: container.VolumeMountTypeVolume, Target: "/d2"},
+		{Name: "v1", Type: container.VolumeMountTypeVolume, Target: "/d1"},
+	}
+
+	a := baseInput()
+	a.Mounts, a.ResolvedVolumeMounts = mountsA, volA
+	b := baseInput()
+	b.Mounts, b.ResolvedVolumeMounts = mountsB, volB
+
+	// Compute() already treats them as equal; the blob must agree.
+	require.Equal(t, a.Compute(), b.Compute(), "precondition: mount order must not affect the hash")
+
+	da, err := canonicalBlob(t, a)
+	require.NoError(t, err)
+	db, err := canonicalBlob(t, b)
+	require.NoError(t, err)
+	assert.Equal(t, da, db, "mount insertion order must not change the canonical blob")
+
+	// The stored order is the sorted order, not the insertion order.
+	blob := unmarshalBlob(t, db)
+	require.Len(t, blob.Mounts, 2)
+	assert.Equal(t, "/a", blob.Mounts[0].Source, "mounts must be stored in sorted order")
+	assert.Equal(t, "/b", blob.Mounts[1].Source)
+	require.Len(t, blob.ResolvedVolumeMounts, 2)
+	assert.Equal(t, "v1", blob.ResolvedVolumeMounts[0].Name, "volume mounts must be stored in sorted order")
+	assert.Equal(t, "v2", blob.ResolvedVolumeMounts[1].Name)
+}
+
 // TestCanonicalJSON_RedactsNonSecretEnvValues is the core guardrail: a plain env
 // value (which could be a credential injected as a literal) is never persisted
 // verbatim — only a digest of it appears, and the digest matches sha256(value).
 func TestCanonicalJSON_RedactsNonSecretEnvValues(t *testing.T) {
 	in := baseInput()
 	in.Env = map[string]string{"API_TOKEN": "super-secret-literal-value"}
-	data, err := in.CanonicalJSON()
+	data, err := canonicalBlob(t, in)
 	require.NoError(t, err)
 
 	assert.NotContains(t, string(data), "super-secret-literal-value",
@@ -309,7 +363,7 @@ func TestCanonicalJSON_RedactsNonSecretEnvValues(t *testing.T) {
 func TestCanonicalJSON_SecretReferencesStoredVerbatim(t *testing.T) {
 	in := baseInput()
 	in.Env = map[string]string{"DB_PASSWORD": "secret://vault/db/password"}
-	data, err := in.CanonicalJSON()
+	data, err := canonicalBlob(t, in)
 	require.NoError(t, err)
 	blob := unmarshalBlob(t, data)
 
@@ -328,16 +382,16 @@ func TestCanonicalJSON_RedactionDistinguishesValues(t *testing.T) {
 	b := baseInput()
 	b.Env = map[string]string{"FOO": "value-2"}
 
-	da, err := a.CanonicalJSON()
+	da, err := canonicalBlob(t, a)
 	require.NoError(t, err)
-	db, err := b.CanonicalJSON()
+	db, err := canonicalBlob(t, b)
 	require.NoError(t, err)
 	assert.NotEqual(t, da, db, "a changed env value must change the redacted blob")
 
 	// ...and an unchanged value yields an identical digest (a stable diff).
 	c := baseInput()
 	c.Env = map[string]string{"FOO": "value-1"}
-	dc, err := c.CanonicalJSON()
+	dc, err := canonicalBlob(t, c)
 	require.NoError(t, err)
 	assert.Equal(t, da, dc)
 }
@@ -356,7 +410,7 @@ func TestCanonicalJSON_OversizedDegrades(t *testing.T) {
 		in.PredecessorOutputs[step] = map[string]string{"out": big}
 	}
 
-	data, err := in.CanonicalJSON()
+	data, err := canonicalBlob(t, in)
 	require.NoError(t, err)
 	require.LessOrEqual(t, len(data), maxHashInputBlobBytes,
 		"oversized blob must be bounded")
@@ -373,7 +427,7 @@ func TestCanonicalJSON_OversizedDegrades(t *testing.T) {
 // TestCanonicalJSON_EmptyInput asserts the empty input serializes cleanly to a
 // minimal, parseable blob (version + zero-value identity), never an error.
 func TestCanonicalJSON_EmptyInput(t *testing.T) {
-	data, err := HashInput{}.CanonicalJSON()
+	data, err := canonicalBlob(t, HashInput{})
 	require.NoError(t, err)
 	blob := unmarshalBlob(t, data)
 	assert.Equal(t, HashInputBlobVersion, blob.BlobVersion)

--- a/internal/cache/hash_test.go
+++ b/internal/cache/hash_test.go
@@ -1,6 +1,11 @@
 package cache
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/caesium-cloud/caesium/pkg/container"
@@ -207,4 +212,172 @@ func TestCompute_DifferentPredecessorOutputs(t *testing.T) {
 	b := baseInput()
 	b.PredecessorOutputs = map[string]map[string]string{"step1": {"key": "different"}}
 	assert.NotEqual(t, a.Compute(), b.Compute())
+}
+
+// --- CanonicalJSON (persisted decomposed HashInput blob) ---
+
+// unmarshalBlob decodes a CanonicalJSON blob, failing the test on error.
+func unmarshalBlob(t *testing.T, data []byte) HashInputBlob {
+	t.Helper()
+	var blob HashInputBlob
+	require.NoError(t, json.Unmarshal(data, &blob))
+	return blob
+}
+
+// TestCanonicalJSON_Deterministic asserts the serialization is stable: the same
+// input (including unordered maps) yields byte-identical blobs, so two runs are
+// comparable and dedup/diff logic is sound.
+func TestCanonicalJSON_Deterministic(t *testing.T) {
+	a, err := baseInput().CanonicalJSON()
+	require.NoError(t, err)
+	b, err := baseInput().CanonicalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, a, b, "same input must serialize to byte-identical blobs")
+
+	// Reorder the map literals; encoding/json sorts keys, so output is identical.
+	reordered := baseInput()
+	reordered.Env = map[string]string{"BAZ": "qux", "FOO": "bar"}
+	reordered.RunParams = map[string]string{"param1": "value1"}
+	c, err := reordered.CanonicalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, a, c, "map ordering must not affect the canonical blob")
+}
+
+// TestCanonicalJSON_BlobHashMatchesCompute asserts the blob carries the same
+// digest Compute() produces, so a reader can confirm a blob decomposes the
+// persisted TaskRun.Hash before trusting it.
+func TestCanonicalJSON_BlobHashMatchesCompute(t *testing.T) {
+	in := baseInput()
+	data, err := in.CanonicalJSON()
+	require.NoError(t, err)
+	blob := unmarshalBlob(t, data)
+	assert.Equal(t, in.Compute(), blob.Hash)
+	assert.Equal(t, HashInputBlobVersion, blob.BlobVersion)
+}
+
+// TestCanonicalJSON_FieldsRoundTrip asserts the non-redacted fields survive
+// serialization verbatim — these are what `caesium why` diffs field-by-field.
+func TestCanonicalJSON_FieldsRoundTrip(t *testing.T) {
+	in := baseInput()
+	in.ResolvedImageDigest = "sha256:abc"
+	in.WorkDir = "/app"
+	data, err := in.CanonicalJSON()
+	require.NoError(t, err)
+	blob := unmarshalBlob(t, data)
+
+	assert.Equal(t, in.JobAlias, blob.JobAlias)
+	assert.Equal(t, in.TaskName, blob.TaskName)
+	assert.Equal(t, in.Image, blob.Image)
+	assert.Equal(t, in.ResolvedImageDigest, blob.ResolvedImageDigest)
+	assert.Equal(t, in.Command, blob.Command)
+	assert.Equal(t, in.WorkDir, blob.WorkDir)
+	assert.Equal(t, in.Mounts, blob.Mounts)
+	assert.Equal(t, in.CacheVersion, blob.CacheVersion)
+	// Predecessor outputs are typed data-contract values (not secrets) and are
+	// stored verbatim so `why` can show the before/after.
+	assert.Equal(t, in.PredecessorOutputs, blob.PredecessorOutputs)
+	// Predecessor hashes are stored sorted (matching Compute's fold order).
+	assert.Equal(t, []string{"abc123", "def456"}, blob.PredecessorHashes)
+}
+
+// TestCanonicalJSON_RedactsNonSecretEnvValues is the core guardrail: a plain env
+// value (which could be a credential injected as a literal) is never persisted
+// verbatim — only a digest of it appears, and the digest matches sha256(value).
+func TestCanonicalJSON_RedactsNonSecretEnvValues(t *testing.T) {
+	in := baseInput()
+	in.Env = map[string]string{"API_TOKEN": "super-secret-literal-value"}
+	data, err := in.CanonicalJSON()
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(data), "super-secret-literal-value",
+		"a literal env value must never appear in the persisted blob")
+
+	blob := unmarshalBlob(t, data)
+	ev, ok := blob.Env["API_TOKEN"]
+	require.True(t, ok, "env key must be retained so `why` can name the changed var")
+	require.NotNil(t, ev.Redacted)
+	assert.True(t, ev.Redacted.Redacted)
+	assert.Empty(t, ev.Secret)
+
+	sum := sha256.Sum256([]byte("super-secret-literal-value"))
+	assert.Equal(t, "sha256:"+hex.EncodeToString(sum[:]), ev.Redacted.Digest)
+}
+
+// TestCanonicalJSON_SecretReferencesStoredVerbatim asserts a secret:// reference
+// (a non-secret pointer resolved after hashing) is kept verbatim — it is the
+// informative thing to show and carries no credential material.
+func TestCanonicalJSON_SecretReferencesStoredVerbatim(t *testing.T) {
+	in := baseInput()
+	in.Env = map[string]string{"DB_PASSWORD": "secret://vault/db/password"}
+	data, err := in.CanonicalJSON()
+	require.NoError(t, err)
+	blob := unmarshalBlob(t, data)
+
+	ev, ok := blob.Env["DB_PASSWORD"]
+	require.True(t, ok)
+	assert.Equal(t, "secret://vault/db/password", ev.Secret)
+	assert.Nil(t, ev.Redacted)
+}
+
+// TestCanonicalJSON_RedactionDistinguishesValues asserts two different non-secret
+// env values produce different redacted digests, so `caesium why` can still
+// detect an env change field-by-field without seeing the plaintext.
+func TestCanonicalJSON_RedactionDistinguishesValues(t *testing.T) {
+	a := baseInput()
+	a.Env = map[string]string{"FOO": "value-1"}
+	b := baseInput()
+	b.Env = map[string]string{"FOO": "value-2"}
+
+	da, err := a.CanonicalJSON()
+	require.NoError(t, err)
+	db, err := b.CanonicalJSON()
+	require.NoError(t, err)
+	assert.NotEqual(t, da, db, "a changed env value must change the redacted blob")
+
+	// ...and an unchanged value yields an identical digest (a stable diff).
+	c := baseInput()
+	c.Env = map[string]string{"FOO": "value-1"}
+	dc, err := c.CanonicalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, da, dc)
+}
+
+// TestCanonicalJSON_OversizedDegrades asserts that a blob exceeding the size
+// bound degrades to a compact marker (identity + counts, verbatim fields
+// dropped) rather than persisting an unbounded payload into dqlite.
+func TestCanonicalJSON_OversizedDegrades(t *testing.T) {
+	in := baseInput()
+	// Build a predecessor-output set large enough to blow past the bound: 200
+	// distinct steps, each emitting a ~1 KB value (~200 KB total > 64 KB).
+	in.PredecessorOutputs = map[string]map[string]string{}
+	big := strings.Repeat("x", 1024)
+	for i := 0; i < 200; i++ {
+		step := "step-" + strconv.Itoa(i)
+		in.PredecessorOutputs[step] = map[string]string{"out": big}
+	}
+
+	data, err := in.CanonicalJSON()
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(data), maxHashInputBlobBytes,
+		"oversized blob must be bounded")
+
+	blob := unmarshalBlob(t, data)
+	require.NotNil(t, blob.Oversized, "an over-bound blob must carry the oversized marker")
+	assert.Equal(t, in.Compute(), blob.Hash, "identity digest survives degradation")
+	assert.Equal(t, len(in.PredecessorOutputs), blob.Oversized.PredecessorOutputCount)
+	// Verbatim fields are dropped on degradation.
+	assert.Nil(t, blob.PredecessorOutputs)
+	assert.Nil(t, blob.Env)
+}
+
+// TestCanonicalJSON_EmptyInput asserts the empty input serializes cleanly to a
+// minimal, parseable blob (version + zero-value identity), never an error.
+func TestCanonicalJSON_EmptyInput(t *testing.T) {
+	data, err := HashInput{}.CanonicalJSON()
+	require.NoError(t, err)
+	blob := unmarshalBlob(t, data)
+	assert.Equal(t, HashInputBlobVersion, blob.BlobVersion)
+	assert.Equal(t, HashInput{}.Compute(), blob.Hash)
+	assert.Nil(t, blob.Env)
+	assert.Nil(t, blob.Oversized)
 }

--- a/internal/cache/store.go
+++ b/internal/cache/store.go
@@ -24,8 +24,13 @@ type Entry struct {
 	// ResolvedImageDigest is the content digest folded into Hash when the
 	// originating task ran with digest pinning on. Empty when pinning was off.
 	ResolvedImageDigest string
-	CreatedAt           time.Time
-	ExpiresAt           *time.Time
+	// HashInputBlob is the canonical, secret-redacted decomposition of the
+	// HashInput that produced Hash (see cache.HashInput.CanonicalJSON). Stored
+	// on the cache entry so a cache hit can be explained field-by-field, not
+	// only attested by the opaque digest. nil when not computed.
+	HashInputBlob []byte
+	CreatedAt     time.Time
+	ExpiresAt     *time.Time
 }
 
 // Store provides cache operations backed by GORM.
@@ -70,7 +75,7 @@ func (s *Store) Put(entry *Entry) error {
 
 	return s.db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "hash"}},
-		DoUpdates: clause.AssignmentColumns([]string{"job_id", "task_name", "result", "output", "branch_selections", "run_id", "task_run_id", "resolved_image_digest", "created_at", "expires_at"}),
+		DoUpdates: clause.AssignmentColumns([]string{"job_id", "task_name", "result", "output", "branch_selections", "run_id", "task_run_id", "resolved_image_digest", "hash_input_blob", "created_at", "expires_at"}),
 	}).Create(model).Error
 }
 
@@ -129,6 +134,10 @@ func modelToEntry(model *models.TaskCache) (*Entry, error) {
 		ExpiresAt:           model.ExpiresAt,
 	}
 
+	if len(model.HashInputBlob) > 0 {
+		entry.HashInputBlob = append([]byte(nil), model.HashInputBlob...)
+	}
+
 	if len(model.Output) > 0 {
 		if err := json.Unmarshal(model.Output, &entry.Output); err != nil {
 			return nil, err
@@ -155,6 +164,10 @@ func entryToModel(entry *Entry) (*models.TaskCache, error) {
 		ResolvedImageDigest: entry.ResolvedImageDigest,
 		CreatedAt:           entry.CreatedAt,
 		ExpiresAt:           entry.ExpiresAt,
+	}
+
+	if len(entry.HashInputBlob) > 0 {
+		model.HashInputBlob = datatypes.JSON(append([]byte(nil), entry.HashInputBlob...))
 	}
 
 	if len(entry.Output) > 0 {

--- a/internal/cache/store_test.go
+++ b/internal/cache/store_test.go
@@ -68,12 +68,13 @@ func TestPutThenGet_HashInputBlobPersists(t *testing.T) {
 	store := newTestStore(t)
 	entry := sampleEntry()
 
-	blob, err := HashInput{
+	in := HashInput{
 		JobAlias: "j",
 		TaskName: "t",
 		Image:    "alpine:3.23",
 		Env:      map[string]string{"FOO": "bar"},
-	}.CanonicalJSON()
+	}
+	blob, err := in.CanonicalJSON(in.Compute())
 	require.NoError(t, err)
 	entry.HashInputBlob = blob
 

--- a/internal/cache/store_test.go
+++ b/internal/cache/store_test.go
@@ -60,6 +60,47 @@ func TestGetNonexistent(t *testing.T) {
 	assert.Nil(t, got)
 }
 
+// TestPutThenGet_HashInputBlobPersists asserts the decomposed-input blob is
+// written to and read back from the new TaskCache JSON column verbatim, so a
+// cache hit can be explained field-by-field. This exercises the AutoMigrate'd
+// nullable column end-to-end.
+func TestPutThenGet_HashInputBlobPersists(t *testing.T) {
+	store := newTestStore(t)
+	entry := sampleEntry()
+
+	blob, err := HashInput{
+		JobAlias: "j",
+		TaskName: "t",
+		Image:    "alpine:3.23",
+		Env:      map[string]string{"FOO": "bar"},
+	}.CanonicalJSON()
+	require.NoError(t, err)
+	entry.HashInputBlob = blob
+
+	require.NoError(t, store.Put(entry))
+
+	got, found, err := store.Get(entry.Hash)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.JSONEq(t, string(blob), string(got.HashInputBlob),
+		"persisted blob must round-trip through the cache column")
+}
+
+// TestPutThenGet_NilHashInputBlob asserts an entry with no blob round-trips with
+// a nil/empty blob column (the nullable contract — pre-A2 rows and cache-off
+// paths stay valid).
+func TestPutThenGet_NilHashInputBlob(t *testing.T) {
+	store := newTestStore(t)
+	entry := sampleEntry() // HashInputBlob unset
+
+	require.NoError(t, store.Put(entry))
+
+	got, found, err := store.Get(entry.Hash)
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Empty(t, got.HashInputBlob)
+}
+
 func TestExpiredEntryReturnsFalse(t *testing.T) {
 	store := newTestStore(t)
 	entry := sampleEntry()

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -822,6 +822,11 @@ func (j *job) Run(ctx context.Context) error {
 		// pinning is on; empty otherwise. Reused when the result is cached so
 		// the cache Entry records which image content the hash covers.
 		var resolvedImageDigest string
+		// hashInputBlob is the canonical secret-redacted decomposition of the
+		// HashInput; declared here (like inputHash) so it survives into the
+		// success path where it is also written onto the cache Entry, letting a
+		// cache hit be explained as well as a re-run.
+		var hashInputBlob []byte
 		// Resolve cache config from step-level, job-level, then env defaults.
 		var stepCache interface{}
 		if taskModel != nil {
@@ -884,7 +889,17 @@ func (j *job) Run(ctx context.Context) error {
 				CacheVersion:         cacheCfg.Version,
 			}
 			inputHash = hashInput.Compute()
-			if err := store.SetTaskHashWithDigest(runID, taskID, inputHash, resolvedImageDigest); err != nil {
+			// Serialize the decomposed input to a canonical, secret-redacted
+			// blob so `caesium why` can later diff this run field-by-field. A
+			// serialization failure is non-fatal: persist the hash without the
+			// blob (a missing blob degrades `why` to digest-only, never wrong).
+			blob, blobErr := hashInput.CanonicalJSON()
+			if blobErr != nil {
+				log.Warn("failed to serialize hash-input blob", "task", taskName, "error", blobErr)
+				blob = nil
+			}
+			hashInputBlob = blob
+			if err := store.SetTaskHashWithBlob(runID, taskID, inputHash, resolvedImageDigest, hashInputBlob); err != nil {
 				log.Warn("failed to persist task hash", "task", taskName, "error", err)
 			}
 
@@ -984,6 +999,7 @@ func (j *job) Run(ctx context.Context) error {
 						RunID:               runID,
 						TaskRunID:           taskID,
 						ResolvedImageDigest: resolvedImageDigest,
+						HashInputBlob:       hashInputBlob,
 						CreatedAt:           time.Now(),
 						ExpiresAt:           expiresAt,
 					}); putErr != nil {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -893,7 +893,7 @@ func (j *job) Run(ctx context.Context) error {
 			// blob so `caesium why` can later diff this run field-by-field. A
 			// serialization failure is non-fatal: persist the hash without the
 			// blob (a missing blob degrades `why` to digest-only, never wrong).
-			blob, blobErr := hashInput.CanonicalJSON()
+			blob, blobErr := hashInput.CanonicalJSON(inputHash)
 			if blobErr != nil {
 				log.Warn("failed to serialize hash-input blob", "task", taskName, "error", blobErr)
 				blob = nil

--- a/internal/models/run.go
+++ b/internal/models/run.go
@@ -67,10 +67,17 @@ type TaskRun struct {
 	// resolved to when pinning is on. Nullable: empty/unset when pinning is off
 	// or the digest could not be resolved (in which case the cache key falls
 	// back to the literal tag).
-	ResolvedImageDigest string     `gorm:"type:text" json:"resolved_image_digest,omitempty"`
-	CacheOriginRunID    *uuid.UUID `gorm:"type:uuid;index" json:"cache_origin_run_id,omitempty"`
-	CacheCreatedAt      *time.Time `json:"cache_created_at,omitempty"`
-	CacheExpiresAt      *time.Time `gorm:"index" json:"cache_expires_at,omitempty"`
+	ResolvedImageDigest string `gorm:"type:text" json:"resolved_image_digest,omitempty"`
+	// HashInputBlob is the canonical, secret-redacted, field-by-field JSON
+	// decomposition of the HashInput that produced Hash. Nullable: written only
+	// when caching is enabled and the hash was computed, left null otherwise.
+	// It lets `caesium why` report *which* input changed between two runs
+	// instead of only "the hashes differ". Env values are redacted in the blob;
+	// see cache.HashInput.CanonicalJSON.
+	HashInputBlob    datatypes.JSON `gorm:"type:json" json:"-"`
+	CacheOriginRunID *uuid.UUID     `gorm:"type:uuid;index" json:"cache_origin_run_id,omitempty"`
+	CacheCreatedAt   *time.Time     `json:"cache_created_at,omitempty"`
+	CacheExpiresAt   *time.Time     `gorm:"index" json:"cache_expires_at,omitempty"`
 	// OutputSchema snapshots the task's declared runtime output schema onto the task run.
 	OutputSchema datatypes.JSON `gorm:"type:json" json:"-"`
 	// SchemaValidation snapshots the job's schema validation mode onto the task run.
@@ -97,9 +104,9 @@ type TaskRun struct {
 	// (job_run_id, terminal_sequence) makes the post-checkpoint tail scan cheap.
 	TerminalSequence int64      `gorm:"not null;default:0;index:idx_taskrun_terminal_seq,priority:2" json:"terminal_sequence,omitempty"`
 	StartedAt        *time.Time `json:"started_at,omitempty"`
-	CompletedAt     *time.Time `json:"completed_at,omitempty"`
-	CreatedAt       time.Time  `gorm:"not null" json:"created_at"`
-	UpdatedAt       time.Time  `gorm:"not null" json:"updated_at"`
+	CompletedAt      *time.Time `json:"completed_at,omitempty"`
+	CreatedAt        time.Time  `gorm:"not null" json:"created_at"`
+	UpdatedAt        time.Time  `gorm:"not null" json:"updated_at"`
 }
 
 // TaskCache stores cached task results keyed by identity hash.
@@ -116,6 +123,10 @@ type TaskCache struct {
 	// originating task ran with digest pinning on. Nullable: empty when pinning
 	// was off. Stored so a cache hit can attest which image content it covers.
 	ResolvedImageDigest string `gorm:"type:text"`
-	CreatedAt           time.Time
-	ExpiresAt           *time.Time `gorm:"index:idx_task_cache_expires"`
+	// HashInputBlob is the canonical, secret-redacted decomposition of the
+	// HashInput that produced Hash, mirrored from the originating TaskRun so a
+	// cache *hit* can also be explained field-by-field. Nullable.
+	HashInputBlob datatypes.JSON `gorm:"type:json"`
+	CreatedAt     time.Time
+	ExpiresAt     *time.Time `gorm:"index:idx_task_cache_expires"`
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -285,9 +285,23 @@ func (s *Store) SetTaskHash(runID, taskID uuid.UUID, hash string) error {
 // and the existing digest column (if any) is left untouched, keeping the row
 // consistent with the literal-tag cache key.
 func (s *Store) SetTaskHashWithDigest(runID, taskID uuid.UUID, hash, resolvedImageDigest string) error {
+	return s.SetTaskHashWithBlob(runID, taskID, hash, resolvedImageDigest, nil)
+}
+
+// SetTaskHashWithBlob persists the task identity hash, the resolved image
+// digest folded into it, and the canonical secret-redacted decomposition of the
+// HashInput (the blob) on the same write — the existing hash write-path. The
+// digest and blob are optional: an empty digest or a nil/empty blob leaves the
+// corresponding column untouched (so a literal-tag, blob-less run stays
+// consistent). The blob lets `caesium why` later diff two runs field-by-field
+// rather than only observing that the opaque hashes differ.
+func (s *Store) SetTaskHashWithBlob(runID, taskID uuid.UUID, hash, resolvedImageDigest string, hashInputBlob []byte) error {
 	updates := map[string]any{"hash": hash}
 	if resolvedImageDigest != "" {
 		updates["resolved_image_digest"] = resolvedImageDigest
+	}
+	if len(hashInputBlob) > 0 {
+		updates["hash_input_blob"] = datatypes.JSON(hashInputBlob)
 	}
 	return s.db.Model(&models.TaskRun{}).
 		Where("job_run_id = ? AND task_id = ?", runID, taskID).

--- a/internal/run/store_test.go
+++ b/internal/run/store_test.go
@@ -1368,3 +1368,88 @@ func TestSkipPropagation_MultiLevel(t *testing.T) {
 	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runRecord.ID, tail.ID).First(&tailRunFinal).Error)
 	require.Equal(t, string(TaskStatusSkipped), tailRunFinal.Status)
 }
+
+// registerSingleTaskRun creates a job/atom/task and registers one TaskRun,
+// returning the run and task IDs for hash-write assertions.
+func registerSingleTaskRun(t *testing.T, store *Store, db *gorm.DB) (runID, taskID uuid.UUID) {
+	t.Helper()
+	jobID := uuid.New()
+	runRecord, err := store.Start(jobID, nil)
+	require.NoError(t, err)
+
+	atom := &models.Atom{
+		ID:      uuid.New(),
+		Engine:  models.AtomEngineDocker,
+		Image:   "alpine:3.23",
+		Command: `["echo","hi"]`,
+	}
+	require.NoError(t, db.Create(atom).Error)
+
+	task := &models.Task{
+		ID:     uuid.New(),
+		JobID:  jobID,
+		AtomID: atom.ID,
+		Name:   "only",
+	}
+	require.NoError(t, db.Create(task).Error)
+	require.NoError(t, store.RegisterTask(runRecord.ID, task, atom, 0))
+	return runRecord.ID, task.ID
+}
+
+// TestSetTaskHashWithBlobPersistsBlobAndDigest asserts the decomposed-input blob
+// and resolved digest are written onto the TaskRun row alongside the hash on the
+// existing write path, so a distributed worker and the local scheduler both
+// leave a queryable record for `caesium why`.
+func TestSetTaskHashWithBlobPersistsBlobAndDigest(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	runID, taskID := registerSingleTaskRun(t, store, db)
+
+	blob := datatypes.JSON(`{"blobVersion":1,"hash":"abc","image":"alpine:3.23"}`)
+	require.NoError(t, store.SetTaskHashWithBlob(runID, taskID, "abc", "sha256:deadbeef", blob))
+
+	var got models.TaskRun
+	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&got).Error)
+	require.Equal(t, "abc", got.Hash)
+	require.Equal(t, "sha256:deadbeef", got.ResolvedImageDigest)
+	require.JSONEq(t, string(blob), string(got.HashInputBlob))
+}
+
+// TestSetTaskHashWithBlobNilBlobLeavesColumnNull asserts the nullable contract:
+// writing a hash with a nil blob (cache-off / serialization-failure path) leaves
+// the blob column unset rather than writing an empty value.
+func TestSetTaskHashWithBlobNilBlobLeavesColumnNull(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	runID, taskID := registerSingleTaskRun(t, store, db)
+
+	require.NoError(t, store.SetTaskHashWithBlob(runID, taskID, "h", "", nil))
+
+	var got models.TaskRun
+	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&got).Error)
+	require.Equal(t, "h", got.Hash)
+	require.Empty(t, got.HashInputBlob)
+}
+
+// TestSetTaskHashWithDigestLeavesBlobNull asserts the back-compat shim
+// (SetTaskHashWithDigest) still writes hash + digest without touching the blob
+// column, so the A1 call sites keep behaving identically.
+func TestSetTaskHashWithDigestLeavesBlobNull(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	runID, taskID := registerSingleTaskRun(t, store, db)
+
+	require.NoError(t, store.SetTaskHashWithDigest(runID, taskID, "h2", "sha256:cafe"))
+
+	var got models.TaskRun
+	require.NoError(t, db.Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&got).Error)
+	require.Equal(t, "h2", got.Hash)
+	require.Equal(t, "sha256:cafe", got.ResolvedImageDigest)
+	require.Empty(t, got.HashInputBlob)
+}

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -210,7 +210,7 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		// path does (the worker rebuilds the identical HashInput from the
 		// scheduler-propagated TaskRun + predecessor data). A serialization
 		// failure is non-fatal — the hash is still written without the blob.
-		blob, blobErr := hashInput.CanonicalJSON()
+		blob, blobErr := hashInput.CanonicalJSON(cacheHash)
 		if blobErr != nil {
 			log.Warn("cache: failed to serialize hash-input blob", "task_id", taskRun.TaskID, "error", blobErr)
 			blob = nil

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -142,6 +142,9 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 	// resolvedImageDigest is the content digest folded into cacheHash when
 	// pinning is on; empty otherwise. Reused when caching the result.
 	var resolvedImageDigest string
+	// hashInputBlob is the canonical secret-redacted decomposition of the
+	// HashInput; reused when caching the result so a cache hit can be explained.
+	var hashInputBlob []byte
 	cacheCfg := jobdefschema.CacheConfig{
 		Enabled:    taskRun.CacheEnabled,
 		TTL:        taskRun.CacheTTL,
@@ -202,7 +205,18 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 			CacheVersion:         cacheCfg.Version,
 		}
 		cacheHash = hashInput.Compute()
-		if err := e.store.SetTaskHashWithDigest(taskRun.JobRunID, taskRun.TaskID, cacheHash, resolvedImageDigest); err != nil {
+		// Serialize the decomposed input to a canonical, secret-redacted blob so
+		// a distributed worker persists the same field-by-field record the local
+		// path does (the worker rebuilds the identical HashInput from the
+		// scheduler-propagated TaskRun + predecessor data). A serialization
+		// failure is non-fatal — the hash is still written without the blob.
+		blob, blobErr := hashInput.CanonicalJSON()
+		if blobErr != nil {
+			log.Warn("cache: failed to serialize hash-input blob", "task_id", taskRun.TaskID, "error", blobErr)
+			blob = nil
+		}
+		hashInputBlob = blob
+		if err := e.store.SetTaskHashWithBlob(taskRun.JobRunID, taskRun.TaskID, cacheHash, resolvedImageDigest, hashInputBlob); err != nil {
 			log.Warn("cache: failed to persist task hash", "task_id", taskRun.TaskID, "hash", cacheHash, "error", err)
 		}
 
@@ -246,7 +260,7 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		if execErr == nil {
 			// Store successful result in cache.
 			if cacheStore != nil && cacheHash != "" {
-				e.storeCacheEntry(cacheStore, cacheCfg, cacheHash, resolvedImageDigest, taskRun)
+				e.storeCacheEntry(cacheStore, cacheCfg, cacheHash, resolvedImageDigest, hashInputBlob, taskRun)
 			}
 			return
 		}
@@ -510,7 +524,7 @@ func (e *runtimeExecutor) runSchemaValidation(taskRun *models.TaskRun, output ma
 }
 
 // storeCacheEntry reads back the completed task run and stores the result in the cache.
-func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobdefschema.CacheConfig, hash, resolvedImageDigest string, taskRun *models.TaskRun) {
+func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobdefschema.CacheConfig, hash, resolvedImageDigest string, hashInputBlob []byte, taskRun *models.TaskRun) {
 	// Read back the completed task run to get output and result.
 	var completed models.TaskRun
 	if err := e.store.DB().Where("job_run_id = ? AND task_id = ?", taskRun.JobRunID, taskRun.TaskID).First(&completed).Error; err != nil {
@@ -557,6 +571,7 @@ func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobd
 		RunID:               taskRun.JobRunID,
 		TaskRunID:           completed.ID,
 		ResolvedImageDigest: resolvedImageDigest,
+		HashInputBlob:       hashInputBlob,
 		CreatedAt:           time.Now().UTC(),
 	}
 


### PR DESCRIPTION
## Summary

Implements **data-plane-memory item A2** (design Component 2): persist the **decomposed `HashInput`** so the system can report *which* input changed between two runs — the keystone that unlocks `caesium why` (A3). Today only the opaque SHA-256 digest is persisted, so the system can conclude "the hashes differ" but not *why*. This stores a canonical, secret-redacted, field-by-field decomposition alongside the digest.

## What changed

- **`HashInput.CanonicalJSON()`** (`internal/cache/hash.go`) — serializes a versioned (`HashInputBlobVersion`), deterministic, field-by-field blob.
  - **Secret guardrail:** env values are never stored verbatim. A `secret://` reference is kept as-is (a safe pointer — secrets resolve *after* hashing, at container-create time, via `internal/jobdef/secret`); every other env value is reduced to a `sha256:` digest, so a credential injected as a *literal* env value never lands in the blob. `caesium why` can still detect "env `FOO` changed" (digests differ) without seeing the plaintext.
  - **Predecessor outputs** (typed data-contract values, not secrets) are stored verbatim so a reader can show the before/after (`extract.row_count` 1.2M→1.4M).
  - **Bounded:** capped at 64 KB; an over-bound blob degrades to a compact oversized marker (identity + counts) rather than bloating dqlite write volume.
- **Nullable `hash_input_blob` JSON column** added to `TaskRun` and `TaskCache` (`internal/models/run.go`) — additive `AutoMigrate`; pre-A2 rows and cache-off paths stay valid.
- **`SetTaskHashWithBlob`** (`internal/run/store.go`) writes the blob alongside the hash on the **existing hash write-path**; `SetTaskHashWithDigest` retained as a back-compat shim.
- Threaded through **`cache.Entry` → `TaskCache`** (`internal/cache/store.go`) so a cache **hit** can also be explained, not only a re-run.
- Wired into **both hash sites** — `internal/job/job.go` (local/scheduler) and `internal/worker/runtime_executor.go` (distributed). The worker rebuilds the *identical* `HashInput` from the scheduler-propagated `TaskRun` + predecessor data (the `PredecessorHashes`/`PredecessorOutputs` pattern), so **no new dispatch-time field was needed** — distributed/local parity holds.

## Test evidence

- `just lint` → **0 issues**.
- `just unit-test` (race + coverage, containerized) → **green**, including 13 new tests:
  - serialization determinism (map ordering invariant), blob-hash matches `Compute()`, fields round-trip
  - env redaction: `secret://` verbatim, non-secret → digest, distinguishes changed values, no plaintext leak
  - oversized degradation stays bounded
  - column round-trip on `TaskRun` (`SetTaskHashWithBlob`) and `TaskCache` (`Put`/`Get`), plus the nullable contract

## Coordination

- Confined to owned files; **no** edits to `api/rest/**`, `internal/lineage/**`, `internal/jobdef/importer.go`, or `internal/models/models.go` (column on existing models, not a new model).
- Plan-doc: ticked **A2** only; `## Progress` untouched.

## Plan

`docs/exec-plans/active/data-plane-memory.md` → item **A2** (Stream A, design Component 2). Unblocks **A3** (`caesium why`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)