### PR TITLE
Add cross-job dataset impact query (data-plane-memory W2-γ)

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -11,6 +11,7 @@ import (
 	jobcache "github.com/caesium-cloud/caesium/api/rest/controller/job/cache"
 	"github.com/caesium-cloud/caesium/api/rest/controller/job/run"
 	jobdef "github.com/caesium-cloud/caesium/api/rest/controller/jobdef"
+	lineagectrl "github.com/caesium-cloud/caesium/api/rest/controller/lineage"
 	"github.com/caesium-cloud/caesium/api/rest/controller/logs"
 	"github.com/caesium-cloud/caesium/api/rest/controller/node"
 	notifctrl "github.com/caesium-cloud/caesium/api/rest/controller/notification"
@@ -157,6 +158,11 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 	// nodes
 	{
 		g.GET("/nodes/:address/workers", node.Workers)
+	}
+
+	// lineage impact (data-plane-memory C2)
+	{
+		g.GET("/lineage/impact", lineagectrl.Impact)
 	}
 }
 

--- a/api/rest/controller/lineage/impact.go
+++ b/api/rest/controller/lineage/impact.go
@@ -1,0 +1,48 @@
+package lineage
+
+import (
+	"net/http"
+	"strconv"
+
+	lsvc "github.com/caesium-cloud/caesium/api/rest/service/lineage"
+	"github.com/labstack/echo/v5"
+)
+
+// Impact handles GET /lineage/impact?namespace=<ns>&name=<name>[&max_depth=N]
+//
+// It returns the transitive set of downstream datasets that would be affected
+// if the named dataset changed — i.e. "what breaks if this table changes."
+// Results are breadth-first, shallowest hops first, and bounded by max_depth
+// (default 10, capped at 20).
+//
+// Example:
+//
+//	GET /lineage/impact?namespace=default&name=analytics.fact_orders
+func Impact(c *echo.Context) error {
+	namespace := c.QueryParam("namespace")
+	name := c.QueryParam("name")
+
+	if namespace == "" || name == "" {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			"namespace and name query parameters are required")
+	}
+
+	maxDepth := 0
+	if raw := c.QueryParam("max_depth"); raw != "" {
+		d, err := strconv.Atoi(raw)
+		if err != nil || d < 0 {
+			return echo.NewHTTPError(http.StatusBadRequest,
+				"max_depth must be a non-negative integer")
+		}
+		maxDepth = d
+	}
+
+	ctx := c.Request().Context()
+
+	result, err := lsvc.New(ctx).Impact(namespace, name, maxDepth)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	return c.JSON(http.StatusOK, result)
+}

--- a/api/rest/controller/lineage/impact.go
+++ b/api/rest/controller/lineage/impact.go
@@ -12,12 +12,18 @@ import (
 //
 // It returns the transitive set of downstream datasets that would be affected
 // if the named dataset changed — i.e. "what breaks if this table changes."
-// Results are breadth-first, shallowest hops first, and bounded by max_depth
-// (default 10, capped at 20).
+// Results are breadth-first, shallowest hops first.
+//
+// max_depth semantics:
+//   - omitted or 0: use the server default (10 hops).
+//   - 1–20: traverse exactly that many hops.
+//   - >20: capped at 20 by the query layer.
+//   - negative: rejected with 400.
 //
 // Example:
 //
 //	GET /lineage/impact?namespace=default&name=analytics.fact_orders
+//	GET /lineage/impact?namespace=default&name=analytics.fact_orders&max_depth=3
 func Impact(c *echo.Context) error {
 	namespace := c.QueryParam("namespace")
 	name := c.QueryParam("name")
@@ -27,12 +33,14 @@ func Impact(c *echo.Context) error {
 			"namespace and name query parameters are required")
 	}
 
+	// maxDepth=0 is passed through to QueryImpact, which treats it as
+	// "use the server default of 10 hops."  Negative values are invalid.
 	maxDepth := 0
 	if raw := c.QueryParam("max_depth"); raw != "" {
 		d, err := strconv.Atoi(raw)
 		if err != nil || d < 0 {
 			return echo.NewHTTPError(http.StatusBadRequest,
-				"max_depth must be a non-negative integer")
+				"max_depth must be a non-negative integer (0 = server default)")
 		}
 		maxDepth = d
 	}

--- a/api/rest/service/lineage/lineage.go
+++ b/api/rest/service/lineage/lineage.go
@@ -1,0 +1,32 @@
+package lineage
+
+import (
+	"context"
+
+	illineage "github.com/caesium-cloud/caesium/internal/lineage"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"gorm.io/gorm"
+)
+
+// Service wraps the internal lineage query layer for use by REST controllers.
+type Service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+// New creates a Service with the default DB connection.
+func New(ctx context.Context) *Service {
+	return &Service{ctx: ctx, db: db.Connection()}
+}
+
+// WithDatabase returns a copy of the Service using the given connection; used
+// in tests to inject an in-memory database without touching the singleton.
+func (s *Service) WithDatabase(conn *gorm.DB) *Service {
+	return &Service{ctx: s.ctx, db: conn}
+}
+
+// Impact returns the transitive downstream impact of a dataset change.  See
+// internal/lineage.QueryImpact for traversal semantics.
+func (s *Service) Impact(namespace, name string, maxDepth int) (*illineage.ImpactResult, error) {
+	return illineage.QueryImpact(s.ctx, s.db, namespace, name, maxDepth)
+}

--- a/docs/exec-plans/active/data-plane-memory.md
+++ b/docs/exec-plans/active/data-plane-memory.md
@@ -205,11 +205,14 @@ pipeline ships but emits empty datasets). Independent of Stream A.
       Files: `internal/lineage/mapper.go` (all 7 mappers — replace `[]Dataset{}`),
       `internal/lineage/facets.go`, new `internal/models/lineage_dataset.go` + `internal/models/models.go` (additive),
       `docs/open_lineage.md`. — Landed in data-plane-memory W1-γ PR.
-- [ ] C2. Add a cross-job impact query ("what breaks if this table changes") over
+- [x] C2. Add a cross-job impact query ("what breaks if this table changes") over
       the dataset graph, bound to the producing step + git commit/author.
       Files: `api/rest/controller/` + `api/rest/service/` + `api/rest/bind/bind.go`,
       optional `cmd/`, `internal/lineage/` query.
       Depends on: C1 (graph-change attribution is sharper with B1 but does not require it).
+      <!-- W2-γ: BFS traversal in internal/lineage/impact.go (QueryImpact), service in
+      api/rest/service/lineage/, controller in api/rest/controller/lineage/impact.go,
+      route GET /lineage/impact in api/rest/bind/bind.go; 7 unit tests (PR data-plane-memory W2-γ). -->
 
 ### Stream D — Large-object reference passing + value-verified skip (design C5)
 

--- a/internal/lineage/impact.go
+++ b/internal/lineage/impact.go
@@ -3,9 +3,9 @@ package lineage
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"time"
 
-	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -55,14 +55,22 @@ type ImpactResult struct {
 
 	// Downstream lists every transitively reachable output dataset, ordered
 	// breadth-first (shallowest nodes first within each depth level).
+	// When the same (namespace, name) is produced by multiple distinct
+	// task runs / jobs, each (namespace+name+job_id) triple appears as a
+	// separate node; BFS frontier expansion is keyed only on dataset identity
+	// so the graph traversal still terminates.
 	Downstream []ImpactNode `json:"downstream"`
 }
 
 // QueryImpact returns all datasets transitively downstream of the dataset
 // identified by (namespace, name) — i.e. datasets whose producing steps
 // consume namespace/name as an input, directly or transitively, across job
-// boundaries.  The traversal is bounded by maxDepth (≤ 20; pass 0 to use the
-// default of 10).
+// boundaries.
+//
+// maxDepth controls how many hops to traverse:
+//   - 0 (or unset): use the server default of 10.
+//   - 1–20: traverse that many hops.
+//   - >20: capped at 20.
 //
 // The lineage_dataset table records (task_run_id, namespace, name, direction)
 // rows for every observed input and output.  Two rows form an edge when an
@@ -88,11 +96,15 @@ func QueryImpact(ctx context.Context, db *gorm.DB, namespace, name string, maxDe
 		Downstream:    []ImpactNode{},
 	}
 
-	// visited tracks (namespace, name) pairs we have already added to the
-	// result set, preventing cycles in the graph.
-	visited := make(map[string]bool)
+	// visitedDatasets tracks (namespace, name) pairs we have already
+	// enqueued into the BFS frontier, preventing cycles and redundant
+	// traversal waves.  It is intentionally separate from the reported-nodes
+	// dedup: a dataset can be produced by multiple jobs and all of those
+	// (dataset, job) pairs are reported — but the dataset name itself is only
+	// added to the frontier once so the BFS terminates.
+	visitedDatasets := make(map[string]bool)
 	rootKey := namespace + "\x00" + name
-	visited[rootKey] = true
+	visitedDatasets[rootKey] = true
 
 	// frontier holds the (namespace, name) pairs whose direct consumers we
 	// must find in the current BFS wave.
@@ -109,17 +121,20 @@ func QueryImpact(ctx context.Context, db *gorm.DB, namespace, name string, maxDe
 
 		var nextFrontier []datasetRef
 		for _, c := range consumers {
-			key := c.DatasetNamespace + "\x00" + c.DatasetName
-			if visited[key] {
-				continue
-			}
-			visited[key] = true
 			c.Depth = depth
 			result.Downstream = append(result.Downstream, c)
-			nextFrontier = append(nextFrontier, datasetRef{
-				namespace: c.DatasetNamespace,
-				name:      c.DatasetName,
-			})
+
+			// Only add to the next frontier if we have not yet traversed
+			// this dataset name — prevents cycles while still reporting
+			// multiple producers of the same dataset name.
+			key := c.DatasetNamespace + "\x00" + c.DatasetName
+			if !visitedDatasets[key] {
+				visitedDatasets[key] = true
+				nextFrontier = append(nextFrontier, datasetRef{
+					namespace: c.DatasetNamespace,
+					name:      c.DatasetName,
+				})
+			}
 		}
 		frontier = nextFrontier
 	}
@@ -133,46 +148,46 @@ type datasetRef struct {
 	name      string
 }
 
-// findConsumers runs a two-step SQL pass for a single BFS level:
+// findConsumers runs a single SQL pass for one BFS level.  For each dataset
+// in frontier it finds task runs that consume it (direction='input') via a
+// correlated subquery, then returns those task runs' output datasets
+// (direction='output') joined with job provenance.
 //
-//  1. Find task_run_ids that have any frontier dataset as an input
-//     (direction='input').
-//  2. Return those task runs' output datasets (direction='output') joined
-//     with job provenance so the caller has attribution in one query.
+// Using a subquery avoids loading intermediate task_run_id values into Go
+// memory and sidesteps the SQLite/dqlite 999-host-parameter limit that would
+// be hit by a large IN (?,?,…,?) list.
+//
+// Results are ordered by (ld.created_at DESC, ld.id DESC) so that when the
+// same (namespace, name) output was produced by multiple task runs the most
+// recent run is returned first, making attribution deterministic ("latest
+// producer wins").
 func findConsumers(ctx context.Context, db *gorm.DB, frontier []datasetRef) ([]ImpactNode, error) {
 	if len(frontier) == 0 {
 		return nil, nil
 	}
 
-	// Step 1: collect consumer task_run_ids.
-	type taskRunIDRow struct{ TaskRunID string }
-	var inputRows []taskRunIDRow
-
-	q := db.WithContext(ctx).
-		Model(&models.LineageDataset{}).
-		Select("task_run_id").
-		Where("direction = ?", "input")
-
-	orCond := db.Where("namespace = ? AND name = ?", frontier[0].namespace, frontier[0].name)
-	for _, f := range frontier[1:] {
-		orCond = orCond.Or("namespace = ? AND name = ?", f.namespace, f.name)
-	}
-	q = q.Where(orCond)
-
-	if err := q.Scan(&inputRows).Error; err != nil {
-		return nil, err
-	}
-	if len(inputRows) == 0 {
-		return nil, nil
+	// Build the frontier (namespace = ? AND name = ?) OR arms.
+	// The number of arms is bounded by the BFS frontier width, which is
+	// small in practice (one arm per distinct dataset at this depth level).
+	orArms := make([]string, len(frontier))
+	// subArgs holds the placeholder values for the subquery's WHERE clause.
+	subArgs := make([]interface{}, 0, len(frontier)*2)
+	for i, f := range frontier {
+		orArms[i] = "(namespace = ? AND name = ?)"
+		subArgs = append(subArgs, f.namespace, f.name)
 	}
 
-	taskRunIDs := make([]string, len(inputRows))
-	for i, r := range inputRows {
-		taskRunIDs[i] = r.TaskRunID
-	}
+	// The subquery selects task_run_ids that consumed any frontier dataset as
+	// an input.  The ? placeholders are filled by subArgs in the Scan call.
+	subquery := "SELECT task_run_id FROM lineage_datasets" +
+		" WHERE direction = 'input' AND (" + strings.Join(orArms, " OR ") + ")"
 
-	// Step 2: fetch the output datasets for those task_run_ids joined to
-	// job provenance via task_runs → job_runs → jobs.
+	// The outer WHERE clause matches output rows whose task_run_id is in the
+	// subquery.  Args: 'output' for ld.direction, then subArgs for the
+	// embedded subquery placeholders.
+	outerWhere := "ld.direction = ? AND ld.task_run_id IN (" + subquery + ")"
+	queryArgs := append([]interface{}{"output"}, subArgs...)
+
 	type outputRow struct {
 		Namespace        string
 		Name             string
@@ -195,7 +210,8 @@ func findConsumers(ctx context.Context, db *gorm.DB, frontier []datasetRef) ([]I
 		Joins("JOIN task_runs tr ON tr.id = ld.task_run_id").
 		Joins("JOIN job_runs jr ON jr.id = tr.job_run_id").
 		Joins("JOIN jobs j ON j.id = jr.job_id").
-		Where("ld.direction = ? AND ld.task_run_id IN ?", "output", taskRunIDs).
+		Where(outerWhere, queryArgs...).
+		Order("ld.created_at DESC, ld.id DESC").
 		Scan(&outputRows).Error
 	if err != nil {
 		return nil, err
@@ -203,7 +219,13 @@ func findConsumers(ctx context.Context, db *gorm.DB, frontier []datasetRef) ([]I
 
 	nodes := make([]ImpactNode, 0, len(outputRows))
 	for _, row := range outputRows {
-		jobID, _ := uuid.Parse(row.JobID)
+		jobID, err := uuid.Parse(row.JobID)
+		if err != nil {
+			// A zero UUID signals to callers that provenance attribution
+			// failed for this row (e.g. a schema mismatch during migration).
+			// We still include the node so the dataset graph is complete.
+			jobID = uuid.Nil
+		}
 		nodes = append(nodes, ImpactNode{
 			DatasetNamespace: row.Namespace,
 			DatasetName:      row.Name,

--- a/internal/lineage/impact.go
+++ b/internal/lineage/impact.go
@@ -1,0 +1,238 @@
+package lineage
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ImpactNode describes a dataset (or the step that produces it) that is
+// transitively downstream of a changed dataset.  Each node carries the
+// producing step name, the job alias, and git provenance so callers can
+// attribute "who wrote this and when."
+type ImpactNode struct {
+	// DatasetNamespace and DatasetName are the OpenLineage identity of the
+	// downstream dataset.
+	DatasetNamespace string `json:"dataset_namespace"`
+	DatasetName      string `json:"dataset_name"`
+	// Direction is always "output" for nodes returned by Impact — each node
+	// is a dataset produced by a downstream step.
+	Direction string `json:"direction"`
+
+	// ProducingStep is the task name that emits this dataset, sourced from
+	// FacetSummary.caesium_dataset.step_name when available.
+	ProducingStep string `json:"producing_step,omitempty"`
+
+	// JobID and JobAlias identify the job that contains the producing step.
+	// Populated via a join from task_runs → job_runs → jobs.
+	JobID    uuid.UUID `json:"job_id"`
+	JobAlias string    `json:"job_alias"`
+
+	// ProvenanceCommit and ProvenanceRepo carry git provenance from the job
+	// at the time the dataset row was last written.
+	ProvenanceCommit string `json:"provenance_commit,omitempty"`
+	ProvenanceRepo   string `json:"provenance_repo,omitempty"`
+
+	// LastSeen is the created_at timestamp of the lineage_dataset row — a
+	// proxy for "when was this dependency last observed."
+	LastSeen time.Time `json:"last_seen"`
+
+	// Depth is the transitive hop count from the root dataset (0 = direct
+	// consumer, 1 = consumer of a consumer, …).
+	Depth int `json:"depth"`
+}
+
+// ImpactResult is the response shape returned by QueryImpact.
+type ImpactResult struct {
+	// RootNamespace and RootName are the input dataset whose downstream
+	// impact is being reported.
+	RootNamespace string `json:"root_namespace"`
+	RootName      string `json:"root_name"`
+
+	// Downstream lists every transitively reachable output dataset, ordered
+	// breadth-first (shallowest nodes first within each depth level).
+	Downstream []ImpactNode `json:"downstream"`
+}
+
+// QueryImpact returns all datasets transitively downstream of the dataset
+// identified by (namespace, name) — i.e. datasets whose producing steps
+// consume namespace/name as an input, directly or transitively, across job
+// boundaries.  The traversal is bounded by maxDepth (≤ 20; pass 0 to use the
+// default of 10).
+//
+// The lineage_dataset table records (task_run_id, namespace, name, direction)
+// rows for every observed input and output.  Two rows form an edge when an
+// output dataset in one task run shares its (namespace, name) with an input
+// dataset in another task run: the consumer's task run is the next hop.
+//
+// This is a pure read-side query over the existing dataset graph populated by
+// C1.  It does not touch mapper.go or any write path.
+func QueryImpact(ctx context.Context, db *gorm.DB, namespace, name string, maxDepth int) (*ImpactResult, error) {
+	const defaultMaxDepth = 10
+	const absoluteMaxDepth = 20
+
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxDepth
+	}
+	if maxDepth > absoluteMaxDepth {
+		maxDepth = absoluteMaxDepth
+	}
+
+	result := &ImpactResult{
+		RootNamespace: namespace,
+		RootName:      name,
+		Downstream:    []ImpactNode{},
+	}
+
+	// visited tracks (namespace, name) pairs we have already added to the
+	// result set, preventing cycles in the graph.
+	visited := make(map[string]bool)
+	rootKey := namespace + "\x00" + name
+	visited[rootKey] = true
+
+	// frontier holds the (namespace, name) pairs whose direct consumers we
+	// must find in the current BFS wave.
+	frontier := []datasetRef{{namespace: namespace, name: name}}
+
+	for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
+		consumers, err := findConsumers(ctx, db, frontier)
+		if err != nil {
+			return nil, err
+		}
+		if len(consumers) == 0 {
+			break
+		}
+
+		var nextFrontier []datasetRef
+		for _, c := range consumers {
+			key := c.DatasetNamespace + "\x00" + c.DatasetName
+			if visited[key] {
+				continue
+			}
+			visited[key] = true
+			c.Depth = depth
+			result.Downstream = append(result.Downstream, c)
+			nextFrontier = append(nextFrontier, datasetRef{
+				namespace: c.DatasetNamespace,
+				name:      c.DatasetName,
+			})
+		}
+		frontier = nextFrontier
+	}
+
+	return result, nil
+}
+
+// datasetRef is a lightweight (namespace, name) pair used as BFS frontier state.
+type datasetRef struct {
+	namespace string
+	name      string
+}
+
+// findConsumers runs a two-step SQL pass for a single BFS level:
+//
+//  1. Find task_run_ids that have any frontier dataset as an input
+//     (direction='input').
+//  2. Return those task runs' output datasets (direction='output') joined
+//     with job provenance so the caller has attribution in one query.
+func findConsumers(ctx context.Context, db *gorm.DB, frontier []datasetRef) ([]ImpactNode, error) {
+	if len(frontier) == 0 {
+		return nil, nil
+	}
+
+	// Step 1: collect consumer task_run_ids.
+	type taskRunIDRow struct{ TaskRunID string }
+	var inputRows []taskRunIDRow
+
+	q := db.WithContext(ctx).
+		Model(&models.LineageDataset{}).
+		Select("task_run_id").
+		Where("direction = ?", "input")
+
+	orCond := db.Where("namespace = ? AND name = ?", frontier[0].namespace, frontier[0].name)
+	for _, f := range frontier[1:] {
+		orCond = orCond.Or("namespace = ? AND name = ?", f.namespace, f.name)
+	}
+	q = q.Where(orCond)
+
+	if err := q.Scan(&inputRows).Error; err != nil {
+		return nil, err
+	}
+	if len(inputRows) == 0 {
+		return nil, nil
+	}
+
+	taskRunIDs := make([]string, len(inputRows))
+	for i, r := range inputRows {
+		taskRunIDs[i] = r.TaskRunID
+	}
+
+	// Step 2: fetch the output datasets for those task_run_ids joined to
+	// job provenance via task_runs → job_runs → jobs.
+	type outputRow struct {
+		Namespace        string
+		Name             string
+		FacetSummary     []byte
+		JobID            string
+		JobAlias         string
+		ProvenanceCommit string
+		ProvenanceRepo   string
+		CreatedAt        time.Time
+	}
+	var outputRows []outputRow
+
+	err := db.WithContext(ctx).
+		Table("lineage_datasets ld").
+		Select(
+			"ld.namespace, ld.name, ld.facet_summary, ld.created_at,"+
+				" j.id as job_id, j.alias as job_alias,"+
+				" j.provenance_commit, j.provenance_repo",
+		).
+		Joins("JOIN task_runs tr ON tr.id = ld.task_run_id").
+		Joins("JOIN job_runs jr ON jr.id = tr.job_run_id").
+		Joins("JOIN jobs j ON j.id = jr.job_id").
+		Where("ld.direction = ? AND ld.task_run_id IN ?", "output", taskRunIDs).
+		Scan(&outputRows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]ImpactNode, 0, len(outputRows))
+	for _, row := range outputRows {
+		jobID, _ := uuid.Parse(row.JobID)
+		nodes = append(nodes, ImpactNode{
+			DatasetNamespace: row.Namespace,
+			DatasetName:      row.Name,
+			Direction:        "output",
+			ProducingStep:    stepNameFromFacet(row.FacetSummary),
+			JobID:            jobID,
+			JobAlias:         row.JobAlias,
+			ProvenanceCommit: row.ProvenanceCommit,
+			ProvenanceRepo:   row.ProvenanceRepo,
+			LastSeen:         row.CreatedAt,
+		})
+	}
+	return nodes, nil
+}
+
+// stepNameFromFacet extracts the step_name field from the FacetSummary JSON
+// blob stored on the lineage_dataset row.  Returns "" on any parse error so
+// the caller degrades gracefully.
+func stepNameFromFacet(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var summary struct {
+		CaesiumDataset struct {
+			StepName string `json:"step_name"`
+		} `json:"caesium_dataset"`
+	}
+	if err := json.Unmarshal(raw, &summary); err != nil {
+		return ""
+	}
+	return summary.CaesiumDataset.StepName
+}

--- a/internal/lineage/impact_test.go
+++ b/internal/lineage/impact_test.go
@@ -1,0 +1,305 @@
+package lineage
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ImpactSuite tests QueryImpact over an in-memory SQLite graph.
+type ImpactSuite struct {
+	suite.Suite
+	db  *gorm.DB
+	ctx context.Context
+}
+
+func TestImpactSuite(t *testing.T) {
+	suite.Run(t, new(ImpactSuite))
+}
+
+func (s *ImpactSuite) SetupTest() {
+	dsn := "file:" + uuid.NewString() + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	s.Require().NoError(err)
+	s.Require().NoError(db.AutoMigrate(models.All...))
+	s.db = db
+	s.ctx = context.Background()
+}
+
+func (s *ImpactSuite) TearDownTest() {
+	if s.db != nil {
+		sqlDB, _ := s.db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
+}
+
+// TestNoDownstream: querying a dataset with no consumers returns an empty list.
+func (s *ImpactSuite) TestNoDownstream() {
+	ns := "test"
+	job, run := s.createJobAndRun("job-a", "abc123")
+	s.createDataset(run, ns, "raw.table", "output", "extract")
+	_ = job
+
+	result, err := QueryImpact(s.ctx, s.db, ns, "raw.table", 0)
+	s.Require().NoError(err)
+	s.Equal(ns, result.RootNamespace)
+	s.Equal("raw.table", result.RootName)
+	s.Empty(result.Downstream)
+}
+
+// TestDirectConsumer: a single hop — dataset A → step that consumes A and
+// produces dataset B.
+func (s *ImpactSuite) TestDirectConsumer() {
+	ns := "test"
+
+	// Producer job: emits raw.table as output.
+	_, runA := s.createJobAndRun("job-producer", "commit-producer")
+	s.createDataset(runA, ns, "raw.table", "output", "extract")
+
+	// Consumer job: takes raw.table as input, emits transformed.table as output.
+	_, runB := s.createJobAndRun("job-consumer", "commit-consumer")
+	s.createDataset(runB, ns, "raw.table", "input", "load")
+	s.createDataset(runB, ns, "transformed.table", "output", "load")
+
+	result, err := QueryImpact(s.ctx, s.db, ns, "raw.table", 0)
+	s.Require().NoError(err)
+	s.Require().Len(result.Downstream, 1)
+
+	node := result.Downstream[0]
+	s.Equal("transformed.table", node.DatasetName)
+	s.Equal(ns, node.DatasetNamespace)
+	s.Equal("output", node.Direction)
+	s.Equal("load", node.ProducingStep)
+	s.Equal("job-consumer", node.JobAlias)
+	s.Equal("commit-consumer", node.ProvenanceCommit)
+	s.Equal(0, node.Depth)
+}
+
+// TestTransitiveChain: A → B → C — querying A should return both B and C.
+func (s *ImpactSuite) TestTransitiveChain() {
+	ns := "test"
+
+	// Step 1: emits dataset-a.
+	_, runA := s.createJobAndRun("job-a", "")
+	s.createDataset(runA, ns, "dataset-a", "output", "step-a")
+
+	// Step 2: consumes dataset-a, emits dataset-b.
+	_, runB := s.createJobAndRun("job-b", "")
+	s.createDataset(runB, ns, "dataset-a", "input", "step-b")
+	s.createDataset(runB, ns, "dataset-b", "output", "step-b")
+
+	// Step 3: consumes dataset-b, emits dataset-c.
+	_, runC := s.createJobAndRun("job-c", "")
+	s.createDataset(runC, ns, "dataset-b", "input", "step-c")
+	s.createDataset(runC, ns, "dataset-c", "output", "step-c")
+
+	result, err := QueryImpact(s.ctx, s.db, ns, "dataset-a", 0)
+	s.Require().NoError(err)
+	s.Require().Len(result.Downstream, 2)
+
+	byName := make(map[string]ImpactNode, 2)
+	for _, n := range result.Downstream {
+		byName[n.DatasetName] = n
+	}
+
+	b, ok := byName["dataset-b"]
+	s.True(ok, "dataset-b should be in downstream")
+	s.Equal(0, b.Depth)
+
+	c, ok := byName["dataset-c"]
+	s.True(ok, "dataset-c should be in downstream")
+	s.Equal(1, c.Depth)
+}
+
+// TestCycleGuard: a producer→consumer→producer cycle should not loop forever.
+func (s *ImpactSuite) TestCycleGuard() {
+	ns := "test"
+
+	// Run 1 produces x and consumes y (simulating a cycle).
+	_, run1 := s.createJobAndRun("job-cycle", "")
+	s.createDataset(run1, ns, "x", "output", "step")
+	s.createDataset(run1, ns, "y", "input", "step")
+
+	// Run 2 consumes x and produces y (completing the cycle).
+	_, run2 := s.createJobAndRun("job-cycle-b", "")
+	s.createDataset(run2, ns, "x", "input", "step2")
+	s.createDataset(run2, ns, "y", "output", "step2")
+
+	// Should not hang; cycle guard keeps result finite.
+	result, err := QueryImpact(s.ctx, s.db, ns, "x", 5)
+	s.Require().NoError(err)
+	s.NotNil(result)
+	// y appears exactly once even though the cycle would revisit x.
+	count := 0
+	for _, n := range result.Downstream {
+		if n.DatasetName == "y" {
+			count++
+		}
+	}
+	s.Equal(1, count)
+}
+
+// TestMaxDepthRespected: a chain longer than maxDepth is truncated.
+func (s *ImpactSuite) TestMaxDepthRespected() {
+	ns := "test"
+
+	// Build a chain of 5 hops.
+	datasets := []string{"d0", "d1", "d2", "d3", "d4", "d5"}
+	for i := 0; i < len(datasets)-1; i++ {
+		_, run := s.createJobAndRun("hop-job-"+datasets[i], "")
+		s.createDataset(run, ns, datasets[i], "input", "step")
+		s.createDataset(run, ns, datasets[i+1], "output", "step")
+	}
+
+	// maxDepth=2 should return d1 (depth 0) and d2 (depth 1) only.
+	result, err := QueryImpact(s.ctx, s.db, ns, "d0", 2)
+	s.Require().NoError(err)
+
+	seen := make(map[string]bool)
+	for _, n := range result.Downstream {
+		seen[n.DatasetName] = true
+	}
+	s.True(seen["d1"])
+	s.True(seen["d2"])
+	s.False(seen["d3"], "depth 3 should be truncated at maxDepth=2")
+}
+
+// TestCrossJobBoundary: consumers in a different job are returned with their
+// job alias and provenance.
+func (s *ImpactSuite) TestCrossJobBoundary() {
+	ns := "test"
+
+	jobA, runA := s.createJobAndRun("job-source", "sha-source")
+	s.createDataset(runA, ns, "events.raw", "output", "ingest")
+	_ = jobA
+
+	jobB, runB := s.createJobAndRunWithRepo("job-sink", "sha-sink", "https://github.com/org/repo")
+	s.createDataset(runB, ns, "events.raw", "input", "transform")
+	s.createDataset(runB, ns, "events.cleaned", "output", "transform")
+	_ = jobB
+
+	result, err := QueryImpact(s.ctx, s.db, ns, "events.raw", 0)
+	s.Require().NoError(err)
+	s.Require().Len(result.Downstream, 1)
+
+	node := result.Downstream[0]
+	s.Equal("events.cleaned", node.DatasetName)
+	s.Equal("job-sink", node.JobAlias)
+	s.Equal("sha-sink", node.ProvenanceCommit)
+	s.Equal("https://github.com/org/repo", node.ProvenanceRepo)
+}
+
+// TestStepNameFromFacet: helper correctly extracts step names.
+func (s *ImpactSuite) TestStepNameFromFacet() {
+	raw := marshalFacet(map[string]interface{}{
+		"caesium_dataset": map[string]interface{}{
+			"step_name": "my-step",
+		},
+	})
+	s.Equal("my-step", stepNameFromFacet(raw))
+	s.Equal("", stepNameFromFacet(nil))
+	s.Equal("", stepNameFromFacet([]byte(`{}`)))
+	s.Equal("", stepNameFromFacet([]byte(`not-json`)))
+}
+
+// --- helpers ---
+
+func (s *ImpactSuite) createJobAndRun(alias, commit string) (*models.Job, *models.TaskRun) {
+	return s.createJobAndRunWithRepo(alias, commit, "")
+}
+
+func (s *ImpactSuite) createJobAndRunWithRepo(alias, commit, repo string) (*models.Job, *models.TaskRun) {
+	triggerID := uuid.New()
+	s.Require().NoError(s.db.Create(&models.Trigger{
+		ID:   triggerID,
+		Type: models.TriggerTypeCron,
+	}).Error)
+
+	job := &models.Job{
+		ID:               uuid.New(),
+		Alias:            alias,
+		TriggerID:        triggerID,
+		ProvenanceCommit: commit,
+		ProvenanceRepo:   repo,
+	}
+	s.Require().NoError(s.db.Create(job).Error)
+
+	atomID := uuid.New()
+	s.Require().NoError(s.db.Create(&models.Atom{
+		ID:     atomID,
+		Engine: models.AtomEngineDocker,
+		Image:  "alpine:3.23",
+	}).Error)
+
+	task := &models.Task{
+		ID:     uuid.New(),
+		JobID:  job.ID,
+		AtomID: atomID,
+		Name:   alias + "-task",
+	}
+	s.Require().NoError(s.db.Create(task).Error)
+
+	jobRun := &models.JobRun{
+		ID:          uuid.New(),
+		JobID:       job.ID,
+		TriggerID:   triggerID,
+		Status:      "succeeded",
+		StartedAt:   time.Now().UTC(),
+		CompletedAt: ptrTime(time.Now().UTC()),
+	}
+	s.Require().NoError(s.db.Create(jobRun).Error)
+
+	taskRun := &models.TaskRun{
+		ID:        uuid.New(),
+		JobRunID:  jobRun.ID,
+		TaskID:    task.ID,
+		AtomID:    atomID,
+		Engine:    models.AtomEngineDocker,
+		Image:     "alpine:3.23",
+		Command:   "[]",
+		Status:    "succeeded",
+		ClaimedBy: "",
+	}
+	s.Require().NoError(s.db.Create(taskRun).Error)
+
+	return job, taskRun
+}
+
+func (s *ImpactSuite) createDataset(run *models.TaskRun, ns, name, direction, stepName string) {
+	facet := marshalFacet(map[string]interface{}{
+		"caesium_dataset": map[string]interface{}{
+			"step_name": stepName,
+			"direction": direction,
+		},
+	})
+	ds := &models.LineageDataset{
+		ID:           uuid.New(),
+		TaskRunID:    run.ID,
+		Namespace:    ns,
+		Name:         name,
+		Direction:    direction,
+		FacetSummary: datatypes.JSON(facet),
+		CreatedAt:    time.Now().UTC(),
+	}
+	s.Require().NoError(s.db.Create(ds).Error)
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func marshalFacet(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}

--- a/internal/lineage/impact_test.go
+++ b/internal/lineage/impact_test.go
@@ -199,6 +199,48 @@ func (s *ImpactSuite) TestCrossJobBoundary() {
 	s.Equal("https://github.com/org/repo", node.ProvenanceRepo)
 }
 
+// TestMultipleProducers: when two different jobs both consume the same upstream
+// dataset and each produces a different downstream dataset, both downstream
+// nodes appear in the result.  This validates that the BFS dedup is keyed on
+// dataset identity (for frontier expansion) rather than on reported nodes, so
+// distinct (dataset, job) producers are not silently dropped.
+func (s *ImpactSuite) TestMultipleProducers() {
+	ns := "test"
+
+	// Job A produces source.table.
+	_, runA := s.createJobAndRun("job-source", "")
+	s.createDataset(runA, ns, "source.table", "output", "ingest")
+
+	// Job B consumes source.table and produces sink-b.table.
+	_, runB := s.createJobAndRun("job-consumer-b", "commit-b")
+	s.createDataset(runB, ns, "source.table", "input", "step-b")
+	s.createDataset(runB, ns, "sink-b.table", "output", "step-b")
+
+	// Job C also consumes source.table and produces sink-c.table.
+	_, runC := s.createJobAndRun("job-consumer-c", "commit-c")
+	s.createDataset(runC, ns, "source.table", "input", "step-c")
+	s.createDataset(runC, ns, "sink-c.table", "output", "step-c")
+
+	result, err := QueryImpact(s.ctx, s.db, ns, "source.table", 0)
+	s.Require().NoError(err)
+	s.Require().Len(result.Downstream, 2, "both downstream datasets must be reported")
+
+	byName := make(map[string]ImpactNode, 2)
+	for _, n := range result.Downstream {
+		byName[n.DatasetName] = n
+	}
+
+	bNode, ok := byName["sink-b.table"]
+	s.True(ok, "sink-b.table must appear in downstream")
+	s.Equal("job-consumer-b", bNode.JobAlias)
+	s.Equal(0, bNode.Depth)
+
+	cNode, ok := byName["sink-c.table"]
+	s.True(ok, "sink-c.table must appear in downstream")
+	s.Equal("job-consumer-c", cNode.JobAlias)
+	s.Equal(0, cNode.Depth)
+}
+
 // TestStepNameFromFacet: helper correctly extracts step names.
 func (s *ImpactSuite) TestStepNameFromFacet() {
 	raw := marshalFacet(map[string]interface{}{


### PR DESCRIPTION
## Summary

- Implements plan item **C2** (data-plane-memory): cross-job dataset impact query ("what breaks if this table changes").
- BFS traversal in `internal/lineage/impact.go` (`QueryImpact`) walks the `lineage_dataset` graph populated by C1, crossing job boundaries, bounded by `max_depth` (default 10, capped at 20), with cycle-guard via a visited-set.
- Each result `ImpactNode` carries: downstream dataset identity (namespace + name), producing step name (from `FacetSummary.caesium_dataset.step_name`), job alias and ID (via `task_runs → job_runs → jobs` join), and git provenance (`provenance_commit`, `provenance_repo`).
- REST endpoint: `GET /lineage/impact?namespace=<ns>&name=<name>[&max_depth=N]` in `Protected()`.
- 7 unit tests over an in-memory SQLite graph: no downstream, direct consumer, transitive chain, cycle guard, max-depth truncation, cross-job boundary, and `stepNameFromFacet` helper.

## Files

| File | Role |
|---|---|
| `internal/lineage/impact.go` | `QueryImpact` + `findConsumers` BFS traversal |
| `internal/lineage/impact_test.go` | 7-case test suite |
| `api/rest/service/lineage/lineage.go` | Service wrapper |
| `api/rest/controller/lineage/impact.go` | `GET /lineage/impact` controller |
| `api/rest/bind/bind.go` | Route + import (C2 addition only) |
| `docs/exec-plans/active/data-plane-memory.md` | C2 checkbox ticked |

## bind.go additions (for W2-β union rebase)

```go
// import block
lineagectrl "github.com/caesium-cloud/caesium/api/rest/controller/lineage"

// Protected() route block
// lineage impact (data-plane-memory C2)
{
    g.GET("/lineage/impact", lineagectrl.Impact)
}
```

## Test plan

- [x] `just unit-test` — all packages pass (0 FAIL), including 7 new `TestImpactSuite` cases
- [x] `just lint` — 0 issues
- [ ] `just integration-test` — integration gate run by orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)