### PR TITLE
Add reproducibility receipt + caesium verify (data-plane-memory W3-β)

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -13,11 +13,12 @@ import (
 	jobdef "github.com/caesium-cloud/caesium/api/rest/controller/jobdef"
 	lineagectrl "github.com/caesium-cloud/caesium/api/rest/controller/lineage"
 	"github.com/caesium-cloud/caesium/api/rest/controller/logs"
-	"github.com/caesium-cloud/caesium/api/rest/controller/topology"
 	"github.com/caesium-cloud/caesium/api/rest/controller/node"
 	notifctrl "github.com/caesium-cloud/caesium/api/rest/controller/notification"
+	receiptctrl "github.com/caesium-cloud/caesium/api/rest/controller/receipt"
 	"github.com/caesium-cloud/caesium/api/rest/controller/stats"
 	"github.com/caesium-cloud/caesium/api/rest/controller/system"
+	"github.com/caesium-cloud/caesium/api/rest/controller/topology"
 	"github.com/caesium-cloud/caesium/api/rest/controller/trigger"
 	"github.com/caesium-cloud/caesium/api/rest/controller/webhook"
 	"github.com/caesium-cloud/caesium/internal/auth"
@@ -83,6 +84,10 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		// historical DAG topology (data-plane-memory B2)
 		g.GET("/jobs/:id/topology", topology.Get)
 		g.GET("/jobs/:id/topology/history", topology.History)
+
+		// reproducibility receipt + verify (data-plane-memory A4)
+		g.GET("/jobs/:id/runs/:run_id/receipt", receiptctrl.Get)
+		g.POST("/jobs/:id/runs/:run_id/receipt/verify", receiptctrl.Verify)
 
 		// job cache management
 		g.GET("/jobs/:id/cache", jobcache.List)

--- a/api/rest/controller/receipt/receipt.go
+++ b/api/rest/controller/receipt/receipt.go
@@ -21,6 +21,14 @@ import (
 // honest: if any task ran on an unpinned, mutable image tag, the receipt cannot
 // attest reproducibility and says so.
 func Get(c *echo.Context) error {
+	// Parse and validate BOTH path params up-front. The job ID must be a valid
+	// UUID so the ownership cross-check below cannot be silently bypassed by a
+	// malformed `id` (a non-UUID would otherwise skip the check and leak the
+	// receipt for any run_id under any path).
+	jobID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
 	runID, err := uuid.Parse(c.Param("run_id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
@@ -38,7 +46,7 @@ func Get(c *echo.Context) error {
 
 	// Cross-check the run belongs to the job in the path so the route is not a
 	// way to read receipts for arbitrary runs under any job ID.
-	if jobID, perr := uuid.Parse(c.Param("id")); perr == nil && r.JobID != jobID {
+	if r.JobID != jobID {
 		return echo.ErrNotFound
 	}
 
@@ -54,6 +62,12 @@ func Get(c *echo.Context) error {
 // tasks were not digest-pinned is reported as degraded and never as a clean
 // match.
 func Verify(c *echo.Context) error {
+	// Parse and validate BOTH path params up-front (see Get) so the ownership
+	// cross-check below cannot be bypassed by a malformed `id`.
+	jobID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
 	runID, err := uuid.Parse(c.Param("run_id"))
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
@@ -79,8 +93,7 @@ func Verify(c *echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 	}
 
-	if jobID, perr := uuid.Parse(c.Param("id")); perr == nil &&
-		result.Rederived != nil && result.Rederived.JobID != jobID {
+	if result.Rederived != nil && result.Rederived.JobID != jobID {
 		return echo.ErrNotFound
 	}
 

--- a/api/rest/controller/receipt/receipt.go
+++ b/api/rest/controller/receipt/receipt.go
@@ -1,0 +1,88 @@
+// Package receipt exposes the reproducibility-receipt REST endpoints: emit a
+// content-addressed receipt for a run, and verify a committed receipt against a
+// run's current persisted state (drift detection).
+package receipt
+
+import (
+	"errors"
+	"net/http"
+
+	rsvc "github.com/caesium-cloud/caesium/api/rest/service/receipt"
+	ireceipt "github.com/caesium-cloud/caesium/internal/receipt"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+// Get handles GET /jobs/:id/runs/:run_id/receipt.
+//
+// It re-derives the run's reproducibility receipt from persisted state and
+// returns it as JSON — a small, content-addressed artifact intended to be
+// committed to git alongside the pipeline. The receipt's `degraded` flag is
+// honest: if any task ran on an unpinned, mutable image tag, the receipt cannot
+// attest reproducibility and says so.
+func Get(c *echo.Context) error {
+	runID, err := uuid.Parse(c.Param("run_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	ctx := c.Request().Context()
+
+	r, err := rsvc.New(ctx).Build(runID)
+	if err != nil {
+		if errors.Is(err, ireceipt.ErrRunNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	// Cross-check the run belongs to the job in the path so the route is not a
+	// way to read receipts for arbitrary runs under any job ID.
+	if jobID, perr := uuid.Parse(c.Param("id")); perr == nil && r.JobID != jobID {
+		return echo.ErrNotFound
+	}
+
+	return c.JSON(http.StatusOK, r)
+}
+
+// Verify handles POST /jobs/:id/runs/:run_id/receipt/verify.
+//
+// The request body is a previously-emitted (committed) receipt. The handler
+// re-derives the receipt from the run's current persisted state and returns a
+// drift report: whether the run still matches, and if not, every divergence
+// ("image tag mutated: digest mismatch", "manifest changed", …). A run whose
+// tasks were not digest-pinned is reported as degraded and never as a clean
+// match.
+func Verify(c *echo.Context) error {
+	runID, err := uuid.Parse(c.Param("run_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	var committed ireceipt.Receipt
+	if err := c.Bind(&committed); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	// The run in the path is authoritative; ignore/override a mismatched RunID
+	// in the body so a caller cannot verify run A's state against run B's
+	// committed receipt by accident.
+	committed.RunID = runID
+
+	ctx := c.Request().Context()
+
+	result, err := rsvc.New(ctx).Verify(&committed)
+	if err != nil {
+		if errors.Is(err, ireceipt.ErrRunNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	if jobID, perr := uuid.Parse(c.Param("id")); perr == nil &&
+		result.Rederived != nil && result.Rederived.JobID != jobID {
+		return echo.ErrNotFound
+	}
+
+	return c.JSON(http.StatusOK, result)
+}

--- a/api/rest/service/receipt/receipt.go
+++ b/api/rest/service/receipt/receipt.go
@@ -1,0 +1,41 @@
+// Package receipt is the REST service wrapper around internal/receipt: it
+// builds a reproducibility receipt for a run and verifies a committed receipt
+// against a run's current persisted state.
+package receipt
+
+import (
+	"context"
+
+	ireceipt "github.com/caesium-cloud/caesium/internal/receipt"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Service wraps the internal receipt build/verify layer for REST controllers.
+type Service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+// New creates a Service with the default DB connection.
+func New(ctx context.Context) *Service {
+	return &Service{ctx: ctx, db: db.Connection()}
+}
+
+// WithDatabase returns a copy of the Service using the given connection; used
+// in tests to inject an in-memory database without touching the singleton.
+func (s *Service) WithDatabase(conn *gorm.DB) *Service {
+	return &Service{ctx: s.ctx, db: conn}
+}
+
+// Build re-derives the reproducibility receipt for a run from persisted state.
+func (s *Service) Build(runID uuid.UUID) (*ireceipt.Receipt, error) {
+	return ireceipt.Build(s.ctx, s.db, runID)
+}
+
+// Verify re-derives the receipt for committed.RunID and reports drift against
+// the committed receipt.
+func (s *Service) Verify(committed *ireceipt.Receipt) (*ireceipt.VerifyResult, error) {
+	return ireceipt.Verify(s.ctx, s.db, committed)
+}

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -6,9 +6,11 @@ import (
 	"github.com/caesium-cloud/caesium/cmd/cache"
 	"github.com/caesium-cloud/caesium/cmd/dev"
 	"github.com/caesium-cloud/caesium/cmd/job"
+	"github.com/caesium-cloud/caesium/cmd/receipt"
 	"github.com/caesium-cloud/caesium/cmd/run"
 	"github.com/caesium-cloud/caesium/cmd/start"
 	"github.com/caesium-cloud/caesium/cmd/test"
+	"github.com/caesium-cloud/caesium/cmd/verify"
 	"github.com/spf13/cobra"
 )
 
@@ -18,9 +20,11 @@ var cmds = []*cobra.Command{
 	cache.Cmd,
 	dev.Cmd,
 	job.Cmd,
+	receipt.Cmd,
 	run.Cmd,
 	start.Cmd,
 	test.Cmd,
+	verify.Cmd,
 }
 
 // Execute builds the command tree and executes commands.

--- a/cmd/receipt/get.go
+++ b/cmd/receipt/get.go
@@ -1,0 +1,96 @@
+package receipt
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	ireceipt "github.com/caesium-cloud/caesium/internal/receipt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	getJobID  string
+	getRunID  string
+	getServer string
+	getOutput string
+)
+
+var getCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Fetch the reproducibility receipt for a run",
+	Long: "Fetch the content-addressed reproducibility receipt for a run from " +
+		"the server and print it (or write it to a file with --output). Commit " +
+		"the receipt into git next to your pipeline so `caesium verify` can later " +
+		"prove what ran.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if getJobID == "" || getRunID == "" {
+			return fmt.Errorf("--job-id and --run-id are required")
+		}
+
+		server := strings.TrimSuffix(getServer, "/")
+		url := fmt.Sprintf("%s/v1/jobs/%s/runs/%s/receipt", server, getJobID, getRunID)
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("receipt get failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		// Pretty-print canonically so the committed file is stable and diffable.
+		var r ireceipt.Receipt
+		if err := json.Unmarshal(body, &r); err != nil {
+			// Server returned something unexpected; surface it verbatim rather
+			// than swallowing it.
+			return writeOut(cmd, body)
+		}
+		pretty, err := json.MarshalIndent(&r, "", "  ")
+		if err != nil {
+			return writeOut(cmd, body)
+		}
+		pretty = append(pretty, '\n')
+
+		if r.Degraded {
+			// A degraded receipt is emitted (it is still the honest record) but
+			// the operator must know it does not attest reproducibility.
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+				"warning: receipt is DEGRADED — %d task(s) ran on unpinned image tags and are not verifiable: %s\n",
+				len(r.DegradedTasks), strings.Join(r.DegradedTasks, ", "))
+		}
+		return writeOut(cmd, pretty)
+	},
+}
+
+// writeOut writes the receipt bytes to --output (if set) or stdout.
+func writeOut(cmd *cobra.Command, data []byte) error {
+	if getOutput == "" {
+		_, err := cmd.OutOrStdout().Write(data)
+		return err
+	}
+	if err := os.WriteFile(getOutput, data, 0o644); err != nil {
+		return fmt.Errorf("write receipt to %s: %w", getOutput, err)
+	}
+	_, _ = fmt.Fprintf(cmd.OutOrStdout(), "Wrote receipt to %s\n", getOutput)
+	return nil
+}
+
+func init() {
+	getCmd.Flags().StringVar(&getJobID, "job-id", "", "Job ID (required)")
+	getCmd.Flags().StringVar(&getRunID, "run-id", "", "Run ID (required)")
+	getCmd.Flags().StringVar(&getServer, "server", "http://localhost:8080", "Caesium server base URL")
+	getCmd.Flags().StringVarP(&getOutput, "output", "o", "", "Write the receipt to this file (default: stdout)")
+	Cmd.AddCommand(getCmd)
+}

--- a/cmd/receipt/receipt.go
+++ b/cmd/receipt/receipt.go
@@ -1,0 +1,17 @@
+// Package receipt is the `caesium receipt` CLI command group: produce a
+// content-addressed, git-committable reproducibility receipt for a run. The
+// companion `caesium verify` command (cmd/verify) re-derives a committed
+// receipt against a run's persisted state and flags drift.
+package receipt
+
+import "github.com/spf13/cobra"
+
+// Cmd is the parent command for receipt operations.
+var Cmd = &cobra.Command{
+	Use:   "receipt",
+	Short: "Produce reproducibility receipts for job runs",
+	Long: "Produce a content-addressed, git-committable reproducibility receipt " +
+		"for a job run. Commit the receipt alongside your pipeline; later, " +
+		"`caesium verify <receipt>` re-derives it from the run's persisted state " +
+		"and flags drift (e.g. a moved image tag).",
+}

--- a/cmd/verify/verify.go
+++ b/cmd/verify/verify.go
@@ -1,0 +1,157 @@
+// Package verify is the `caesium verify <receipt>` CLI command: re-derive a
+// committed reproducibility receipt against a run's current persisted state and
+// flag drift.
+package verify
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	ireceipt "github.com/caesium-cloud/caesium/internal/receipt"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+var (
+	verifyServer string
+	verifyJSON   bool
+)
+
+// Cmd is `caesium verify <receipt-file>`.
+var Cmd = &cobra.Command{
+	Use:   "verify <receipt-file>",
+	Short: "Verify a committed reproducibility receipt against a run's state",
+	Long: "Re-derive the reproducibility receipt named by <receipt-file> from the " +
+		"run's persisted state and report drift: a moved image tag (digest " +
+		"mismatch), a changed manifest, a changed input. It does NOT resurrect " +
+		"deleted source data — it re-derives the signature and proves what ran.\n\n" +
+		"The job and run IDs are read from the receipt file. Exits non-zero when " +
+		"the run drifted from the receipt OR cannot be soundly verified (it ran " +
+		"on an unpinned, mutable image tag).",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		committed, err := loadReceipt(args[0])
+		if err != nil {
+			return err
+		}
+		if committed.RunID == uuid.Nil || committed.JobID == uuid.Nil {
+			return fmt.Errorf("receipt %s has no run_id/job_id; is it a valid caesium receipt?", args[0])
+		}
+
+		server := strings.TrimSuffix(verifyServer, "/")
+		url := fmt.Sprintf("%s/v1/jobs/%s/runs/%s/receipt/verify", server, committed.JobID, committed.RunID)
+
+		payload, err := json.Marshal(committed)
+		if err != nil {
+			return err
+		}
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, url, bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("verify failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		var result ireceipt.VerifyResult
+		if err := json.Unmarshal(body, &result); err != nil {
+			return fmt.Errorf("decode verify response: %w", err)
+		}
+
+		if verifyJSON {
+			pretty, mErr := json.MarshalIndent(&result, "", "  ")
+			if mErr != nil {
+				return mErr
+			}
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(pretty))
+		} else {
+			printHuman(cmd, &result)
+		}
+
+		// Non-zero exit when the run is not a clean, sound match so this command
+		// is usable as a CI gate. SilenceUsage/SilenceErrors keep cobra from
+		// printing usage on a legitimate drift exit.
+		if !result.Match {
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			if result.Degraded {
+				return fmt.Errorf("UNVERIFIABLE: run ran on unpinned image tag(s); not reproducible")
+			}
+			return fmt.Errorf("DRIFT: run no longer matches the committed receipt")
+		}
+		return nil
+	},
+}
+
+// loadReceipt reads and decodes a committed receipt from a file.
+func loadReceipt(path string) (*ireceipt.Receipt, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read receipt %s: %w", path, err)
+	}
+	var r ireceipt.Receipt
+	if err := json.Unmarshal(data, &r); err != nil {
+		return nil, fmt.Errorf("parse receipt %s: %w", path, err)
+	}
+	return &r, nil
+}
+
+// printHuman renders a concise, honest verdict and any drift to stdout.
+func printHuman(cmd *cobra.Command, result *ireceipt.VerifyResult) {
+	out := cmd.OutOrStdout()
+	switch {
+	case result.Match:
+		_, _ = fmt.Fprintf(out, "OK: run %s matches the committed receipt (digest %s)\n",
+			result.RunID, shortDigest(result.ActualDigest))
+	case result.Degraded:
+		_, _ = fmt.Fprintf(out, "UNVERIFIABLE: run %s ran on unpinned image tag(s); the receipt cannot attest reproducibility.\n",
+			result.RunID)
+		if len(result.DegradedTasks) > 0 {
+			_, _ = fmt.Fprintf(out, "  not digest-pinned: %s\n", strings.Join(result.DegradedTasks, ", "))
+		}
+	default:
+		_, _ = fmt.Fprintf(out, "DRIFT: run %s no longer matches the committed receipt.\n", result.RunID)
+		_, _ = fmt.Fprintf(out, "  expected digest: %s\n  actual digest:   %s\n",
+			shortDigest(result.ExpectedDigest), shortDigest(result.ActualDigest))
+	}
+
+	for _, d := range result.Drifts {
+		if d.Task != "" {
+			_, _ = fmt.Fprintf(out, "  - [%s] task %q: %s\n", d.Kind, d.Task, d.Detail)
+		} else {
+			_, _ = fmt.Fprintf(out, "  - [%s] %s\n", d.Kind, d.Detail)
+		}
+		if d.Expected != "" || d.Actual != "" {
+			_, _ = fmt.Fprintf(out, "      expected: %s\n      actual:   %s\n", d.Expected, d.Actual)
+		}
+	}
+}
+
+// shortDigest abbreviates a sha256 hex digest for human output, keeping the
+// full value available in --json mode.
+func shortDigest(d string) string {
+	if len(d) <= 16 {
+		return d
+	}
+	return d[:16] + "…"
+}
+
+func init() {
+	Cmd.Flags().StringVar(&verifyServer, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.Flags().BoolVar(&verifyJSON, "json", false, "Emit the full machine-readable verify result as JSON")
+}

--- a/cmd/verify/verify_test.go
+++ b/cmd/verify/verify_test.go
@@ -1,0 +1,53 @@
+package verify
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ireceipt "github.com/caesium-cloud/caesium/internal/receipt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadReceiptRoundTrip: a written receipt file loads back with its IDs and
+// digest intact.
+func TestLoadReceiptRoundTrip(t *testing.T) {
+	r := &ireceipt.Receipt{
+		ReceiptVersion: ireceipt.Version,
+		RunID:          uuid.New(),
+		JobID:          uuid.New(),
+		ReceiptDigest:  "abc123",
+	}
+	data, err := json.MarshalIndent(r, "", "  ")
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "receipt.json")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+
+	loaded, err := loadReceipt(path)
+	require.NoError(t, err)
+	require.Equal(t, r.RunID, loaded.RunID)
+	require.Equal(t, r.JobID, loaded.JobID)
+	require.Equal(t, "abc123", loaded.ReceiptDigest)
+}
+
+// TestLoadReceiptMissingFile: a missing file is a clear error, not a panic.
+func TestLoadReceiptMissingFile(t *testing.T) {
+	_, err := loadReceipt(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	require.Error(t, err)
+}
+
+// TestLoadReceiptBadJSON: malformed JSON is reported as a parse error.
+func TestLoadReceiptBadJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o644))
+	_, err := loadReceipt(path)
+	require.Error(t, err)
+}
+
+func TestShortDigest(t *testing.T) {
+	require.Equal(t, "short", shortDigest("short"))
+	require.Equal(t, "0123456789abcdef…", shortDigest("0123456789abcdef0123456789abcdef"))
+}

--- a/docs/design-data-plane-memory.md
+++ b/docs/design-data-plane-memory.md
@@ -79,7 +79,7 @@ Caesium uniquely computes a transitive content hash that folds in the **typed da
 | Feature | Requires | Honest scope until then |
 |---|---|---|
 | `caesium why` (field-level) | C2 (+ C3 for graph-change causation) | Scope to cache hit/miss, predecessor-hash change, param change — call it that, not "data causality" |
-| Reproducibility receipt / `verify` | **C1 first**, then C2 | Do not ship — an unpinned-tag receipt is a silent correctness failure |
+| Reproducibility receipt / `verify` | **C1 first**, then C2 | **Shipped** (C1+C2 landed): `caesium receipt get` / `caesium verify` re-derive a content-addressed receipt and flag drift. An unpinned-tag task is marked **degraded/unverifiable** and never attested as reproducible — the silent-failure mode is surfaced, not suppressed. |
 | Quarantined what-if replay | C1, C2 (+ C5 for data-diff) | Re-run only hash-changed tasks; unchanged = provably-identical cache hits |
 | `caesium run diff` (causal) | C2 | Cache-bust attribution only; hand off value diffs to dbt/Datafold |
 | Value-verified skip ("Bazel for data") | C5 (+ C1) | Metadata-only skip exists today (shipped cache); value-verification needs C5 |

--- a/docs/exec-plans/active/data-plane-memory.md
+++ b/docs/exec-plans/active/data-plane-memory.md
@@ -180,7 +180,7 @@ from a tamper-prone opaque digest into a tamper-evident, explainable record.
       `api/rest/controller/why/` + `api/rest/service/why/` + route in `api/rest/bind/bind.go`,
       `internal/run/` (read-side diff), harness assertion support.
       Depends on: A2.
-- [ ] A4. Add the reproducibility receipt + `caesium verify`: a content-addressed,
+- [x] A4. Add the reproducibility receipt + `caesium verify`: a content-addressed,
       git-committable Merkle receipt = hash(sorted per-task identity hashes +
       resolved image digests + manifest content hash + git commit); `verify`
       re-derives and flags drift ("tag mutated: digest mismatch"). Does **not**
@@ -190,6 +190,21 @@ from a tamper-prone opaque digest into a tamper-evident, explainable record.
       `api/rest/controller/receipt/` + service + `api/rest/bind/bind.go`,
       `docs/design-data-plane-memory.md` (mark REPRODUCE shipped).
       Depends on: A1 + A2.
+      Done (W3-β): `internal/receipt` builds a finalized `Receipt` (sorted per-task
+      identity hashes + resolved image digests + manifest content hash from the
+      matching `dag_snapshot` + git provenance), Merkle-aggregated into a single
+      `ReceiptDigest`. `Verify` re-derives from persisted `models.TaskRun` state and
+      reports typed drift (`image_digest_mismatch`, `identity_hash_mismatch`,
+      `manifest_changed`, `git_commit_changed`, task added/missing). **Correctness
+      rule enforced:** a task with an empty `ResolvedImageDigest` (pinning off or
+      Podman/k8s tag fallback) or no identity hash is marked `degraded` with an
+      honest reason, the whole receipt is `degraded`, and a degraded run *never*
+      reports a clean `Match` even when the tag-only digest is byte-equal — a mutable
+      tag is never silently attested. CLI: `caesium receipt get` (emit, with a
+      degraded warning) + `caesium verify <receipt>` (drift report, non-zero exit on
+      drift/unverifiable). REST: `GET /jobs/:id/runs/:run_id/receipt` +
+      `POST /jobs/:id/runs/:run_id/receipt/verify`. No new table — re-derives from
+      existing persisted state.
 
 #### Deferred to a follow-on feature plan
 

--- a/internal/receipt/build.go
+++ b/internal/receipt/build.go
@@ -41,12 +41,16 @@ func Build(ctx context.Context, db *gorm.DB, runID uuid.UUID) (*Receipt, error) 
 		return nil, fmt.Errorf("receipt: load run: %w", err)
 	}
 
-	// Load the job for git provenance. A soft-deleted job still carries the
-	// provenance the run executed under, so this is best-effort: a missing job
-	// (hard-deleted) leaves GitCommit empty rather than failing the build.
+	// Load the job for git provenance. A receipt is a record of the PAST: it
+	// must reflect the provenance the run actually executed under, even if the
+	// job definition was soft-deleted afterward. GORM's default scope hides
+	// soft-deleted rows, so Unscoped() is required — otherwise deleting a job
+	// would silently strip the git provenance from receipts of its historical
+	// runs. Best-effort: a hard-deleted job leaves GitCommit empty rather than
+	// failing the build.
 	var job models.Job
 	gitCommit := ""
-	if err := conn.Where("id = ?", run.JobID).First(&job).Error; err == nil {
+	if err := conn.Unscoped().Where("id = ?", run.JobID).First(&job).Error; err == nil {
 		gitCommit = job.ProvenanceCommit
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, fmt.Errorf("receipt: load job: %w", err)
@@ -58,6 +62,14 @@ func Build(ctx context.Context, db *gorm.DB, runID uuid.UUID) (*Receipt, error) 
 	if err := conn.Where("job_run_id = ?", runID).Find(&taskRuns).Error; err != nil {
 		return nil, fmt.Errorf("receipt: load task runs: %w", err)
 	}
+
+	// Retries produce multiple TaskRun rows for the same TaskID (one per
+	// attempt). Collapse to the terminal attempt per task so the receipt attests
+	// what each task FINALLY ran as — and so duplicate TaskName entries can never
+	// corrupt the (order-sensitive) Merkle aggregation. Without this, two equal
+	// task names would both fold into the digest and `caesium why`/verify drift
+	// detection would key on an arbitrary attempt.
+	taskRuns = terminalAttempts(taskRuns)
 
 	// Resolve task names. TaskRun carries only TaskID; the human-meaningful
 	// name lives on Task. Build the name map in one query rather than N.
@@ -97,6 +109,47 @@ func Build(ctx context.Context, db *gorm.DB, runID uuid.UUID) (*Receipt, error) 
 	return receipt, nil
 }
 
+// terminalAttempts collapses multiple TaskRun rows that share a TaskID (the
+// retry case) to the single terminal attempt per task, preserving input order
+// of the first time each TaskID is seen so the result is deterministic. The
+// terminal attempt is the highest Attempt; ties (which should not occur) break
+// on the later UpdatedAt, then the lexicographically larger row ID, so the
+// choice is fully determined and never depends on database row order.
+func terminalAttempts(taskRuns []models.TaskRun) []models.TaskRun {
+	if len(taskRuns) <= 1 {
+		return taskRuns
+	}
+
+	bestIdx := make(map[uuid.UUID]int, len(taskRuns)) // TaskID -> index into out
+	out := make([]models.TaskRun, 0, len(taskRuns))
+
+	for i := range taskRuns {
+		tr := taskRuns[i]
+		if idx, ok := bestIdx[tr.TaskID]; ok {
+			if isLaterAttempt(tr, out[idx]) {
+				out[idx] = tr
+			}
+			continue
+		}
+		bestIdx[tr.TaskID] = len(out)
+		out = append(out, tr)
+	}
+	return out
+}
+
+// isLaterAttempt reports whether candidate should replace incumbent as the
+// terminal attempt for a task. Ordering: higher Attempt wins; then later
+// UpdatedAt; then the larger row ID as a final deterministic tiebreaker.
+func isLaterAttempt(candidate, incumbent models.TaskRun) bool {
+	if candidate.Attempt != incumbent.Attempt {
+		return candidate.Attempt > incumbent.Attempt
+	}
+	if !candidate.UpdatedAt.Equal(incumbent.UpdatedAt) {
+		return candidate.UpdatedAt.After(incumbent.UpdatedAt)
+	}
+	return candidate.ID.String() > incumbent.ID.String()
+}
+
 // taskNames returns a TaskID -> name map for the given task runs in a single
 // query. An empty input yields an empty map.
 func taskNames(conn *gorm.DB, taskRuns []models.TaskRun) (map[uuid.UUID]string, error) {
@@ -116,8 +169,11 @@ func taskNames(conn *gorm.DB, taskRuns []models.TaskRun) (map[uuid.UUID]string, 
 		ids = append(ids, id)
 	}
 
+	// Unscoped() so a task soft-deleted after the run still resolves its
+	// human-meaningful name in the receipt (a record of the past), rather than
+	// falling back to the raw Task ID UUID.
 	var tasks []models.Task
-	if err := conn.Where("id IN ?", ids).Find(&tasks).Error; err != nil {
+	if err := conn.Unscoped().Where("id IN ?", ids).Find(&tasks).Error; err != nil {
 		return nil, fmt.Errorf("receipt: load task names: %w", err)
 	}
 	for i := range tasks {

--- a/internal/receipt/build.go
+++ b/internal/receipt/build.go
@@ -1,0 +1,156 @@
+package receipt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ErrRunNotFound is returned by Build when the requested run does not exist.
+var ErrRunNotFound = errors.New("receipt: run not found")
+
+// Build re-derives the reproducibility receipt for a run from its persisted
+// state. It reads only what the system recorded — TaskRun identity hashes and
+// resolved image digests, the job's git provenance, and the matching DAG
+// snapshot's manifest content hash — and never re-executes anything. This is
+// the single derivation used both when first emitting a receipt and (via the
+// same code path) when `caesium verify` re-derives one to compare.
+//
+// The returned receipt is finalized: tasks sorted, degraded summary populated,
+// and ReceiptDigest computed. A run with any unpinned (mutable-tag) task is
+// marked Degraded — its digest is still derived from the literal tag, the only
+// identity available, but it must not be presented as a reproducibility
+// guarantee.
+func Build(ctx context.Context, db *gorm.DB, runID uuid.UUID) (*Receipt, error) {
+	if db == nil {
+		return nil, fmt.Errorf("receipt: nil database connection")
+	}
+
+	conn := db.WithContext(ctx)
+
+	var run models.JobRun
+	err := conn.Where("id = ?", runID).First(&run).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrRunNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("receipt: load run: %w", err)
+	}
+
+	// Load the job for git provenance. A soft-deleted job still carries the
+	// provenance the run executed under, so this is best-effort: a missing job
+	// (hard-deleted) leaves GitCommit empty rather than failing the build.
+	var job models.Job
+	gitCommit := ""
+	if err := conn.Where("id = ?", run.JobID).First(&job).Error; err == nil {
+		gitCommit = job.ProvenanceCommit
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("receipt: load job: %w", err)
+	}
+
+	// Load the task runs for this run. Each carries the identity hash and the
+	// resolved digest the receipt attests over.
+	var taskRuns []models.TaskRun
+	if err := conn.Where("job_run_id = ?", runID).Find(&taskRuns).Error; err != nil {
+		return nil, fmt.Errorf("receipt: load task runs: %w", err)
+	}
+
+	// Resolve task names. TaskRun carries only TaskID; the human-meaningful
+	// name lives on Task. Build the name map in one query rather than N.
+	names, err := taskNames(conn, taskRuns)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]TaskEntry, 0, len(taskRuns))
+	for i := range taskRuns {
+		tr := &taskRuns[i]
+		name := names[tr.TaskID]
+		if name == "" {
+			// Fall back to the task ID so the entry is still addressable and
+			// the receipt stays total even if the Task row was pruned.
+			name = tr.TaskID.String()
+		}
+		entry := TaskEntry{
+			TaskName:            name,
+			IdentityHash:        tr.Hash,
+			Image:               tr.Image,
+			ResolvedImageDigest: tr.ResolvedImageDigest,
+		}
+		markDegraded(&entry)
+		entries = append(entries, entry)
+	}
+
+	receipt := &Receipt{
+		RunID:               run.ID,
+		JobID:               run.JobID,
+		JobAlias:            job.Alias,
+		GitCommit:           gitCommit,
+		ManifestContentHash: manifestContentHash(conn, run.JobID, gitCommit),
+		Tasks:               entries,
+	}
+	receipt.finalize()
+	return receipt, nil
+}
+
+// taskNames returns a TaskID -> name map for the given task runs in a single
+// query. An empty input yields an empty map.
+func taskNames(conn *gorm.DB, taskRuns []models.TaskRun) (map[uuid.UUID]string, error) {
+	out := make(map[uuid.UUID]string, len(taskRuns))
+	if len(taskRuns) == 0 {
+		return out, nil
+	}
+
+	ids := make([]uuid.UUID, 0, len(taskRuns))
+	seen := make(map[uuid.UUID]struct{}, len(taskRuns))
+	for i := range taskRuns {
+		id := taskRuns[i].TaskID
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+
+	var tasks []models.Task
+	if err := conn.Where("id IN ?", ids).Find(&tasks).Error; err != nil {
+		return nil, fmt.Errorf("receipt: load task names: %w", err)
+	}
+	for i := range tasks {
+		out[tasks[i].ID] = tasks[i].Name
+	}
+	return out, nil
+}
+
+// manifestContentHash returns the content hash of the DAG topology this run
+// executed, sourced from the append-only dag_snapshot table (Component 3 / B1).
+// It prefers the snapshot matching the run's git commit (the topology actually
+// applied from that commit); failing that it falls back to the job's most
+// recent snapshot. It is best-effort: an empty string when no snapshot exists
+// (e.g. a job applied before DAG versioning shipped) simply omits the manifest
+// term from the digest rather than failing the build — the per-task identity
+// hashes remain the primary attestation.
+func manifestContentHash(conn *gorm.DB, jobID uuid.UUID, gitCommit string) string {
+	if gitCommit != "" {
+		var snap models.DagSnapshot
+		err := conn.Where("job_id = ? AND git_commit = ?", jobID, gitCommit).
+			Order("created_at DESC").
+			First(&snap).Error
+		if err == nil {
+			return snap.ContentHash
+		}
+	}
+
+	var snap models.DagSnapshot
+	err := conn.Where("job_id = ?", jobID).
+		Order("created_at DESC").
+		First(&snap).Error
+	if err == nil {
+		return snap.ContentHash
+	}
+	return ""
+}

--- a/internal/receipt/diff_test.go
+++ b/internal/receipt/diff_test.go
@@ -1,0 +1,132 @@
+package receipt
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// makeReceipt finalizes a receipt from raw entries so the digest is populated.
+func makeReceipt(git, manifest string, tasks []TaskEntry) *Receipt {
+	r := &Receipt{
+		RunID:               uuid.New(),
+		JobID:               uuid.New(),
+		GitCommit:           git,
+		ManifestContentHash: manifest,
+		Tasks:               tasks,
+	}
+	r.finalize()
+	return r
+}
+
+func pinnedEntry(name, hash, digest string) TaskEntry {
+	e := TaskEntry{TaskName: name, IdentityHash: hash, Image: name + ":1", ResolvedImageDigest: digest}
+	markDegraded(&e)
+	return e
+}
+
+// TestComputeDigestStableAcrossOrder: finalize sorts, so two receipts built
+// from the same entries in different orders share a digest.
+func TestComputeDigestStableAcrossOrder(t *testing.T) {
+	a := makeReceipt("g", "m", []TaskEntry{
+		pinnedEntry("b", "hb", "sha256:b"),
+		pinnedEntry("a", "ha", "sha256:a"),
+	})
+	b := makeReceipt("g", "m", []TaskEntry{
+		pinnedEntry("a", "ha", "sha256:a"),
+		pinnedEntry("b", "hb", "sha256:b"),
+	})
+	require.Equal(t, a.ReceiptDigest, b.ReceiptDigest)
+}
+
+// TestComputeDigestSensitiveToDigest: changing a resolved digest changes the
+// receipt digest (the whole point of folding the digest in).
+func TestComputeDigestSensitiveToDigest(t *testing.T) {
+	a := makeReceipt("g", "m", []TaskEntry{pinnedEntry("a", "ha", "sha256:a")})
+	b := makeReceipt("g", "m", []TaskEntry{pinnedEntry("a", "ha", "sha256:DIFFERENT")})
+	require.NotEqual(t, a.ReceiptDigest, b.ReceiptDigest)
+}
+
+// TestComputeDigestSensitiveToManifestAndGit: manifest and git commit are both
+// folded into the digest.
+func TestComputeDigestSensitiveToManifestAndGit(t *testing.T) {
+	base := makeReceipt("g1", "m1", []TaskEntry{pinnedEntry("a", "ha", "sha256:a")})
+	diffManifest := makeReceipt("g1", "m2", []TaskEntry{pinnedEntry("a", "ha", "sha256:a")})
+	diffGit := makeReceipt("g2", "m1", []TaskEntry{pinnedEntry("a", "ha", "sha256:a")})
+
+	require.NotEqual(t, base.ReceiptDigest, diffManifest.ReceiptDigest)
+	require.NotEqual(t, base.ReceiptDigest, diffGit.ReceiptDigest)
+}
+
+// TestDiffTaskAddedAndMissing: a task added in one receipt and missing from the
+// other is reported in both directions.
+func TestDiffTaskAddedAndMissing(t *testing.T) {
+	committed := makeReceipt("g", "m", []TaskEntry{
+		pinnedEntry("a", "ha", "sha256:a"),
+		pinnedEntry("b", "hb", "sha256:b"),
+	})
+	rederived := makeReceipt("g", "m", []TaskEntry{
+		pinnedEntry("a", "ha", "sha256:a"),
+		pinnedEntry("c", "hc", "sha256:c"),
+	})
+
+	drifts := diff(committed, rederived)
+
+	require.True(t, hasDrift(drifts, DriftTaskMissing, "b"), "b dropped → missing")
+	require.True(t, hasDrift(drifts, DriftTaskAdded, "c"), "c appeared → added")
+	require.True(t, hasDrift(drifts, DriftReceiptDigest, ""))
+}
+
+// TestDiffVersionMismatch: receipts of different schema versions are flagged as
+// not directly comparable.
+func TestDiffVersionMismatch(t *testing.T) {
+	committed := makeReceipt("g", "m", []TaskEntry{pinnedEntry("a", "ha", "sha256:a")})
+	committed.ReceiptVersion = Version + 1 // pretend it came from a newer builder
+
+	rederived := makeReceipt("g", "m", []TaskEntry{pinnedEntry("a", "ha", "sha256:a")})
+
+	drifts := diff(committed, rederived)
+	require.True(t, hasDrift(drifts, DriftVersion, ""))
+}
+
+// TestDiffCleanNoDrift: identical receipts produce no drift.
+func TestDiffCleanNoDrift(t *testing.T) {
+	a := makeReceipt("g", "m", []TaskEntry{
+		pinnedEntry("a", "ha", "sha256:a"),
+		pinnedEntry("b", "hb", "sha256:b"),
+	})
+	b := makeReceipt("g", "m", []TaskEntry{
+		pinnedEntry("a", "ha", "sha256:a"),
+		pinnedEntry("b", "hb", "sha256:b"),
+	})
+	require.Empty(t, diff(a, b))
+}
+
+// TestMarkDegradedClassification covers the three branches of markDegraded.
+func TestMarkDegradedClassification(t *testing.T) {
+	pinned := TaskEntry{TaskName: "ok", IdentityHash: "h", Image: "x:1", ResolvedImageDigest: "sha256:x"}
+	markDegraded(&pinned)
+	require.True(t, pinned.DigestPinned)
+	require.False(t, pinned.Degraded)
+
+	unpinned := TaskEntry{TaskName: "u", IdentityHash: "h", Image: "x:latest"}
+	markDegraded(&unpinned)
+	require.False(t, unpinned.DigestPinned)
+	require.True(t, unpinned.Degraded)
+	require.Contains(t, unpinned.DegradedReason, "not digest-pinned")
+
+	noHash := TaskEntry{TaskName: "n", IdentityHash: "", Image: "x:1", ResolvedImageDigest: "sha256:x"}
+	markDegraded(&noHash)
+	require.True(t, noHash.Degraded)
+	require.Contains(t, noHash.DegradedReason, "no identity hash")
+}
+
+func hasDrift(drifts []Drift, kind DriftKind, task string) bool {
+	for _, d := range drifts {
+		if d.Kind == kind && d.Task == task {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/receipt/receipt.go
+++ b/internal/receipt/receipt.go
@@ -1,0 +1,224 @@
+// Package receipt builds and verifies content-addressed, git-committable
+// reproducibility receipts for a job run.
+//
+// A receipt is a Merkle-style aggregation over a run's persisted identity:
+//
+//	receiptDigest = sha256(
+//	    sorted per-task identity hashes +
+//	    resolved image digests +
+//	    manifest content hash +
+//	    git commit )
+//
+// It is the REPRODUCE half of the data-plane-memory substrate (see
+// docs/design-data-plane-memory.md): a small, deterministic, commit-into-git
+// artifact that attests *what ran*. `caesium verify` re-derives the receipt
+// from the run's persisted state and flags DRIFT — e.g. a `:latest` tag that
+// moved to new content (digest mismatch) or a changed manifest. It does NOT
+// resurrect deleted source data; it re-derives the signature and proves what
+// the system recorded as having run.
+//
+// # Correctness rule (from the design)
+//
+// A receipt over an UNPINNED, mutable tag is unsound: nothing in the recorded
+// identity is tamper-evident against a tag that moves underneath. So when a
+// task's ResolvedImageDigest is empty — digest pinning was off, or a
+// Podman/k8s path fell back to the literal tag — that task is marked
+// DigestPinned=false / Degraded=true, and the receipt as a whole is marked
+// Degraded. The receipt digest is still computed (it folds in the literal tag,
+// the only identity available), but verify reports honestly that the run is
+// NOT fully reproducible. We never silently attest a mutable tag as
+// reproducible.
+package receipt
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"hash"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Version is the schema version of the receipt format. Bump it whenever the
+// canonical serialization or the digest derivation changes, so a verifier can
+// refuse to compare receipts produced by incompatible builders rather than
+// reporting spurious drift.
+const Version = 1
+
+// TaskEntry is one task's contribution to the receipt: its identity hash (the
+// cache key that decided whether it ran or was served from cache) plus the
+// image identity that hash covers. Entries are sorted by TaskName before the
+// receipt digest folds them in, so the digest is independent of run-order.
+type TaskEntry struct {
+	// TaskName is the stable, human-meaningful name of the task within the job.
+	// It is the sort key for deterministic aggregation.
+	TaskName string `json:"task_name"`
+
+	// IdentityHash is the persisted TaskRun.Hash — the content-addressed cache
+	// key computed by internal/cache.HashInput.Compute. Empty when the task
+	// never had a hash computed (caching disabled for it); such a task cannot
+	// be attested and forces Degraded.
+	IdentityHash string `json:"identity_hash"`
+
+	// Image is the literal image reference (tag) the task ran with, recorded
+	// for human readability and as the fallback identity when no digest was
+	// resolved.
+	Image string `json:"image"`
+
+	// ResolvedImageDigest is the content digest (sha256:...) the tag resolved
+	// to when digest pinning was on. Empty when pinning was off or a
+	// Podman/k8s path fell back to the tag.
+	ResolvedImageDigest string `json:"resolved_image_digest,omitempty"`
+
+	// DigestPinned is true iff ResolvedImageDigest is non-empty — i.e. the
+	// image identity is tamper-evident for this task.
+	DigestPinned bool `json:"digest_pinned"`
+
+	// Degraded is true when this task cannot be soundly attested as
+	// reproducible: either its image was not digest-pinned (mutable tag) or it
+	// has no identity hash at all. Such a task is honestly surfaced rather than
+	// silently attested.
+	Degraded bool `json:"degraded"`
+
+	// DegradedReason is a short human-readable explanation set when Degraded is
+	// true (e.g. "image not digest-pinned: mutable tag 'myimage:latest'").
+	DegradedReason string `json:"degraded_reason,omitempty"`
+}
+
+// Receipt is the full, content-addressed reproducibility receipt for one run.
+// It is JSON-serializable and intended to be committed to git alongside the
+// pipeline that produced it. ReceiptDigest is the single value `caesium verify`
+// re-derives and compares.
+type Receipt struct {
+	// ReceiptVersion is Version at build time.
+	ReceiptVersion int `json:"receipt_version"`
+
+	// RunID, JobID and JobAlias identify the run this receipt attests. They are
+	// metadata for humans and lookups; they are NOT folded into ReceiptDigest
+	// (two runs of byte-identical inputs produce the same digest, which is the
+	// point — the digest addresses *what ran*, not *which run instance*).
+	RunID    uuid.UUID `json:"run_id"`
+	JobID    uuid.UUID `json:"job_id"`
+	JobAlias string    `json:"job_alias,omitempty"`
+
+	// GitCommit is the provenance commit SHA the manifest was applied from
+	// (empty for non-GitOps applies). Folded into ReceiptDigest.
+	GitCommit string `json:"git_commit,omitempty"`
+
+	// ManifestContentHash is the content hash of the DAG topology the run
+	// executed (from the matching dag_snapshot). Folded into ReceiptDigest so a
+	// changed manifest yields a changed receipt.
+	ManifestContentHash string `json:"manifest_content_hash,omitempty"`
+
+	// Tasks are the per-task entries, sorted by TaskName. Folded into
+	// ReceiptDigest in that order.
+	Tasks []TaskEntry `json:"tasks"`
+
+	// Degraded is true iff any task is Degraded — i.e. the run is NOT fully
+	// reproducible (at least one mutable, unpinned tag, or a task with no
+	// identity hash). When true, callers must not present this receipt as a
+	// reproducibility guarantee.
+	Degraded bool `json:"degraded"`
+
+	// DegradedTasks lists the names of every degraded task, for a concise
+	// honest summary.
+	DegradedTasks []string `json:"degraded_tasks,omitempty"`
+
+	// ReceiptDigest is the sha256 hex Merkle aggregate over the canonical
+	// per-task lines + manifest content hash + git commit. It is the receipt's
+	// content address and the value `verify` re-derives.
+	ReceiptDigest string `json:"receipt_digest"`
+}
+
+// canonicalTaskLine renders a single task entry to the exact byte sequence
+// folded into the receipt digest. The format is stable and unambiguous: every
+// field is length-delimited by a separator that cannot appear in the values
+// (task names, hashes, and digests do not contain newlines or the \x00 unit
+// separator). The "degraded" bit is included so that an unpinned task and a
+// pinned one with the same tag can never collide on the same digest.
+func canonicalTaskLine(t TaskEntry) string {
+	return fmt.Sprintf("task\x00%s\x00hash\x00%s\x00image\x00%s\x00digest\x00%s\x00pinned\x00%t\n",
+		t.TaskName, t.IdentityHash, t.Image, t.ResolvedImageDigest, t.DigestPinned)
+}
+
+// computeDigest derives the receipt digest from already-sorted task entries
+// plus the manifest content hash and git commit. It is the single source of
+// truth for the aggregation, used by both Build and re-derivation in Verify so
+// the two can never diverge.
+//
+// Entries MUST be sorted by TaskName before calling (Build guarantees this).
+func computeDigest(tasks []TaskEntry, manifestContentHash, gitCommit string) string {
+	h := sha256.New()
+	// Domain-separated, versioned preamble so receipts of different schema
+	// versions never share a digest space.
+	writeHashf(h, "caesium-receipt\x00v%d\n", Version)
+	writeHashf(h, "git_commit\x00%s\n", gitCommit)
+	writeHashf(h, "manifest\x00%s\n", manifestContentHash)
+	writeHashf(h, "task_count\x00%d\n", len(tasks))
+	for _, t := range tasks {
+		_, _ = h.Write([]byte(canonicalTaskLine(t)))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// writeHashf writes a formatted line to a hash.Hash. hash.Hash.Write never
+// returns an error, so the result is intentionally discarded (mirrors the w()
+// helper in internal/cache/hash.go).
+func writeHashf(h hash.Hash, format string, args ...any) {
+	_, _ = fmt.Fprintf(h, format, args...)
+}
+
+// sortTasks orders entries by TaskName, then by IdentityHash as a tiebreaker
+// (a single task name should not repeat in a run, but the tiebreaker keeps the
+// aggregation total and deterministic even if it somehow does). It sorts in
+// place and returns the slice for chaining.
+func sortTasks(tasks []TaskEntry) []TaskEntry {
+	sort.Slice(tasks, func(i, j int) bool {
+		if tasks[i].TaskName != tasks[j].TaskName {
+			return tasks[i].TaskName < tasks[j].TaskName
+		}
+		return tasks[i].IdentityHash < tasks[j].IdentityHash
+	})
+	return tasks
+}
+
+// finalize sorts the tasks, derives the degraded summary, and computes the
+// receipt digest, mutating r in place. Both Build and the test helpers call it
+// so a Receipt is never returned with a stale digest.
+func (r *Receipt) finalize() {
+	r.ReceiptVersion = Version
+	sortTasks(r.Tasks)
+
+	degraded := make([]string, 0)
+	for i := range r.Tasks {
+		if r.Tasks[i].Degraded {
+			degraded = append(degraded, r.Tasks[i].TaskName)
+		}
+	}
+	sort.Strings(degraded)
+	r.DegradedTasks = degraded
+	r.Degraded = len(degraded) > 0
+
+	r.ReceiptDigest = computeDigest(r.Tasks, r.ManifestContentHash, r.GitCommit)
+}
+
+// markDegraded classifies a task entry: it is degraded when it has no identity
+// hash (never hashed — caching was off) or when its image was not
+// digest-pinned (a mutable tag). The reason string is honest and specific so
+// `verify` can tell the operator exactly why the run is not reproducible.
+func markDegraded(t *TaskEntry) {
+	t.DigestPinned = t.ResolvedImageDigest != ""
+	switch {
+	case strings.TrimSpace(t.IdentityHash) == "":
+		t.Degraded = true
+		t.DegradedReason = "no identity hash recorded (caching disabled for this task) — cannot attest"
+	case !t.DigestPinned:
+		t.Degraded = true
+		t.DegradedReason = fmt.Sprintf("image not digest-pinned: mutable tag %q — not verifiable", t.Image)
+	default:
+		t.Degraded = false
+		t.DegradedReason = ""
+	}
+}

--- a/internal/receipt/receipt_test.go
+++ b/internal/receipt/receipt_test.go
@@ -322,6 +322,86 @@ func (s *ReceiptSuite) TestBuildRunNotFound() {
 	s.ErrorIs(err, ErrRunNotFound)
 }
 
+// TestRetryUsesTerminalAttempt: when a task was retried (multiple TaskRun rows
+// for one TaskID), the receipt attests the terminal (highest-Attempt) attempt
+// and never emits a duplicate task entry that would corrupt the Merkle digest.
+func (s *ReceiptSuite) TestRetryUsesTerminalAttempt() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", []taskSpec{
+		{name: "extract", image: "alpine:3.23", hash: "attempt-1", digest: "sha256:old", pinRequested: true},
+	})
+
+	// Find the run's task and add a second, terminal attempt with a different
+	// identity (the retry that actually decided the outcome).
+	var tr models.TaskRun
+	s.Require().NoError(s.db.Where("job_run_id = ?", runID).First(&tr).Error)
+
+	now := time.Now()
+	s.Require().NoError(s.db.Create(&models.TaskRun{
+		ID:                  uuid.New(),
+		JobRunID:            runID,
+		TaskID:              tr.TaskID,
+		AtomID:              uuid.New(),
+		Engine:              models.AtomEngineDocker,
+		Image:               "alpine:3.23",
+		Command:             "[]",
+		Status:              "succeeded",
+		Attempt:             2,
+		Hash:                "attempt-2",
+		ResolvedImageDigest: "sha256:new",
+		CachePinDigests:     true,
+		CreatedAt:           now,
+		UpdatedAt:           now.Add(time.Second),
+	}).Error)
+
+	r, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	// Exactly one entry for the task, and it is the terminal attempt.
+	s.Require().Len(r.Tasks, 1, "duplicate attempts must collapse to one entry")
+	s.Equal("extract", r.Tasks[0].TaskName)
+	s.Equal("attempt-2", r.Tasks[0].IdentityHash)
+	s.Equal("sha256:new", r.Tasks[0].ResolvedImageDigest)
+
+	// And the digest must be deterministic regardless of which attempt row the
+	// database returns first: rebuild and compare.
+	r2, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+	s.Equal(r.ReceiptDigest, r2.ReceiptDigest)
+}
+
+// TestSoftDeletedJobProvenancePreserved: a receipt is a record of the past, so
+// soft-deleting the job afterward must NOT strip the git provenance the run
+// executed under (requires Unscoped() on the job load).
+func (s *ReceiptSuite) TestSoftDeletedJobProvenancePreserved() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", pinnedSpecs())
+
+	// Soft-delete the job (sets deleted_at; default scope would now hide it).
+	s.Require().NoError(s.db.Where("alias = ?", "etl").Delete(&models.Job{}).Error)
+
+	r, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+	s.Equal("commit-1", r.GitCommit, "soft-deleted job must still yield its provenance")
+	s.Equal("etl", r.JobAlias)
+}
+
+// TestSoftDeletedTaskNamePreserved: a task soft-deleted after the run still
+// resolves its human name in the receipt rather than falling back to the UUID
+// (requires Unscoped() on the task-name load).
+func (s *ReceiptSuite) TestSoftDeletedTaskNamePreserved() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", []taskSpec{
+		{name: "extract", image: "alpine:3.23", hash: "h1", digest: "sha256:a", pinRequested: true},
+	})
+
+	var tr models.TaskRun
+	s.Require().NoError(s.db.Where("job_run_id = ?", runID).First(&tr).Error)
+	s.Require().NoError(s.db.Where("id = ?", tr.TaskID).Delete(&models.Task{}).Error)
+
+	r, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+	s.Require().Len(r.Tasks, 1)
+	s.Equal("extract", r.Tasks[0].TaskName, "soft-deleted task must still resolve its name")
+}
+
 // --- helpers ---
 
 func (s *ReceiptSuite) indexOf(r *Receipt, name string) int {

--- a/internal/receipt/receipt_test.go
+++ b/internal/receipt/receipt_test.go
@@ -1,0 +1,344 @@
+package receipt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ReceiptSuite exercises Build/Verify over an in-memory SQLite database holding
+// the same persisted shape a real run produces (Job, JobRun, Task, TaskRun,
+// DagSnapshot).
+type ReceiptSuite struct {
+	suite.Suite
+	db  *gorm.DB
+	ctx context.Context
+}
+
+func TestReceiptSuite(t *testing.T) {
+	suite.Run(t, new(ReceiptSuite))
+}
+
+func (s *ReceiptSuite) SetupTest() {
+	dsn := "file:" + uuid.NewString() + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	s.Require().NoError(err)
+	s.Require().NoError(db.AutoMigrate(models.All...))
+	s.db = db
+	s.ctx = context.Background()
+}
+
+func (s *ReceiptSuite) TearDownTest() {
+	if s.db != nil {
+		if sqlDB, _ := s.db.DB(); sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
+}
+
+// taskSpec describes a task to seed into a run.
+type taskSpec struct {
+	name         string
+	image        string
+	hash         string
+	digest       string // resolved image digest; "" = unpinned
+	pinRequested bool
+}
+
+// seedRun writes a Job, JobRun, the Tasks, and the TaskRuns for the given
+// specs, plus (optionally) a DagSnapshot carrying the manifest content hash.
+// It returns the run ID.
+func (s *ReceiptSuite) seedRun(alias, gitCommit, manifestHash string, specs []taskSpec) uuid.UUID {
+	jobID := uuid.New()
+	runID := uuid.New()
+	now := time.Now()
+
+	s.Require().NoError(s.db.Create(&models.Job{
+		ID:               jobID,
+		Alias:            alias,
+		TriggerID:        uuid.New(),
+		ProvenanceCommit: gitCommit,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}).Error)
+
+	s.Require().NoError(s.db.Create(&models.JobRun{
+		ID:        runID,
+		JobID:     jobID,
+		TriggerID: uuid.New(),
+		Status:    "succeeded",
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+
+	for _, sp := range specs {
+		taskID := uuid.New()
+		s.Require().NoError(s.db.Create(&models.Task{
+			ID:        taskID,
+			JobID:     jobID,
+			AtomID:    uuid.New(),
+			Name:      sp.name,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}).Error)
+
+		s.Require().NoError(s.db.Create(&models.TaskRun{
+			ID:                  uuid.New(),
+			JobRunID:            runID,
+			TaskID:              taskID,
+			AtomID:              uuid.New(),
+			Engine:              models.AtomEngineDocker,
+			Image:               sp.image,
+			Command:             "[]",
+			Status:              "succeeded",
+			Hash:                sp.hash,
+			ResolvedImageDigest: sp.digest,
+			CachePinDigests:     sp.pinRequested,
+			CreatedAt:           now,
+			UpdatedAt:           now,
+		}).Error)
+	}
+
+	if manifestHash != "" {
+		s.Require().NoError(s.db.Create(&models.DagSnapshot{
+			ID:          uuid.New(),
+			JobID:       jobID,
+			ContentHash: manifestHash,
+			GitCommit:   gitCommit,
+			Tasks:       []byte("[]"),
+			Edges:       []byte("[]"),
+			CreatedAt:   now,
+		}).Error)
+	}
+
+	return runID
+}
+
+// pinnedSpecs is a two-task, fully-digest-pinned run.
+func pinnedSpecs() []taskSpec {
+	return []taskSpec{
+		{name: "extract", image: "alpine:3.23", hash: "hash-extract", digest: "sha256:aaa", pinRequested: true},
+		{name: "load", image: "python:3.12", hash: "hash-load", digest: "sha256:bbb", pinRequested: true},
+	}
+}
+
+func (s *ReceiptSuite) TestBuildPinnedNotDegraded() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", pinnedSpecs())
+
+	r, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	s.Equal(Version, r.ReceiptVersion)
+	s.Equal(runID, r.RunID)
+	s.Equal("etl", r.JobAlias)
+	s.Equal("commit-1", r.GitCommit)
+	s.Equal("manifest-1", r.ManifestContentHash)
+	s.False(r.Degraded, "fully digest-pinned run must not be degraded")
+	s.Empty(r.DegradedTasks)
+	s.NotEmpty(r.ReceiptDigest)
+
+	// Tasks are sorted by name: extract before load.
+	s.Require().Len(r.Tasks, 2)
+	s.Equal("extract", r.Tasks[0].TaskName)
+	s.Equal("load", r.Tasks[1].TaskName)
+	s.True(r.Tasks[0].DigestPinned)
+	s.True(r.Tasks[1].DigestPinned)
+}
+
+// TestDeterminism: building the receipt twice over identical persisted state
+// yields the byte-identical receipt digest; task seed order does not matter.
+func (s *ReceiptSuite) TestDeterminism() {
+	specs := pinnedSpecs()
+	// Distinct aliases (the alias is metadata, not folded into the digest), so
+	// the unique-alias index is satisfied while inputs that DO affect the digest
+	// — git commit, manifest hash, and the per-task identities — are identical.
+	runA := s.seedRun("etl-a", "commit-x", "manifest-x", specs)
+
+	// Reverse the seed order for the second run; the digest must be identical.
+	reversed := []taskSpec{specs[1], specs[0]}
+	runB := s.seedRun("etl-b", "commit-x", "manifest-x", reversed)
+
+	rA, err := Build(s.ctx, s.db, runA)
+	s.Require().NoError(err)
+	rB, err := Build(s.ctx, s.db, runB)
+	s.Require().NoError(err)
+
+	s.Equal(rA.ReceiptDigest, rB.ReceiptDigest,
+		"identical inputs in any order must produce the same receipt digest")
+}
+
+// TestUnpinnedDegraded: a task with pinning requested but no resolved digest
+// (the Podman/k8s tag-fallback case) is marked degraded with an honest reason,
+// and the whole receipt is degraded.
+func (s *ReceiptSuite) TestUnpinnedDegraded() {
+	specs := []taskSpec{
+		{name: "extract", image: "alpine:3.23", hash: "h1", digest: "sha256:aaa", pinRequested: true},
+		{name: "transform", image: "busybox:1.36.1", hash: "h2", digest: "", pinRequested: true},
+	}
+	runID := s.seedRun("etl", "commit-1", "manifest-1", specs)
+
+	r, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	s.True(r.Degraded, "a run with an unpinned task must be degraded")
+	s.Equal([]string{"transform"}, r.DegradedTasks)
+
+	transform := r.Tasks[s.indexOf(r, "transform")]
+	s.False(transform.DigestPinned)
+	s.True(transform.Degraded)
+	s.Contains(transform.DegradedReason, "not digest-pinned")
+	s.Contains(transform.DegradedReason, "busybox:1.36.1")
+}
+
+// TestNoHashDegraded: a task with no identity hash at all (caching disabled)
+// cannot be attested and is degraded.
+func (s *ReceiptSuite) TestNoHashDegraded() {
+	specs := []taskSpec{
+		{name: "extract", image: "alpine:3.23", hash: "", digest: "sha256:aaa", pinRequested: true},
+	}
+	runID := s.seedRun("etl", "commit-1", "manifest-1", specs)
+
+	r, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	s.True(r.Degraded)
+	s.Equal([]string{"extract"}, r.DegradedTasks)
+	s.Contains(r.Tasks[0].DegradedReason, "no identity hash")
+}
+
+// TestVerifyClean: re-deriving an unchanged, fully-pinned run against its own
+// committed receipt reports a clean match with no drift.
+func (s *ReceiptSuite) TestVerifyClean() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", pinnedSpecs())
+	committed, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	result, err := Verify(s.ctx, s.db, committed)
+	s.Require().NoError(err)
+
+	s.True(result.Match, "unchanged pinned run must verify clean")
+	s.False(result.Degraded)
+	s.Empty(result.Drifts)
+	s.Equal(committed.ReceiptDigest, result.ActualDigest)
+}
+
+// TestVerifyDigestDrift: mutate the resolved image digest of a task after the
+// receipt was committed (a moved :latest) and verify catches the drift with an
+// image-digest-mismatch and the umbrella receipt-digest-mismatch.
+func (s *ReceiptSuite) TestVerifyDigestDrift() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", pinnedSpecs())
+	committed, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	// Simulate the tag moving: the load task's image digest changed underneath.
+	s.Require().NoError(s.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND image = ?", runID, "python:3.12").
+		Update("resolved_image_digest", "sha256:MUTATED").Error)
+	// The identity hash would also change in reality (the digest is folded into
+	// it); simulate that too so the test mirrors production.
+	s.Require().NoError(s.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND image = ?", runID, "python:3.12").
+		Update("hash", "hash-load-NEW").Error)
+
+	result, err := Verify(s.ctx, s.db, committed)
+	s.Require().NoError(err)
+
+	s.False(result.Match, "a moved digest must fail verification")
+	s.False(result.Degraded, "the run is still pinned — drift, not degradation")
+
+	s.True(s.hasDrift(result, DriftImageDigest, "load"))
+	s.True(s.hasDrift(result, DriftIdentityHash, "load"))
+	s.True(s.hasDrift(result, DriftReceiptDigest, ""))
+}
+
+// TestVerifyManifestDrift: the manifest content hash changed since the receipt
+// was committed.
+func (s *ReceiptSuite) TestVerifyManifestDrift() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", pinnedSpecs())
+	committed, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	// A newer snapshot for the same commit changes the manifest hash Build picks.
+	s.Require().NoError(s.db.Model(&models.DagSnapshot{}).
+		Where("git_commit = ?", "commit-1").
+		Update("content_hash", "manifest-CHANGED").Error)
+
+	result, err := Verify(s.ctx, s.db, committed)
+	s.Require().NoError(err)
+
+	s.False(result.Match)
+	s.True(s.hasDrift(result, DriftManifest, ""))
+}
+
+// TestVerifyDegradedNeverMatches: even when the digests are byte-equal, a run
+// that ran on an unpinned tag must never report a clean match — the unpinned
+// tag could have moved without changing the tag-only digest.
+func (s *ReceiptSuite) TestVerifyDegradedNeverMatches() {
+	specs := []taskSpec{
+		{name: "extract", image: "busybox:1.36.1", hash: "h1", digest: "", pinRequested: true},
+	}
+	runID := s.seedRun("etl", "commit-1", "manifest-1", specs)
+	committed, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	// Nothing changed — digests are identical.
+	result, err := Verify(s.ctx, s.db, committed)
+	s.Require().NoError(err)
+
+	s.Equal(committed.ReceiptDigest, result.ActualDigest, "digests match...")
+	s.True(result.Degraded, "...but the run is degraded")
+	s.False(result.Match, "a degraded run must never report a clean match")
+	s.Equal([]string{"extract"}, result.DegradedTasks)
+}
+
+// TestVerifyGitCommitDrift: the job's provenance commit changed (re-applied
+// from a different commit).
+func (s *ReceiptSuite) TestVerifyGitCommitDrift() {
+	runID := s.seedRun("etl", "commit-1", "manifest-1", pinnedSpecs())
+	committed, err := Build(s.ctx, s.db, runID)
+	s.Require().NoError(err)
+
+	s.Require().NoError(s.db.Model(&models.Job{}).
+		Where("alias = ?", "etl").
+		Update("provenance_commit", "commit-2").Error)
+
+	result, err := Verify(s.ctx, s.db, committed)
+	s.Require().NoError(err)
+
+	s.False(result.Match)
+	s.True(s.hasDrift(result, DriftGitCommit, ""))
+}
+
+// TestBuildRunNotFound: a missing run returns ErrRunNotFound.
+func (s *ReceiptSuite) TestBuildRunNotFound() {
+	_, err := Build(s.ctx, s.db, uuid.New())
+	s.ErrorIs(err, ErrRunNotFound)
+}
+
+// --- helpers ---
+
+func (s *ReceiptSuite) indexOf(r *Receipt, name string) int {
+	for i := range r.Tasks {
+		if r.Tasks[i].TaskName == name {
+			return i
+		}
+	}
+	s.FailNowf("task not found", "task %q not in receipt", name)
+	return -1
+}
+
+func (s *ReceiptSuite) hasDrift(result *VerifyResult, kind DriftKind, task string) bool {
+	for _, d := range result.Drifts {
+		if d.Kind == kind && d.Task == task {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/receipt/verify.go
+++ b/internal/receipt/verify.go
@@ -1,0 +1,270 @@
+package receipt
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// DriftKind classifies a single way a re-derived receipt diverges from a
+// committed one. Each value names a concrete, operator-actionable cause.
+type DriftKind string
+
+const (
+	// DriftReceiptDigest is the top-level signal: the re-derived receipt digest
+	// does not match the committed one. It is always accompanied by one or more
+	// of the specific drifts below explaining why.
+	DriftReceiptDigest DriftKind = "receipt_digest_mismatch"
+	// DriftImageDigest means a task's resolved image digest changed — the tag
+	// was mutated to point at new content (e.g. a re-pushed :latest). This is
+	// the headline reproducibility failure the receipt exists to catch.
+	DriftImageDigest DriftKind = "image_digest_mismatch"
+	// DriftIdentityHash means a task's identity (cache-key) hash changed —
+	// command, env, predecessor outputs, params, or the image digest differ.
+	DriftIdentityHash DriftKind = "identity_hash_mismatch"
+	// DriftManifest means the DAG manifest content hash changed — the pipeline
+	// topology applied for the run differs from what the committed receipt
+	// recorded.
+	DriftManifest DriftKind = "manifest_changed"
+	// DriftGitCommit means the git provenance commit changed.
+	DriftGitCommit DriftKind = "git_commit_changed"
+	// DriftTaskMissing means a task present in the committed receipt is absent
+	// from the re-derived one.
+	DriftTaskMissing DriftKind = "task_missing"
+	// DriftTaskAdded means a task present in the re-derived receipt is absent
+	// from the committed one.
+	DriftTaskAdded DriftKind = "task_added"
+	// DriftVersion means the two receipts were produced by different schema
+	// versions and are not directly comparable.
+	DriftVersion DriftKind = "receipt_version_mismatch"
+)
+
+// Drift is one detected divergence between a committed receipt and the
+// re-derived one. Task is empty for run-level drifts (manifest, git commit,
+// version, receipt digest).
+type Drift struct {
+	Kind     DriftKind `json:"kind"`
+	Task     string    `json:"task,omitempty"`
+	Expected string    `json:"expected,omitempty"`
+	Actual   string    `json:"actual,omitempty"`
+	Detail   string    `json:"detail"`
+}
+
+// VerifyResult is the outcome of comparing a committed receipt against the
+// run's current persisted state.
+type VerifyResult struct {
+	// RunID echoes the run that was re-derived.
+	RunID uuid.UUID `json:"run_id"`
+
+	// Match is true iff the re-derived receipt digest equals the committed one
+	// AND the run is not degraded. A degraded run never reports a clean
+	// reproducibility match even when the digests are equal, because an
+	// unpinned tag could have moved without changing the (tag-only) digest —
+	// the very condition the receipt cannot attest against.
+	Match bool `json:"match"`
+
+	// Degraded is true iff the re-derived receipt is degraded (any task ran on
+	// an unpinned, mutable tag, or had no identity hash). When true, the
+	// receipt cannot soundly attest reproducibility regardless of digest
+	// equality; Drifts will include the degraded tasks via the rederived
+	// receipt's DegradedTasks.
+	Degraded bool `json:"degraded"`
+
+	// DegradedTasks lists the tasks that make the run unverifiable.
+	DegradedTasks []string `json:"degraded_tasks,omitempty"`
+
+	// ExpectedDigest is the committed receipt's digest; ActualDigest is the
+	// freshly re-derived one.
+	ExpectedDigest string `json:"expected_digest"`
+	ActualDigest   string `json:"actual_digest"`
+
+	// Drifts enumerates every divergence found, empty when Match is true.
+	Drifts []Drift `json:"drifts,omitempty"`
+
+	// Rederived is the receipt Build produced from current state, for callers
+	// that want to inspect or re-commit it.
+	Rederived *Receipt `json:"rederived"`
+}
+
+// Verify re-derives the receipt for the run named by committed.RunID from
+// current persisted state and compares it against committed, reporting every
+// drift. It is the engine behind `caesium verify`: it proves what ran by
+// re-deriving the signature, and it surfaces — never hides — the case where the
+// run cannot be soundly attested because a task ran on an unpinned tag.
+func Verify(ctx context.Context, db *gorm.DB, committed *Receipt) (*VerifyResult, error) {
+	if committed == nil {
+		return nil, fmt.Errorf("receipt: nil committed receipt")
+	}
+
+	rederived, err := Build(ctx, db, committed.RunID)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &VerifyResult{
+		RunID:          committed.RunID,
+		Degraded:       rederived.Degraded,
+		DegradedTasks:  rederived.DegradedTasks,
+		ExpectedDigest: committed.ReceiptDigest,
+		ActualDigest:   rederived.ReceiptDigest,
+		Rederived:      rederived,
+	}
+
+	result.Drifts = diff(committed, rederived)
+
+	// A clean match requires equal digests AND a non-degraded run. The degraded
+	// case is the design's correctness rule: an unpinned tag may have moved
+	// without changing the tag-only digest, so we must not claim a match.
+	result.Match = committed.ReceiptDigest == rederived.ReceiptDigest && !rederived.Degraded
+
+	return result, nil
+}
+
+// diff compares a committed receipt against a re-derived one and returns every
+// divergence. It is exported-package-internal so build and verify share one
+// definition of "what counts as drift," and so tests can exercise it directly
+// without a database.
+func diff(committed, rederived *Receipt) []Drift {
+	var drifts []Drift
+
+	if committed.ReceiptVersion != rederived.ReceiptVersion {
+		drifts = append(drifts, Drift{
+			Kind:     DriftVersion,
+			Expected: fmt.Sprintf("v%d", committed.ReceiptVersion),
+			Actual:   fmt.Sprintf("v%d", rederived.ReceiptVersion),
+			Detail: fmt.Sprintf("receipt schema versions differ (committed v%d, re-derived v%d); not directly comparable",
+				committed.ReceiptVersion, rederived.ReceiptVersion),
+		})
+	}
+
+	if committed.GitCommit != rederived.GitCommit {
+		drifts = append(drifts, Drift{
+			Kind:     DriftGitCommit,
+			Expected: committed.GitCommit,
+			Actual:   rederived.GitCommit,
+			Detail:   "git provenance commit changed since the receipt was committed",
+		})
+	}
+
+	if committed.ManifestContentHash != rederived.ManifestContentHash {
+		drifts = append(drifts, Drift{
+			Kind:     DriftManifest,
+			Expected: committed.ManifestContentHash,
+			Actual:   rederived.ManifestContentHash,
+			Detail:   "DAG manifest content hash changed: the pipeline topology differs from the committed receipt",
+		})
+	}
+
+	drifts = append(drifts, diffTasks(committed, rederived)...)
+
+	// The receipt-digest mismatch is the umbrella signal; emit it last so the
+	// specific causes above read first.
+	if committed.ReceiptDigest != rederived.ReceiptDigest {
+		drifts = append(drifts, Drift{
+			Kind:     DriftReceiptDigest,
+			Expected: committed.ReceiptDigest,
+			Actual:   rederived.ReceiptDigest,
+			Detail:   "re-derived receipt digest does not match the committed receipt",
+		})
+	}
+
+	return drifts
+}
+
+// diffTasks pairs tasks by name and reports per-task drift: missing, added,
+// digest mismatch, and identity-hash mismatch. Both receipts are sorted by
+// Build/finalize, but diffTasks builds maps so it is order-independent and
+// robust to a hand-edited committed receipt.
+func diffTasks(committed, rederived *Receipt) []Drift {
+	var drifts []Drift
+
+	committedByName := indexByName(committed.Tasks)
+	rederivedByName := indexByName(rederived.Tasks)
+
+	// Stable iteration order over the union of names.
+	names := unionNames(committedByName, rederivedByName)
+
+	for _, name := range names {
+		c, inC := committedByName[name]
+		r, inR := rederivedByName[name]
+
+		switch {
+		case inC && !inR:
+			drifts = append(drifts, Drift{
+				Kind:   DriftTaskMissing,
+				Task:   name,
+				Detail: "task present in the committed receipt is absent from the current run state",
+			})
+		case !inC && inR:
+			drifts = append(drifts, Drift{
+				Kind:   DriftTaskAdded,
+				Task:   name,
+				Detail: "task present in the current run state is absent from the committed receipt",
+			})
+		default:
+			// Present on both sides — compare identity.
+			if c.ResolvedImageDigest != r.ResolvedImageDigest {
+				drifts = append(drifts, Drift{
+					Kind:     DriftImageDigest,
+					Task:     name,
+					Expected: digestOrTag(c),
+					Actual:   digestOrTag(r),
+					Detail:   "image tag mutated: resolved content digest differs from the committed receipt",
+				})
+			}
+			if c.IdentityHash != r.IdentityHash {
+				drifts = append(drifts, Drift{
+					Kind:     DriftIdentityHash,
+					Task:     name,
+					Expected: c.IdentityHash,
+					Actual:   r.IdentityHash,
+					Detail:   "task identity (cache-key) hash changed: an input to this task differs",
+				})
+			}
+		}
+	}
+
+	return drifts
+}
+
+// indexByName maps task entries by name. When a name repeats (it should not
+// within a run), the last entry wins — diffTasks's behavior is undefined for
+// duplicate names by design, and Build never produces them.
+func indexByName(tasks []TaskEntry) map[string]TaskEntry {
+	m := make(map[string]TaskEntry, len(tasks))
+	for _, t := range tasks {
+		m[t.TaskName] = t
+	}
+	return m
+}
+
+// unionNames returns the sorted union of keys from two task maps so drift
+// reporting is deterministic regardless of input order.
+func unionNames(a, b map[string]TaskEntry) []string {
+	set := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	names := make([]string, 0, len(set))
+	for k := range set {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// digestOrTag returns the resolved digest when present, else the literal tag —
+// so a drift report on an unpinned task still shows something meaningful
+// (and makes the "was never pinned" case legible).
+func digestOrTag(t TaskEntry) string {
+	if t.ResolvedImageDigest != "" {
+		return t.ResolvedImageDigest
+	}
+	return t.Image + " (unpinned tag)"
+}


### PR DESCRIPTION
## What

Implements **item A4** of the [data-plane-memory plan](docs/exec-plans/active/data-plane-memory.md) — the **REPRODUCE** half of the substrate (design: [`docs/design-data-plane-memory.md`](docs/design-data-plane-memory.md), Component 1).

A **reproducibility receipt** is a content-addressed, git-committable Merkle aggregate over a run's persisted identity:

```
receiptDigest = sha256(
    sorted per-task identity hashes +
    resolved image digests +
    manifest content hash (dag_snapshot) +
    git provenance commit )
```

`caesium verify <receipt>` re-derives the receipt from the run's **persisted state** (`models.TaskRun` identity hashes + resolved digests from A1, job git provenance, the matching `dag_snapshot` from B1) and flags **drift** — it does *not* resurrect deleted source data; it re-derives the signature and proves what ran.

## Correctness rule (from the design)

A receipt over an **unpinned, mutable tag is unsound**. So:

- A task whose `ResolvedImageDigest` is empty (pinning off, or a Podman/k8s tag fallback) — or that has no identity hash at all — is marked **`degraded` / unverifiable** with an honest reason (e.g. `image not digest-pinned: mutable tag "busybox:1.36.1" — not verifiable`).
- The whole receipt is then `degraded`, and a degraded run **never reports a clean `Match`** even when the tag-only digest is byte-equal — because the tag could have moved without changing it.
- A mutable tag is **never silently attested** as reproducible.

## Drift kinds surfaced by `verify`

`image_digest_mismatch` ("tag mutated: digest mismatch"), `identity_hash_mismatch`, `manifest_changed`, `git_commit_changed`, `task_missing`, `task_added`, plus the umbrella `receipt_digest_mismatch`.

## Surface area

- **`internal/receipt/`** — build + verify + Merkle aggregation + degradation classification.
- **`cmd/receipt get`** (emit a receipt to commit) and top-level **`cmd/verify`** (`caesium verify <receipt>`, non-zero exit on drift / unverifiable) — thin HTTP clients.
- **`api/rest/controller/receipt/` + `api/rest/service/receipt/`** + two routes in `Protected()`:
  - `GET  /v1/jobs/:id/runs/:run_id/receipt`
  - `POST /v1/jobs/:id/runs/:run_id/receipt/verify`
- **No new table** — re-derives from existing persisted state.

## Tests

`internal/receipt` (89.7% coverage): receipt determinism (order-independent), drift detection (digest/identity/manifest/git, task added/missing), the unpinned-tag degradation path, and the no-identity-hash path; pure `diff()` unit tests with no DB; `cmd/verify` file-load tests.

## Verification

- `just lint` → **0 issues**
- `just unit-test` → **pass** (full suite green, exit 0)
- Integration skipped per stream scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)