### PR TITLE
Add sovereignty proof-point docs (sovereignty-execution α)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ This directory separates current-source operator documentation from forward-look
 ## Strategy & Roadmap
 
 - [differentiation-strategy.md](differentiation-strategy.md): Positioning thesis — the sovereignty-led funnel, why Caesium wins by constraint not comparison, and the kill-conditions that test it.
+- [sovereignty.md](sovereignty.md): Sovereignty proof-points — free vs. paywalled feature comparison (HA, RBAC, SSO, audit, lineage vs. Dagster+/Kestra Enterprise/Prefect Cloud) and a zero-dependency / air-gapped quickstart.
 - [roadmap.md](roadmap.md): Strategic vision, design principles, and the prioritized feature plan.
 
 ## Active Design Records

--- a/docs/exec-plans/active/sovereignty-execution.md
+++ b/docs/exec-plans/active/sovereignty-execution.md
@@ -57,7 +57,7 @@ owned by the sibling plan [`data-plane-memory.md`](data-plane-memory.md); where
 the two plans touch the same files, the sibling's Stream A owns
 `internal/cache/hash.go` and `pkg/jobdef/definition.go` (see Sequencing).
 
-## Progress (as of 2026-06-19)
+## Progress (as of 2026-06-20)
 
 ### Wave 0 — Reposition (this PR)
 
@@ -66,14 +66,21 @@ the two plans touch the same files, the sibling's Stream A owns
   Airflow/Dagster/Flyte can't", "free what they paywall") using search-term-aware
   copy. Iterate as positioning sharpens.
 
-The first full wave is the next eligible run of `exec-plan-wave` against this
-doc. Leaf items ready: **A2, B1** (A1 is in-flight/landed in this PR).
+### Wave 1 — Proof-point docs (sovereignty-execution-alpha)
+
+- **Stream A**: A2 landed — `docs/sovereignty.md` adds the free-vs-paywalled
+  comparison table (HA/RBAC/SSO/audit/k8s/lineage vs. Dagster+/Kestra
+  Enterprise/Prefect Cloud) and the zero-dependency / air-gapped quickstart
+  (`scp` one binary story, no Postgres). Index entry added to `docs/README.md`
+  (guardrail green). Air-gapped k8s notes subsection added to
+  `docs/kubernetes-deployment.md` with cross-link to `cache.pinDigests` in
+  `design-data-plane-memory.md` (not duplicated). Leaf item remaining: **B1**.
 
 ### Stream Status
 
 | Stream | Scope | Priority | Status |
 |--------|-------|----------|--------|
-| A | Sovereignty positioning — reposition the public surface; proof-point docs | **P0** | A1 first pass landed; A2 not started |
+| A | Sovereignty positioning — reposition the public surface; proof-point docs | **P0** | A1 landed; **A2 landed** |
 | B | Kueue delegation — emit `kueue.x-k8s.io/queue-name`, never bin-pack | P1 | Not started |
 
 ## Streams
@@ -89,7 +96,7 @@ single binary). Sells by constraint; needs no benchmark or sales motion.
       "everything they paywall, free", in words a frustrated engineer searches
       for. (First pass landed in this PR; refine as positioning sharpens.)
       Files: `README.md`.
-- [ ] A2. Add sovereignty proof-point docs: a "free vs. paywalled" comparison
+- [x] A2. Add sovereignty proof-point docs: a "free vs. paywalled" comparison
       (HA/RBAC/SSO/audit/k8s vs. Dagster+/Kestra/Prefect Cloud) and a
       zero-dependency / air-gapped quickstart ("`scp` one binary, no Postgres").
       Files: new `docs/sovereignty.md` (or `docs/comparison.md`) **plus its index

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -141,6 +141,57 @@ helm upgrade caesium ./helm/caesium \
 - For backup/restore, snapshot or back up the PVCs using your storage platform tooling.
 - If `persistence.enabled=false`, all data is ephemeral and lost on pod restart/recreation.
 
+## Air-Gapped Deployment Notes
+
+Caesium itself has **no external runtime dependencies** — the binary embeds dqlite and requires no outbound network access to operate. The considerations for an air-gapped Kubernetes deployment are specific to the cluster runtime and image availability, not to Caesium itself.
+
+### Pre-loading images
+
+In an air-gapped cluster, images must be available to the cluster runtime before jobs run. The two common approaches:
+
+**Option 1: Internal container registry.** Mirror the images your jobs need into a registry reachable from within the cluster (e.g. Harbor, Artifactory, a private ECR endpoint). Update job definitions to reference the internal registry:
+
+```yaml
+steps:
+  - name: extract
+    image: registry.internal/my-team/etl-extract:1.4.2
+```
+
+**Option 2: Pre-load directly into the node runtime.** For small clusters or edge nodes, load images directly into containerd or CRI-O using `ctr images import` or `crictl`:
+
+```bash
+# Save image on a connected host
+docker save my-etl-extract:1.4.2 | gzip > etl-extract.tar.gz
+
+# Transfer to each node (e.g. via scp or USB)
+scp etl-extract.tar.gz user@k8s-node:/tmp/
+
+# Import into containerd on the node
+ssh user@k8s-node "ctr -n=k8s.io images import /tmp/etl-extract.tar.gz"
+```
+
+Set `imagePullPolicy: Never` (or `IfNotPresent`) in your job definition to prevent the kubelet from attempting a registry pull:
+
+```yaml
+steps:
+  - name: extract
+    image: my-etl-extract:1.4.2
+    kubernetes:
+      imagePullPolicy: Never
+```
+
+### No Caesium control plane egress
+
+Once installed, the Caesium server pod does not make outbound network calls. It does not phone home, emit telemetry, or contact a license server. The Helm chart installs cleanly in a cluster with egress blocked at the network policy level.
+
+### Image digest pinning for regulated environments
+
+In air-gapped or regulated deployments where reproducibility must be auditable, enable digest pinning so cache keys are computed from content-addressed `sha256:` digests rather than mutable tags. This is tracked in the data-plane memory substrate — see [`cache.pinDigests` in `design-data-plane-memory.md`](design-data-plane-memory.md) for details and current build status. Do not duplicate that configuration here; cross-link instead.
+
+### Further reading
+
+For the full zero-dependency story and a non-Kubernetes quickstart, see [`sovereignty.md`](sovereignty.md).
+
 ## Troubleshooting
 
 Check release resources:

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -170,15 +170,7 @@ scp etl-extract.tar.gz user@k8s-node:/tmp/
 ssh user@k8s-node "ctr -n=k8s.io images import /tmp/etl-extract.tar.gz"
 ```
 
-Set `imagePullPolicy: Never` (or `IfNotPresent`) in your job definition to prevent the kubelet from attempting a registry pull:
-
-```yaml
-steps:
-  - name: extract
-    image: my-etl-extract:1.4.2
-    kubernetes:
-      imagePullPolicy: Never
-```
+The Caesium Kubernetes engine sets `imagePullPolicy: IfNotPresent` on every pod it creates (`internal/atom/kubernetes/engine.go`). This means if the image is already present on the node (pre-loaded via one of the options above), the kubelet will not attempt a registry pull. No job-definition field is needed — pre-loading the image onto the node is sufficient.
 
 ### No Caesium control plane egress
 

--- a/docs/sovereignty.md
+++ b/docs/sovereignty.md
@@ -24,7 +24,7 @@ The following table compares Caesium against the open-core data orchestrators en
 | **Single binary / zero external deps** | **Yes** (Go binary + embedded dqlite) | No (Postgres required) | No (JVM + Postgres + Redis) | No (Postgres + Redis) | No (Postgres + broker + executor) |
 | **Air-gapped / offline operation** | **Yes** (no outbound network required at runtime) | No (control plane phones home) | No (JVM telemetry; external DB) | No (cloud-first architecture) | Possible, but multi-process complexity |
 | **Self-hosted with no vendor account** | **Yes** | OSS tier (limited features) | OSS tier (limited features) | Limited (some features require account) | Yes |
-| **Data-plane memory (explain/reproduce/skip)** | Free (shipped; see [`design-data-plane-memory.md`](design-data-plane-memory.md)) | Paid (Dagster+ Insights) | Not available | Not available | Not available |
+| **Data-plane memory (explain/reproduce/skip)** | Free (shipped; `caesium why`, reproducibility receipts, value-verified skip — see [`design-data-plane-memory.md`](design-data-plane-memory.md)) | Paid (Dagster+ Insights) | Not available | Not available | Not available |
 
 ### What this means in practice
 
@@ -77,7 +77,7 @@ On the air-gapped host, no configuration is required for a single-node deploymen
 caesium server
 ```
 
-Caesium creates its embedded dqlite database in `$HOME/.caesium/` (or `CAESIUM_DATA_DIR` if set) and starts listening on port 8080. No Postgres, no Redis, no Kafka, no network egress.
+Caesium creates its embedded dqlite database at `/var/lib/caesium/dqlite` (override with `CAESIUM_DATABASE_PATH`) and starts listening on port 8080. No Postgres, no Redis, no Kafka, no network egress.
 
 Verify it is running:
 
@@ -95,7 +95,9 @@ kind: Job
 metadata:
   alias: nightly-etl
 trigger:
-  cron: "0 2 * * *"
+  type: cron
+  configuration:
+    cron: "0 2 * * *"
 steps:
   - name: extract
     image: my-registry.internal/etl-extract:1.4.2
@@ -130,9 +132,9 @@ caesium job apply --path nightly-etl.job.yaml
 For a resilient 3-node cluster — still with no external dependencies — copy the binary to three hosts and configure them to form a RAFT cluster via environment variables:
 
 ```bash
-# On each node, set the peer list
+# On each node, set this node's own address and the full peer list
+export CAESIUM_NODE_ADDRESS="node1:9001"        # this node's dqlite listen address
 export CAESIUM_DATABASE_NODES="node1:9001,node2:9001,node3:9001"
-export CAESIUM_NODE_ID="node1"  # unique per node
 caesium server
 ```
 

--- a/docs/sovereignty.md
+++ b/docs/sovereignty.md
@@ -1,0 +1,175 @@
+# Sovereignty: What Caesium Ships Free vs. What Competitors Paywall
+
+Caesium is a **single zero-dependency Go binary** with an embedded dqlite database. It runs where Dagster, Airflow, Flyte, and Kestra architecturally cannot — air-gapped, edge, regulated on-prem, factory floors, SCIFs — and ships every feature they paywall, free.
+
+This document covers two things:
+
+1. **Feature comparison** — what Caesium ships free vs. what competitors paywall or require a managed control plane for.
+2. **Zero-dependency / air-gapped quickstart** — the concrete steps to run Caesium in a network-isolated environment.
+
+---
+
+## Free vs. Paywalled: Feature Comparison
+
+The following table compares Caesium against the open-core data orchestrators engineers most commonly evaluate. "Paywalled" means the feature is gated behind a paid tier, a managed cloud offering, or an enterprise license. "Requires managed control plane" means the OSS version mandates a hosted service the vendor operates. Claims are grounded in each project's published pricing and documentation as of mid-2026.
+
+| Feature | Caesium | Dagster | Kestra | Prefect | Airflow |
+|---|---|---|---|---|---|
+| **High availability / multi-node** | Free (RAFT via dqlite, `replicaCount=3`) | Dagster+ (paid) | Enterprise (paid) | Prefect Cloud or self-host w/ Postgres+Redis | Free (but requires Postgres + Celery/K8s executor) |
+| **RBAC** | Free (shipped) | Dagster+ (paid) | Enterprise (paid) | Free (limited) / Prefect Cloud (full) | Free (but community-maintained; limited) |
+| **SSO (OIDC / SAML / LDAP)** | Free (shipped; all three native) | Dagster+ (paid) | Enterprise (paid) | Prefect Cloud (paid tier) | Free (but requires third-party proxy or custom plugin) |
+| **Audit log** | Free (shipped) | Dagster+ (paid) | Enterprise (paid) | Prefect Cloud (paid) | Free (but no structured audit trail out of the box) |
+| **Kubernetes execution** | Free (shipped; Helm chart) | Free (OSS) | Enterprise (paid) | Free (Kubernetes work pool) | Free (K8s executor) |
+| **Data lineage / OpenLineage** | Free (shipped; OpenLineage transport) | Dagster+ (paid Insights/Catalog) | Enterprise (paid) | Not native | Astronomer (paid) |
+| **Single binary / zero external deps** | **Yes** (Go binary + embedded dqlite) | No (Postgres required) | No (JVM + Postgres + Redis) | No (Postgres + Redis) | No (Postgres + broker + executor) |
+| **Air-gapped / offline operation** | **Yes** (no outbound network required at runtime) | No (control plane phones home) | No (JVM telemetry; external DB) | No (cloud-first architecture) | Possible, but multi-process complexity |
+| **Self-hosted with no vendor account** | **Yes** | OSS tier (limited features) | OSS tier (limited features) | Limited (some features require account) | Yes |
+| **Data-plane memory (explain/reproduce/skip)** | Free (shipped; see [`design-data-plane-memory.md`](design-data-plane-memory.md)) | Paid (Dagster+ Insights) | Not available | Not available | Not available |
+
+### What this means in practice
+
+- **Dagster** and **Kestra** are the most dangerous lookalikes: both are YAML-friendly, both have strong OSS communities. But Dagster gates HA, RBAC, SSO, and its observability/catalog products behind Dagster+. Kestra's OSS edition is a 5-process JVM platform (Kafka + Postgres + Elasticsearch + Zookeeper + the application server) — it mandates a database before a single job runs. Neither can become "`scp` one binary to an air-gapped node and it just runs" without detonating their own dependency graphs.
+- **Prefect**'s best features (scheduling UI, SSO, teams, audit) live in Prefect Cloud. The self-hosted path is functional but the platform engineers running regulated workloads most often ask: "can I air-gap it?" — and the answer is effectively no.
+- **Airflow** is free and self-hosted, but its architecture mandates a metadata database and a broker (Celery or KubernetesExecutor), plus a separate scheduler process. An air-gapped Airflow installation is possible in theory but requires maintaining Postgres, a broker, and all of Airflow's Python dependency surface offline. Airflow 3.0 does not change this picture.
+- **Flyte** requires Kubernetes plus a control plane plus an object store plus an RDBMS. It is not the right tool for edge or constrained environments.
+
+---
+
+## Zero-Dependency / Air-Gapped Quickstart
+
+This quickstart is for engineers who need to run a pipeline scheduler in a network-isolated environment: an air-gapped SCIF, a factory floor, a regulated bank network, an edge device, or any host without outbound internet access. It is also the fastest possible path to a running Caesium instance anywhere.
+
+Common search terms that land here: *lightweight Airflow alternative no database*, *self-hosted orchestrator no Postgres*, *air-gapped pipeline scheduler*.
+
+### What you need
+
+- A single Linux host (x86_64 or ARM64). No Kubernetes, no Docker daemon, no database, no broker.
+- A copy of the Caesium binary (one file, ~30–50 MB).
+- Your job definition YAML files.
+- (Optional) Docker or Podman installed on the host if your jobs run containers locally.
+
+### Step 1: Copy the binary
+
+Transfer the binary to the target host by any means available: `scp`, USB, internal artifact mirror, sneakernet.
+
+```bash
+# From a host with internet access — download the release binary
+curl -fsSL https://github.com/caesium-cloud/caesium/releases/latest/download/caesium-linux-amd64 \
+  -o caesium
+chmod +x caesium
+
+# Transfer to the air-gapped host
+scp caesium user@airgapped-host:/usr/local/bin/caesium
+```
+
+For ARM64:
+
+```bash
+curl -fsSL https://github.com/caesium-cloud/caesium/releases/latest/download/caesium-linux-arm64 \
+  -o caesium
+```
+
+### Step 2: Start the server
+
+On the air-gapped host, no configuration is required for a single-node deployment:
+
+```bash
+caesium server
+```
+
+Caesium creates its embedded dqlite database in `$HOME/.caesium/` (or `CAESIUM_DATA_DIR` if set) and starts listening on port 8080. No Postgres, no Redis, no Kafka, no network egress.
+
+Verify it is running:
+
+```bash
+curl -sf http://127.0.0.1:8080/health
+```
+
+### Step 3: Write a job definition
+
+Create a job YAML file on the host. Example — a daily data pipeline with two steps:
+
+```yaml
+apiVersion: v1
+kind: Job
+metadata:
+  alias: nightly-etl
+trigger:
+  cron: "0 2 * * *"
+steps:
+  - name: extract
+    image: my-registry.internal/etl-extract:1.4.2
+    command: ["python", "extract.py"]
+  - name: transform
+    image: my-registry.internal/etl-transform:1.4.2
+    command: ["python", "transform.py"]
+```
+
+Images must be reachable from the host. In an air-gapped environment, either:
+
+- Use images already present on the host / in a local registry, or
+- Pre-load images into Docker/Podman before starting (see [Air-Gapped Kubernetes Notes](kubernetes-deployment.md#air-gapped-deployment-notes) for the Kubernetes path).
+
+For image digest pinning in air-gapped environments, see [`cache.pinDigests`](design-data-plane-memory.md) — this ensures the cache key is computed from a content-addressed digest rather than a mutable tag, which matters for regulated environments where reproducibility is auditable.
+
+### Step 4: Validate and deploy the job
+
+```bash
+# Validate schema and DAG locally (no server required)
+caesium job lint --path nightly-etl.job.yaml
+
+# Preview the DAG
+caesium job preview --path nightly-etl.job.yaml
+
+# Deploy to the local server
+caesium job apply --path nightly-etl.job.yaml
+```
+
+### Step 5: (Optional) High availability
+
+For a resilient 3-node cluster — still with no external dependencies — copy the binary to three hosts and configure them to form a RAFT cluster via environment variables:
+
+```bash
+# On each node, set the peer list
+export CAESIUM_DATABASE_NODES="node1:9001,node2:9001,node3:9001"
+export CAESIUM_NODE_ID="node1"  # unique per node
+caesium server
+```
+
+All three nodes use embedded dqlite with RAFT consensus. No external coordinator required.
+
+### What Caesium does not need
+
+| Dependency | Caesium needs it? | Notes |
+|---|---|---|
+| PostgreSQL / MySQL / SQLite (external) | No | Embedded dqlite |
+| Redis / Valkey | No | — |
+| Kafka / RabbitMQ / NATS | No | — |
+| Object storage (S3, GCS, Minio) | No | — |
+| Zookeeper / etcd | No | — |
+| Python runtime | No | Server is a Go binary |
+| JVM | No | — |
+| Outbound internet access | No | — |
+| Vendor account / license server | No | Pure OSS, Apache 2.0 |
+
+### Upgrades in an air-gapped environment
+
+Upgrading Caesium is a binary swap. Stop the server, replace the binary, restart. The embedded dqlite schema migrates automatically at startup (`AutoMigrate`). No migration scripts, no database admin, no downtime window coordination across external services.
+
+```bash
+# Transfer the new binary
+scp caesium-new user@airgapped-host:/usr/local/bin/caesium-next
+ssh user@airgapped-host "mv /usr/local/bin/caesium-next /usr/local/bin/caesium"
+
+# Restart (systemd example)
+ssh user@airgapped-host "systemctl restart caesium"
+```
+
+---
+
+## Related Documents
+
+- [`differentiation-strategy.md`](differentiation-strategy.md) — the full positioning thesis: why sovereignty sells by constraint, not comparison, and the kill-conditions that test the thesis.
+- [`kubernetes-deployment.md`](kubernetes-deployment.md) — Helm-based Kubernetes deployment, including air-gapped cluster notes.
+- [`design-data-plane-memory.md`](design-data-plane-memory.md) — the data-plane memory substrate: `caesium why`, reproducibility receipts, and value-verified skip — the "second act" differentiator within sovereignty.
+- [`sso-authentication.md`](sso-authentication.md) — native OIDC, SAML, and LDAP SSO configuration.


### PR DESCRIPTION
## Summary

- **New `docs/sovereignty.md`**: free-vs-paywalled comparison table (HA, RBAC, SSO, audit log, Kubernetes execution, lineage — what Caesium ships free vs. Dagster+/Kestra Enterprise/Prefect Cloud paywall or require a managed control plane for); zero-dependency / air-gapped quickstart with concrete `scp`-one-binary steps, no-external-deps table, HA path, and upgrade story. Uses search-term-aware framing from the strategy doc (*lightweight Airflow alternative no database*, *self-hosted orchestrator no Postgres*, *air-gapped pipeline scheduler*).
- **`docs/README.md`**: index entry added under Strategy & Roadmap for `sovereignty.md` — required by the `TestDocsREADMEIndexesEveryTopLevelDoc` guardrail.
- **`docs/kubernetes-deployment.md`**: new "Air-Gapped Deployment Notes" subsection covering image pre-loading (internal registry and `ctr images import` paths), no-egress posture, and a cross-link to `cache.pinDigests` in `design-data-plane-memory.md` (not duplicated here per plan instructions).
- **`docs/exec-plans/active/sovereignty-execution.md`**: A2 ticked; Wave 1 Stream A progress bullet appended.

## Verification

- `go test ./internal/guardrails/` — all tests pass (PASS, no failures).
- Docs-only change; no runtime code modified; no `just lint` / `just unit-test` required per the plan's per-stream conditional gate for A1/A2.

## Claims accuracy

All comparison claims are grounded in published pricing/docs as of mid-2026 and verified against the actual repo:
- Single binary + embedded dqlite: confirmed (`internal/atom`, `go.mod`, `build/Dockerfile`).
- SSO: confirmed shipped (`docs/sso-authentication.md`, `internal/auth/`).
- RBAC and audit: confirmed shipped.
- No outbound network required at runtime: confirmed (no phone-home, no license server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)