### PR TITLE
Add caesium why causal explainer (data-plane-memory W3-α)

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -20,6 +20,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/system"
 	"github.com/caesium-cloud/caesium/api/rest/controller/trigger"
 	"github.com/caesium-cloud/caesium/api/rest/controller/webhook"
+	whyctrl "github.com/caesium-cloud/caesium/api/rest/controller/why"
 	"github.com/caesium-cloud/caesium/internal/auth"
 	internal_event "github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/pkg/env"
@@ -72,6 +73,8 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		g.GET("/jobs/:id/runs", run.List)
 		g.GET("/jobs/:id/runs/:run_id", run.Get)
 		g.GET("/jobs/:id/runs/:run_id/logs", run.Logs)
+		// causal explainer (data-plane-memory A3): why a task ran/hit cache/re-ran
+		g.GET("/jobs/:id/runs/:run_id/why", whyctrl.Get)
 		g.POST("/jobs/:id/runs/:run_id/callbacks/retry", run.RetryCallbacks)
 		g.POST("/jobs/:id/runs/:run_id/retry", run.Retry)
 		g.POST("/jobs/:id/run", run.Post)

--- a/api/rest/controller/why/why.go
+++ b/api/rest/controller/why/why.go
@@ -1,0 +1,66 @@
+// Package why implements the causal-explainer endpoint (data-plane-memory A3):
+//
+//	GET /v1/jobs/:id/runs/:run_id/why?task=<task-name-or-id>
+//
+// It returns a field-by-field explanation of why the given task in the run
+// executed, hit the cache, or re-ran — diffing the persisted HashInput blobs and
+// joining trigger-side causation from the event store.
+package why
+
+import (
+	"errors"
+	"net/http"
+
+	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
+	whysvc "github.com/caesium-cloud/caesium/api/rest/service/why"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+// Get handles GET /v1/jobs/:id/runs/:run_id/why?task=<task>.
+func Get(c *echo.Context) error {
+	ctx := c.Request().Context()
+
+	jobID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	runID, err := uuid.Parse(c.Param("run_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	task := c.QueryParam("task")
+	if task == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "task query parameter is required")
+	}
+
+	// Verify the job exists before touching the run.
+	if _, err = jsvc.Service(ctx).Get(jobID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	explanation, err := whysvc.New(ctx).Why(runID, task)
+	if err != nil {
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound), errors.Is(err, runstorage.ErrTaskRunNotFound):
+			return echo.ErrNotFound
+		default:
+			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+		}
+	}
+
+	// Guard against a run from a different job being addressed under this job's
+	// path.
+	if explanation.JobID != jobID {
+		return echo.ErrNotFound
+	}
+
+	return c.JSON(http.StatusOK, explanation)
+}

--- a/api/rest/service/why/why.go
+++ b/api/rest/service/why/why.go
@@ -1,0 +1,39 @@
+// Package why wraps the internal run-level causal explainer (data-plane-memory
+// A3) for use by the REST controller. It mirrors the thin service pattern used
+// by the lineage and run services: a context + a run.Store, with a WithDatabase
+// override for tests.
+package why
+
+import (
+	"context"
+
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Service explains why a task in a run executed / hit cache / re-ran.
+type Service struct {
+	ctx   context.Context
+	store *runstorage.Store
+}
+
+// New creates a Service backed by the default run store.
+func New(ctx context.Context) *Service {
+	return &Service{ctx: ctx, store: runstorage.Default()}
+}
+
+// WithDatabase returns a copy of the Service whose run store is backed by the
+// given connection; used in tests to inject an in-memory database.
+func (s *Service) WithDatabase(conn *gorm.DB) *Service {
+	if conn == nil {
+		return s
+	}
+	return &Service{ctx: s.ctx, store: runstorage.NewStore(conn)}
+}
+
+// Why returns the causal explanation for taskRef (a task UUID or name) in run
+// runID.
+func (s *Service) Why(runID uuid.UUID, taskRef string) (*runstorage.WhyExplanation, error) {
+	return s.store.WhyTask(s.ctx, runID, taskRef)
+}

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -9,6 +9,7 @@ import (
 	"github.com/caesium-cloud/caesium/cmd/run"
 	"github.com/caesium-cloud/caesium/cmd/start"
 	"github.com/caesium-cloud/caesium/cmd/test"
+	"github.com/caesium-cloud/caesium/cmd/why"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +22,7 @@ var cmds = []*cobra.Command{
 	run.Cmd,
 	start.Cmd,
 	test.Cmd,
+	why.Cmd,
 }
 
 // Execute builds the command tree and executes commands.

--- a/cmd/why/why.go
+++ b/cmd/why/why.go
@@ -1,0 +1,229 @@
+// Package why implements `caesium why <run> --task <t>` (data-plane-memory A3):
+// the causal explainer for why a task in a run executed, hit the cache, or
+// re-ran. It calls the server's
+// GET /v1/jobs/:id/runs/:run_id/why?task=<t> endpoint and renders either a
+// human-readable summary table (default) or the raw machine-readable JSON
+// (--json), so the explanation can be both eyeballed and asserted in a harness.
+package why
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+const apiKeyEnvVar = "CAESIUM_API_KEY"
+
+var (
+	whyJobID  string
+	whyTask   string
+	whyServer string
+	whyAPIKey string
+	whyJSON   bool
+)
+
+// explanation mirrors the server's run.WhyExplanation JSON so the CLI can render
+// a table. Only the fields the table renders are typed; the rest round-trips via
+// --json (which prints the server body verbatim).
+type explanation struct {
+	RunID    string `json:"runId"`
+	JobID    string `json:"jobId"`
+	TaskID   string `json:"taskId"`
+	TaskName string `json:"taskName"`
+	Verdict  string `json:"verdict"`
+	Status   string `json:"status"`
+	Hash     string `json:"hash"`
+	Summary  string `json:"summary"`
+	Trigger  struct {
+		Type   string            `json:"type"`
+		Alias  string            `json:"alias"`
+		Params map[string]string `json:"params"`
+	} `json:"trigger"`
+	Baseline struct {
+		Kind  string `json:"kind"`
+		RunID string `json:"runId"`
+	} `json:"baseline"`
+	Diff *struct {
+		HashEqual    bool   `json:"hashEqual"`
+		SubjectHash  string `json:"subjectHash"`
+		BaselineHash string `json:"baselineHash"`
+		Degraded     string `json:"degraded"`
+		Changes      []struct {
+			Field    string `json:"field"`
+			Kind     string `json:"kind"`
+			Before   string `json:"before"`
+			After    string `json:"after"`
+			Added    bool   `json:"added"`
+			Removed  bool   `json:"removed"`
+			Redacted bool   `json:"redacted"`
+		} `json:"changes"`
+	} `json:"diff"`
+}
+
+// Cmd is the `caesium why` command.
+var Cmd = &cobra.Command{
+	Use:   "why <run-id> --task <task> --job-id <job-id>",
+	Short: "Explain why a task ran, hit the cache, or re-ran",
+	Long: "Explain why a specific task in a run executed, was served from cache, " +
+		"or re-ran — by diffing the task's persisted identity-hash inputs against " +
+		"the prior/cached run and naming the discriminating field(s). Prints a " +
+		"human-readable summary by default, or machine-readable JSON with --json.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		runID := strings.TrimSpace(args[0])
+		if whyJobID == "" {
+			return fmt.Errorf("--job-id is required")
+		}
+		if whyTask == "" {
+			return fmt.Errorf("--task is required")
+		}
+
+		server := strings.TrimSuffix(whyServer, "/")
+		reqURL := fmt.Sprintf("%s/v1/jobs/%s/runs/%s/why?task=%s",
+			server, whyJobID, runID, url.QueryEscape(whyTask))
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
+		if err != nil {
+			return err
+		}
+		if apiKey := resolveAPIKey(cmd, whyAPIKey); apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("why failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		if whyJSON {
+			// Re-indent for readability; fall back to the raw body if it isn't
+			// JSON (it always should be).
+			var out interface{}
+			if err := json.Unmarshal(body, &out); err != nil {
+				cmd.Print(string(body))
+				return nil
+			}
+			pretty, _ := json.MarshalIndent(out, "", "  ")
+			cmd.Println(string(pretty))
+			return nil
+		}
+
+		var exp explanation
+		if err := json.Unmarshal(body, &exp); err != nil {
+			// Unknown shape — just print what we got.
+			cmd.Print(string(body))
+			return nil
+		}
+		renderTable(cmd, &exp)
+		return nil
+	},
+}
+
+func renderTable(cmd *cobra.Command, exp *explanation) {
+	cmd.Println(exp.Summary)
+	cmd.Println()
+
+	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(tw, "TASK\t%s\n", exp.TaskName)
+	_, _ = fmt.Fprintf(tw, "VERDICT\t%s\n", exp.Verdict)
+	_, _ = fmt.Fprintf(tw, "STATUS\t%s\n", exp.Status)
+	if exp.Hash != "" {
+		_, _ = fmt.Fprintf(tw, "HASH\t%s\n", exp.Hash)
+	}
+	trigger := exp.Trigger.Type
+	if exp.Trigger.Alias != "" {
+		trigger = fmt.Sprintf("%s (%s)", exp.Trigger.Type, exp.Trigger.Alias)
+	}
+	if trigger != "" {
+		_, _ = fmt.Fprintf(tw, "TRIGGER\t%s\n", trigger)
+	}
+	if exp.Baseline.Kind != "" {
+		baseline := exp.Baseline.Kind
+		if exp.Baseline.RunID != "" {
+			baseline = fmt.Sprintf("%s (run %s)", exp.Baseline.Kind, exp.Baseline.RunID)
+		}
+		_, _ = fmt.Fprintf(tw, "COMPARED-TO\t%s\n", baseline)
+	}
+	_ = tw.Flush()
+
+	if exp.Diff == nil {
+		return
+	}
+	if exp.Diff.Degraded != "" {
+		cmd.Println()
+		cmd.Printf("note: %s\n", exp.Diff.Degraded)
+		return
+	}
+	if len(exp.Diff.Changes) == 0 {
+		cmd.Println()
+		if exp.Diff.HashEqual {
+			cmd.Println("All hashed inputs are identical (no discriminating field).")
+		} else {
+			cmd.Println("No discriminating input field found.")
+		}
+		return
+	}
+
+	cmd.Println()
+	cmd.Printf("Discriminating fields (%d):\n", len(exp.Diff.Changes))
+	dw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(dw, "FIELD\tCHANGE\tBEFORE\tAFTER")
+	for _, ch := range exp.Diff.Changes {
+		before, after := ch.Before, ch.After
+		if ch.Redacted {
+			if before != "" {
+				before += " (redacted)"
+			}
+			if after != "" {
+				after += " (redacted)"
+			}
+		}
+		change := "changed"
+		switch {
+		case ch.Added:
+			change = "added"
+		case ch.Removed:
+			change = "removed"
+		case ch.Kind == "structural":
+			change = "changed (structural)"
+		}
+		_, _ = fmt.Fprintf(dw, "%s\t%s\t%s\t%s\n", ch.Field, change, dashIfEmpty(before), dashIfEmpty(after))
+	}
+	_ = dw.Flush()
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func resolveAPIKey(cmd *cobra.Command, flagValue string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		cmd.PrintErrln(fmt.Sprintf("warning: --api-key is visible in process listings; prefer %s", apiKeyEnvVar))
+		return strings.TrimSpace(flagValue)
+	}
+	return strings.TrimSpace(os.Getenv(apiKeyEnvVar))
+}
+
+func init() {
+	Cmd.Flags().StringVar(&whyJobID, "job-id", "", "Job ID that owns the run (required)")
+	Cmd.Flags().StringVar(&whyTask, "task", "", "Task name or ID to explain (required)")
+	Cmd.Flags().StringVar(&whyServer, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.Flags().StringVar(&whyAPIKey, "api-key", "", "API key for authentication (prefer "+apiKeyEnvVar+"; --api-key is visible in process listings)")
+	Cmd.Flags().BoolVar(&whyJSON, "json", false, "Emit machine-readable JSON instead of a table")
+}

--- a/docs/exec-plans/active/data-plane-memory.md
+++ b/docs/exec-plans/active/data-plane-memory.md
@@ -170,7 +170,7 @@ from a tamper-prone opaque digest into a tamper-evident, explainable record.
       `internal/dispatch/`, `internal/worker/` (distributed propagation).
       Depends on: A1.
       Done (W2-α): `HashInput.CanonicalJSON()` serializes a versioned, secret-redacted, field-by-field blob (env values redacted to a `sha256:` digest, `secret://` references kept verbatim; bounded at 64 KB with a graceful oversized-marker fallback). Nullable `hash_input_blob` JSON column added to `TaskRun` and `TaskCache` (additive AutoMigrate). `SetTaskHashWithBlob` writes it alongside the hash on the existing write-path (`SetTaskHashWithDigest` retained as a shim). Threaded through `cache.Entry` → `TaskCache`. Wired into both hash sites — `internal/job/job.go` (local/scheduler) and `internal/worker/runtime_executor.go` (distributed): the worker rebuilds the identical `HashInput` from the scheduler-propagated `TaskRun` + predecessor data, so no new dispatch-time field was needed.
-- [ ] A3. Add `caesium why <run> --task <t>`: a read-side, field-by-field diff of
+- [x] A3. Add `caesium why <run> --task <t>`: a read-side, field-by-field diff of
       two stored `HashInput` blobs ("CACHE MISS — predecessor `extract.row_count`
       changed 1.2M→1.4M; image, command, env identical"), joined to the
       `ExecutionEvent` store for trigger-side causation, emitting machine-readable
@@ -180,6 +180,7 @@ from a tamper-prone opaque digest into a tamper-evident, explainable record.
       `api/rest/controller/why/` + `api/rest/service/why/` + route in `api/rest/bind/bind.go`,
       `internal/run/` (read-side diff), harness assertion support.
       Depends on: A2.
+      Done (W3-α): `GET /v1/jobs/:id/runs/:run_id/why?task=<name-or-id>` + `caesium why <run-id> --task <t> --job-id <id> [--json]`. `internal/run/whydiff.go` decodes two canonical `HashInput` blobs (A2) and emits a sorted, field-by-field `BlobDiff` — scalars (image/digest/command/workdir/cacheVersion), per-key env (literal values stay redacted to their `sha256:` digest, `secret://` refs shown verbatim), per-step predecessor outputs (the headline data-contract diff, shown verbatim), run params, predecessor-hash set, and structural mounts/volumes/k8s (canonical-JSON equality). `internal/run/why.go` classifies the verdict (CACHE_HIT/MISS/DISABLED), picks the baseline (cache-origin task-run/entry for a hit; most-recent earlier run of the same task for a miss), joins the `run_started` `ExecutionEvent` for trigger/param causation, and renders a one-line summary. Degrades gracefully on missing/oversized/version-mismatched blobs. Unit tests cover the diff + verdict/summary logic.
 - [ ] A4. Add the reproducibility receipt + `caesium verify`: a content-addressed,
       git-committable Merkle receipt = hash(sorted per-task identity hashes +
       resolved image digests + manifest content hash + git commit); `verify`

--- a/internal/run/why.go
+++ b/internal/run/why.go
@@ -139,7 +139,7 @@ func (s *Store) WhyTask(ctx context.Context, runID uuid.UUID, taskRef string) (*
 
 	exp.Trigger = s.loadTrigger(ctx, &jobRun)
 
-	baselineBlob, baseline, err := s.resolveBaseline(ctx, taskRun, jobRun.JobID)
+	baselineBlob, baseline, err := s.resolveBaseline(ctx, taskRun, jobRun.JobID, jobRun.StartedAt)
 	if err != nil {
 		return nil, err
 	}
@@ -266,23 +266,33 @@ func (s *Store) loadTrigger(ctx context.Context, jobRun *models.JobRun) WhyTrigg
 //     hash) if the origin task-run row is gone.
 //   - Cache MISS / OFF: the most-recent earlier run of the same task that has a
 //     persisted blob, so the diff names what changed and forced the re-run.
-func (s *Store) resolveBaseline(ctx context.Context, subject *models.TaskRun, jobID uuid.UUID) ([]byte, WhyBaseline, error) {
+// subjectStartedAt is the subject run's start time (already loaded by the
+// caller); the prior-run lookup uses it to consider only strictly-earlier runs,
+// avoiding a redundant re-query.
+func (s *Store) resolveBaseline(ctx context.Context, subject *models.TaskRun, jobID uuid.UUID, subjectStartedAt time.Time) ([]byte, WhyBaseline, error) {
 	db := s.db.WithContext(ctx)
 
-	if TaskStatus(subject.Status) == TaskStatusCached && subject.CacheOriginRunID != nil {
-		var origin models.TaskRun
-		err := db.Where("job_run_id = ? AND task_id = ?", *subject.CacheOriginRunID, subject.TaskID).
-			First(&origin).Error
-		if err == nil {
-			b := WhyBaseline{Kind: "cache_origin", RunID: subject.CacheOriginRunID, TaskRunID: &origin.ID}
-			if originStart := origin.StartedAt; originStart != nil {
-				b.StartedAt = originStart
+	// A cached task is always a cache hit, regardless of whether
+	// CacheOriginRunID is populated: try the named origin task-run first, then
+	// fall back to the live cache entry keyed by the subject's hash. (A nil
+	// CacheOriginRunID must not fall through to the MISS path — that would
+	// mislabel a hit as a re-run.)
+	if TaskStatus(subject.Status) == TaskStatusCached {
+		if subject.CacheOriginRunID != nil {
+			var origin models.TaskRun
+			err := db.Where("job_run_id = ? AND task_id = ?", *subject.CacheOriginRunID, subject.TaskID).
+				First(&origin).Error
+			if err == nil {
+				b := WhyBaseline{Kind: "cache_origin", RunID: subject.CacheOriginRunID, TaskRunID: &origin.ID}
+				if originStart := origin.StartedAt; originStart != nil {
+					b.StartedAt = originStart
+				}
+				if len(origin.HashInputBlob) > 0 {
+					return origin.HashInputBlob, b, nil
+				}
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, WhyBaseline{}, err
 			}
-			if len(origin.HashInputBlob) > 0 {
-				return origin.HashInputBlob, b, nil
-			}
-		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, WhyBaseline{}, err
 		}
 
 		// Fall back to the live cache entry keyed by the subject's hash.
@@ -308,7 +318,7 @@ func (s *Store) resolveBaseline(ctx context.Context, subject *models.TaskRun, jo
 	err := db.
 		Joins("JOIN job_runs ON job_runs.id = task_runs.job_run_id").
 		Where("task_runs.task_id = ? AND job_runs.job_id = ? AND task_runs.job_run_id <> ? AND job_runs.started_at < ? AND task_runs.hash_input_blob IS NOT NULL",
-			subject.TaskID, jobID, subject.JobRunID, subjectRunStart(ctx, db, subject)).
+			subject.TaskID, jobID, subject.JobRunID, subjectStartedAt).
 		Order("job_runs.started_at DESC").
 		First(&prior).Error
 	if err != nil {
@@ -323,17 +333,6 @@ func (s *Store) resolveBaseline(ctx context.Context, subject *models.TaskRun, jo
 		b.StartedAt = prior.StartedAt
 	}
 	return prior.HashInputBlob, b, nil
-}
-
-// subjectRunStart returns the subject run's start time so the prior-run lookup
-// only considers strictly-earlier runs. On any error it returns the current time
-// (a permissive upper bound), preserving the "earlier run" intent.
-func subjectRunStart(ctx context.Context, db *gorm.DB, subject *models.TaskRun) time.Time {
-	var jr models.JobRun
-	if err := db.Select("started_at").First(&jr, "id = ?", subject.JobRunID).Error; err == nil {
-		return jr.StartedAt
-	}
-	return time.Now().UTC()
 }
 
 // summarize renders the one-line human-readable verdict from the structured
@@ -362,13 +361,17 @@ func summarizeChanged(exp *WhyExplanation, verdict, ranVerb string) string {
 	if exp.Diff == nil {
 		return fmt.Sprintf("%s — task %q %s", verdict, exp.TaskName, ranVerb)
 	}
+	// No comparison run at all is the "first run" case — report that rather than
+	// the generic degraded-blob message (the diff degrades because the baseline
+	// blob is absent, but the *reason* it is absent is that there is nothing to
+	// compare against, which is the more useful thing to say).
+	if exp.Baseline.Kind == "none" {
+		return fmt.Sprintf("%s — task %q %s; no prior run to compare against (first run of this task)", verdict, exp.TaskName, ranVerb)
+	}
 	if exp.Diff.Degraded != "" {
 		return fmt.Sprintf("%s — task %q %s; %s", verdict, exp.TaskName, ranVerb, exp.Diff.Degraded)
 	}
 	if len(exp.Diff.Changes) == 0 {
-		if exp.Baseline.Kind == "none" {
-			return fmt.Sprintf("%s — task %q %s; no prior run to compare against (first run of this task)", verdict, exp.TaskName, ranVerb)
-		}
 		return fmt.Sprintf("%s — task %q %s; no input field differs from the prior run (cause is outside the persisted hash inputs, e.g. an expired/pruned cache entry)", verdict, exp.TaskName, ranVerb)
 	}
 

--- a/internal/run/why.go
+++ b/internal/run/why.go
@@ -1,0 +1,410 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// why.go is the read-side query that powers `caesium why <run> --task <t>`
+// (data-plane-memory A3). It explains why a task in a given run executed, hit the
+// cache, or re-ran, by:
+//
+//  1. classifying the verdict (cache HIT / cache MISS / cache OFF) from the
+//     task-run's persisted status + cache columns;
+//  2. diffing this run's persisted, canonical HashInput blob against a baseline
+//     blob (the cache-origin entry for a hit; the most-recent prior run of the
+//     same task for a miss) to name the discriminating input field(s) — see
+//     whydiff.go; and
+//  3. joining the ExecutionEvent store for trigger-side causation (what fired the
+//     run and with which params).
+//
+// It is honestly scoped: it attributes which declared input or upstream
+// data-contract output changed, NOT row/column-level data causality. Everything
+// is a read of already-persisted state; nothing is recomputed.
+
+// WhyVerdict is the high-level cache outcome for the explained task.
+type WhyVerdict string
+
+const (
+	// VerdictCacheHit — the task did not execute; its identity hash matched a
+	// live cache entry and the prior result was reused.
+	VerdictCacheHit WhyVerdict = "CACHE_HIT"
+	// VerdictCacheMiss — caching was enabled but the task's identity hash did not
+	// match any live cache entry, so the task executed. The diff names what
+	// changed versus the prior run (had it been unchanged, this would have
+	// skipped).
+	VerdictCacheMiss WhyVerdict = "CACHE_MISS"
+	// VerdictCacheOff — caching was not enabled for this task, so it executed
+	// unconditionally and no hit/miss attribution applies. A field diff versus a
+	// prior run is still offered when a blob exists.
+	VerdictCacheOff WhyVerdict = "CACHE_DISABLED"
+	// VerdictUnknown — the task run is not in a terminal/decided state (e.g. still
+	// pending or running), so no cache verdict can be given yet.
+	VerdictUnknown WhyVerdict = "UNKNOWN"
+)
+
+// WhyTrigger captures the trigger-side causation for the run, read from the
+// run row and the run_started ExecutionEvent.
+type WhyTrigger struct {
+	// Type is the trigger type that fired the run (e.g. "cron", "http",
+	// "manual"), as recorded on the run.
+	Type string `json:"type,omitempty"`
+	// Alias is the trigger alias, when set.
+	Alias string `json:"alias,omitempty"`
+	// Params are the run parameters captured at trigger time; these feed into the
+	// HashInput (RunParams), so a changed param is also a possible miss cause and
+	// will appear in the diff under "runParams.<key>".
+	Params map[string]string `json:"params,omitempty"`
+	// FiredAt is the run's start time.
+	FiredAt time.Time `json:"firedAt,omitempty"`
+}
+
+// WhyBaseline describes which run/entry the subject was diffed against, so the
+// answer is auditable.
+type WhyBaseline struct {
+	// Kind is "cache_origin" (the run that populated the matched cache entry),
+	// "prior_run" (the most-recent earlier run of the same task), or "none".
+	Kind string `json:"kind"`
+	// RunID is the baseline run, when applicable.
+	RunID *uuid.UUID `json:"runId,omitempty"`
+	// TaskRunID is the baseline task-run, when applicable.
+	TaskRunID *uuid.UUID `json:"taskRunId,omitempty"`
+	// StartedAt is when the baseline run started, when known.
+	StartedAt *time.Time `json:"startedAt,omitempty"`
+}
+
+// WhyExplanation is the full, machine-readable answer the why service returns.
+// It is rendered as JSON by the API and as both a table and JSON by the CLI.
+type WhyExplanation struct {
+	RunID     uuid.UUID `json:"runId"`
+	JobID     uuid.UUID `json:"jobId"`
+	TaskID    uuid.UUID `json:"taskId"`
+	TaskName  string    `json:"taskName"`
+	TaskRunID uuid.UUID `json:"taskRunId"`
+
+	Verdict WhyVerdict `json:"verdict"`
+	Status  string     `json:"status"`
+	// CacheEnabled reflects whether caching applied to this task.
+	CacheEnabled bool `json:"cacheEnabled"`
+	// Hash is this task-run's identity hash.
+	Hash string `json:"hash,omitempty"`
+
+	// Summary is a one-line human-readable explanation, e.g.
+	// "CACHE_MISS — predecessor `extract.row_count` changed 1.2M→1.4M; image,
+	// command, env identical".
+	Summary string `json:"summary"`
+
+	Trigger  WhyTrigger  `json:"trigger"`
+	Baseline WhyBaseline `json:"baseline"`
+	Diff     *BlobDiff   `json:"diff,omitempty"`
+}
+
+// ErrTaskRunNotFound is returned when no task matching the given id/name exists
+// in the run.
+var ErrTaskRunNotFound = errors.New("run: task not found in run")
+
+// WhyTask explains why the task identified by taskRef (a task UUID or a task
+// name) in run runID executed / hit cache / re-ran. taskRef is matched first as
+// a UUID against task_id, then as a task name within the run's job.
+func (s *Store) WhyTask(ctx context.Context, runID uuid.UUID, taskRef string) (*WhyExplanation, error) {
+	var jobRun models.JobRun
+	if err := s.db.WithContext(ctx).First(&jobRun, "id = ?", runID).Error; err != nil {
+		return nil, err
+	}
+
+	taskRun, taskName, err := s.resolveTaskRun(ctx, runID, jobRun.JobID, taskRef)
+	if err != nil {
+		return nil, err
+	}
+
+	exp := &WhyExplanation{
+		RunID:        runID,
+		JobID:        jobRun.JobID,
+		TaskID:       taskRun.TaskID,
+		TaskName:     taskName,
+		TaskRunID:    taskRun.ID,
+		Status:       taskRun.Status,
+		CacheEnabled: taskRun.CacheEnabled,
+		Hash:         taskRun.Hash,
+		Verdict:      classifyVerdict(taskRun),
+	}
+
+	exp.Trigger = s.loadTrigger(ctx, &jobRun)
+
+	baselineBlob, baseline, err := s.resolveBaseline(ctx, taskRun, jobRun.JobID)
+	if err != nil {
+		return nil, err
+	}
+	exp.Baseline = baseline
+
+	diff, err := DiffHashInputBlobs(taskRun.HashInputBlob, baselineBlob)
+	if err != nil {
+		return nil, err
+	}
+	exp.Diff = diff
+
+	exp.Summary = summarize(exp)
+	return exp, nil
+}
+
+// resolveTaskRun finds the task_runs row for taskRef in the run, returning the
+// row and the resolved task name. taskRef is tried as a task UUID first, then as
+// a task name (looked up via the job's tasks table).
+func (s *Store) resolveTaskRun(ctx context.Context, runID, jobID uuid.UUID, taskRef string) (*models.TaskRun, string, error) {
+	db := s.db.WithContext(ctx)
+
+	var taskID uuid.UUID
+	taskName := taskRef
+	if parsed, perr := uuid.Parse(taskRef); perr == nil {
+		taskID = parsed
+	} else {
+		// Resolve by name within the job.
+		var task models.Task
+		if err := db.Select("id", "name").
+			Where("job_id = ? AND name = ?", jobID, taskRef).
+			First(&task).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, "", ErrTaskRunNotFound
+			}
+			return nil, "", err
+		}
+		taskID = task.ID
+	}
+
+	var taskRun models.TaskRun
+	if err := db.Where("job_run_id = ? AND task_id = ?", runID, taskID).
+		First(&taskRun).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, "", ErrTaskRunNotFound
+		}
+		return nil, "", err
+	}
+
+	// Backfill the task name when taskRef was a UUID.
+	if _, perr := uuid.Parse(taskRef); perr == nil {
+		var task models.Task
+		if err := db.Select("name").First(&task, "id = ?", taskID).Error; err == nil && task.Name != "" {
+			taskName = task.Name
+		}
+	}
+
+	return &taskRun, taskName, nil
+}
+
+func classifyVerdict(tr *models.TaskRun) WhyVerdict {
+	switch TaskStatus(tr.Status) {
+	case TaskStatusCached:
+		return VerdictCacheHit
+	case TaskStatusSucceeded, TaskStatusFailed:
+		if tr.CacheEnabled {
+			return VerdictCacheMiss
+		}
+		return VerdictCacheOff
+	default:
+		return VerdictUnknown
+	}
+}
+
+func (s *Store) loadTrigger(ctx context.Context, jobRun *models.JobRun) WhyTrigger {
+	t := WhyTrigger{
+		Type:    jobRun.TriggerType,
+		Alias:   jobRun.TriggerAlias,
+		FiredAt: jobRun.StartedAt,
+	}
+	if len(jobRun.Params) > 0 {
+		var params map[string]string
+		if err := json.Unmarshal(jobRun.Params, &params); err == nil {
+			t.Params = params
+		}
+	}
+
+	// Enrich trigger type/alias from the run_started event payload when the run
+	// row left them blank (older rows recorded trigger context only in the
+	// event). Best-effort: a missing or unparseable event leaves the row values.
+	if (t.Type == "" || t.Alias == "") && s.eventStore != nil {
+		evts, err := s.eventStore.ListSince(ctx, 0, 1, event.Filter{
+			RunID: jobRun.ID,
+			Types: []event.Type{event.TypeRunStarted},
+		})
+		if err == nil && len(evts) > 0 && len(evts[0].Payload) > 0 {
+			var payload struct {
+				TriggerType  string            `json:"trigger_type"`
+				TriggerAlias string            `json:"trigger_alias"`
+				Params       map[string]string `json:"params"`
+			}
+			if json.Unmarshal(evts[0].Payload, &payload) == nil {
+				if t.Type == "" {
+					t.Type = payload.TriggerType
+				}
+				if t.Alias == "" {
+					t.Alias = payload.TriggerAlias
+				}
+				if len(t.Params) == 0 && len(payload.Params) > 0 {
+					t.Params = payload.Params
+				}
+			}
+		}
+	}
+
+	return t
+}
+
+// resolveBaseline picks the blob to diff the subject against and describes it.
+//
+//   - Cache HIT: the cache-origin run's task blob (same task, run =
+//     CacheOriginRunID). By construction its identity hash equals the subject's,
+//     so the diff confirms every hashed input was identical — the proof of the
+//     hit. Falls back to the live TaskCache entry's blob (keyed by the subject
+//     hash) if the origin task-run row is gone.
+//   - Cache MISS / OFF: the most-recent earlier run of the same task that has a
+//     persisted blob, so the diff names what changed and forced the re-run.
+func (s *Store) resolveBaseline(ctx context.Context, subject *models.TaskRun, jobID uuid.UUID) ([]byte, WhyBaseline, error) {
+	db := s.db.WithContext(ctx)
+
+	if TaskStatus(subject.Status) == TaskStatusCached && subject.CacheOriginRunID != nil {
+		var origin models.TaskRun
+		err := db.Where("job_run_id = ? AND task_id = ?", *subject.CacheOriginRunID, subject.TaskID).
+			First(&origin).Error
+		if err == nil {
+			b := WhyBaseline{Kind: "cache_origin", RunID: subject.CacheOriginRunID, TaskRunID: &origin.ID}
+			if originStart := origin.StartedAt; originStart != nil {
+				b.StartedAt = originStart
+			}
+			if len(origin.HashInputBlob) > 0 {
+				return origin.HashInputBlob, b, nil
+			}
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, WhyBaseline{}, err
+		}
+
+		// Fall back to the live cache entry keyed by the subject's hash.
+		if subject.Hash != "" {
+			var entry models.TaskCache
+			if err := db.Where("hash = ?", subject.Hash).First(&entry).Error; err == nil {
+				b := WhyBaseline{Kind: "cache_origin"}
+				originRunID := entry.RunID
+				b.RunID = &originRunID
+				if len(entry.HashInputBlob) > 0 {
+					return entry.HashInputBlob, b, nil
+				}
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, WhyBaseline{}, err
+			}
+		}
+
+		return nil, WhyBaseline{Kind: "none"}, nil
+	}
+
+	// MISS / OFF: most-recent earlier run of the same task with a blob.
+	var prior models.TaskRun
+	err := db.
+		Joins("JOIN job_runs ON job_runs.id = task_runs.job_run_id").
+		Where("task_runs.task_id = ? AND job_runs.job_id = ? AND task_runs.job_run_id <> ? AND job_runs.started_at < ? AND task_runs.hash_input_blob IS NOT NULL",
+			subject.TaskID, jobID, subject.JobRunID, subjectRunStart(ctx, db, subject)).
+		Order("job_runs.started_at DESC").
+		First(&prior).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, WhyBaseline{Kind: "none"}, nil
+		}
+		return nil, WhyBaseline{}, err
+	}
+
+	b := WhyBaseline{Kind: "prior_run", RunID: &prior.JobRunID, TaskRunID: &prior.ID}
+	if prior.StartedAt != nil {
+		b.StartedAt = prior.StartedAt
+	}
+	return prior.HashInputBlob, b, nil
+}
+
+// subjectRunStart returns the subject run's start time so the prior-run lookup
+// only considers strictly-earlier runs. On any error it returns the current time
+// (a permissive upper bound), preserving the "earlier run" intent.
+func subjectRunStart(ctx context.Context, db *gorm.DB, subject *models.TaskRun) time.Time {
+	var jr models.JobRun
+	if err := db.Select("started_at").First(&jr, "id = ?", subject.JobRunID).Error; err == nil {
+		return jr.StartedAt
+	}
+	return time.Now().UTC()
+}
+
+// summarize renders the one-line human-readable verdict from the structured
+// explanation: the headline discriminating field for a miss, or the
+// identical-inputs proof for a hit.
+func summarize(exp *WhyExplanation) string {
+	switch exp.Verdict {
+	case VerdictCacheHit:
+		if exp.Diff != nil && exp.Diff.HashEqual {
+			return fmt.Sprintf("CACHE HIT — every hashed input identical to the cached run; the prior result was reused (task %q did not execute)", exp.TaskName)
+		}
+		return fmt.Sprintf("CACHE HIT — task %q reused a cached result", exp.TaskName)
+	case VerdictCacheMiss:
+		return summarizeChanged(exp, "CACHE MISS", "re-ran")
+	case VerdictCacheOff:
+		if exp.Diff != nil && len(exp.Diff.Changes) > 0 {
+			return summarizeChanged(exp, "CACHE DISABLED", "ran")
+		}
+		return fmt.Sprintf("CACHE DISABLED — caching was not enabled for task %q, so it ran unconditionally", exp.TaskName)
+	default:
+		return fmt.Sprintf("task %q is %s — no cache verdict yet", exp.TaskName, exp.Status)
+	}
+}
+
+func summarizeChanged(exp *WhyExplanation, verdict, ranVerb string) string {
+	if exp.Diff == nil {
+		return fmt.Sprintf("%s — task %q %s", verdict, exp.TaskName, ranVerb)
+	}
+	if exp.Diff.Degraded != "" {
+		return fmt.Sprintf("%s — task %q %s; %s", verdict, exp.TaskName, ranVerb, exp.Diff.Degraded)
+	}
+	if len(exp.Diff.Changes) == 0 {
+		if exp.Baseline.Kind == "none" {
+			return fmt.Sprintf("%s — task %q %s; no prior run to compare against (first run of this task)", verdict, exp.TaskName, ranVerb)
+		}
+		return fmt.Sprintf("%s — task %q %s; no input field differs from the prior run (cause is outside the persisted hash inputs, e.g. an expired/pruned cache entry)", verdict, exp.TaskName, ranVerb)
+	}
+
+	head := exp.Diff.Changes[0]
+	detail := describeChange(head)
+	if len(exp.Diff.Changes) > 1 {
+		detail = fmt.Sprintf("%s (and %d other field(s))", detail, len(exp.Diff.Changes)-1)
+	}
+	return fmt.Sprintf("%s — %s", verdict, detail)
+}
+
+// describeChange renders a single FieldChange as a human phrase. Redacted env
+// values are labeled rather than printed as if literal.
+func describeChange(c FieldChange) string {
+	switch {
+	case c.Added:
+		if c.Redacted {
+			return fmt.Sprintf("`%s` was added (redacted; digest %s)", c.Field, c.After)
+		}
+		if c.Kind == fieldStructural {
+			return fmt.Sprintf("`%s` was added", c.Field)
+		}
+		return fmt.Sprintf("`%s` was added (%s)", c.Field, c.After)
+	case c.Removed:
+		if c.Redacted {
+			return fmt.Sprintf("`%s` was removed (redacted; digest %s)", c.Field, c.Before)
+		}
+		if c.Kind == fieldStructural {
+			return fmt.Sprintf("`%s` was removed", c.Field)
+		}
+		return fmt.Sprintf("`%s` was removed (%s)", c.Field, c.Before)
+	case c.Kind == fieldStructural:
+		return fmt.Sprintf("`%s` changed", c.Field)
+	case c.Redacted:
+		return fmt.Sprintf("`%s` changed (redacted; digest %s→%s)", c.Field, c.Before, c.After)
+	default:
+		return fmt.Sprintf("`%s` changed %s→%s", c.Field, c.Before, c.After)
+	}
+}

--- a/internal/run/why_test.go
+++ b/internal/run/why_test.go
@@ -1,0 +1,108 @@
+package run
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+func TestClassifyVerdict(t *testing.T) {
+	cases := []struct {
+		name   string
+		status TaskStatus
+		cache  bool
+		want   WhyVerdict
+	}{
+		{"cached", TaskStatusCached, true, VerdictCacheHit},
+		{"succeeded-cache-on", TaskStatusSucceeded, true, VerdictCacheMiss},
+		{"succeeded-cache-off", TaskStatusSucceeded, false, VerdictCacheOff},
+		{"failed-cache-on", TaskStatusFailed, true, VerdictCacheMiss},
+		{"running", TaskStatusRunning, true, VerdictUnknown},
+		{"pending", TaskStatusPending, false, VerdictUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := &models.TaskRun{Status: string(tc.status), CacheEnabled: tc.cache}
+			if got := classifyVerdict(tr); got != tc.want {
+				t.Errorf("classifyVerdict(%s, cache=%v) = %s, want %s", tc.status, tc.cache, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSummarize_CacheMissNamesHeadlineField(t *testing.T) {
+	exp := &WhyExplanation{
+		TaskName: "load",
+		Verdict:  VerdictCacheMiss,
+		Baseline: WhyBaseline{Kind: "prior_run"},
+		Diff: &BlobDiff{
+			Changes: []FieldChange{
+				{Field: "predecessorOutputs.extract.row_count", Kind: fieldMapEntry, Before: "1200000", After: "1400000"},
+				{Field: "image", Kind: fieldScalar, Before: "alpine:3.23", After: "busybox:1.36.1"},
+			},
+		},
+	}
+	got := summarize(exp)
+	if !strings.HasPrefix(got, "CACHE MISS") {
+		t.Errorf("expected CACHE MISS prefix, got %q", got)
+	}
+	if !strings.Contains(got, "extract.row_count") || !strings.Contains(got, "1200000") || !strings.Contains(got, "1400000") {
+		t.Errorf("expected headline field + before/after in summary, got %q", got)
+	}
+	if !strings.Contains(got, "and 1 other field") {
+		t.Errorf("expected secondary-change count, got %q", got)
+	}
+}
+
+func TestSummarize_CacheHitIdentical(t *testing.T) {
+	exp := &WhyExplanation{
+		TaskName: "transform",
+		Verdict:  VerdictCacheHit,
+		Diff:     &BlobDiff{HashEqual: true},
+	}
+	got := summarize(exp)
+	if !strings.HasPrefix(got, "CACHE HIT") {
+		t.Errorf("expected CACHE HIT prefix, got %q", got)
+	}
+	if !strings.Contains(got, "identical") {
+		t.Errorf("expected identical-inputs proof, got %q", got)
+	}
+}
+
+func TestSummarize_CacheMissNoPriorRun(t *testing.T) {
+	exp := &WhyExplanation{
+		TaskName: "extract",
+		Verdict:  VerdictCacheMiss,
+		Baseline: WhyBaseline{Kind: "none"},
+		Diff:     &BlobDiff{},
+	}
+	got := summarize(exp)
+	if !strings.Contains(got, "first run") {
+		t.Errorf("expected first-run explanation, got %q", got)
+	}
+}
+
+func TestSummarize_Degraded(t *testing.T) {
+	exp := &WhyExplanation{
+		TaskName: "x",
+		Verdict:  VerdictCacheMiss,
+		Baseline: WhyBaseline{Kind: "prior_run"},
+		Diff:     &BlobDiff{Degraded: "one or both blobs were stored oversized"},
+	}
+	got := summarize(exp)
+	if !strings.Contains(got, "oversized") {
+		t.Errorf("expected degraded reason surfaced, got %q", got)
+	}
+}
+
+func TestDescribeChange_RedactedNeverShowsPlaintext(t *testing.T) {
+	c := FieldChange{Field: "env.SECRET", Kind: fieldMapEntry, Before: "sha256:aaa", After: "sha256:bbb", Redacted: true}
+	got := describeChange(c)
+	if !strings.Contains(got, "redacted") {
+		t.Errorf("expected redacted label, got %q", got)
+	}
+	if !strings.Contains(got, "sha256:aaa") || !strings.Contains(got, "sha256:bbb") {
+		t.Errorf("expected digests in redacted description, got %q", got)
+	}
+}

--- a/internal/run/why_test.go
+++ b/internal/run/why_test.go
@@ -1,10 +1,17 @@
 package run
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/caesium-cloud/caesium/internal/cache"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 func TestClassifyVerdict(t *testing.T) {
@@ -105,4 +112,168 @@ func TestDescribeChange_RedactedNeverShowsPlaintext(t *testing.T) {
 	if !strings.Contains(got, "sha256:aaa") || !strings.Contains(got, "sha256:bbb") {
 		t.Errorf("expected digests in redacted description, got %q", got)
 	}
+}
+
+// blobBytes canonicalizes a HashInput the way the A2 write-path does.
+func blobBytes(t *testing.T, h cache.HashInput) []byte {
+	t.Helper()
+	data, err := h.CanonicalJSON(h.Compute())
+	require.NoError(t, err)
+	return data
+}
+
+func TestWhyTask_CacheHitNilOriginUsesLiveEntry(t *testing.T) {
+	// Regression guard for the nil-CacheOriginRunID bug: a cached task whose
+	// CacheOriginRunID is nil must still be explained as a CACHE HIT via the live
+	// TaskCache entry — not mislabeled as a re-run via the MISS path.
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	taskID := uuid.New()
+	runID := uuid.New()
+	now := time.Now().UTC()
+
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: runID, JobID: jobID, Status: string(StatusRunning),
+		TriggerType: "cron", StartedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Task{ID: taskID, JobID: jobID, Name: "transform"}).Error)
+
+	hi := cache.HashInput{JobAlias: "etl", TaskName: "transform", Image: "alpine:3.23"}
+	hash := hi.Compute()
+	blob := blobBytes(t, hi)
+
+	// Cached task run with NO CacheOriginRunID set.
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: runID, TaskID: taskID, AtomID: uuid.New(),
+		Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo"]`,
+		Status: string(TaskStatusCached), CacheHit: true, CacheEnabled: true,
+		Hash: hash, HashInputBlob: datatypes.JSON(blob),
+		CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	// Live cache entry keyed by the same hash, carrying the blob.
+	require.NoError(t, db.Create(&models.TaskCache{
+		Hash: hash, JobID: jobID, TaskName: "transform", Result: "ok",
+		RunID: uuid.New(), TaskRunID: uuid.New(), HashInputBlob: datatypes.JSON(blob),
+		CreatedAt: now,
+	}).Error)
+
+	exp, err := store.WhyTask(ctx, runID, "transform")
+	require.NoError(t, err)
+	require.Equal(t, VerdictCacheHit, exp.Verdict, "cached task with nil origin must be a HIT, not a re-run")
+	require.Equal(t, "cache_origin", exp.Baseline.Kind, "must fall back to the live cache entry")
+	require.NotNil(t, exp.Diff)
+	require.True(t, exp.Diff.HashEqual, "hit diff should confirm identical hashed inputs")
+	require.True(t, strings.HasPrefix(exp.Summary, "CACHE HIT"), "summary=%q", exp.Summary)
+}
+
+func TestWhyTask_CacheMissDiffsPriorRun(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	taskID := uuid.New()
+	priorRunID := uuid.New()
+	subjectRunID := uuid.New()
+	base := time.Now().UTC()
+
+	require.NoError(t, db.Create(&models.Task{ID: taskID, JobID: jobID, Name: "load"}).Error)
+
+	// Prior run (earlier) with row_count=1.2M.
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: priorRunID, JobID: jobID, Status: string(StatusSucceeded),
+		TriggerType: "cron", StartedAt: base,
+	}).Error)
+	priorHI := cache.HashInput{TaskName: "load", Image: "alpine:3.23",
+		PredecessorOutputs: map[string]map[string]string{"extract": {"row_count": "1200000"}}}
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: priorRunID, TaskID: taskID, AtomID: uuid.New(),
+		Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo"]`,
+		Status: string(TaskStatusSucceeded), CacheEnabled: true,
+		Hash: priorHI.Compute(), HashInputBlob: datatypes.JSON(blobBytes(t, priorHI)),
+		StartedAt: &base, CreatedAt: base, UpdatedAt: base,
+	}).Error)
+
+	// Subject run (later) with row_count=1.4M — a cache miss.
+	later := base.Add(time.Hour)
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: subjectRunID, JobID: jobID, Status: string(StatusSucceeded),
+		TriggerType: "http", TriggerAlias: "webhook-1", StartedAt: later,
+	}).Error)
+	subjectHI := cache.HashInput{TaskName: "load", Image: "alpine:3.23",
+		PredecessorOutputs: map[string]map[string]string{"extract": {"row_count": "1400000"}}}
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: subjectRunID, TaskID: taskID, AtomID: uuid.New(),
+		Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo"]`,
+		Status: string(TaskStatusSucceeded), CacheEnabled: true,
+		Hash: subjectHI.Compute(), HashInputBlob: datatypes.JSON(blobBytes(t, subjectHI)),
+		StartedAt: &later, CreatedAt: later, UpdatedAt: later,
+	}).Error)
+
+	exp, err := store.WhyTask(ctx, subjectRunID, "load")
+	require.NoError(t, err)
+	require.Equal(t, VerdictCacheMiss, exp.Verdict)
+	require.Equal(t, "prior_run", exp.Baseline.Kind)
+	require.Equal(t, "http", exp.Trigger.Type)
+	require.Equal(t, "webhook-1", exp.Trigger.Alias)
+	require.NotNil(t, exp.Diff)
+	c, ok := findChange(exp.Diff.Changes, "predecessorOutputs.extract.row_count")
+	require.True(t, ok, "expected the row_count change, got %+v", exp.Diff.Changes)
+	require.Equal(t, "1200000", c.Before)
+	require.Equal(t, "1400000", c.After)
+	require.Contains(t, exp.Summary, "row_count")
+}
+
+func TestWhyTask_FirstRunNoPriorBaseline(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	taskID := uuid.New()
+	runID := uuid.New()
+	now := time.Now().UTC()
+
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: runID, JobID: jobID, Status: string(StatusSucceeded), TriggerType: "manual", StartedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Task{ID: taskID, JobID: jobID, Name: "extract"}).Error)
+
+	hi := cache.HashInput{TaskName: "extract", Image: "alpine:3.23"}
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: runID, TaskID: taskID, AtomID: uuid.New(),
+		Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo"]`,
+		Status: string(TaskStatusSucceeded), CacheEnabled: true,
+		Hash: hi.Compute(), HashInputBlob: datatypes.JSON(blobBytes(t, hi)),
+		StartedAt: &now, CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	exp, err := store.WhyTask(ctx, runID, "extract")
+	require.NoError(t, err)
+	require.Equal(t, VerdictCacheMiss, exp.Verdict)
+	require.Equal(t, "none", exp.Baseline.Kind)
+	require.Contains(t, exp.Summary, "first run")
+}
+
+func TestWhyTask_UnknownTaskReturnsNotFound(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: runID, JobID: jobID, Status: string(StatusRunning), StartedAt: time.Now().UTC(),
+	}).Error)
+
+	_, err := store.WhyTask(ctx, runID, "does-not-exist")
+	require.ErrorIs(t, err, ErrTaskRunNotFound)
 }

--- a/internal/run/whydiff.go
+++ b/internal/run/whydiff.go
@@ -1,0 +1,429 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+)
+
+// whydiff.go implements the read-side, field-by-field diff that powers
+// `caesium why` (data-plane-memory A3). It compares two persisted, canonical
+// HashInput blobs (see cache.HashInput.CanonicalJSON, written by A2 onto
+// TaskRun.HashInputBlob / TaskCache.HashInputBlob) and names the field(s) that
+// discriminate them — i.e. the inputs whose change forced a cache miss / re-run,
+// or, for a cache hit, the proof that every hashed input was identical.
+//
+// The diff is honestly scoped to what the blob actually contains: the decomposed
+// task-identity hash inputs (image, resolved digest, command, env, workdir,
+// mounts, k8s spec, predecessor hashes, predecessor *outputs* — the typed
+// data-contract values that flowed between steps — run params, cache version).
+// It does NOT claim row/column-level data causality; it attributes which
+// declared input or upstream output changed. Trigger-side causation (why the run
+// fired at all) is layered on in the why service via the ExecutionEvent store,
+// not here.
+
+// blobFieldKind classifies the shape of a diffed field so a renderer can decide
+// whether to show a before/after value (scalar / map) or merely "changed"
+// (structural).
+type blobFieldKind string
+
+const (
+	// fieldScalar is a single value (image, command, workdir, cacheVersion).
+	fieldScalar blobFieldKind = "scalar"
+	// fieldMapEntry is one key within a map-valued field (an env var, a run
+	// param, a single predecessor output key). The Field carries the dotted path
+	// (e.g. "predecessorOutputs.extract.row_count" or "env.FOO").
+	fieldMapEntry blobFieldKind = "map_entry"
+	// fieldStructural is an opaque structural field (mounts, volume mounts, the
+	// kubernetes spec) compared by canonical-JSON equality. Before/After are
+	// omitted because a full structural dump is rarely the useful signal; the
+	// renderer reports only that it changed.
+	fieldStructural blobFieldKind = "structural"
+)
+
+// FieldChange is one discriminating field between two HashInput blobs.
+type FieldChange struct {
+	// Field is the dotted path of the changed input, e.g. "image",
+	// "env.DATABASE_URL", "predecessorOutputs.extract.row_count".
+	Field string `json:"field"`
+	// Kind classifies how to interpret Before/After.
+	Kind blobFieldKind `json:"kind"`
+	// Before is the value in the baseline blob ("" / null when the field was
+	// absent there — i.e. the input was added). For redacted env values this is
+	// the digest, never the plaintext.
+	Before string `json:"before,omitempty"`
+	// After is the value in the subject blob ("" / null when the field was
+	// removed). For redacted env values this is the digest.
+	After string `json:"after,omitempty"`
+	// Added is true when the field exists only in the subject blob.
+	Added bool `json:"added,omitempty"`
+	// Removed is true when the field exists only in the baseline blob.
+	Removed bool `json:"removed,omitempty"`
+	// Redacted is true when the compared value is a redacted env digest, so a
+	// renderer can label it "(redacted; digest differs)" rather than printing the
+	// digest as if it were the literal value.
+	Redacted bool `json:"redacted,omitempty"`
+}
+
+// hashInputBlob is a read-side mirror of the persisted blob produced by
+// cache.HashInput.CanonicalJSON. It is decoded straight from the JSON (whose
+// shape is pinned by HashInputBlobVersion) rather than reusing cache's struct,
+// so the diff stays decoupled from cache's unexported env types and from any
+// future internal change to the cache package's in-memory representation. The
+// json tags MUST match cache.HashInputBlob exactly.
+type hashInputBlob struct {
+	BlobVersion int    `json:"blobVersion"`
+	Hash        string `json:"hash"`
+
+	JobAlias             string                       `json:"jobAlias,omitempty"`
+	TaskName             string                       `json:"taskName,omitempty"`
+	Image                string                       `json:"image,omitempty"`
+	ResolvedImageDigest  string                       `json:"resolvedImageDigest,omitempty"`
+	Command              []string                     `json:"command,omitempty"`
+	Env                  map[string]envBlobValue      `json:"env,omitempty"`
+	WorkDir              string                       `json:"workDir,omitempty"`
+	Mounts               json.RawMessage              `json:"mounts,omitempty"`
+	ResolvedVolumeMounts json.RawMessage              `json:"resolvedVolumeMounts,omitempty"`
+	Kubernetes           json.RawMessage              `json:"kubernetes,omitempty"`
+	PredecessorHashes    []string                     `json:"predecessorHashes,omitempty"`
+	PredecessorOutputs   map[string]map[string]string `json:"predecessorOutputs,omitempty"`
+	RunParams            map[string]string            `json:"runParams,omitempty"`
+	CacheVersion         int                          `json:"cacheVersion"`
+
+	Oversized *oversizedBlob `json:"oversized,omitempty"`
+}
+
+// envBlobValue mirrors cache's persisted env entry: either a verbatim secret://
+// reference or a redacted digest of a literal value.
+type envBlobValue struct {
+	Secret   string            `json:"secret,omitempty"`
+	Redacted *redactedEnvValue `json:"redacted,omitempty"`
+}
+
+// display returns a stable, printable representation of an env value and whether
+// it is a redacted digest. secret:// references are shown verbatim (they carry
+// no credential material); literal values are shown as their sha256: digest.
+func (v envBlobValue) display() (value string, redacted bool) {
+	if v.Secret != "" {
+		return v.Secret, false
+	}
+	if v.Redacted != nil {
+		return v.Redacted.Digest, true
+	}
+	return "", false
+}
+
+type redactedEnvValue struct {
+	Digest   string `json:"digest"`
+	Redacted bool   `json:"redacted"`
+}
+
+// oversizedBlob mirrors cache's degraded marker stored when a full blob would
+// exceed the size bound. When either side is oversized the diff cannot report
+// field-level changes and says so.
+type oversizedBlob struct {
+	EnvCount               int `json:"envCount"`
+	PredecessorCount       int `json:"predecessorCount"`
+	PredecessorOutputCount int `json:"predecessorOutputCount"`
+}
+
+// BlobDiff is the structured result of diffing two HashInput blobs.
+type BlobDiff struct {
+	// HashEqual is true when the two blobs decompose the same identity hash. By
+	// construction equal hashes mean every hashed input was identical, so Changes
+	// is empty; HashEqual=false with empty Changes can only happen when a blob is
+	// oversized/unparseable (see Degraded).
+	HashEqual bool `json:"hashEqual"`
+	// SubjectHash / BaselineHash are the inline Compute() digests each blob
+	// carries, surfaced so a caller can confirm the diff matched the runs it
+	// expected.
+	SubjectHash  string `json:"subjectHash,omitempty"`
+	BaselineHash string `json:"baselineHash,omitempty"`
+	// Changes lists every discriminating field, sorted by Field for determinism.
+	Changes []FieldChange `json:"changes,omitempty"`
+	// Degraded is set with a human-readable reason when a field-level diff was
+	// not possible (an oversized blob, a version mismatch, or unparseable JSON).
+	// The hash-level verdict (HashEqual) is still valid; only the field detail is
+	// unavailable.
+	Degraded string `json:"degraded,omitempty"`
+}
+
+// DiffHashInputBlobs decodes and diffs two canonical HashInput blobs: subject is
+// the run being explained, baseline is what it is compared against (the prior
+// run of the same task for a miss, or the cache-origin entry for a hit). Either
+// blob may be nil/empty (e.g. caching was disabled, or there is no prior run);
+// the result reports that gracefully via Degraded rather than erroring.
+func DiffHashInputBlobs(subject, baseline []byte) (*BlobDiff, error) {
+	d := &BlobDiff{}
+
+	if len(subject) == 0 || len(baseline) == 0 {
+		d.Degraded = "no decomposed input blob available on " + missingSide(subject, baseline) +
+			" (caching disabled, the blob predates A2, or there is no comparison run)"
+		// Still surface a hash verdict when at least the subject parsed.
+		if len(subject) > 0 {
+			if sb, err := decodeBlob(subject); err == nil {
+				d.SubjectHash = sb.Hash
+			}
+		}
+		if len(baseline) > 0 {
+			if bb, err := decodeBlob(baseline); err == nil {
+				d.BaselineHash = bb.Hash
+			}
+		}
+		return d, nil
+	}
+
+	sb, err := decodeBlob(subject)
+	if err != nil {
+		return nil, fmt.Errorf("run: decode subject hash-input blob: %w", err)
+	}
+	bb, err := decodeBlob(baseline)
+	if err != nil {
+		return nil, fmt.Errorf("run: decode baseline hash-input blob: %w", err)
+	}
+
+	d.SubjectHash = sb.Hash
+	d.BaselineHash = bb.Hash
+	d.HashEqual = sb.Hash != "" && sb.Hash == bb.Hash
+
+	if sb.BlobVersion != bb.BlobVersion {
+		d.Degraded = fmt.Sprintf("blob version mismatch (subject v%d, baseline v%d): cannot diff field-by-field; comparing identity hash only", sb.BlobVersion, bb.BlobVersion)
+		return d, nil
+	}
+	if sb.Oversized != nil || bb.Oversized != nil {
+		d.Degraded = "one or both blobs were stored oversized (truncated to identity + digest); cannot diff field-by-field"
+		return d, nil
+	}
+
+	d.Changes = diffBlobs(bb, sb) // (baseline, subject) so Before/After read naturally
+	return d, nil
+}
+
+func missingSide(subject, baseline []byte) string {
+	switch {
+	case len(subject) == 0 && len(baseline) == 0:
+		return "both runs"
+	case len(subject) == 0:
+		return "this run"
+	default:
+		return "the comparison run"
+	}
+}
+
+func decodeBlob(raw []byte) (*hashInputBlob, error) {
+	var b hashInputBlob
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return nil, err
+	}
+	return &b, nil
+}
+
+// diffBlobs compares baseline (before) against subject (after) field-by-field,
+// returning the changes sorted by field path for deterministic output.
+func diffBlobs(before, after *hashInputBlob) []FieldChange {
+	var changes []FieldChange
+
+	addScalar := func(field, b, a string) {
+		if b != a {
+			changes = append(changes, FieldChange{Field: field, Kind: fieldScalar, Before: b, After: a})
+		}
+	}
+
+	addScalar("image", before.Image, after.Image)
+	addScalar("resolvedImageDigest", before.ResolvedImageDigest, after.ResolvedImageDigest)
+	addScalar("command", joinCommand(before.Command), joinCommand(after.Command))
+	addScalar("workDir", before.WorkDir, after.WorkDir)
+	if before.CacheVersion != after.CacheVersion {
+		changes = append(changes, FieldChange{
+			Field:  "cacheVersion",
+			Kind:   fieldScalar,
+			Before: fmt.Sprintf("%d", before.CacheVersion),
+			After:  fmt.Sprintf("%d", after.CacheVersion),
+		})
+	}
+
+	changes = append(changes, diffEnv(before.Env, after.Env)...)
+	changes = append(changes, diffPredecessorHashes(before.PredecessorHashes, after.PredecessorHashes)...)
+	changes = append(changes, diffPredecessorOutputs(before.PredecessorOutputs, after.PredecessorOutputs)...)
+	changes = append(changes, diffStringMap("runParams", before.RunParams, after.RunParams)...)
+
+	addStructural := func(field string, b, a json.RawMessage) {
+		if !rawJSONEqual(b, a) {
+			changes = append(changes, FieldChange{Field: field, Kind: fieldStructural})
+		}
+	}
+	addStructural("mounts", before.Mounts, after.Mounts)
+	addStructural("resolvedVolumeMounts", before.ResolvedVolumeMounts, after.ResolvedVolumeMounts)
+	addStructural("kubernetes", before.Kubernetes, after.Kubernetes)
+
+	sort.Slice(changes, func(i, j int) bool { return changes[i].Field < changes[j].Field })
+	return changes
+}
+
+// joinCommand renders a command slice as a single newline-free string for scalar
+// comparison; nil and empty both render as "".
+func joinCommand(cmd []string) string {
+	if len(cmd) == 0 {
+		return ""
+	}
+	b, _ := json.Marshal(cmd)
+	return string(b)
+}
+
+func diffEnv(before, after map[string]envBlobValue) []FieldChange {
+	var changes []FieldChange
+	for _, key := range unionKeysEnv(before, after) {
+		bv, bok := before[key]
+		av, aok := after[key]
+		bval, bred := bv.display()
+		aval, ared := av.display()
+		switch {
+		case bok && !aok:
+			changes = append(changes, FieldChange{Field: "env." + key, Kind: fieldMapEntry, Before: bval, Removed: true, Redacted: bred})
+		case !bok && aok:
+			changes = append(changes, FieldChange{Field: "env." + key, Kind: fieldMapEntry, After: aval, Added: true, Redacted: ared})
+		case bval != aval:
+			changes = append(changes, FieldChange{Field: "env." + key, Kind: fieldMapEntry, Before: bval, After: aval, Redacted: bred || ared})
+		}
+	}
+	return changes
+}
+
+func diffStringMap(prefix string, before, after map[string]string) []FieldChange {
+	var changes []FieldChange
+	for _, key := range unionKeysStr(before, after) {
+		bv, bok := before[key]
+		av, aok := after[key]
+		switch {
+		case bok && !aok:
+			changes = append(changes, FieldChange{Field: prefix + "." + key, Kind: fieldMapEntry, Before: bv, Removed: true})
+		case !bok && aok:
+			changes = append(changes, FieldChange{Field: prefix + "." + key, Kind: fieldMapEntry, After: av, Added: true})
+		case bv != av:
+			changes = append(changes, FieldChange{Field: prefix + "." + key, Kind: fieldMapEntry, Before: bv, After: av})
+		}
+	}
+	return changes
+}
+
+// diffPredecessorOutputs is the headline of `caesium why`: it names the upstream
+// step + output key whose typed value changed ("predecessorOutputs.extract.row_count
+// 1.2M→1.4M"). These are data-contract values, not secrets, so they are shown
+// verbatim.
+func diffPredecessorOutputs(before, after map[string]map[string]string) []FieldChange {
+	var changes []FieldChange
+	for _, step := range unionKeysOutputs(before, after) {
+		changes = append(changes, diffStringMap("predecessorOutputs."+step, before[step], after[step])...)
+	}
+	return changes
+}
+
+func diffPredecessorHashes(before, after []string) []FieldChange {
+	if equalStringSets(before, after) {
+		return nil
+	}
+	// Predecessor hashes are an unordered set in identity terms; report the net
+	// add/remove rather than a positional diff.
+	var changes []FieldChange
+	beforeSet := toSet(before)
+	afterSet := toSet(after)
+	for _, h := range sortedSet(beforeSet) {
+		if _, ok := afterSet[h]; !ok {
+			changes = append(changes, FieldChange{Field: "predecessorHashes", Kind: fieldMapEntry, Before: h, Removed: true})
+		}
+	}
+	for _, h := range sortedSet(afterSet) {
+		if _, ok := beforeSet[h]; !ok {
+			changes = append(changes, FieldChange{Field: "predecessorHashes", Kind: fieldMapEntry, After: h, Added: true})
+		}
+	}
+	return changes
+}
+
+func rawJSONEqual(a, b json.RawMessage) bool {
+	an := canonicalizeRaw(a)
+	bn := canonicalizeRaw(b)
+	return bytes.Equal(an, bn)
+}
+
+// canonicalizeRaw normalizes a JSON fragment (decode then re-encode) so two
+// semantically-equal objects with different key ordering or whitespace compare
+// equal. An empty/nil/"null" fragment normalizes to nil.
+func canonicalizeRaw(raw json.RawMessage) []byte {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil
+	}
+	var v interface{}
+	if err := json.Unmarshal(raw, &v); err != nil {
+		return raw
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		return raw
+	}
+	return out
+}
+
+func unionKeysEnv(a, b map[string]envBlobValue) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	return sortedSet(seen)
+}
+
+func unionKeysStr(a, b map[string]string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	return sortedSet(seen)
+}
+
+func unionKeysOutputs(a, b map[string]map[string]string) []string {
+	seen := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		seen[k] = struct{}{}
+	}
+	for k := range b {
+		seen[k] = struct{}{}
+	}
+	return sortedSet(seen)
+}
+
+func toSet(s []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(s))
+	for _, v := range s {
+		out[v] = struct{}{}
+	}
+	return out
+}
+
+func sortedSet(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func equalStringSets(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	as := toSet(a)
+	for _, v := range b {
+		if _, ok := as[v]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/run/whydiff_test.go
+++ b/internal/run/whydiff_test.go
@@ -1,0 +1,327 @@
+package run
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/cache"
+	"github.com/caesium-cloud/caesium/pkg/container"
+)
+
+// blobFor canonicalizes a HashInput the same way the write-path does (A2), so the
+// diff tests exercise real, version-pinned blobs rather than hand-rolled JSON.
+func blobFor(t *testing.T, h cache.HashInput) []byte {
+	t.Helper()
+	data, err := h.CanonicalJSON(h.Compute())
+	if err != nil {
+		t.Fatalf("CanonicalJSON: %v", err)
+	}
+	return data
+}
+
+func envDigest(v string) string {
+	sum := sha256.Sum256([]byte(v))
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func findChange(changes []FieldChange, field string) (FieldChange, bool) {
+	for _, c := range changes {
+		if c.Field == field {
+			return c, true
+		}
+	}
+	return FieldChange{}, false
+}
+
+func TestDiff_IdenticalBlobsHashEqualNoChanges(t *testing.T) {
+	h := cache.HashInput{
+		JobAlias: "etl", TaskName: "transform",
+		Image:   "alpine:3.23",
+		Command: []string{"sh", "-c", "echo hi"},
+		Env:     map[string]string{"FOO": "bar"},
+	}
+	blob := blobFor(t, h)
+
+	d, err := DiffHashInputBlobs(blob, blob)
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	if !d.HashEqual {
+		t.Errorf("expected HashEqual=true for identical blobs")
+	}
+	if len(d.Changes) != 0 {
+		t.Errorf("expected no changes, got %+v", d.Changes)
+	}
+	if d.Degraded != "" {
+		t.Errorf("unexpected degraded: %q", d.Degraded)
+	}
+}
+
+func TestDiff_PredecessorOutputChangeIsHeadline(t *testing.T) {
+	base := cache.HashInput{
+		TaskName: "load",
+		Image:    "alpine:3.23",
+		PredecessorOutputs: map[string]map[string]string{
+			"extract": {"row_count": "1200000"},
+		},
+	}
+	subject := cache.HashInput{
+		TaskName: "load",
+		Image:    "alpine:3.23",
+		PredecessorOutputs: map[string]map[string]string{
+			"extract": {"row_count": "1400000"},
+		},
+	}
+
+	d, err := DiffHashInputBlobs(blobFor(t, subject), blobFor(t, base))
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	if d.HashEqual {
+		t.Fatalf("expected hashes to differ")
+	}
+	c, ok := findChange(d.Changes, "predecessorOutputs.extract.row_count")
+	if !ok {
+		t.Fatalf("expected predecessorOutputs.extract.row_count change, got %+v", d.Changes)
+	}
+	if c.Before != "1200000" || c.After != "1400000" {
+		t.Errorf("before/after = %q/%q, want 1200000/1400000", c.Before, c.After)
+	}
+	if c.Redacted {
+		t.Errorf("predecessor outputs are data-contract values, must not be redacted")
+	}
+	// Only the one field should differ.
+	if len(d.Changes) != 1 {
+		t.Errorf("expected exactly 1 change, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_EnvValueRedactedDigestComparison(t *testing.T) {
+	base := cache.HashInput{TaskName: "t", Env: map[string]string{"DATABASE_URL": "postgres://old"}}
+	subject := cache.HashInput{TaskName: "t", Env: map[string]string{"DATABASE_URL": "postgres://new"}}
+
+	d, err := DiffHashInputBlobs(blobFor(t, subject), blobFor(t, base))
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	c, ok := findChange(d.Changes, "env.DATABASE_URL")
+	if !ok {
+		t.Fatalf("expected env.DATABASE_URL change, got %+v", d.Changes)
+	}
+	if !c.Redacted {
+		t.Errorf("expected literal env value diff to be marked Redacted")
+	}
+	if c.Before != envDigest("postgres://old") || c.After != envDigest("postgres://new") {
+		t.Errorf("expected digests, got before=%q after=%q", c.Before, c.After)
+	}
+	// The plaintext must never appear in the diff.
+	raw, _ := json.Marshal(d)
+	if strings.Contains(string(raw), "postgres://old") || strings.Contains(string(raw), "postgres://new") {
+		t.Errorf("plaintext env value leaked into diff JSON: %s", raw)
+	}
+}
+
+func TestDiff_SecretRefShownVerbatim(t *testing.T) {
+	base := cache.HashInput{TaskName: "t", Env: map[string]string{"TOKEN": "secret://vault/db/pass"}}
+	subject := cache.HashInput{TaskName: "t", Env: map[string]string{"TOKEN": "secret://vault/db/pass-v2"}}
+
+	d, err := DiffHashInputBlobs(blobFor(t, subject), blobFor(t, base))
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	c, ok := findChange(d.Changes, "env.TOKEN")
+	if !ok {
+		t.Fatalf("expected env.TOKEN change, got %+v", d.Changes)
+	}
+	if c.Redacted {
+		t.Errorf("secret:// references are non-secret pointers; must not be marked Redacted")
+	}
+	if c.Before != "secret://vault/db/pass" || c.After != "secret://vault/db/pass-v2" {
+		t.Errorf("expected verbatim secret refs, got before=%q after=%q", c.Before, c.After)
+	}
+}
+
+func TestDiff_AddedAndRemovedFields(t *testing.T) {
+	base := cache.HashInput{
+		TaskName:  "t",
+		Env:       map[string]string{"KEEP": "x", "GONE": "y"},
+		RunParams: map[string]string{"region": "us"},
+	}
+	subject := cache.HashInput{
+		TaskName:  "t",
+		Env:       map[string]string{"KEEP": "x", "NEW": "z"},
+		RunParams: map[string]string{"region": "us", "tier": "gold"},
+	}
+
+	d, err := DiffHashInputBlobs(blobFor(t, subject), blobFor(t, base))
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+
+	gone, ok := findChange(d.Changes, "env.GONE")
+	if !ok || !gone.Removed {
+		t.Errorf("expected env.GONE removed, got %+v", d.Changes)
+	}
+	added, ok := findChange(d.Changes, "env.NEW")
+	if !ok || !added.Added {
+		t.Errorf("expected env.NEW added, got %+v", d.Changes)
+	}
+	param, ok := findChange(d.Changes, "runParams.tier")
+	if !ok || !param.Added || param.After != "gold" {
+		t.Errorf("expected runParams.tier added=gold, got %+v", param)
+	}
+	if _, ok := findChange(d.Changes, "env.KEEP"); ok {
+		t.Errorf("env.KEEP unchanged should not appear")
+	}
+}
+
+func TestDiff_ScalarImageAndCommand(t *testing.T) {
+	// Two distinct canonical pinned images so the change is real but the repo
+	// image-pinning guardrail stays satisfied.
+	const baseImage, subjectImage = "alpine:3.23", "busybox:1.36.1"
+	base := cache.HashInput{TaskName: "t", Image: baseImage, Command: []string{"echo", "a"}}
+	subject := cache.HashInput{TaskName: "t", Image: subjectImage, Command: []string{"echo", "b"}}
+
+	d, err := DiffHashInputBlobs(blobFor(t, subject), blobFor(t, base))
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	img, ok := findChange(d.Changes, "image")
+	if !ok || img.Before != baseImage || img.After != subjectImage {
+		t.Errorf("expected image change %s->%s, got %+v", baseImage, subjectImage, img)
+	}
+	if _, ok := findChange(d.Changes, "command"); !ok {
+		t.Errorf("expected command change, got %+v", d.Changes)
+	}
+	// Changes must be sorted by field for determinism.
+	for i := 1; i < len(d.Changes); i++ {
+		if d.Changes[i-1].Field > d.Changes[i].Field {
+			t.Errorf("changes not sorted: %s before %s", d.Changes[i-1].Field, d.Changes[i].Field)
+		}
+	}
+}
+
+func TestDiff_StructuralMountChange(t *testing.T) {
+	base := cache.HashInput{
+		TaskName: "t",
+		Mounts:   []container.Mount{{Source: "/a", Target: "/in", Type: "bind"}},
+	}
+	subject := cache.HashInput{
+		TaskName: "t",
+		Mounts:   []container.Mount{{Source: "/b", Target: "/in", Type: "bind"}},
+	}
+
+	d, err := DiffHashInputBlobs(blobFor(t, subject), blobFor(t, base))
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	c, ok := findChange(d.Changes, "mounts")
+	if !ok {
+		t.Fatalf("expected mounts structural change, got %+v", d.Changes)
+	}
+	if c.Kind != fieldStructural {
+		t.Errorf("expected structural kind, got %s", c.Kind)
+	}
+}
+
+func TestDiff_PredecessorHashSetChange(t *testing.T) {
+	base := cache.HashInput{TaskName: "t", PredecessorHashes: []string{"h1", "h2"}}
+	subject := cache.HashInput{TaskName: "t", PredecessorHashes: []string{"h1", "h3"}}
+
+	d, err := DiffHashInputBlobs(blobFor(t, subject), blobFor(t, base))
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	var removed, added bool
+	for _, c := range d.Changes {
+		if c.Field != "predecessorHashes" {
+			continue
+		}
+		if c.Removed && c.Before == "h2" {
+			removed = true
+		}
+		if c.Added && c.After == "h3" {
+			added = true
+		}
+	}
+	if !removed || !added {
+		t.Errorf("expected h2 removed and h3 added, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_MissingBaselineBlobDegrades(t *testing.T) {
+	subject := blobFor(t, cache.HashInput{TaskName: "t", Image: "alpine:3.23"})
+
+	d, err := DiffHashInputBlobs(subject, nil)
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	if d.Degraded == "" {
+		t.Errorf("expected a degraded reason when baseline is missing")
+	}
+	if d.SubjectHash == "" {
+		t.Errorf("expected subject hash to still be surfaced, got empty")
+	}
+	if len(d.Changes) != 0 {
+		t.Errorf("expected no field changes when degraded, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_OversizedBlobDegrades(t *testing.T) {
+	// Build a HashInput large enough to trip the 64 KB oversized fallback so the
+	// persisted blob carries an oversized marker.
+	big := map[string]map[string]string{}
+	huge := map[string]string{}
+	for i := 0; i < 5000; i++ {
+		huge[padKey(i)] = padKey(i)
+	}
+	big["step"] = huge
+	subject := blobFor(t, cache.HashInput{TaskName: "t", PredecessorOutputs: big})
+	baseline := blobFor(t, cache.HashInput{TaskName: "t", Image: "alpine:3.23"})
+
+	d, err := DiffHashInputBlobs(subject, baseline)
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	if d.Degraded == "" {
+		t.Errorf("expected degraded when a blob is oversized, got none (changes=%+v)", d.Changes)
+	}
+	if len(d.Changes) != 0 {
+		t.Errorf("expected no field-level changes for an oversized blob")
+	}
+}
+
+func TestDiff_VersionMismatchDegrades(t *testing.T) {
+	// Force a version mismatch by editing the decoded JSON's blobVersion.
+	base := blobFor(t, cache.HashInput{TaskName: "t", Image: "a"})
+	var m map[string]interface{}
+	if err := json.Unmarshal(base, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	m["blobVersion"] = float64(cache.HashInputBlobVersion + 1)
+	bumped, _ := json.Marshal(m)
+
+	d, err := DiffHashInputBlobs(bumped, base)
+	if err != nil {
+		t.Fatalf("DiffHashInputBlobs: %v", err)
+	}
+	if d.Degraded == "" {
+		t.Errorf("expected degraded on version mismatch")
+	}
+}
+
+func TestDiff_InvalidJSONErrors(t *testing.T) {
+	if _, err := DiffHashInputBlobs([]byte("{not json"), []byte(`{"blobVersion":1}`)); err == nil {
+		t.Errorf("expected error decoding invalid subject blob")
+	}
+}
+
+// padKey returns a distinct, multi-byte key per index so a few thousand entries
+// reliably push the canonical blob past the 64 KB oversized bound.
+func padKey(i int) string {
+	return "padding-key-to-inflate-blob-size-" + strconv.Itoa(i)
+}


### PR DESCRIPTION
## Summary

Implements item **A3** of the [`data-plane-memory`](docs/exec-plans/active/data-plane-memory.md) plan (design [Component 2](docs/design-data-plane-memory.md)): **`caesium why <run> --task <t>`**, the read-side EXPLAIN feature — the headline payoff of this plan.

A2 (merged) persists the decomposed `HashInput` as a canonical, secret-redacted JSON blob (`hash_input_blob`) on `TaskRun` and `TaskCache`. This PR builds the read side: a **field-by-field diff** of two such blobs that names the discriminating input(s) explaining why a task ran, was a cache **hit**, or **re-ran** — joined to the `ExecutionEvent` store for trigger-side causation. Scoped honestly to what the blob + event store actually contain (no row/column-level data causality).

Example summary:
> `CACHE MISS — predecessor outputs `extract.row_count` changed 1200000→1400000 (and 1 other field)`

## What's here

- **`internal/run/whydiff.go`** — decodes two canonical `HashInput` blobs and emits a deterministic, field-sorted `BlobDiff`:
  - scalars (image, resolved digest, command, workdir, cacheVersion);
  - per-key **env** — literal values stay redacted to their `sha256:` digest (plaintext never appears), `secret://` references shown verbatim;
  - per-step **predecessor outputs** — the typed data-contract values that flowed between steps, shown verbatim (the headline diff);
  - run params, predecessor-hash set, and structural mounts / volume mounts / k8s spec (canonical-JSON equality);
  - degrades gracefully on a missing / oversized / version-mismatched blob (hash-level verdict still given).
- **`internal/run/why.go`** — classifies the verdict (`CACHE_HIT` / `CACHE_MISS` / `CACHE_DISABLED` / `UNKNOWN`), picks the baseline (cache-origin task-run/entry for a hit; most-recent earlier run of the same task for a miss), joins the `run_started` `ExecutionEvent` for trigger/param causation, and renders a one-line summary.
- **`api/rest/service/why` + `api/rest/controller/why` + route** — `GET /v1/jobs/:id/runs/:run_id/why?task=<name-or-id>` in `Protected()`.
- **`cmd/why`** — `caesium why <run-id> --task <t> --job-id <id> [--json]`; human-readable summary table by default, machine-readable JSON (harness-assertable) with `--json`.
- Unit tests for the diff (env redaction, secret refs, predecessor-output headline, add/remove, structural, oversized/version/missing degrade) and the verdict/summary logic.

`internal/cache/hash.go` and `pkg/task/output.go` are intentionally **untouched** (owned by sibling D1).

## Verification

- `just lint` → **0 issues**
- `just unit-test` → **pass** (`internal/run` green incl. new tests; full suite exit 0). The repo image-pinning guardrail caught hardcoded `alpine:3.18/3.19` in the new tests — fixed to canonical pinned tags (`alpine:3.23`, `busybox:1.36.1`).
- Did not run `just integration-test` (orchestrator-gated).

## Plan doc

Ticked item **A3** in `docs/exec-plans/active/data-plane-memory.md` with a Done (W3-α) note. `## Progress` left for the orchestrator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)