### PR TITLE
Add Kueue delegation passthrough (sovereignty-execution β)

### DIFF
--- a/docs/caesium-job-llm-reference.md
+++ b/docs/caesium-job-llm-reference.md
@@ -96,6 +96,22 @@ trigger:
 | `workdir` / `mounts` / `nodeSelector` | string / array / map | no | Working dir, bind mounts (`source`/`target`/`readOnly`), and distributed-mode node labels — full shape in the [generated reference](job-schema-reference.md) |
 | `volumeMounts` | array | no | Mount a declared job volume: `{volume, path, readOnly?, subPath?}` |
 | `serviceAccountName` / `podAnnotations` / `automountServiceAccountToken` | string / map / bool | no | Kubernetes workload-identity passthrough |
+| `kueue` | object | no | Delegate admission to a [Kueue](https://kueue.sigs.k8s.io/) LocalQueue (kubernetes engine only): `{queueName: <local-queue>}`. Caesium stamps `kueue.x-k8s.io/queue-name` on the pod; Kueue gates scheduling against the queue's quota. Pure scheduling metadata — excluded from the cache hash. See [Delegating scheduling to Kueue](#delegating-scheduling-to-kueue) |
+
+### Delegating scheduling to Kueue
+
+Caesium does not bin-pack, prioritize, or gang-schedule — it delegates that to [Kueue](https://kueue.sigs.k8s.io/), the Kubernetes-native queueing controller. Set `kueue.queueName` on a `kubernetes` step and Caesium stamps the `kueue.x-k8s.io/queue-name` label on the pod; Kueue's webhook then gates the pod (via the `kueue.x-k8s.io/admission` scheduling gate it injects) until the named LocalQueue has quota, and un-gates it on admission.
+
+```yaml
+steps:
+  - name: train
+    engine: kubernetes          # kueue is rejected on docker/podman
+    image: ghcr.io/acme/trainer:1.4
+    kueue:
+      queueName: data-eng       # an existing Kueue LocalQueue in the pod namespace
+```
+
+The queue is scheduling metadata, **not** an execution input, so it is excluded from the cache identity hash (like secrets and workload identity): changing the queue never busts the cache. The cluster must have Kueue installed with the LocalQueue and its backing ClusterQueue provisioned — see [`kubernetes-deployment.md`](kubernetes-deployment.md#delegating-scheduling-to-kueue).
 
 ### Volumes
 

--- a/docs/examples-k8s/kueue-delegation.job.yaml
+++ b/docs/examples-k8s/kueue-delegation.job.yaml
@@ -1,0 +1,33 @@
+$schema: https://yourorg.io/schemas/job.v1.json
+apiVersion: v1
+kind: Job
+metadata:
+  alias: k8s-kueue-delegation
+  labels:
+    team: data-eng
+    runtime: kubernetes
+  annotations:
+    purpose: "Delegate scheduling to Kueue — Caesium never bin-packs"
+trigger:
+  type: cron
+  configuration:
+    cron: "0 * * * *"
+    timezone: "UTC"
+steps:
+  # Each kubernetes step delegates admission to a Kueue LocalQueue. Caesium
+  # stamps the kueue.x-k8s.io/queue-name label on the pod and Kueue gates
+  # scheduling against the queue's quota — Caesium does not schedule itself.
+  # The queue is scheduling metadata and is excluded from the cache identity
+  # hash, so re-queuing a task never busts its cache.
+  - name: extract
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo extracting data"]
+    kueue:
+      queueName: data-eng
+  - name: train
+    engine: kubernetes
+    image: alpine:3.23
+    command: ["sh", "-c", "echo training on GPU quota gated by Kueue"]
+    kueue:
+      queueName: gpu-shared

--- a/docs/exec-plans/active/sovereignty-execution.md
+++ b/docs/exec-plans/active/sovereignty-execution.md
@@ -66,15 +66,26 @@ the two plans touch the same files, the sibling's Stream A owns
   Airflow/Dagster/Flyte can't", "free what they paywall") using search-term-aware
   copy. Iterate as positioning sharpens.
 
-The first full wave is the next eligible run of `exec-plan-wave` against this
-doc. Leaf items ready: **A2, B1** (A1 is in-flight/landed in this PR).
+### Wave 1 — Kueue delegation
+
+- **Stream B**: B1 landed — steps declare `kueue: {queueName: "..."}` on the
+  kubernetes engine; the engine stamps the `kueue.x-k8s.io/queue-name` label on
+  the pod and delegates admission to Kueue (Caesium never bin-packs). The queue
+  is excluded from the cache identity hash (carried on `KubernetesSpec`, gated out
+  of `Compute()` by `HasIdentityFields()`, stripped from the persisted blob by
+  `hashableKubernetes()`); unit tests assert hash-equality with/without the queue.
+  Schema docs, the schema-doc generator, the k8s-deployment guide, and a
+  `docs/examples-k8s/kueue-delegation.job.yaml` sample updated. `just lint` and
+  `just unit-test` green.
+
+Leaf items remaining: **A2** (sovereignty proof-point docs).
 
 ### Stream Status
 
 | Stream | Scope | Priority | Status |
 |--------|-------|----------|--------|
 | A | Sovereignty positioning — reposition the public surface; proof-point docs | **P0** | A1 first pass landed; A2 not started |
-| B | Kueue delegation — emit `kueue.x-k8s.io/queue-name`, never bin-pack | P1 | Not started |
+| B | Kueue delegation — emit `kueue.x-k8s.io/queue-name`, never bin-pack | P1 | B1 landed (Wave 1) |
 
 ## Streams
 
@@ -103,17 +114,23 @@ single binary). Sells by constraint; needs no benchmark or sales motion.
 Answer "why not Kueue?" by *using* Kueue for admission instead of reimplementing
 it. The data DAG inherits Kueue's quota/fair-share/preemption for free.
 
-- [ ] B1. Add a Kueue passthrough: a job/step field that creates the Kubernetes
-      Job **suspended** with the `kueue.x-k8s.io/queue-name` label so Kueue gates
-      admission (un-suspends on quota). The field is **excluded from the cache
-      identity hash** — it is scheduling metadata, not execution input (treat it
-      like secrets / workload-identity, which are already excluded). Add a unit
-      test asserting the hash is identical with and without it.
-      Files: `pkg/jobdef/definition.go` (+ `pkg/jobdef/schema.go`),
-      `internal/jobdef/runtime/spec.go`, `internal/atom/kubernetes/engine.go`
-      (suspend + label), `internal/cache/hash.go` (assert exclusion + test),
+- [x] B1. Add a Kueue passthrough: a step `kueue: {queueName: "..."}` field that,
+      on the kubernetes engine, stamps the `kueue.x-k8s.io/queue-name` label on the
+      created pod so Kueue gates admission (its webhook injects the
+      `kueue.x-k8s.io/admission` scheduling gate — the pod-level equivalent of a
+      suspended Job — and un-gates on quota; Caesium's engine creates a Pod, not a
+      batch/v1 Job). The field is **excluded from the cache identity hash** — it is
+      scheduling metadata, not execution input — carried on `container.KubernetesSpec`
+      and gated out of `Compute()` via `HasIdentityFields()` and stripped from the
+      persisted blob via `hashableKubernetes()`. Unit tests assert the hash is
+      identical with and without the queue (and that a queue-only spec equals an
+      absent one). Landed in PR (sovereignty-execution β).
+      Files: `pkg/container/spec.go` (the `QueueName` carrier + `HasIdentityFields`),
+      `pkg/jobdef/definition.go` (the `kueue` field + Validate + threading),
+      `internal/atom/kubernetes/engine.go` (label), `internal/cache/hash.go`
+      (exclusion + tests), `internal/jobdef/report/report.go` (schema-doc generator),
       `docs/caesium-job-llm-reference.md` + `docs/job-schema-reference.md` +
-      `docs/kubernetes-deployment.md`, `docs/examples-k8s/*.job.yaml`.
+      `docs/kubernetes-deployment.md`, `docs/examples-k8s/kueue-delegation.job.yaml`.
 
 ## Sequencing & Dependencies
 

--- a/docs/job-schema-reference.md
+++ b/docs/job-schema-reference.md
@@ -94,6 +94,7 @@ Each step represents a DAG node backed by a task/atom pair. Steps default to the
 | `serviceAccountName` | string | optional | Kubernetes ServiceAccount for this step's pod. |
 | `podAnnotations` | map[string]string | optional | Kubernetes pod annotations for this step. |
 | `automountServiceAccountToken` | boolean | optional | Kubernetes pod service-account token setting for this step. |
+| `kueue` | object | optional | Delegate this step's admission to a Kueue LocalQueue (kubernetes engine only). See [Kueue](#kueue) below. Excluded from the cache identity hash — it is scheduling metadata, not an execution input. |
 | `next` | array[string] | optional | Successor steps triggered when this step completes. Accepts either a string or list in manifests. |
 | `dependsOn` | array[string] | optional | Predecessor steps that must complete before this step can run. |
 | `retries` | integer | optional | Number of retry attempts after the initial failure. |
@@ -112,6 +113,16 @@ Each step represents a DAG node backed by a task/atom pair. Steps default to the
 | `version` | integer | optional | Bump to invalidate existing cache entries without changing task definition. |
 | `pinDigests` | boolean | optional | Resolve each step's image tag to its content digest (`sha256:…`) and fold the digest, not the mutable tag, into the cache key. A tag that moves to new content (e.g. a re-pushed `:latest`) then produces a cache **miss** instead of serving a stale hit. Defaults to `CAESIUM_CACHE_PIN_DIGESTS`. Set at job (`metadata.cache`) or step level; a step value overrides the job default. Resolution is opt-in because it costs a registry round-trip on first sight; the resolved tag→digest mapping is cached for `digestTTL` so steady-state runs pay no network cost. |
 | `digestTTL` | duration string or 0 | optional | How long a resolved tag→digest mapping is reused before re-resolution (a **perf cache**). Within the window a moved tag is **not** re-detected — the prior digest is served. `0` re-resolves on every check, so a moved tag is detected immediately at the cost of a registry round-trip per check. Defaults to `CAESIUM_CACHE_DIGEST_TTL` (5m). Only meaningful with `pinDigests`. |
+
+### Kueue
+
+`kueue` delegates a step's scheduling to [Kueue](https://kueue.sigs.k8s.io/), the Kubernetes-native job-queueing controller. Caesium does not bin-pack, prioritize, or gang-schedule — when `kueue` is set on a `kubernetes` step, Caesium stamps the `kueue.x-k8s.io/queue-name` label on the created pod and Kueue gates admission against the named LocalQueue's quota, holding the pod (via the `kueue.x-k8s.io/admission` scheduling gate its webhook injects) until capacity is available. This is only valid on the `kubernetes` engine; `docker`/`podman` reject it.
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `queueName` | string | required | The Kueue LocalQueue (in the pod's namespace) to admit through. Becomes the value of the `kueue.x-k8s.io/queue-name` label. |
+
+The queue is **scheduling metadata, not an execution input**, so it is excluded from the cache identity hash exactly like secrets and workload identity: two otherwise-identical tasks that differ only in queue share one cache identity, and re-queuing a task never busts its cache. Your cluster must have Kueue installed with the LocalQueue (and a backing ClusterQueue) provisioned; see [`kubernetes-deployment.md`](kubernetes-deployment.md#delegating-scheduling-to-kueue).
 
 ## Secret References
 

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -134,6 +134,51 @@ helm upgrade caesium ./helm/caesium \
   --set ingress.hosts[0].host=caesium.local
 ```
 
+## Delegating scheduling to Kueue
+
+Caesium does not bin-pack, prioritize, or gang-schedule workloads — it delegates
+admission control to [Kueue](https://kueue.sigs.k8s.io/), the Kubernetes-native
+job-queueing controller, so the data DAG inherits Kueue's quota, fair-share, and
+preemption without Caesium reimplementing any of it.
+
+When a step sets `kueue.queueName`, Caesium stamps the
+`kueue.x-k8s.io/queue-name` label on the pod it creates. Kueue's admission
+webhook then gates the pod — it injects the `kueue.x-k8s.io/admission`
+scheduling gate (the pod-level equivalent of a suspended Job), holding the pod
+out of scheduling until the named LocalQueue's ClusterQueue has quota, and
+removes the gate once the workload is admitted. Caesium never schedules the pod
+itself.
+
+### Cluster prerequisites
+
+1. **Install Kueue** and enable its pod integration (`pod` in
+   `integrations.frameworks`), so its webhook manages plain pods. See the
+   [Kueue installation guide](https://kueue.sigs.k8s.io/docs/installation/) and
+   [Run Plain Pods](https://kueue.sigs.k8s.io/docs/tasks/run/plain_pods/).
+2. **Provision a ClusterQueue and a LocalQueue** in the namespace Caesium runs
+   pods in (`CAESIUM_KUBERNETES_NAMESPACE`). The `queueName` in a job manifest
+   must match a LocalQueue `metadata.name`.
+3. Ensure Caesium's namespace is in scope for Kueue's
+   `managedJobsNamespaceSelector` (it must not be excluded like `kube-system`).
+
+### Job manifest
+
+```yaml
+steps:
+  - name: train
+    engine: kubernetes
+    image: ghcr.io/acme/trainer:1.4
+    kueue:
+      queueName: data-eng     # an existing Kueue LocalQueue in the pod namespace
+```
+
+The queue is scheduling metadata, not an execution input, so it is excluded from
+Caesium's cache identity hash — changing the queue never busts the task cache.
+The full field shape is in
+[`job-schema-reference.md`](job-schema-reference.md#kueue). A pod stuck in the
+`SchedulingGated` state is waiting on Kueue quota; inspect its Workload with
+`kubectl get workloads` and the [Kueue pod troubleshooting guide](https://kueue.sigs.k8s.io/docs/tasks/troubleshooting/troubleshooting_pods/).
+
 ## Persistence and Backup
 
 - dqlite data is stored under `/var/lib/caesium/dqlite` in each pod.

--- a/internal/atom/kubernetes/engine.go
+++ b/internal/atom/kubernetes/engine.go
@@ -24,6 +24,14 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// kueueQueueLabel is the label Kueue reads to assign a workload to a LocalQueue.
+// Stamping it on the pod delegates admission to Kueue: its webhook gates the pod
+// (injecting the kueue.x-k8s.io/admission scheduling gate) until the named
+// queue's quota is available, then un-gates it. Caesium never bin-packs or
+// schedules itself — it hands scheduling to Kueue. See
+// https://kueue.sigs.k8s.io/docs/tasks/run/plain_pods/.
+const kueueQueueLabel = "kueue.x-k8s.io/queue-name"
+
 // Engine defines the interface for treating the
 // Kubernetes API as a atom.Engine.
 type Engine interface {
@@ -149,6 +157,13 @@ func (e *kubernetesEngine) Create(req *atom.EngineCreateRequest) (atom.Atom, err
 		}
 		if req.Spec.Kubernetes.AutomountServiceAccountToken != nil {
 			spec.Spec.AutomountServiceAccountToken = req.Spec.Kubernetes.AutomountServiceAccountToken
+		}
+		// Delegate admission to Kueue. The label is all Caesium sets — Kueue's
+		// webhook gates the pod (injecting the kueue.x-k8s.io/admission
+		// scheduling gate, the pod-level equivalent of a suspended Job) until the
+		// LocalQueue has quota, then un-gates it. Caesium does not schedule.
+		if q := req.Spec.Kubernetes.QueueName; q != "" {
+			spec.Labels[kueueQueueLabel] = q
 		}
 	}
 

--- a/internal/atom/kubernetes/engine_test.go
+++ b/internal/atom/kubernetes/engine_test.go
@@ -210,6 +210,66 @@ func (s *KubernetesTestSuite) TestCreateAppliesResolvedVolumesAndIdentity() {
 	s.engine.backend.(*mockKubernetesBackend).AssertExpectations(s.T())
 }
 
+// TestCreateDelegatesToKueue asserts that a step declaring a Kueue queue stamps
+// the kueue.x-k8s.io/queue-name label on the created pod (and preserves the
+// Caesium management label). The label is all Caesium sets — Kueue's webhook
+// gates the pod for admission, which is how scheduling is delegated rather than
+// performed by Caesium.
+func (s *KubernetesTestSuite) TestCreateDelegatesToKueue() {
+	req := &atom.EngineCreateRequest{
+		Name:    testAtomID,
+		Image:   testImage,
+		Command: []string{"test"},
+		Spec: container.Spec{
+			Kubernetes: &container.KubernetesSpec{
+				QueueName: "data-eng",
+			},
+		},
+	}
+
+	podMatcher := mock.MatchedBy(func(pod *v1.Pod) bool {
+		if pod.Labels[kueueQueueLabel] != "data-eng" {
+			return false
+		}
+		// The Caesium management label must not be clobbered by the queue label.
+		if _, ok := pod.Labels[atom.Label]; !ok {
+			return false
+		}
+		return true
+	})
+
+	s.engine.backend.(*mockKubernetesBackend).
+		On("Create", podMatcher).
+		Return()
+
+	_, err := s.engine.Create(req)
+	s.Require().NoError(err)
+	s.engine.backend.(*mockKubernetesBackend).AssertExpectations(s.T())
+}
+
+// TestCreateNoQueueOmitsKueueLabel asserts the queue label is absent when no
+// queue is declared, so non-Kueue clusters are unaffected.
+func (s *KubernetesTestSuite) TestCreateNoQueueOmitsKueueLabel() {
+	req := &atom.EngineCreateRequest{
+		Name:    testAtomID,
+		Image:   testImage,
+		Command: []string{"test"},
+	}
+
+	podMatcher := mock.MatchedBy(func(pod *v1.Pod) bool {
+		_, hasQueue := pod.Labels[kueueQueueLabel]
+		return !hasQueue
+	})
+
+	s.engine.backend.(*mockKubernetesBackend).
+		On("Create", podMatcher).
+		Return()
+
+	_, err := s.engine.Create(req)
+	s.Require().NoError(err)
+	s.engine.backend.(*mockKubernetesBackend).AssertExpectations(s.T())
+}
+
 func (s *KubernetesTestSuite) TestCreateError() {
 	req := &atom.EngineCreateRequest{
 		Name:    "",

--- a/internal/cache/hash.go
+++ b/internal/cache/hash.go
@@ -168,7 +168,7 @@ func (h HashInput) CanonicalJSON(precomputed string) ([]byte, error) {
 		WorkDir:              h.WorkDir,
 		Mounts:               sortedMounts(h.Mounts),
 		ResolvedVolumeMounts: sortedVolumeMounts(h.ResolvedVolumeMounts),
-		Kubernetes:           h.Kubernetes,
+		Kubernetes:           hashableKubernetes(h.Kubernetes),
 		PredecessorHashes:    sortedCopy(h.PredecessorHashes),
 		PredecessorOutputs:   h.PredecessorOutputs,
 		RunParams:            h.RunParams,
@@ -324,7 +324,15 @@ func (h HashInput) Compute() string {
 		w(digest, "volume_mount:%s\n", volumeMountSortKey(m))
 	}
 
-	if h.Kubernetes != nil {
+	// Gate on HasIdentityFields, not a nil check: a KubernetesSpec whose ONLY
+	// populated field is QueueName carries no execution identity, so it must hash
+	// byte-identically to an absent spec. QueueName (the Kueue LocalQueue) is
+	// deliberately NOT folded in below — it is scheduling metadata, like secrets
+	// and workload identity, not an execution input: two otherwise-identical
+	// tasks that differ only in queue must share one cache identity, or a
+	// scheduling tweak would silently bust the cache. hashableKubernetes()
+	// likewise strips it from the persisted blob so the two stay in lockstep.
+	if h.Kubernetes.HasIdentityFields() {
 		w(digest, "kubernetes.service_account:%s\n", h.Kubernetes.ServiceAccountName)
 		if h.Kubernetes.AutomountServiceAccountToken != nil {
 			w(digest, "kubernetes.automount:%t\n", *h.Kubernetes.AutomountServiceAccountToken)
@@ -403,4 +411,21 @@ func canonicalJSON(value any) string {
 		return fmt.Sprintf("%v", value)
 	}
 	return string(data)
+}
+
+// hashableKubernetes returns the KubernetesSpec stripped of fields that do not
+// contribute to the cache identity, so the persisted blob (CanonicalJSON) lists
+// exactly the fields Compute() folds in. Today that means dropping QueueName:
+// the Kueue queue is scheduling metadata, not an execution input, and must not
+// appear in the identity record any more than it appears in the hash. A spec
+// whose only content was QueueName has no identity fields and collapses to nil —
+// matching Compute(), which skips the Kubernetes block unless HasIdentityFields.
+// It returns a copy and never mutates the caller's spec. nil in, nil out.
+func hashableKubernetes(k *container.KubernetesSpec) *container.KubernetesSpec {
+	if !k.HasIdentityFields() {
+		return nil
+	}
+	out := *k
+	out.QueueName = ""
+	return &out
 }

--- a/internal/cache/hash_test.go
+++ b/internal/cache/hash_test.go
@@ -510,3 +510,79 @@ func TestCanonicalJSON_EmptyInput(t *testing.T) {
 	assert.Nil(t, blob.Env)
 	assert.Nil(t, blob.Oversized)
 }
+
+// --- Kueue queue name (scheduling metadata, excluded from identity) ---
+
+// TestCompute_KueueQueueNameExcluded is the B1 cache-identity guarantee: the
+// Kueue queue is scheduling metadata, not an execution input, so two otherwise
+// identical tasks that differ ONLY in queue name must produce the SAME hash —
+// changing the queue must never bust the cache.
+func TestCompute_KueueQueueNameExcluded(t *testing.T) {
+	a := baseInput()
+	a.Kubernetes = &container.KubernetesSpec{QueueName: "team-a"}
+	b := baseInput()
+	b.Kubernetes = &container.KubernetesSpec{QueueName: "team-b"}
+	assert.Equal(t, a.Compute(), b.Compute(),
+		"queue name is scheduling metadata and must not change the cache hash")
+}
+
+// TestCompute_KueueQueueOnlyEqualsNoKubernetes asserts that a KubernetesSpec
+// whose only populated field is QueueName hashes byte-identically to a task with
+// no KubernetesSpec at all. Without this, setting a queue on an otherwise
+// non-k8s-identity task would silently bust its cache.
+func TestCompute_KueueQueueOnlyEqualsNoKubernetes(t *testing.T) {
+	noK8s := baseInput()
+	queueOnly := baseInput()
+	queueOnly.Kubernetes = &container.KubernetesSpec{QueueName: "team-a"}
+	assert.Equal(t, noK8s.Compute(), queueOnly.Compute(),
+		"a queue-only KubernetesSpec carries no identity and must match an absent one")
+}
+
+// TestCompute_KueueQueueNameDoesNotMaskIdentityFields guards the inverse: adding
+// a queue must not erase the contribution of real identity fields. The hash with
+// identity fields present must still differ from one without them, whether or not
+// a queue is also set.
+func TestCompute_KueueQueueNameDoesNotMaskIdentityFields(t *testing.T) {
+	plain := baseInput()
+	withSA := baseInput()
+	withSA.Kubernetes = &container.KubernetesSpec{ServiceAccountName: "deployer"}
+	withSAAndQueue := baseInput()
+	withSAAndQueue.Kubernetes = &container.KubernetesSpec{ServiceAccountName: "deployer", QueueName: "team-a"}
+
+	assert.NotEqual(t, plain.Compute(), withSA.Compute(),
+		"service account is an identity field and must change the hash")
+	assert.Equal(t, withSA.Compute(), withSAAndQueue.Compute(),
+		"adding a queue on top of identity fields must not change the hash")
+}
+
+// TestCanonicalJSON_KueueQueueNameStrippedFromBlob asserts the persisted
+// decomposed blob (the basis of `caesium why`) never records the queue name, so
+// the identity record stays in lockstep with the hash — a queue change must not
+// even appear as a field-level diff.
+func TestCanonicalJSON_KueueQueueNameStrippedFromBlob(t *testing.T) {
+	in := baseInput()
+	in.Kubernetes = &container.KubernetesSpec{ServiceAccountName: "deployer", QueueName: "team-a"}
+	data, err := canonicalBlob(t, in)
+	require.NoError(t, err)
+
+	// The raw JSON must not mention the queue at all.
+	assert.NotContains(t, string(data), "team-a", "queue name must not appear in the blob")
+	assert.NotContains(t, string(data), "queueName", "queueName key must not appear in the blob")
+
+	blob := unmarshalBlob(t, data)
+	require.NotNil(t, blob.Kubernetes, "identity-bearing k8s fields must still be recorded")
+	assert.Equal(t, "deployer", blob.Kubernetes.ServiceAccountName)
+	assert.Empty(t, blob.Kubernetes.QueueName, "queue name must be stripped from the persisted blob")
+}
+
+// TestCanonicalJSON_KueueQueueOnlyOmitsKubernetes asserts that when the queue was
+// the only reason a KubernetesSpec existed, the blob omits the Kubernetes object
+// entirely — matching Compute(), which skips it unless HasIdentityFields.
+func TestCanonicalJSON_KueueQueueOnlyOmitsKubernetes(t *testing.T) {
+	in := baseInput()
+	in.Kubernetes = &container.KubernetesSpec{QueueName: "team-a"}
+	data, err := canonicalBlob(t, in)
+	require.NoError(t, err)
+	blob := unmarshalBlob(t, data)
+	assert.Nil(t, blob.Kubernetes, "a queue-only KubernetesSpec must not appear in the blob")
+}

--- a/internal/jobdef/report/report.go
+++ b/internal/jobdef/report/report.go
@@ -136,6 +136,7 @@ func Markdown() string {
 	b.WriteString("| `serviceAccountName` | string | optional | Kubernetes ServiceAccount for this step's pod. |\n")
 	b.WriteString("| `podAnnotations` | map[string]string | optional | Kubernetes pod annotations for this step. |\n")
 	b.WriteString("| `automountServiceAccountToken` | boolean | optional | Kubernetes pod service-account token setting for this step. |\n")
+	b.WriteString("| `kueue` | object | optional | Delegate this step's admission to a Kueue LocalQueue (kubernetes engine only). See [Kueue](#kueue) below. Excluded from the cache identity hash — it is scheduling metadata, not an execution input. |\n")
 	b.WriteString("| `next` | array[string] | optional | Successor steps triggered when this step completes. Accepts either a string or list in manifests. |\n")
 	b.WriteString("| `dependsOn` | array[string] | optional | Predecessor steps that must complete before this step can run. |\n")
 	b.WriteString("| `retries` | integer | optional | Number of retry attempts after the initial failure. |\n")
@@ -153,6 +154,13 @@ func Markdown() string {
 	b.WriteString("| `version` | integer | optional | Bump to invalidate existing cache entries without changing task definition. |\n")
 	b.WriteString("| `pinDigests` | boolean | optional | Resolve each step's image tag to its content digest (`sha256:…`) and fold the digest, not the mutable tag, into the cache key. A tag that moves to new content (e.g. a re-pushed `:latest`) then produces a cache **miss** instead of serving a stale hit. Defaults to `CAESIUM_CACHE_PIN_DIGESTS`. Set at job (`metadata.cache`) or step level; a step value overrides the job default. Resolution is opt-in because it costs a registry round-trip on first sight; the resolved tag→digest mapping is cached for `digestTTL` so steady-state runs pay no network cost. |\n")
 	b.WriteString("| `digestTTL` | duration string or 0 | optional | How long a resolved tag→digest mapping is reused before re-resolution (a **perf cache**). Within the window a moved tag is **not** re-detected — the prior digest is served. `0` re-resolves on every check, so a moved tag is detected immediately at the cost of a registry round-trip per check. Defaults to `CAESIUM_CACHE_DIGEST_TTL` (5m). Only meaningful with `pinDigests`. |\n\n")
+
+	b.WriteString("### Kueue\n\n")
+	b.WriteString("`kueue` delegates a step's scheduling to [Kueue](https://kueue.sigs.k8s.io/), the Kubernetes-native job-queueing controller. Caesium does not bin-pack, prioritize, or gang-schedule — when `kueue` is set on a `kubernetes` step, Caesium stamps the `kueue.x-k8s.io/queue-name` label on the created pod and Kueue gates admission against the named LocalQueue's quota, holding the pod (via the `kueue.x-k8s.io/admission` scheduling gate its webhook injects) until capacity is available. This is only valid on the `kubernetes` engine; `docker`/`podman` reject it.\n\n")
+	b.WriteString("| Field | Type | Required | Notes |\n")
+	b.WriteString("|-------|------|----------|-------|\n")
+	b.WriteString("| `queueName` | string | required | The Kueue LocalQueue (in the pod's namespace) to admit through. Becomes the value of the `kueue.x-k8s.io/queue-name` label. |\n\n")
+	b.WriteString("The queue is **scheduling metadata, not an execution input**, so it is excluded from the cache identity hash exactly like secrets and workload identity: two otherwise-identical tasks that differ only in queue share one cache identity, and re-queuing a task never busts its cache. Your cluster must have Kueue installed with the LocalQueue (and a backing ClusterQueue) provisioned; see [`kubernetes-deployment.md`](kubernetes-deployment.md#delegating-scheduling-to-kueue).\n\n")
 
 	b.WriteString("## Secret References\n\n")
 	b.WriteString("Use `secret://` URIs for sensitive values. Supported providers: `env`, `k8s`, `vault`. See `docs/job-definitions.md` for details.\n")

--- a/pkg/container/spec.go
+++ b/pkg/container/spec.go
@@ -71,6 +71,28 @@ type KubernetesSpec struct {
 	ServiceAccountName           string            `json:"serviceAccountName,omitempty" yaml:"serviceAccountName,omitempty"`
 	PodAnnotations               map[string]string `json:"podAnnotations,omitempty" yaml:"podAnnotations,omitempty"`
 	AutomountServiceAccountToken *bool             `json:"automountServiceAccountToken,omitempty" yaml:"automountServiceAccountToken,omitempty"`
+	// QueueName is the Kueue LocalQueue this task is admitted through. When set,
+	// the Kubernetes engine stamps the `kueue.x-k8s.io/queue-name` label on the
+	// created pod and delegates admission to Kueue, which gates scheduling until
+	// quota is available. It is pure scheduling metadata — Caesium never
+	// bin-packs or schedules itself — and is therefore deliberately EXCLUDED
+	// from the cache identity hash (see internal/cache/hash.go): two otherwise
+	// identical tasks that differ only in queue must share one cache identity.
+	QueueName string `json:"queueName,omitempty" yaml:"queueName,omitempty"`
+}
+
+// HasIdentityFields reports whether the spec carries any field that contributes
+// to a task's cache identity (service account, pod annotations, automount).
+// QueueName is excluded: it is scheduling metadata, not an execution input, so a
+// spec whose only populated field is QueueName has no identity content and the
+// cache hash must treat it the same as an absent KubernetesSpec.
+func (k *KubernetesSpec) HasIdentityFields() bool {
+	if k == nil {
+		return false
+	}
+	return k.ServiceAccountName != "" ||
+		len(k.PodAnnotations) > 0 ||
+		k.AutomountServiceAccountToken != nil
 }
 
 // Spec captures shared container runtime knobs regardless of engine.

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -169,7 +169,10 @@ type VolumeMount struct {
 type Kueue struct {
 	// QueueName is the Kueue LocalQueue (in the pod's namespace) to admit
 	// through. It is the value of the `kueue.x-k8s.io/queue-name` label.
-	QueueName string `yaml:"queueName" json:"queueName"`
+	// omitempty keeps the marshaled form symmetric with
+	// container.KubernetesSpec.QueueName; an empty value is unreachable through
+	// normal parsing because Validate() rejects a blank queueName.
+	QueueName string `yaml:"queueName,omitempty" json:"queueName,omitempty"`
 }
 
 // Step defines an execution step.

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -38,6 +38,13 @@ const (
 
 var simpleJSONPathPattern = regexp.MustCompile(`^\$(?:\.[^.\s]+)*$`)
 
+// kueueQueueNamePattern matches a Kubernetes DNS-1123 label, the form Kueue
+// requires for a LocalQueue name (which Caesium emits verbatim as the
+// `kueue.x-k8s.io/queue-name` label value). Validating it at lint time turns an
+// invalid name into an upfront `caesium job lint` error rather than a pod that
+// the API server rejects at apply/run time.
+var kueueQueueNamePattern = regexp.MustCompile(`^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$`)
+
 // Definition models the root job document.
 type Definition struct {
 	Schema     string     `yaml:"$schema,omitempty" json:"$schema,omitempty"`
@@ -688,8 +695,16 @@ func validateStepVolumeMounts(steps []Step, volumes map[string]*Volume) error {
 				return fmt.Errorf("steps[%d].kueue is only supported for kubernetes steps", i)
 			}
 		}
-		if step.Kueue != nil && strings.TrimSpace(step.Kueue.QueueName) == "" {
-			return fmt.Errorf("steps[%d].kueue.queueName is required when kueue is set", i)
+		if step.Kueue != nil {
+			queueName := strings.TrimSpace(step.Kueue.QueueName)
+			switch {
+			case queueName == "":
+				return fmt.Errorf("steps[%d].kueue.queueName is required when kueue is set", i)
+			case len(queueName) > 63:
+				return fmt.Errorf("steps[%d].kueue.queueName %q must be at most 63 characters", i, queueName)
+			case !kueueQueueNamePattern.MatchString(queueName):
+				return fmt.Errorf("steps[%d].kueue.queueName %q must be a valid DNS-1123 label (lowercase alphanumeric, '-' or '.', starting and ending with an alphanumeric)", i, queueName)
+			}
 		}
 	}
 	return nil

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -153,6 +153,18 @@ type VolumeMount struct {
 	SubPath  string `yaml:"subPath,omitempty" json:"subPath,omitempty"`
 }
 
+// Kueue declares that a step delegates admission to Kueue. When set on a
+// kubernetes step, Caesium stamps the `kueue.x-k8s.io/queue-name` label on the
+// created pod so Kueue gates scheduling against the named LocalQueue's quota and
+// admits the task only when capacity is available. Caesium never bin-packs or
+// prioritizes itself — it delegates scheduling to Kueue — so this field is pure
+// scheduling metadata and is excluded from the cache identity hash.
+type Kueue struct {
+	// QueueName is the Kueue LocalQueue (in the pod's namespace) to admit
+	// through. It is the value of the `kueue.x-k8s.io/queue-name` label.
+	QueueName string `yaml:"queueName" json:"queueName"`
+}
+
 // Step defines an execution step.
 type Step struct {
 	Name                         string            `yaml:"name" json:"name"`
@@ -171,6 +183,9 @@ type Step struct {
 	ServiceAccountName           string            `yaml:"serviceAccountName,omitempty" json:"serviceAccountName,omitempty"`
 	PodAnnotations               map[string]string `yaml:"podAnnotations,omitempty" json:"podAnnotations,omitempty"`
 	AutomountServiceAccountToken *bool             `yaml:"automountServiceAccountToken,omitempty" json:"automountServiceAccountToken,omitempty"`
+	// Kueue delegates this step's admission to a Kueue LocalQueue (kubernetes
+	// engine only). It is scheduling metadata and does not affect the cache hash.
+	Kueue *Kueue `yaml:"kueue,omitempty" json:"kueue,omitempty"`
 	// OutputSchema is a JSON Schema describing this step's expected output keys.
 	OutputSchema map[string]any `yaml:"outputSchema,omitempty" json:"outputSchema,omitempty"`
 	// InputSchema maps predecessor step names to JSON Schema fragments describing
@@ -199,6 +214,7 @@ func (s *Step) UnmarshalYAML(value *yaml.Node) error {
 		ServiceAccountName           string                    `yaml:"serviceAccountName"`
 		PodAnnotations               map[string]string         `yaml:"podAnnotations"`
 		AutomountServiceAccountToken *bool                     `yaml:"automountServiceAccountToken"`
+		Kueue                        *Kueue                    `yaml:"kueue"`
 		OutputSchema                 map[string]any            `yaml:"outputSchema"`
 		InputSchema                  map[string]map[string]any `yaml:"inputSchema"`
 		Cache                        interface{}               `yaml:"cache"`
@@ -242,6 +258,7 @@ func (s *Step) UnmarshalYAML(value *yaml.Node) error {
 	s.ServiceAccountName = rs.ServiceAccountName
 	s.PodAnnotations = rs.PodAnnotations
 	s.AutomountServiceAccountToken = rs.AutomountServiceAccountToken
+	s.Kueue = rs.Kueue
 	s.OutputSchema = rs.OutputSchema
 	s.InputSchema = rs.InputSchema
 	s.Cache = rs.Cache
@@ -270,6 +287,7 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 		ServiceAccountName           string                    `json:"serviceAccountName"`
 		PodAnnotations               map[string]string         `json:"podAnnotations"`
 		AutomountServiceAccountToken *bool                     `json:"automountServiceAccountToken"`
+		Kueue                        *Kueue                    `json:"kueue"`
 		OutputSchema                 map[string]any            `json:"outputSchema"`
 		InputSchema                  map[string]map[string]any `json:"inputSchema"`
 		Cache                        interface{}               `json:"cache"`
@@ -303,6 +321,7 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 	s.ServiceAccountName = rs.ServiceAccountName
 	s.PodAnnotations = rs.PodAnnotations
 	s.AutomountServiceAccountToken = rs.AutomountServiceAccountToken
+	s.Kueue = rs.Kueue
 	s.OutputSchema = rs.OutputSchema
 	s.InputSchema = rs.InputSchema
 	s.Cache = rs.Cache
@@ -665,6 +684,12 @@ func validateStepVolumeMounts(steps []Step, volumes map[string]*Volume) error {
 			if step.AutomountServiceAccountToken != nil {
 				return fmt.Errorf("steps[%d].automountServiceAccountToken is only supported for kubernetes steps", i)
 			}
+			if step.Kueue != nil {
+				return fmt.Errorf("steps[%d].kueue is only supported for kubernetes steps", i)
+			}
+		}
+		if step.Kueue != nil && strings.TrimSpace(step.Kueue.QueueName) == "" {
+			return fmt.Errorf("steps[%d].kueue.queueName is required when kueue is set", i)
 		}
 	}
 	return nil
@@ -738,7 +763,10 @@ func (d *Definition) RuntimeSpecForStep(step *Step) (container.Spec, error) {
 		if step.AutomountServiceAccountToken != nil {
 			k8sSpec.AutomountServiceAccountToken = cloneBoolPtr(step.AutomountServiceAccountToken)
 		}
-		if k8sSpec.ServiceAccountName != "" || len(k8sSpec.PodAnnotations) > 0 || k8sSpec.AutomountServiceAccountToken != nil {
+		if step.Kueue != nil {
+			k8sSpec.QueueName = strings.TrimSpace(step.Kueue.QueueName)
+		}
+		if k8sSpec.ServiceAccountName != "" || len(k8sSpec.PodAnnotations) > 0 || k8sSpec.AutomountServiceAccountToken != nil || k8sSpec.QueueName != "" {
 			spec.Kubernetes = k8sSpec
 		}
 	}
@@ -823,6 +851,7 @@ func cloneContainerSpec(spec container.Spec) container.Spec {
 			ServiceAccountName:           spec.Kubernetes.ServiceAccountName,
 			PodAnnotations:               cloneStringMap(spec.Kubernetes.PodAnnotations),
 			AutomountServiceAccountToken: cloneBoolPtr(spec.Kubernetes.AutomountServiceAccountToken),
+			QueueName:                    spec.Kubernetes.QueueName,
 		}
 	}
 	return out

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/caesium-cloud/caesium/pkg/container"
@@ -372,6 +373,45 @@ steps:
     image: example
     kueue: {queueName: "  "}
 `,
+		"kueue uppercase queue name": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: cron
+  configuration: {cron: "* * * * *"}
+steps:
+  - name: build
+    engine: kubernetes
+    image: example
+    kueue: {queueName: Data-Eng}
+`,
+		"kueue queue name with spaces": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: cron
+  configuration: {cron: "* * * * *"}
+steps:
+  - name: build
+    engine: kubernetes
+    image: example
+    kueue: {queueName: "data eng"}
+`,
+		"kueue queue name too long": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: cron
+  configuration: {cron: "* * * * *"}
+steps:
+  - name: build
+    engine: kubernetes
+    image: example
+    kueue: {queueName: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}
+`,
 	}
 
 	for name, src := range cases {
@@ -476,6 +516,39 @@ steps:
 	require.Equal(t, "data-eng", clusterSpec.Kubernetes.QueueName)
 	// The queue alone carries no execution identity.
 	require.False(t, clusterSpec.Kubernetes.HasIdentityFields())
+}
+
+// TestKueueQueueNameAcceptsValidDNSLabels asserts the queueName validation
+// accepts the DNS-1123 forms Kueue uses for a LocalQueue name — a plain label, a
+// dotted subdomain, and the 63-character boundary — so the guard rejects only
+// genuinely invalid names. The invalid forms (uppercase, spaces, >63 chars) are
+// covered as error cases in TestParseInvalidDefinitions.
+func TestKueueQueueNameAcceptsValidDNSLabels(t *testing.T) {
+	valid := []string{
+		"data-eng",
+		"gpu.shared",
+		"q0",
+		strings.Repeat("a", 63), // length boundary
+	}
+	for _, name := range valid {
+		src := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: kueue-valid
+trigger:
+  type: cron
+  configuration: {cron: "0 * * * *"}
+steps:
+  - name: cluster
+    engine: kubernetes
+    image: alpine:3.23
+    kueue:
+      queueName: ` + name + `
+`
+		_, err := Parse([]byte(src))
+		require.NoErrorf(t, err, "queueName %q should be valid", name)
+	}
 }
 
 func TestLegacyMountRelativeTargetStillValidates(t *testing.T) {

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -347,6 +347,31 @@ steps:
     image: example
     serviceAccountName: deployer
 `,
+		"kueue on docker": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: cron
+  configuration: {cron: "* * * * *"}
+steps:
+  - name: build
+    image: example
+    kueue: {queueName: data-eng}
+`,
+		"kueue missing queue name": `apiVersion: v1
+kind: Job
+metadata:
+  alias: test
+trigger:
+  type: cron
+  configuration: {cron: "* * * * *"}
+steps:
+  - name: build
+    engine: kubernetes
+    image: example
+    kueue: {queueName: "  "}
+`,
 	}
 
 	for name, src := range cases {
@@ -413,6 +438,44 @@ steps:
 	require.Equal(t, map[string]string{"team": "platform", "purpose": "deploy"}, clusterSpec.Kubernetes.PodAnnotations)
 	require.NotNil(t, clusterSpec.Kubernetes.AutomountServiceAccountToken)
 	require.False(t, *clusterSpec.Kubernetes.AutomountServiceAccountToken)
+}
+
+// TestKueueDelegationRuntimeSpec asserts a kubernetes step declaring a Kueue
+// queue threads the queue name into the runtime KubernetesSpec (the carrier the
+// engine reads to stamp the kueue.x-k8s.io/queue-name label), and that a docker
+// step is unaffected. Validation already rejects kueue on non-kubernetes steps;
+// here a queue-only kubernetes step must still materialize a KubernetesSpec.
+func TestKueueDelegationRuntimeSpec(t *testing.T) {
+	src := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: kueue-delegation
+trigger:
+  type: cron
+  configuration: {cron: "0 * * * *"}
+steps:
+  - name: local
+    image: alpine:3.23
+  - name: cluster
+    engine: kubernetes
+    image: alpine:3.23
+    kueue:
+      queueName: data-eng
+`
+	def, err := Parse([]byte(src))
+	require.NoError(t, err)
+
+	localSpec, err := def.RuntimeSpecForStep(&def.Steps[0])
+	require.NoError(t, err)
+	require.Nil(t, localSpec.Kubernetes, "docker step must not carry a KubernetesSpec")
+
+	clusterSpec, err := def.RuntimeSpecForStep(&def.Steps[1])
+	require.NoError(t, err)
+	require.NotNil(t, clusterSpec.Kubernetes, "a queue-only kubernetes step must materialize a KubernetesSpec")
+	require.Equal(t, "data-eng", clusterSpec.Kubernetes.QueueName)
+	// The queue alone carries no execution identity.
+	require.False(t, clusterSpec.Kubernetes.HasIdentityFields())
 }
 
 func TestLegacyMountRelativeTargetStillValidates(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements **B1** of the [`sovereignty-execution`](docs/exec-plans/active/sovereignty-execution.md) plan: a Kueue passthrough that answers "why not Kueue?" by *using* Kueue for admission instead of reimplementing scheduling. Per the project posture — **delegate scheduling to Kueue; never bin-pack** — Caesium only sets a label and lets Kueue gate the workload.

A step declares:

```yaml
steps:
  - name: train
    engine: kubernetes      # rejected on docker/podman
    image: ghcr.io/acme/trainer:1.4
    kueue:
      queueName: data-eng
```

On the kubernetes engine, Caesium stamps the `kueue.x-k8s.io/queue-name` label on the pod it creates. Kueue's webhook then gates the pod — injecting the `kueue.x-k8s.io/admission` scheduling gate (the pod-level equivalent of a suspended `batch/v1` Job; Caesium's engine creates a Pod, not a Job) — holding it out of scheduling until the named LocalQueue has quota, and un-gating it on admission. Caesium never schedules the pod itself.

## Cache-hash exclusion (the load-bearing invariant)

The queue is **scheduling metadata, not an execution input**, so it is excluded from the cache identity hash exactly like secrets and workload identity — two otherwise-identical tasks that differ only in queue **must** produce the same identity hash, or a scheduling tweak would silently bust the cache. Implemented as:

- The field is carried on `container.KubernetesSpec.QueueName`.
- `Compute()` gates the Kubernetes block on a new `KubernetesSpec.HasIdentityFields()` (service account / pod annotations / automount) — **not** a nil check — so a queue-only spec hashes byte-identically to an absent spec, and `QueueName` is never folded into the digest.
- `CanonicalJSON()` (the `caesium why` blob) routes the spec through `hashableKubernetes()`, which clears `QueueName` and collapses a queue-only spec to nil, keeping the persisted identity record in lockstep with the hash.

`internal/cache/hash_test.go` asserts: identical hash with two different queues; queue-only spec equals no-Kubernetes-spec; a queue does not mask real identity fields; and the queue name appears in neither the blob nor as a field-level diff.

## Files

- `pkg/container/spec.go` — `QueueName` carrier + `HasIdentityFields()`
- `pkg/jobdef/definition.go` — the `kueue` step field, kubernetes-only + non-empty validation, threading into the runtime `KubernetesSpec`
- `internal/atom/kubernetes/engine.go` — stamps the `kueue.x-k8s.io/queue-name` label (kubernetes engine only)
- `internal/cache/hash.go` — the exclusion (`HasIdentityFields` gate + `hashableKubernetes`) and tests
- `internal/jobdef/report/report.go` — schema-doc generator (so the generated reference stays current)
- Docs: `docs/job-schema-reference.md` (regenerated), `docs/caesium-job-llm-reference.md`, `docs/kubernetes-deployment.md`
- `docs/examples-k8s/kueue-delegation.job.yaml` — example manifest

## Tests

- `just lint` — **0 issues** (go fmt + go vet + golangci-lint)
- `just unit-test` — **all green**, 0 failures across the full suite
- New unit tests: cache-hash exclusion (`internal/cache/hash_test.go`), engine label behavior (`internal/atom/kubernetes/engine_test.go`), schema validation + runtime-spec threading (`pkg/jobdef/definition_test.go`); the example parses via the repo-examples guardrail.

Plan item B1 ticked; `## Progress` updated (Wave 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)