### PR TITLE
Add value-verified short-circuit (data-plane-memory W4-α)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory.md
+++ b/docs/exec-plans/active/data-plane-memory.md
@@ -315,13 +315,36 @@ sequences after Stream A.
       machinery). `job-schema-reference.md` unchanged (generated; the protocol is a stdout
       convention, not a YAML field). Guard test pins that an encoded reference is not
       promoted to a lineage dataset (C1).
-- [ ] D2. Implement the value-verified short-circuit: replay a changed step; if its
+- [x] D2. Implement the value-verified short-circuit: replay a changed step; if its
       output reference digest matches the last successful run's, stop —
       downstream stays green (proven via content equality, preserving the
       cache-correctness invariant).
       Files: `internal/job/job.go` + `internal/worker/` (cache decision),
       new `test/` harness scenario asserting byte-identical short-circuit.
       Depends on: D1.
+      Done (W4-α): when a step re-executes because its OWN identity hash changed
+      (a cache MISS) but produces output byte-identical to a prior successful run,
+      it presents that prior run's identity to downstream consumers so a downstream
+      whose only changed input was this step stays a cache HIT — proven by output
+      equality, not heuristic. `cache.EquivalentPriorHash` (new
+      `internal/cache/shortcircuit.go`) is the proof: it compares the current
+      output to the canonical output of `cache.Store.PriorEntriesByTask` candidates
+      (same job+task, the new hash excluded) and returns the most-recent
+      proven-equal prior hash, else the new hash (default-to-rerun). Equality is
+      byte-identical canonical output — exactly the bytes `HashInput.Compute` folds
+      into the downstream key (for a large object that embeds the sha256 reference
+      digest), so it is never weaker than the cache key itself. A new nullable
+      `TaskRun.EffectiveHash` column carries the substituted prior identity;
+      `PredecessorHashes` reads `COALESCE(effective_hash, hash)`, so downstream
+      hashing uses the proven prior identity while the step's own `Hash` (receipt /
+      `caesium why`) stays its true identity. Wired into both the local
+      (`internal/job/job.go`) and distributed (`internal/worker/runtime_executor.go`)
+      paths; new `caesium_task_cache_short_circuits_total` metric. Default-to-rerun
+      guards: empty current hash, no current output, no prior with a non-empty hash
+      and byte-identical output, or any query failure → no substitution.
+      `test/dataplane_test.go` asserts both directions (identical output → downstream
+      stays `cached`; changed output → downstream re-runs `succeeded`). **Stream D
+      complete.**
 
 ## Sequencing & Dependencies
 

--- a/internal/cache/shortcircuit.go
+++ b/internal/cache/shortcircuit.go
@@ -1,0 +1,154 @@
+package cache
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+// PriorEntry is a candidate prior successful execution of a task, used to prove
+// a value-verified short-circuit. It carries only the two fields the proof
+// needs: the identity Hash that execution committed to, and the Output it
+// produced. Both come from a persisted cache Entry for the same (job, task),
+// so a match is proof — not a heuristic — that the prior identity produced the
+// same bytes the current re-execution did.
+type PriorEntry struct {
+	// Hash is the identity hash the prior successful execution committed to.
+	Hash string
+	// Output is the structured output that execution produced. For a
+	// large-object reference (pkg/task.OutputRef) the value embeds the content
+	// digest, so byte-equality of this map proves payload-content equality.
+	Output map[string]string
+	// CreatedAt orders candidates so the most recent proven-equal prior wins.
+	CreatedAt int64
+}
+
+// EquivalentPriorHash implements the value-verified short-circuit (design
+// Component 5 / exec-plan item D2).
+//
+// When a step re-executes because its OWN identity hash changed (a cache MISS —
+// e.g. its image or command changed), its NEW identity hash would normally fold
+// into every downstream task's PredecessorHashes set and force those downstream
+// tasks to re-run too — even if the step produced byte-identical output. That
+// cascade is the cost a content scheduler pays for a no-op code change.
+//
+// EquivalentPriorHash stops that cascade *only when content equality is PROVEN*.
+// It searches the step's prior successful executions (same job + task name) for
+// one whose persisted Output is byte-identical to the output this run just
+// produced. If found, it returns that prior execution's identity hash — the
+// proven-equivalent identity — which the caller substitutes for the new hash
+// when presenting this step to its downstream consumers. A downstream task whose
+// only changed input was this step's identity then sees an UNCHANGED predecessor
+// hash, cache-hits, and stays green. The skip is proven by digest equality, not
+// inferred.
+//
+// CRITICAL — cache-correctness invariant. A cache miss must always be safe; a
+// FALSE short-circuit (presenting a prior identity for a step whose output
+// actually changed) would serve a stale downstream result. So this function
+// defaults to re-run on ANY uncertainty and only substitutes when ALL hold:
+//
+//   - newHash is non-empty (the step has a real identity this run).
+//   - newOutput is non-nil — a step that emitted no structured output offers no
+//     content to prove equality against; we cannot prove the value is unchanged,
+//     so we never short-circuit it.
+//   - A prior candidate exists whose Hash is non-empty, differs from newHash
+//     (an identical hash is already a cache hit — nothing to short-circuit), and
+//     whose Output is byte-identical to newOutput by canonical comparison.
+//
+// On any failure of these it returns newHash unchanged: the conservative,
+// always-safe result is to let the changed identity propagate and re-run
+// downstream. The most-recent matching prior wins (candidates are compared by
+// CreatedAt) so the substituted identity is the freshest proven-equal one.
+func EquivalentPriorHash(newHash string, newOutput map[string]string, priors []PriorEntry) string {
+	// Guard 1: no real current identity → nothing to substitute.
+	if newHash == "" {
+		return newHash
+	}
+	// Guard 2: no structured output → cannot prove the value is unchanged.
+	// A step that emits nothing offers no content address to compare, so a
+	// changed identity must propagate (re-run downstream). This is deliberately
+	// conservative: silence is not proof of equality.
+	if len(newOutput) == 0 {
+		return newHash
+	}
+
+	newCanonical, ok := canonicalOutput(newOutput)
+	if !ok {
+		// The current output could not be canonicalized — treat as unprovable.
+		return newHash
+	}
+
+	var (
+		best      string
+		bestStamp int64
+		found     bool
+	)
+	for _, p := range priors {
+		// Guard 3a: a prior with no committed identity cannot be substituted in.
+		if p.Hash == "" {
+			continue
+		}
+		// Guard 3b: an identical hash means the current identity already matches
+		// this prior — the normal cache path would hit; nothing to short-circuit.
+		if p.Hash == newHash {
+			continue
+		}
+		priorCanonical, ok := canonicalOutput(p.Output)
+		if !ok {
+			continue
+		}
+		// The proof: byte-identical canonical output — exactly the bytes
+		// HashInput.Compute folds into a downstream cache key (its pred_output
+		// line). For a large-object reference those bytes embed the sha256
+		// content digest, so a re-emitted byte-identical payload proves content
+		// equality. This is deliberately no weaker than the cache key itself: if
+		// the encoded output differs at all (a changed digest, or a changed
+		// reference path that the key also hashes), it is not proven equal and we
+		// re-run. Conservative by construction — never a false short-circuit.
+		if priorCanonical != newCanonical {
+			continue
+		}
+		if !found || p.CreatedAt >= bestStamp {
+			best = p.Hash
+			bestStamp = p.CreatedAt
+			found = true
+		}
+	}
+
+	if !found {
+		return newHash
+	}
+	return best
+}
+
+// canonicalOutput renders an output map to a deterministic byte string for
+// equality comparison. Keys are sorted so map iteration order never produces a
+// spurious inequality; values are compared verbatim (a reference value already
+// embeds its content digest, so verbatim equality IS content equality). It
+// returns ok=false only if the (string-keyed, string-valued) map somehow fails
+// to marshal, which the JSON encoder does not do for this type — the guard
+// exists so an unexpected failure degrades to "cannot prove equality" (re-run)
+// rather than to a panic or a false match.
+func canonicalOutput(out map[string]string) (string, bool) {
+	if len(out) == 0 {
+		// An empty/nil map canonicalizes to a stable empty marker. Callers only
+		// reach here for prior candidates; the current output is already screened
+		// for emptiness before any comparison, so an empty prior never matches a
+		// non-empty current.
+		return "{}", true
+	}
+	keys := make([]string, 0, len(out))
+	for k := range out {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	ordered := make([][2]string, 0, len(out))
+	for _, k := range keys {
+		ordered = append(ordered, [2]string{k, out[k]})
+	}
+	data, err := json.Marshal(ordered)
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}

--- a/internal/cache/shortcircuit.go
+++ b/internal/cache/shortcircuit.go
@@ -1,10 +1,5 @@
 package cache
 
-import (
-	"encoding/json"
-	"sort"
-)
-
 // PriorEntry is a candidate prior successful execution of a task, used to prove
 // a value-verified short-circuit. It carries only the two fields the proof
 // needs: the identity Hash that execution committed to, and the Output it
@@ -71,12 +66,6 @@ func EquivalentPriorHash(newHash string, newOutput map[string]string, priors []P
 		return newHash
 	}
 
-	newCanonical, ok := canonicalOutput(newOutput)
-	if !ok {
-		// The current output could not be canonicalized — treat as unprovable.
-		return newHash
-	}
-
 	var (
 		best      string
 		bestStamp int64
@@ -92,19 +81,15 @@ func EquivalentPriorHash(newHash string, newOutput map[string]string, priors []P
 		if p.Hash == newHash {
 			continue
 		}
-		priorCanonical, ok := canonicalOutput(p.Output)
-		if !ok {
-			continue
-		}
-		// The proof: byte-identical canonical output — exactly the bytes
-		// HashInput.Compute folds into a downstream cache key (its pred_output
-		// line). For a large-object reference those bytes embed the sha256
-		// content digest, so a re-emitted byte-identical payload proves content
-		// equality. This is deliberately no weaker than the cache key itself: if
-		// the encoded output differs at all (a changed digest, or a changed
-		// reference path that the key also hashes), it is not proven equal and we
-		// re-run. Conservative by construction — never a false short-circuit.
-		if priorCanonical != newCanonical {
+		// The proof: byte-identical output — exactly the bytes HashInput.Compute
+		// folds into a downstream cache key (its pred_output line). For a
+		// large-object reference those bytes embed the sha256 content digest, so a
+		// re-emitted byte-identical payload proves content equality. This is
+		// deliberately no weaker than the cache key itself: if the output differs
+		// at all (a changed digest, or a changed reference path that the key also
+		// hashes), it is not proven equal and we re-run. Conservative by
+		// construction — never a false short-circuit.
+		if !mapsEqual(newOutput, p.Output) {
 			continue
 		}
 		if !found || p.CreatedAt >= bestStamp {
@@ -120,35 +105,23 @@ func EquivalentPriorHash(newHash string, newOutput map[string]string, priors []P
 	return best
 }
 
-// canonicalOutput renders an output map to a deterministic byte string for
-// equality comparison. Keys are sorted so map iteration order never produces a
-// spurious inequality; values are compared verbatim (a reference value already
-// embeds its content digest, so verbatim equality IS content equality). It
-// returns ok=false only if the (string-keyed, string-valued) map somehow fails
-// to marshal, which the JSON encoder does not do for this type — the guard
-// exists so an unexpected failure degrades to "cannot prove equality" (re-run)
-// rather than to a panic or a false match.
-func canonicalOutput(out map[string]string) (string, bool) {
-	if len(out) == 0 {
-		// An empty/nil map canonicalizes to a stable empty marker. Callers only
-		// reach here for prior candidates; the current output is already screened
-		// for emptiness before any comparison, so an empty prior never matches a
-		// non-empty current.
-		return "{}", true
+// mapsEqual reports whether two string→string output maps are equal,
+// independent of map iteration order. Value equality IS content equality here:
+// a large-object reference value embeds its sha256 content digest, so two maps
+// are equal exactly when every key carries byte-identical bytes — the same
+// bytes HashInput.Compute folds into a downstream cache key. It is O(N) and
+// zero-alloc (no serialization), and a length mismatch or any missing/unequal
+// key short-circuits to false, so a changed/added/removed output never proves
+// equal.
+func mapsEqual(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
 	}
-	keys := make([]string, 0, len(out))
-	for k := range out {
-		keys = append(keys, k)
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || av != bv {
+			return false
+		}
 	}
-	sort.Strings(keys)
-
-	ordered := make([][2]string, 0, len(out))
-	for _, k := range keys {
-		ordered = append(ordered, [2]string{k, out[k]})
-	}
-	data, err := json.Marshal(ordered)
-	if err != nil {
-		return "", false
-	}
-	return string(data), true
+	return true
 }

--- a/internal/cache/shortcircuit_test.go
+++ b/internal/cache/shortcircuit_test.go
@@ -1,0 +1,182 @@
+package cache
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// refValue (the encoded large-object reference helper) is defined in
+// hash_test.go in this same package; the short-circuit tests reuse it so the
+// bytes compared here match exactly what production stores. These digests feed
+// it to prove equality tracks the embedded content digest, not the path.
+var (
+	scDigestA = "sha256:" + strings.Repeat("a", 64)
+	scDigestB = "sha256:" + strings.Repeat("b", 64)
+)
+
+func TestEquivalentPriorHash_ProvenEqual_ScalarOutput_ShortCircuits(t *testing.T) {
+	// The step re-executed (new identity "h_new") but produced output
+	// byte-identical to a prior successful run whose identity was "h_old".
+	// The proof must substitute h_old so downstream stays a cache hit.
+	out := map[string]string{"row_count": "42"}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_old", got, "byte-identical output must present the prior identity")
+}
+
+func TestEquivalentPriorHash_ProvenEqual_ReferenceDigest_ShortCircuits(t *testing.T) {
+	// A large-object reference: the encoded value carries the sha256 content
+	// digest AND the path, exactly as it folds into the downstream cache key
+	// (HashInput.Compute's pred_output line). A byte-identical encoded reference
+	// — same digest, same path — is proven value-equal and short-circuits.
+	out := map[string]string{"frame": refValue(t, "/data/out.parquet", scDigestA)}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"frame": refValue(t, "/data/out.parquet", scDigestA)}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_old", got, "a byte-identical reference (same digest+path) must short-circuit")
+}
+
+func TestEquivalentPriorHash_GenuinelyChanged_ReferenceDigest_ReRuns(t *testing.T) {
+	// Different content digest -> the value really changed -> NO short-circuit.
+	// Serving the prior identity here would be a P0 false short-circuit. The
+	// digest is the load-bearing difference (same path, changed bytes).
+	out := map[string]string{"frame": refValue(t, "/data/out.parquet", scDigestA)}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"frame": refValue(t, "/data/out.parquet", scDigestB)}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_new", got, "a changed content digest must re-run downstream")
+}
+
+func TestEquivalentPriorHash_ReferenceDifferentPath_ReRuns(t *testing.T) {
+	// Conservatism: the encoded reference includes the path, and the path is
+	// part of the downstream cache key today (Compute hashes the whole encoded
+	// value). So a same-digest payload written to a DIFFERENT path is NOT
+	// byte-identical output and must default to re-run — matching the cache
+	// key's own equality, never weaker than it.
+	out := map[string]string{"frame": refValue(t, "/data/run-new.parquet", scDigestA)}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"frame": refValue(t, "/data/run-old.parquet", scDigestA)}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_new", got, "a changed reference path is not byte-identical output -> re-run (conservative)")
+}
+
+func TestEquivalentPriorHash_GenuinelyChanged_ScalarOutput_ReRuns(t *testing.T) {
+	out := map[string]string{"row_count": "43"}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_new", got, "changed scalar output must re-run downstream")
+}
+
+func TestEquivalentPriorHash_NoPriors_ReRuns(t *testing.T) {
+	out := map[string]string{"row_count": "42"}
+	got := EquivalentPriorHash("h_new", out, nil)
+	assert.Equal(t, "h_new", got, "no prior to prove against must re-run")
+}
+
+func TestEquivalentPriorHash_EmptyCurrentOutput_ReRuns(t *testing.T) {
+	// A step that emitted no structured output offers no content to prove
+	// equality, so a changed identity must propagate (re-run) even if a prior
+	// also emitted nothing — silence is not proof.
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: nil, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", nil, priors)
+	assert.Equal(t, "h_new", got, "no current output cannot be proven equal")
+}
+
+func TestEquivalentPriorHash_PriorMissingOutput_ReRuns(t *testing.T) {
+	// The current run produced output but the only prior emitted none: not
+	// provably equal, so re-run.
+	out := map[string]string{"row_count": "42"}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: nil, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_new", got, "a prior with no output cannot prove equality")
+}
+
+func TestEquivalentPriorHash_PriorMissingHash_ReRuns(t *testing.T) {
+	// A prior with a byte-identical output but no committed identity cannot be
+	// substituted in — there is no prior hash to present.
+	out := map[string]string{"row_count": "42"}
+	priors := []PriorEntry{
+		{Hash: "", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_new", got, "a prior with no identity hash cannot short-circuit")
+}
+
+func TestEquivalentPriorHash_EmptyNewHash_ReturnsEmpty(t *testing.T) {
+	out := map[string]string{"row_count": "42"}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("", out, priors)
+	assert.Equal(t, "", got, "no current identity -> nothing to substitute")
+}
+
+func TestEquivalentPriorHash_IdenticalHash_SkippedAsCandidate(t *testing.T) {
+	// A prior whose hash equals the current identity is already a normal cache
+	// hit; it must not be treated as a short-circuit candidate. With only that
+	// prior, the result stays the (unchanged) current hash.
+	out := map[string]string{"row_count": "42"}
+	priors := []PriorEntry{
+		{Hash: "h_new", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_new", got, "a prior identical to the current identity is not a short-circuit")
+}
+
+func TestEquivalentPriorHash_MostRecentProvenEqualWins(t *testing.T) {
+	// Two distinct prior identities both produced byte-identical output; the
+	// most recent (highest CreatedAt) proven-equal identity is presented.
+	out := map[string]string{"row_count": "42"}
+	priors := []PriorEntry{
+		{Hash: "h_older", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+		{Hash: "h_newer", Output: map[string]string{"row_count": "42"}, CreatedAt: 200},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_newer", got, "the freshest proven-equal prior identity must win")
+}
+
+func TestEquivalentPriorHash_MixedCandidates_PicksTheEqualOne(t *testing.T) {
+	// A genuinely-different prior (newer) must NOT mask an equal prior (older):
+	// only the byte-identical candidate is eligible.
+	out := map[string]string{"row_count": "42"}
+	priors := []PriorEntry{
+		{Hash: "h_equal", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+		{Hash: "h_diff", Output: map[string]string{"row_count": "99"}, CreatedAt: 300},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_equal", got, "a newer non-matching prior must not block an older proven-equal one")
+}
+
+func TestEquivalentPriorHash_OutputKeyOrderIrrelevant(t *testing.T) {
+	// Map iteration order must never produce a spurious inequality.
+	out := map[string]string{"a": "1", "b": "2", "c": "3"}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"c": "3", "a": "1", "b": "2"}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_old", got, "key order must not affect the equality proof")
+}
+
+func TestEquivalentPriorHash_PartialKeyMatch_ReRuns(t *testing.T) {
+	// Same value for one key but an extra key in the current output is NOT
+	// equal — the output changed, so re-run.
+	out := map[string]string{"row_count": "42", "checksum": "deadbeef"}
+	priors := []PriorEntry{
+		{Hash: "h_old", Output: map[string]string{"row_count": "42"}, CreatedAt: 100},
+	}
+	got := EquivalentPriorHash("h_new", out, priors)
+	assert.Equal(t, "h_new", got, "an added output key means the value changed -> re-run")
+}

--- a/internal/cache/store.go
+++ b/internal/cache/store.go
@@ -79,6 +79,51 @@ func (s *Store) Put(entry *Entry) error {
 	}).Create(model).Error
 }
 
+// PriorEntriesByTask returns the non-expired cache entries for a (job, task)
+// as PriorEntry candidates for the value-verified short-circuit
+// (EquivalentPriorHash). It deliberately excludes the entry whose Hash equals
+// excludeHash — that is the current re-execution's own (new) identity, which is
+// never its own prior. Only Hash + Output + CreatedAt are needed by the proof,
+// so this is a narrow projection that stays cheap even with many historical
+// entries. A query failure returns the error; the caller treats any failure as
+// "no provable prior" and re-runs (a miss is always safe).
+func (s *Store) PriorEntriesByTask(jobID uuid.UUID, taskName, excludeHash string) ([]PriorEntry, error) {
+	if taskName == "" {
+		return nil, nil
+	}
+	now := time.Now().UTC()
+	var rows []models.TaskCache
+	if err := s.db.
+		Select("hash", "output", "created_at").
+		Where("job_id = ? AND task_name = ? AND hash <> ? AND (expires_at IS NULL OR expires_at > ?)",
+			jobID, taskName, excludeHash, now).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 {
+		return nil, nil
+	}
+
+	out := make([]PriorEntry, 0, len(rows))
+	for i := range rows {
+		m := &rows[i]
+		var output map[string]string
+		if len(m.Output) > 0 {
+			if err := json.Unmarshal(m.Output, &output); err != nil {
+				// A corrupt prior output cannot prove equality — skip it rather
+				// than abort, so other valid candidates still apply.
+				continue
+			}
+		}
+		out = append(out, PriorEntry{
+			Hash:      m.Hash,
+			Output:    output,
+			CreatedAt: m.CreatedAt.UnixNano(),
+		})
+	}
+	return out, nil
+}
+
 // Invalidate removes cache entries for a specific task.
 func (s *Store) Invalidate(jobID uuid.UUID, taskName string) error {
 	return s.db.Where("job_id = ? AND task_name = ?", jobID, taskName).

--- a/internal/cache/store.go
+++ b/internal/cache/store.go
@@ -79,14 +79,26 @@ func (s *Store) Put(entry *Entry) error {
 	}).Create(model).Error
 }
 
-// PriorEntriesByTask returns the non-expired cache entries for a (job, task)
-// as PriorEntry candidates for the value-verified short-circuit
-// (EquivalentPriorHash). It deliberately excludes the entry whose Hash equals
-// excludeHash — that is the current re-execution's own (new) identity, which is
-// never its own prior. Only Hash + Output + CreatedAt are needed by the proof,
-// so this is a narrow projection that stays cheap even with many historical
-// entries. A query failure returns the error; the caller treats any failure as
-// "no provable prior" and re-runs (a miss is always safe).
+// maxPriorEntriesForShortCircuit bounds how many historical cache entries
+// PriorEntriesByTask loads as short-circuit candidates. The proof
+// (EquivalentPriorHash) substitutes the MOST-RECENT proven-equal prior, so
+// ordering by created_at DESC and capping the scan loses nothing: an entry
+// older than the N most recent could only win if every newer one differed, and
+// a value reverting to a form last produced beyond the N-most-recent runs is a
+// vanishingly rare case where conservatively re-running (a miss is always safe)
+// is acceptable. The bound keeps the per-task scan O(1) instead of growing with
+// run history.
+const maxPriorEntriesForShortCircuit = 64
+
+// PriorEntriesByTask returns up to maxPriorEntriesForShortCircuit of the
+// most-recent non-expired cache entries for a (job, task) as PriorEntry
+// candidates for the value-verified short-circuit (EquivalentPriorHash). It
+// deliberately excludes the entry whose Hash equals excludeHash — that is the
+// current re-execution's own (new) identity, which is never its own prior. Only
+// Hash + Output + CreatedAt are needed by the proof, so this is a narrow
+// projection; ordering by created_at DESC with a LIMIT keeps it cheap even for
+// a task with a long run history. A query failure returns the error; the caller
+// treats any failure as "no provable prior" and re-runs (a miss is always safe).
 func (s *Store) PriorEntriesByTask(jobID uuid.UUID, taskName, excludeHash string) ([]PriorEntry, error) {
 	if taskName == "" {
 		return nil, nil
@@ -97,6 +109,8 @@ func (s *Store) PriorEntriesByTask(jobID uuid.UUID, taskName, excludeHash string
 		Select("hash", "output", "created_at").
 		Where("job_id = ? AND task_name = ? AND hash <> ? AND (expires_at IS NULL OR expires_at > ?)",
 			jobID, taskName, excludeHash, now).
+		Order("created_at DESC").
+		Limit(maxPriorEntriesForShortCircuit).
 		Find(&rows).Error; err != nil {
 		return nil, err
 	}

--- a/internal/cache/store_test.go
+++ b/internal/cache/store_test.go
@@ -208,6 +208,60 @@ func TestListByJobReturnsNonExpired(t *testing.T) {
 	assert.Equal(t, "hash1", entries[0].Hash)
 }
 
+func TestPriorEntriesByTask_ExcludesHashAndExpired(t *testing.T) {
+	store := newTestStore(t)
+	jobID := uuid.New()
+
+	// A prior successful entry for the task.
+	prior := sampleEntry()
+	prior.JobID = jobID
+	prior.TaskName = "extract"
+	prior.Hash = "h_old"
+	prior.Output = map[string]string{"row_count": "42"}
+	require.NoError(t, store.Put(prior))
+
+	// The current re-execution's own (new) entry — must be excluded.
+	current := sampleEntry()
+	current.JobID = jobID
+	current.TaskName = "extract"
+	current.Hash = "h_new"
+	current.Output = map[string]string{"row_count": "42"}
+	require.NoError(t, store.Put(current))
+
+	// An expired prior — must be excluded.
+	expiredEntry := sampleEntry()
+	expiredEntry.JobID = jobID
+	expiredEntry.TaskName = "extract"
+	expiredEntry.Hash = "h_expired"
+	past := time.Now().UTC().Add(-time.Hour)
+	expiredEntry.ExpiresAt = &past
+	require.NoError(t, store.Put(expiredEntry))
+
+	// A different task's entry — must be excluded.
+	other := sampleEntry()
+	other.JobID = jobID
+	other.TaskName = "load"
+	other.Hash = "h_other"
+	require.NoError(t, store.Put(other))
+
+	priors, err := store.PriorEntriesByTask(jobID, "extract", "h_new")
+	require.NoError(t, err)
+	require.Len(t, priors, 1)
+	assert.Equal(t, "h_old", priors[0].Hash)
+	assert.Equal(t, map[string]string{"row_count": "42"}, priors[0].Output)
+
+	// End to end: the proof presents h_old for the byte-identical re-execution.
+	got := EquivalentPriorHash("h_new", map[string]string{"row_count": "42"}, priors)
+	assert.Equal(t, "h_old", got)
+}
+
+func TestPriorEntriesByTask_EmptyTaskName(t *testing.T) {
+	store := newTestStore(t)
+	priors, err := store.PriorEntriesByTask(uuid.New(), "", "h_new")
+	require.NoError(t, err)
+	assert.Empty(t, priors)
+}
+
 func TestPruneRemovesExpiredEntries(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -982,7 +982,35 @@ func (j *job) Run(ctx context.Context) error {
 					if taskModel != nil {
 						taskName = taskModel.Name
 					}
-					taskHashes[taskID] = inputHash
+
+					// Value-verified short-circuit (D2): this task re-executed
+					// because its OWN identity hash (inputHash) changed. If it
+					// produced output byte-identical to a prior successful run,
+					// present that prior run's identity to downstream consumers so
+					// a downstream whose only changed input was this step stays a
+					// cache hit instead of re-running. The substitution only
+					// happens when content equality is PROVEN (see
+					// cache.EquivalentPriorHash); on any uncertainty it returns
+					// inputHash unchanged (re-run downstream — always safe). The
+					// proof reads priors filtered to exclude inputHash, so the
+					// order relative to the Put below does not matter.
+					effectiveHash := inputHash
+					if priors, priorErr := cacheStore.PriorEntriesByTask(j.id, taskName, inputHash); priorErr != nil {
+						log.Warn("short-circuit: failed to load prior entries", "task", taskName, "error", priorErr)
+					} else {
+						effectiveHash = cache.EquivalentPriorHash(inputHash, output, priors)
+					}
+					// taskHashes drives the in-memory predHashes a downstream task
+					// folds into its own key; storing the effective (possibly
+					// prior) identity is what stops the cascade locally.
+					taskHashes[taskID] = effectiveHash
+					if effectiveHash != inputHash {
+						metrics.TaskCacheShortCircuitsTotal.WithLabelValues(j.alias, taskName).Inc()
+						log.Info("value-verified short-circuit", "task", taskName, "new_hash", inputHash[:12], "effective_hash", effectiveHash[:12])
+						if scErr := store.SetTaskEffectiveHash(runID, taskID, effectiveHash); scErr != nil {
+							log.Warn("short-circuit: failed to persist effective hash", "task", taskName, "error", scErr)
+						}
+					}
 
 					var expiresAt *time.Time
 					if cacheCfg.TTL > 0 {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -165,6 +165,18 @@ var (
 		[]string{"job_alias", "task_name"},
 	)
 
+	// TaskCacheShortCircuitsTotal counts value-verified short-circuits (D2): a
+	// task that re-executed because its own identity changed but produced
+	// byte-identical output to a prior successful run, so it presented that
+	// prior identity to downstream consumers and spared them a re-run.
+	TaskCacheShortCircuitsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_task_cache_short_circuits_total",
+			Help: "Total number of value-verified short-circuits (unchanged output despite a changed identity hash).",
+		},
+		[]string{"job_alias", "task_name"},
+	)
+
 	TaskCacheEntries = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: "caesium_task_cache_entries",
@@ -394,6 +406,7 @@ func Register() {
 			BackfillsActive,
 			TaskCacheHitsTotal,
 			TaskCacheMissesTotal,
+			TaskCacheShortCircuitsTotal,
 			TaskCacheEntries,
 			AuthRequestsTotal,
 			AuthFailuresTotal,

--- a/internal/models/run.go
+++ b/internal/models/run.go
@@ -47,6 +47,18 @@ type TaskRun struct {
 	MaxAttempts      int               `gorm:"not null;default:1" json:"max_attempts"`
 	NodeSelector     datatypes.JSONMap `gorm:"type:json" json:"node_selector,omitempty"`
 	Hash             string            `gorm:"type:text;index" json:"-"`
+	// EffectiveHash is the identity this task presents to its DOWNSTREAM
+	// consumers when a value-verified short-circuit was proven (design Component
+	// 5 / D2). Nullable: empty means "use Hash" — the common case. When this
+	// task re-executed because its OWN identity changed (Hash != a prior run's)
+	// but it produced byte-identical output to a prior successful run, this is
+	// set to that prior run's identity hash. Downstream PredecessorHashes reads
+	// COALESCE(effective_hash, hash), so a downstream task whose only changed
+	// input was this step sees an UNCHANGED predecessor and cache-hits — proven,
+	// not heuristic. Hash itself is left untouched so this task's own receipt /
+	// `caesium why` still reflect its true identity. See
+	// cache.EquivalentPriorHash for the proof and its default-to-rerun guards.
+	EffectiveHash    string            `gorm:"type:text" json:"-"`
 	Result           string            `json:"result,omitempty"`
 	Output           datatypes.JSON    `gorm:"type:json" json:"output,omitempty"`
 	BranchSelections datatypes.JSON    `gorm:"type:json" json:"branch_selections,omitempty"`

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -308,6 +308,24 @@ func (s *Store) SetTaskHashWithBlob(runID, taskID uuid.UUID, hash, resolvedImage
 		Updates(updates).Error
 }
 
+// SetTaskEffectiveHash records the proven-equivalent prior identity a task
+// presents to its downstream consumers when a value-verified short-circuit was
+// proven (design Component 5 / D2). It writes ONLY the effective_hash column;
+// the task's own Hash, output, and result are untouched, so its receipt and
+// `caesium why` still reflect its true identity. Passing an empty effectiveHash
+// is a no-op (the common case — no short-circuit), keeping the column nil and
+// PredecessorHashes falling back to the true hash. This is the only writer of
+// effective_hash, so a downstream reader observes either the proven prior
+// identity or nothing.
+func (s *Store) SetTaskEffectiveHash(runID, taskID uuid.UUID, effectiveHash string) error {
+	if effectiveHash == "" {
+		return nil
+	}
+	return s.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", runID, taskID).
+		Update("effective_hash", effectiveHash).Error
+}
+
 func (s *Store) Start(jobID uuid.UUID, triggerID *uuid.UUID, params ...map[string]string) (*JobRun, error) {
 	model := &models.JobRun{
 		ID:        uuid.New(),
@@ -2912,6 +2930,16 @@ func (s *Store) PredecessorOutputs(runID, taskID uuid.UUID) (map[string]map[stri
 // PredecessorHashes returns the execution hashes recorded on predecessor task
 // runs that completed successfully in the current run. This keeps distributed
 // cache hashing aligned with local execution, including transitive cache hits.
+//
+// The hash returned per predecessor is its EFFECTIVE identity: effective_hash
+// when a value-verified short-circuit was proven for that predecessor (its code
+// changed but it produced byte-identical output, see cache.EquivalentPriorHash
+// and TaskRun.EffectiveHash), otherwise its own hash. Reading the effective
+// hash is what stops a no-op upstream change from cascading a re-run downstream:
+// the predecessor presents its prior, proven-equivalent identity, so a
+// downstream whose only changed input was this predecessor sees an unchanged
+// hash and cache-hits. Falling back to hash (effective_hash empty) is the
+// common case and is byte-identical to the pre-D2 behavior.
 func (s *Store) PredecessorHashes(runID, taskID uuid.UUID) ([]string, error) {
 	var edges []models.TaskEdge
 	if err := s.db.Where("to_task_id = ?", taskID).Find(&edges).Error; err != nil {
@@ -2929,7 +2957,7 @@ func (s *Store) PredecessorHashes(runID, taskID uuid.UUID) ([]string, error) {
 
 	var taskRuns []models.TaskRun
 	if err := s.db.
-		Select("hash").
+		Select("hash", "effective_hash").
 		Where("job_run_id = ? AND task_id IN ? AND status IN ? AND hash <> ''",
 			runID,
 			predTaskIDs,
@@ -2945,8 +2973,8 @@ func (s *Store) PredecessorHashes(runID, taskID uuid.UUID) ([]string, error) {
 
 	hashes := make([]string, 0, len(taskRuns))
 	for _, taskRun := range taskRuns {
-		if taskRun.Hash != "" {
-			hashes = append(hashes, taskRun.Hash)
+		if h := effectiveTaskHash(taskRun.Hash, taskRun.EffectiveHash); h != "" {
+			hashes = append(hashes, h)
 		}
 	}
 	if len(hashes) == 0 {
@@ -2954,6 +2982,16 @@ func (s *Store) PredecessorHashes(runID, taskID uuid.UUID) ([]string, error) {
 	}
 	sort.Strings(hashes)
 	return hashes, nil
+}
+
+// effectiveTaskHash returns the identity a predecessor presents to downstream
+// cache hashing: its proven-equivalent effectiveHash when set, otherwise its
+// own hash. Centralized so the local and distributed paths agree on the rule.
+func effectiveTaskHash(hash, effectiveHash string) string {
+	if effectiveHash != "" {
+		return effectiveHash
+	}
+	return hash
 }
 
 // RetryFromFailure resets a failed run so that previously-succeeded and cached

--- a/internal/run/store_test.go
+++ b/internal/run/store_test.go
@@ -813,6 +813,57 @@ func TestPredecessorHashes(t *testing.T) {
 	require.Equal(t, []string{"pred-hash-1"}, hashes)
 }
 
+// TestPredecessorHashesUsesEffectiveHash asserts the value-verified
+// short-circuit (D2): when a predecessor recorded an effective_hash (its code
+// changed but its output was proven byte-identical to a prior run), downstream
+// PredecessorHashes presents that prior identity, not the predecessor's new
+// hash — so the downstream task sees an unchanged input and stays a cache hit.
+func TestPredecessorHashesUsesEffectiveHash(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		testutil.CloseDB(db)
+	})
+
+	store := NewStore(db)
+
+	jobID := uuid.New()
+	runRecord, err := store.Start(jobID, nil)
+	require.NoError(t, err)
+
+	atomA := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo","a"]`}
+	atomB := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo","b"]`}
+	require.NoError(t, db.Create(atomA).Error)
+	require.NoError(t, db.Create(atomB).Error)
+
+	taskA := &models.Task{ID: uuid.New(), JobID: jobID, AtomID: atomA.ID, Name: "step-a"}
+	taskB := &models.Task{ID: uuid.New(), JobID: jobID, AtomID: atomB.ID, Name: "step-b"}
+	require.NoError(t, db.Create(taskA).Error)
+	require.NoError(t, db.Create(taskB).Error)
+
+	edge := &models.TaskEdge{ID: uuid.New(), JobID: jobID, FromTaskID: taskA.ID, ToTaskID: taskB.ID, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	require.NoError(t, db.Create(edge).Error)
+
+	require.NoError(t, store.RegisterTask(runRecord.ID, taskA, atomA, 0))
+	require.NoError(t, store.RegisterTask(runRecord.ID, taskB, atomB, 1))
+	require.NoError(t, store.StartTask(runRecord.ID, taskA.ID, "runtime-a"))
+	require.NoError(t, store.CompleteTask(runRecord.ID, taskA.ID, "ok", map[string]string{"row_count": "42"}, nil))
+
+	// taskA re-executed with a NEW identity but was proven value-equal to a
+	// prior run whose identity was "pred-hash-old".
+	require.NoError(t, store.SetTaskHash(runRecord.ID, taskA.ID, "pred-hash-new"))
+	require.NoError(t, store.SetTaskEffectiveHash(runRecord.ID, taskA.ID, "pred-hash-old"))
+
+	hashes, err := store.PredecessorHashes(runRecord.ID, taskB.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"pred-hash-old"}, hashes, "downstream must see the proven prior identity, not the new one")
+
+	// Sanity: an empty effective hash is a no-op (falls back to the true hash).
+	require.NoError(t, store.SetTaskEffectiveHash(runRecord.ID, taskA.ID, ""))
+	hashes, err = store.PredecessorHashes(runRecord.ID, taskB.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"pred-hash-old"}, hashes, "empty effective hash must not clear an already-set one")
+}
+
 func TestPredecessorHashesIncludesCachedPredecessors(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() {

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -260,7 +260,7 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		if execErr == nil {
 			// Store successful result in cache.
 			if cacheStore != nil && cacheHash != "" {
-				e.storeCacheEntry(cacheStore, cacheCfg, cacheHash, resolvedImageDigest, hashInputBlob, taskRun)
+				e.storeCacheEntry(cacheStore, cacheCfg, cacheHash, resolvedImageDigest, hashInputBlob, taskRun, resolveJobAlias())
 			}
 			return
 		}
@@ -524,7 +524,7 @@ func (e *runtimeExecutor) runSchemaValidation(taskRun *models.TaskRun, output ma
 }
 
 // storeCacheEntry reads back the completed task run and stores the result in the cache.
-func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobdefschema.CacheConfig, hash, resolvedImageDigest string, hashInputBlob []byte, taskRun *models.TaskRun) {
+func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobdefschema.CacheConfig, hash, resolvedImageDigest string, hashInputBlob []byte, taskRun *models.TaskRun, jobAlias string) {
 	// Read back the completed task run to get output and result.
 	var completed models.TaskRun
 	if err := e.store.DB().Where("job_run_id = ? AND task_id = ?", taskRun.JobRunID, taskRun.TaskID).First(&completed).Error; err != nil {
@@ -559,6 +559,33 @@ func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobd
 	var branchSelections []string
 	if len(completed.BranchSelections) > 0 {
 		_ = json.Unmarshal(completed.BranchSelections, &branchSelections)
+	}
+
+	// Value-verified short-circuit (D2): this worker task re-executed because
+	// its own identity hash changed (a cache miss). If it produced output
+	// byte-identical to a prior successful run, persist that prior run's
+	// identity as the effective hash so downstream tasks — which read
+	// PredecessorHashes (COALESCE(effective_hash, hash)) from the DB — see an
+	// unchanged predecessor and cache-hit instead of re-running. The
+	// substitution only happens when content equality is PROVEN; otherwise
+	// EquivalentPriorHash returns hash and no effective_hash is written
+	// (re-run downstream — always safe). Excluding hash from the prior query
+	// makes the order relative to the Put below irrelevant.
+	//
+	// Ordering note: this task is already marked Succeeded (sink.Succeeded ran
+	// before storeCacheEntry) when effective_hash is written here. A downstream
+	// claimed in that narrow window would read the producer's true hash without
+	// the effective_hash and therefore re-run — a missed optimization, NEVER a
+	// stale result. The invariant (a miss is always safe) is preserved; we
+	// optimize the common case and never risk a false short-circuit.
+	if priors, priorErr := cacheStore.PriorEntriesByTask(jobRun.JobID, taskModel.Name, hash); priorErr != nil {
+		log.Warn("short-circuit: failed to load prior entries", "task_id", taskRun.TaskID, "error", priorErr)
+	} else if effectiveHash := cache.EquivalentPriorHash(hash, output, priors); effectiveHash != hash {
+		metrics.TaskCacheShortCircuitsTotal.WithLabelValues(jobAlias, taskModel.Name).Inc()
+		log.Info("value-verified short-circuit for worker task", "task_id", taskRun.TaskID, "new_hash", hash, "effective_hash", effectiveHash)
+		if scErr := e.store.SetTaskEffectiveHash(taskRun.JobRunID, taskRun.TaskID, effectiveHash); scErr != nil {
+			log.Warn("short-circuit: failed to persist effective hash", "task_id", taskRun.TaskID, "error", scErr)
+		}
 	}
 
 	entry := &cache.Entry{

--- a/test/dataplane_test.go
+++ b/test/dataplane_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types/image"
@@ -161,6 +163,188 @@ steps:
 	s.Equal("succeeded", run2.Status)
 	s.Equal("cached", s.taskStatusesByName(job.ID, run2)["pinned"],
 		"an unchanged pinned digest must still hit the cache")
+}
+
+// --------------------------------------------------------------------------
+// Data-plane memory D2: value-verified short-circuit
+// --------------------------------------------------------------------------
+
+// TestValueVerifiedShortCircuit is the D2 headline assertion. A producer step's
+// CODE changes between runs (its command is rewritten) so its identity hash
+// changes and it re-executes — a cache MISS. But it emits BYTE-IDENTICAL output.
+// A downstream consumer whose only changed input was the producer's identity
+// must therefore stay GREEN as a cache hit ("cached"), not cascade a re-run.
+// The skip is proven by output equality, not inferred.
+//
+//   - Run 1: producer + consumer both execute and cache.
+//   - Re-apply: producer command rewritten (different code) but the emitted
+//     ##caesium::output is the SAME bytes; consumer is byte-for-byte unchanged.
+//   - Run 2: producer MISSES (its identity changed) and re-executes, but its
+//     output is proven equal to the prior run, so consumer short-circuits and
+//     stays "cached".
+func (s *IntegrationTestSuite) TestValueVerifiedShortCircuit() {
+	alias := fmt.Sprintf("integration-d2-shortcircuit-%d", time.Now().UnixNano())
+
+	// Producer v1: a no-op `true` then the canonical output line.
+	manifestV1 := fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  cache: true
+trigger:
+  type: cron
+  configuration:
+    expression: "0 0 31 2 *"
+steps:
+  - name: producer
+    image: alpine:3.23
+    command: ["sh", "-c", "true; echo '##caesium::output {\"val\": \"42\"}'"]
+    next: consumer
+  - name: consumer
+    image: alpine:3.23
+    command: ["sh", "-c", "echo got=$CAESIUM_OUTPUT_PRODUCER_VAL && echo '##caesium::output {\"done\": \"yes\"}'"]
+    dependsOn: producer
+`, alias)
+
+	dir := s.writeJobManifest(manifestV1)
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	run1 := s.awaitRun(job.ID, s.triggerRun(job.ID), runTimeout)
+	s.Equal("succeeded", run1.Status, "first run should succeed")
+	statuses1 := s.taskStatusesByName(job.ID, run1)
+	s.Equal("succeeded", statuses1["producer"], "producer executes on first run")
+	s.Equal("succeeded", statuses1["consumer"], "consumer executes on first run")
+
+	// Producer v2: DIFFERENT code (`false || true` instead of `true`) so its
+	// identity hash changes — but the emitted output is byte-identical. The
+	// consumer step is unchanged.
+	manifestV2 := fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  cache: true
+trigger:
+  type: cron
+  configuration:
+    expression: "0 0 31 2 *"
+steps:
+  - name: producer
+    image: alpine:3.23
+    command: ["sh", "-c", "false || true; echo '##caesium::output {\"val\": \"42\"}'"]
+    next: consumer
+  - name: consumer
+    image: alpine:3.23
+    command: ["sh", "-c", "echo got=$CAESIUM_OUTPUT_PRODUCER_VAL && echo '##caesium::output {\"done\": \"yes\"}'"]
+    dependsOn: producer
+`, alias)
+	s.rewriteJobManifest(dir, manifestV2)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	run2 := s.awaitRun(job.ID, s.triggerRun(job.ID), runTimeout)
+	s.Equal("succeeded", run2.Status, "second run should succeed")
+	statuses2 := s.taskStatusesByName(job.ID, run2)
+	// Producer's code changed -> identity changed -> it must re-execute (MISS).
+	s.Equal("succeeded", statuses2["producer"],
+		"producer's code changed, so it must re-execute (cache MISS)")
+	// Consumer's only changed input was the producer's identity, but the
+	// producer's output is byte-identical, so the value-verified short-circuit
+	// keeps the consumer a cache hit.
+	s.Equal("cached", statuses2["consumer"],
+		"a code-only producer change with identical output must NOT cascade a downstream re-run")
+}
+
+// TestValueVerifiedShortCircuitRerunsOnRealChange is the correctness control:
+// when the producer's output ACTUALLY changes, the consumer's inputs really
+// changed, so it MUST re-run. This guards the cache-correctness invariant — a
+// short-circuit here would serve a stale downstream result (a P0 bug).
+//
+//   - Run 1: producer emits {"val":"42"}; both steps execute + cache.
+//   - Re-apply: producer emits {"val":"99"} (genuinely different output).
+//   - Run 2: producer MISSES and re-executes; the consumer's predecessor output
+//     changed, so it MUST re-execute ("succeeded"), never short-circuit.
+func (s *IntegrationTestSuite) TestValueVerifiedShortCircuitRerunsOnRealChange() {
+	alias := fmt.Sprintf("integration-d2-realchange-%d", time.Now().UnixNano())
+
+	manifestV1 := fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  cache: true
+trigger:
+  type: cron
+  configuration:
+    expression: "0 0 31 2 *"
+steps:
+  - name: producer
+    image: alpine:3.23
+    command: ["sh", "-c", "echo '##caesium::output {\"val\": \"42\"}'"]
+    next: consumer
+  - name: consumer
+    image: alpine:3.23
+    command: ["sh", "-c", "echo got=$CAESIUM_OUTPUT_PRODUCER_VAL && echo '##caesium::output {\"done\": \"yes\"}'"]
+    dependsOn: producer
+`, alias)
+
+	dir := s.writeJobManifest(manifestV1)
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	run1 := s.awaitRun(job.ID, s.triggerRun(job.ID), runTimeout)
+	s.Equal("succeeded", run1.Status)
+	statuses1 := s.taskStatusesByName(job.ID, run1)
+	s.Equal("succeeded", statuses1["producer"])
+	s.Equal("succeeded", statuses1["consumer"])
+
+	// Producer now emits genuinely different output.
+	manifestV2 := fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  cache: true
+trigger:
+  type: cron
+  configuration:
+    expression: "0 0 31 2 *"
+steps:
+  - name: producer
+    image: alpine:3.23
+    command: ["sh", "-c", "echo '##caesium::output {\"val\": \"99\"}'"]
+    next: consumer
+  - name: consumer
+    image: alpine:3.23
+    command: ["sh", "-c", "echo got=$CAESIUM_OUTPUT_PRODUCER_VAL && echo '##caesium::output {\"done\": \"yes\"}'"]
+    dependsOn: producer
+`, alias)
+	s.rewriteJobManifest(dir, manifestV2)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	run2 := s.awaitRun(job.ID, s.triggerRun(job.ID), runTimeout)
+	s.Equal("succeeded", run2.Status)
+	statuses2 := s.taskStatusesByName(job.ID, run2)
+	s.Equal("succeeded", statuses2["producer"],
+		"producer's output changed, so it must re-execute")
+	s.Equal("succeeded", statuses2["consumer"],
+		"a real upstream output change MUST re-run the consumer, never short-circuit")
+}
+
+// rewriteJobManifest overwrites the single job.yaml in dir (created by
+// writeJobManifest) with new contents, applying the same engine injection so
+// non-docker engines still run. Used to simulate a code change between applies.
+func (s *IntegrationTestSuite) rewriteJobManifest(dir, contents string) {
+	s.T().Helper()
+	path := filepath.Join(dir, "job.yaml")
+	s.Require().NoError(os.WriteFile(path, []byte(strings.TrimSpace(s.injectEngine(contents))), 0o644))
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Final item of the `data-plane-memory` plan (item **D2**, design Component 5 — the value-verified SKIP). It stops a **code-only upstream change that produces byte-identical data** from cascading a re-run through the rest of the DAG — "Bazel for data pipelines," but proven, not heuristic.

### The cascade D2 removes

A downstream task's identity hash folds in its predecessors' identity hashes (`PredecessorHashes`). When an upstream step's *code* changes (its identity hash changes → cache MISS → it re-executes) but it emits byte-identical output, the downstream still missed today — purely because the predecessor's *identity* changed, even though the *data* did not.

### How content equality is proven

- `cache.EquivalentPriorHash` (new `internal/cache/shortcircuit.go`) compares the step's just-produced output to the candidates from `cache.Store.PriorEntriesByTask` (same job + task name, the step's *new* hash excluded so it is never its own prior, expired entries excluded). It returns the **most-recent prior whose canonical output is byte-identical** to the current output, else the new hash.
- Equality is **byte-identical canonical output** — exactly the bytes `HashInput.Compute` folds into a downstream key (the `pred_output:` line). For a large object (D1's `##caesium::output-ref`) those bytes embed the **sha256 content digest**, so this is content equality across heterogeneous payloads. It is deliberately **no weaker than the cache key itself**: a changed digest *or* a changed reference path (which the key also hashes) is not proven equal.
- A new nullable `TaskRun.EffectiveHash` carries the substituted prior identity. `PredecessorHashes` reads `COALESCE(effective_hash, hash)`, so a downstream task whose only changed input was this predecessor sees an **unchanged** predecessor hash and cache-hits. The step's own `Hash` is left untouched, so its reproducibility receipt and `caesium why` still reflect its true identity.
- Wired into both execution paths: local (`internal/job/job.go`) and distributed (`internal/worker/runtime_executor.go`). New `caesium_task_cache_short_circuits_total` metric.

### Cache-correctness invariant (the whole risk)

A miss is always safe; a **false short-circuit** would serve a stale downstream result (a P0 bug). The proof **defaults to re-run on any uncertainty** — it substitutes the prior identity ONLY when content equality is proven. Guards that fall back to re-run: empty current hash; no current structured output (silence is not proof); no prior with a non-empty hash AND byte-identical output; any prior-lookup query failure. In distributed mode the `effective_hash` is written after the task is marked terminal, so a downstream claimed in that narrow window simply re-runs — a missed optimization, never a stale result.

## Test plan

- `just lint` — 0 issues.
- `just unit-test` — green (exit 0).
  - `EquivalentPriorHash` unit tests: proven-equal scalar/reference → short-circuit; changed digest / changed scalar / changed reference path / partial-key → re-run; no prior / empty current output / prior missing output / prior missing hash / empty new hash / identical-hash candidate → re-run; most-recent proven-equal wins; key-order irrelevant.
  - `PriorEntriesByTask` store test (excludes the new hash, expired entries, and other tasks) + end-to-end proof.
  - `PredecessorHashes` honors `effective_hash` (`COALESCE`), and an empty effective hash is a no-op.
- `test/dataplane_test.go` (`//go:build integration`, compiles under the tag) asserts **both directions**:
  - `TestValueVerifiedShortCircuit`: producer command rewritten (identity changes) but emits identical output → producer re-executes, **consumer stays `cached`**.
  - `TestValueVerifiedShortCircuitRerunsOnRealChange`: producer emits genuinely different output → **consumer re-runs (`succeeded`)**.

  Authored per the orchestrator's integration gate (not run here).

Ticks item **D2** in `docs/exec-plans/active/data-plane-memory.md` (Stream D complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)