### PR TITLE
Fix CLI log stdout contamination + wire lineage dataset persistence

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -83,6 +83,11 @@ var (
 )
 
 func start(cmd *cobra.Command, args []string) error {
+	// The server logs to stdout (main() defaulted the CLI to stderr). Restore
+	// stdout BEFORE CaptureStderr redirects fd 2 through a pipe back into the
+	// logger — routing logs to stderr here would feed that pipe in a loop.
+	log.ToStdout()
+
 	if err := log.CaptureStderr(); err != nil {
 		log.Warn("failed to capture stderr for unified logging", "error", err)
 	}

--- a/internal/lineage/impact_test.go
+++ b/internal/lineage/impact_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
@@ -315,6 +316,91 @@ func (s *ImpactSuite) createJobAndRunWithRepo(alias, commit, repo string) (*mode
 	s.Require().NoError(s.db.Create(taskRun).Error)
 
 	return job, taskRun
+}
+
+// createTaskWithRun seeds a named task (with optional declared schemas) plus its
+// succeeded task run under the given job, and returns the task run.
+func (s *ImpactSuite) createTaskWithRun(jobID, jobRunID uuid.UUID, name string, inputSchema, outputSchema []byte) *models.TaskRun {
+	atomID := uuid.New()
+	s.Require().NoError(s.db.Create(&models.Atom{
+		ID: atomID, Engine: models.AtomEngineDocker, Image: "alpine:3.23",
+	}).Error)
+	task := &models.Task{
+		ID:           uuid.New(),
+		JobID:        jobID,
+		AtomID:       atomID,
+		Name:         name,
+		InputSchema:  datatypes.JSON(inputSchema),
+		OutputSchema: datatypes.JSON(outputSchema),
+	}
+	s.Require().NoError(s.db.Create(task).Error)
+	tr := &models.TaskRun{
+		ID: uuid.New(), JobRunID: jobRunID, TaskID: task.ID, AtomID: atomID,
+		Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: "[]",
+		Status: "succeeded", Attempt: 1,
+	}
+	s.Require().NoError(s.db.Create(tr).Error)
+	return tr
+}
+
+// TestMapperPersistsAndLinksImpact is the end-to-end regression for the
+// data-plane-memory lineage impact feature: it drives the REAL mapper path
+// (which resolves step names + schemas from the task record and persists the
+// dataset graph) rather than inserting synthetic lineage_datasets rows, then
+// asserts QueryImpact links a producer's output to its downstream consumer.
+// Before the fix, the mapper never persisted any datasets, so this query was
+// permanently empty even though the unit tests over hand-seeded rows passed.
+func (s *ImpactSuite) TestMapperPersistsAndLinksImpact() {
+	const ns = "caesium"
+	job, _ := s.createJobAndRun("impact-e2e", "deadbeef")
+	// Reuse the run created above (it already has one task run for impact-e2e-task).
+	var jobRun models.JobRun
+	s.Require().NoError(s.db.Where("job_id = ?", job.ID).First(&jobRun).Error)
+
+	outSchema := []byte(`{"type":"object","properties":{"rows":{"type":"string"}}}`)
+	inSchema := []byte(`{"extract":{"properties":{"rows":{"type":"string"}}}}`)
+
+	extractRun := s.createTaskWithRun(job.ID, jobRun.ID, "extract", nil, outSchema)
+	transformRun := s.createTaskWithRun(job.ID, jobRun.ID, "transform", inSchema, outSchema)
+
+	m := newMapper(ns, s.db)
+
+	// Drive a COMPLETE event for each task through the real mapper. The payload
+	// deliberately omits TaskName/schemas — enrichTaskPayload must recover them
+	// from the seeded task records.
+	for _, tr := range []*models.TaskRun{extractRun, transformRun} {
+		payload := taskRunPayload{
+			ID: tr.ID, JobRunID: jobRun.ID, TaskID: tr.TaskID,
+			Engine: "docker", Image: "alpine:3.23", Status: "succeeded",
+		}
+		evt := event.Event{
+			Type:      event.TypeTaskSucceeded,
+			JobID:     job.ID,
+			RunID:     jobRun.ID,
+			TaskID:    tr.TaskID,
+			Timestamp: time.Now().UTC(),
+			Payload:   marshalFacet(payload),
+		}
+		_, err := m.mapEvent(evt)
+		s.Require().NoError(err)
+	}
+
+	// The mapper must have written the bounded dataset graph.
+	var count int64
+	s.Require().NoError(s.db.Model(&models.LineageDataset{}).Count(&count).Error)
+	s.Greater(count, int64(0), "mapper persisted no lineage datasets")
+
+	// Impact of the producer's output must reach the consumer's output.
+	res, err := QueryImpact(s.ctx, s.db, ns, "impact-e2e.extract.output", 0)
+	s.Require().NoError(err)
+	s.Require().NotEmpty(res.Downstream, "impact query returned no downstream consumer")
+	found := false
+	for _, n := range res.Downstream {
+		if n.DatasetName == "impact-e2e.transform.output" {
+			found = true
+		}
+	}
+	s.True(found, "expected transform.output downstream of extract.output, got %+v", res.Downstream)
 }
 
 func (s *ImpactSuite) createDataset(run *models.TaskRun, ns, name, direction, stepName string) {

--- a/internal/lineage/mapper.go
+++ b/internal/lineage/mapper.go
@@ -319,6 +319,9 @@ func (m *mapper) mapTaskFail(evt event.Event) (*RunEvent, error) {
 	}
 
 	inputs, outputs := m.buildTaskDatasets(jobAlias, payload)
+	// A failed task's declared inputs (and any partial outputs) are still
+	// recorded so lineage impact queries reflect failed runs too.
+	m.persistTaskDatasets(payload, inputs, outputs)
 
 	return &RunEvent{
 		EventTime: evt.Timestamp,
@@ -561,10 +564,20 @@ func (m *mapper) persistTaskDatasets(payload taskRunPayload, inputs, outputs []D
 
 	summary, _ := json.Marshal(map[string]string{"step_name": payload.TaskName})
 	rows := make([]models.LineageDataset, 0, len(inputs)+len(outputs))
+	// Deduplicate within the batch: distinct output keys can resolve to the same
+	// dataset value (e.g. the same file path), and a duplicate
+	// (task_run, namespace, name, direction) tuple would otherwise violate the
+	// unique index within a single multi-row insert.
+	seen := make(map[string]struct{}, len(inputs)+len(outputs))
 	appendRow := func(ds Dataset, direction string) {
 		if ds.Name == "" {
 			return
 		}
+		key := ds.Namespace + "\x00" + ds.Name + "\x00" + direction
+		if _, dup := seen[key]; dup {
+			return
+		}
+		seen[key] = struct{}{}
 		rows = append(rows, models.LineageDataset{
 			ID:           uuid.New(),
 			TaskRunID:    taskRunID,

--- a/internal/lineage/mapper.go
+++ b/internal/lineage/mapper.go
@@ -8,8 +8,11 @@ import (
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
+	"gorm.io/datatypes"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
@@ -220,6 +223,7 @@ func (m *mapper) mapTaskStart(evt event.Event) (*RunEvent, error) {
 	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
 		return nil, fmt.Errorf("unmarshal task payload: %w", err)
 	}
+	m.enrichTaskPayload(&payload)
 
 	jobAlias := m.resolveJobAlias(evt.JobID, "")
 	taskJobName := fmt.Sprintf("%s.task.%s", jobAlias, payload.TaskID)
@@ -228,6 +232,12 @@ func (m *mapper) mapTaskStart(evt event.Event) (*RunEvent, error) {
 	m.addExecutionFacet(runFacets, payload)
 
 	inputs, outputs := m.buildTaskDatasets(jobAlias, payload)
+	// Persist the bounded dataset graph on each terminal task event so the
+	// cross-job impact query has edges to traverse. Without this, the
+	// lineage_datasets table is never written and /lineage/impact always
+	// returns empty. The upsert keys on (task_run, namespace, name, direction),
+	// so re-emitted events are idempotent.
+	m.persistTaskDatasets(payload, inputs, outputs)
 
 	return &RunEvent{
 		EventTime: evt.Timestamp,
@@ -253,6 +263,7 @@ func (m *mapper) mapTaskComplete(evt event.Event) (*RunEvent, error) {
 	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
 		return nil, fmt.Errorf("unmarshal task payload: %w", err)
 	}
+	m.enrichTaskPayload(&payload)
 
 	jobAlias := m.resolveJobAlias(evt.JobID, "")
 	taskJobName := fmt.Sprintf("%s.task.%s", jobAlias, payload.TaskID)
@@ -261,6 +272,12 @@ func (m *mapper) mapTaskComplete(evt event.Event) (*RunEvent, error) {
 	m.addExecutionFacet(runFacets, payload)
 
 	inputs, outputs := m.buildTaskDatasets(jobAlias, payload)
+	// Persist the bounded dataset graph on each terminal task event so the
+	// cross-job impact query has edges to traverse. Without this, the
+	// lineage_datasets table is never written and /lineage/impact always
+	// returns empty. The upsert keys on (task_run, namespace, name, direction),
+	// so re-emitted events are idempotent.
+	m.persistTaskDatasets(payload, inputs, outputs)
 
 	return &RunEvent{
 		EventTime: evt.Timestamp,
@@ -286,6 +303,7 @@ func (m *mapper) mapTaskFail(evt event.Event) (*RunEvent, error) {
 	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
 		return nil, fmt.Errorf("unmarshal task payload: %w", err)
 	}
+	m.enrichTaskPayload(&payload)
 
 	jobAlias := m.resolveJobAlias(evt.JobID, "")
 	taskJobName := fmt.Sprintf("%s.task.%s", jobAlias, payload.TaskID)
@@ -326,6 +344,7 @@ func (m *mapper) mapTaskAbort(evt event.Event) (*RunEvent, error) {
 	if err := json.Unmarshal(evt.Payload, &payload); err != nil {
 		return nil, fmt.Errorf("unmarshal task payload: %w", err)
 	}
+	m.enrichTaskPayload(&payload)
 
 	jobAlias := m.resolveJobAlias(evt.JobID, "")
 	taskJobName := fmt.Sprintf("%s.task.%s", jobAlias, payload.TaskID)
@@ -334,6 +353,12 @@ func (m *mapper) mapTaskAbort(evt event.Event) (*RunEvent, error) {
 	m.addExecutionFacet(runFacets, payload)
 
 	inputs, outputs := m.buildTaskDatasets(jobAlias, payload)
+	// Persist the bounded dataset graph on each terminal task event so the
+	// cross-job impact query has edges to traverse. Without this, the
+	// lineage_datasets table is never written and /lineage/impact always
+	// returns empty. The upsert keys on (task_run, namespace, name, direction),
+	// so re-emitted events are idempotent.
+	m.persistTaskDatasets(payload, inputs, outputs)
 
 	return &RunEvent{
 		EventTime: evt.Timestamp,
@@ -457,6 +482,116 @@ func (m *mapper) buildJobFacets(jobID uuid.UUID, jobType string) map[string]inte
 //  3. For inputs, each predecessor name listed in inputSchema becomes an input
 //     Dataset referencing that step's logical output namespace.
 //
+// taskRecord is the subset of the tasks table the lineage mapper reads to
+// recover a task's step name and declared schemas (mirrors jobRecord's pattern
+// of mapping a local struct to a table to avoid importing internal/models).
+type taskRecord struct {
+	Name         string `gorm:"column:name"`
+	OutputSchema []byte `gorm:"column:output_schema"`
+	InputSchema  []byte `gorm:"column:input_schema"`
+}
+
+func (taskRecord) TableName() string { return "tasks" }
+
+// enrichTaskPayload fills the step name and declared input/output schemas from
+// the persisted task record when the lifecycle event omitted them. The event
+// payload carries execution state, not the static task definition, so these
+// fields arrive empty — yet buildTaskDatasets needs them:
+//   - Without the step name, datasets fall back to the task UUID and never link
+//     across steps or jobs (a producer's `job.<uuid>.output` can't match a
+//     consumer's `job.<stepName>.output`).
+//   - Without the schemas, no input datasets are emitted at all, so the
+//     cross-job impact query has no edges to traverse and always returns empty.
+//
+// On any lookup failure it leaves the payload as-is — the worst case is the
+// pre-existing (degraded) behavior, never a wrong dataset.
+func (m *mapper) enrichTaskPayload(payload *taskRunPayload) {
+	if m.db == nil || payload.TaskID == uuid.Nil {
+		return
+	}
+	if payload.TaskName != "" && payload.OutputSchema != nil && payload.InputSchema != nil {
+		return
+	}
+	var rec taskRecord
+	if err := m.db.Select("name", "output_schema", "input_schema").
+		Where("id = ?", payload.TaskID).First(&rec).Error; err != nil {
+		return
+	}
+	if payload.TaskName == "" {
+		payload.TaskName = rec.Name
+	}
+	if payload.OutputSchema == nil && len(rec.OutputSchema) > 0 {
+		var os map[string]interface{}
+		if json.Unmarshal(rec.OutputSchema, &os) == nil {
+			payload.OutputSchema = os
+		}
+	}
+	if payload.InputSchema == nil && len(rec.InputSchema) > 0 {
+		var is map[string]map[string]interface{}
+		if json.Unmarshal(rec.InputSchema, &is) == nil {
+			payload.InputSchema = is
+		}
+	}
+}
+
+// persistTaskDatasets writes the task's input/output datasets to the bounded
+// lineage_datasets graph that the cross-job impact query (QueryImpact) reads.
+// It is best-effort: any failure leaves the graph as-is rather than disrupting
+// event emission. Rows are upserted on the (task_run, namespace, name,
+// direction) unique key so re-emitted lifecycle events are idempotent.
+func (m *mapper) persistTaskDatasets(payload taskRunPayload, inputs, outputs []Dataset) {
+	if m.db == nil || (len(inputs) == 0 && len(outputs) == 0) {
+		return
+	}
+	// Resolve the task_run PK (the FK target) from the run+task identity,
+	// preferring the most recent attempt. Scan into a struct (GORM cannot Scan
+	// a single column into a bare scalar).
+	var rec struct {
+		ID uuid.UUID `gorm:"column:id"`
+	}
+	if err := m.db.Table("task_runs").
+		Select("id").
+		Where("job_run_id = ? AND task_id = ?", payload.JobRunID, payload.TaskID).
+		Order("attempt DESC").
+		Limit(1).
+		Scan(&rec).Error; err != nil || rec.ID == uuid.Nil {
+		return
+	}
+	taskRunID := rec.ID
+
+	summary, _ := json.Marshal(map[string]string{"step_name": payload.TaskName})
+	rows := make([]models.LineageDataset, 0, len(inputs)+len(outputs))
+	appendRow := func(ds Dataset, direction string) {
+		if ds.Name == "" {
+			return
+		}
+		rows = append(rows, models.LineageDataset{
+			ID:           uuid.New(),
+			TaskRunID:    taskRunID,
+			Namespace:    ds.Namespace,
+			Name:         ds.Name,
+			Direction:    direction,
+			FacetSummary: datatypes.JSON(summary),
+			CreatedAt:    time.Now().UTC(),
+		})
+	}
+	for _, ds := range inputs {
+		appendRow(ds, "input")
+	}
+	for _, ds := range outputs {
+		appendRow(ds, "output")
+	}
+	if len(rows) == 0 {
+		return
+	}
+	_ = m.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "task_run_id"}, {Name: "namespace"}, {Name: "name"}, {Name: "direction"},
+		},
+		DoNothing: true,
+	}).Create(&rows).Error
+}
+
 // The namespace is always the mapper's configured namespace so datasets from
 // the same Caesium instance share a namespace and can be joined across jobs.
 func (m *mapper) buildTaskDatasets(jobAlias string, payload taskRunPayload) (inputs, outputs []Dataset) {

--- a/internal/lineage/mapper.go
+++ b/internal/lineage/mapper.go
@@ -232,11 +232,12 @@ func (m *mapper) mapTaskStart(evt event.Event) (*RunEvent, error) {
 	m.addExecutionFacet(runFacets, payload)
 
 	inputs, outputs := m.buildTaskDatasets(jobAlias, payload)
-	// Persist the bounded dataset graph on each terminal task event so the
-	// cross-job impact query has edges to traverse. Without this, the
-	// lineage_datasets table is never written and /lineage/impact always
-	// returns empty. The upsert keys on (task_run, namespace, name, direction),
-	// so re-emitted events are idempotent.
+	// Persist the bounded dataset graph on each task lifecycle event (start
+	// through terminal) so the impact query has edges to traverse — eagerly, so
+	// even an in-progress task's declared datasets are present. Without this the
+	// lineage_datasets table is never written and /lineage/impact always returns
+	// empty. The upsert keys on (task_run, namespace, name, direction), so
+	// re-emitted events are idempotent.
 	m.persistTaskDatasets(payload, inputs, outputs)
 
 	return &RunEvent{
@@ -272,11 +273,12 @@ func (m *mapper) mapTaskComplete(evt event.Event) (*RunEvent, error) {
 	m.addExecutionFacet(runFacets, payload)
 
 	inputs, outputs := m.buildTaskDatasets(jobAlias, payload)
-	// Persist the bounded dataset graph on each terminal task event so the
-	// cross-job impact query has edges to traverse. Without this, the
-	// lineage_datasets table is never written and /lineage/impact always
-	// returns empty. The upsert keys on (task_run, namespace, name, direction),
-	// so re-emitted events are idempotent.
+	// Persist the bounded dataset graph on each task lifecycle event (start
+	// through terminal) so the impact query has edges to traverse — eagerly, so
+	// even an in-progress task's declared datasets are present. Without this the
+	// lineage_datasets table is never written and /lineage/impact always returns
+	// empty. The upsert keys on (task_run, namespace, name, direction), so
+	// re-emitted events are idempotent.
 	m.persistTaskDatasets(payload, inputs, outputs)
 
 	return &RunEvent{
@@ -356,11 +358,12 @@ func (m *mapper) mapTaskAbort(evt event.Event) (*RunEvent, error) {
 	m.addExecutionFacet(runFacets, payload)
 
 	inputs, outputs := m.buildTaskDatasets(jobAlias, payload)
-	// Persist the bounded dataset graph on each terminal task event so the
-	// cross-job impact query has edges to traverse. Without this, the
-	// lineage_datasets table is never written and /lineage/impact always
-	// returns empty. The upsert keys on (task_run, namespace, name, direction),
-	// so re-emitted events are idempotent.
+	// Persist the bounded dataset graph on each task lifecycle event (start
+	// through terminal) so the impact query has edges to traverse — eagerly, so
+	// even an in-progress task's declared datasets are present. Without this the
+	// lineage_datasets table is never written and /lineage/impact always returns
+	// empty. The upsert keys on (task_run, namespace, name, direction), so
+	// re-emitted events are idempotent.
 	m.persistTaskDatasets(payload, inputs, outputs)
 
 	return &RunEvent{
@@ -546,21 +549,15 @@ func (m *mapper) persistTaskDatasets(payload taskRunPayload, inputs, outputs []D
 	if m.db == nil || (len(inputs) == 0 && len(outputs) == 0) {
 		return
 	}
-	// Resolve the task_run PK (the FK target) from the run+task identity,
-	// preferring the most recent attempt. Scan into a struct (GORM cannot Scan
-	// a single column into a bare scalar).
-	var rec struct {
-		ID uuid.UUID `gorm:"column:id"`
-	}
-	if err := m.db.Table("task_runs").
-		Select("id").
-		Where("job_run_id = ? AND task_id = ?", payload.JobRunID, payload.TaskID).
-		Order("attempt DESC").
-		Limit(1).
-		Scan(&rec).Error; err != nil || rec.ID == uuid.Nil {
+	// payload.ID is the task_run PK (the FK target): every task-event publish
+	// path sets it to the task run's own ID — the convert-based publishes and
+	// recordTaskEventTx alike — and a retried attempt emits its own event with
+	// its own ID, so this is already the right attempt. Use it directly rather
+	// than a per-event SELECT on the hot lineage path.
+	taskRunID := payload.ID
+	if taskRunID == uuid.Nil {
 		return
 	}
-	taskRunID := rec.ID
 
 	summary, _ := json.Marshal(map[string]string{"step_name": payload.TaskName})
 	rows := make([]models.LineageDataset, 0, len(inputs)+len(outputs))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -18,33 +18,49 @@ const defaultRingSize = 2000
 
 func init() {
 	logLevel = zap.NewAtomicLevelAt(zapcore.DebugLevel)
-
-	format := strings.ToLower(strings.TrimSpace(os.Getenv("CAESIUM_LOG_FORMAT")))
-
-	var encoder zapcore.Encoder
-	switch format {
-	case "text":
-		encoder = zapcore.NewConsoleEncoder(textConfig())
-	default:
-		encoder = zapcore.NewJSONEncoder(jsonConfig())
-	}
-
-	stdoutCore := zapcore.NewCore(
-		encoder,
-		zapcore.Lock(os.Stdout),
-		logLevel,
-	)
-
 	ring = NewRingBuffer(defaultRingSize, zapcore.DebugLevel)
+	// Default the structured logger to STDERR so that machine-readable command
+	// output on stdout (e.g. `caesium receipt get` → a JSON receipt piped into
+	// `caesium verify`) is never interleaved with log lines — including logs
+	// emitted from package init() functions, which run before main(). The
+	// server restores stdout in its start command (see ToStdout) before it
+	// installs the stderr capture pipe.
+	rebuildLogger(os.Stderr)
+}
 
+// newEncoder builds the encoder honoring CAESIUM_LOG_FORMAT (text|json).
+func newEncoder() zapcore.Encoder {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CAESIUM_LOG_FORMAT"))) {
+	case "text":
+		return zapcore.NewConsoleEncoder(textConfig())
+	default:
+		return zapcore.NewJSONEncoder(jsonConfig())
+	}
+}
+
+// rebuildLogger installs the global logger writing structured logs to ws,
+// teed into the in-memory ring buffer. Safe to call repeatedly.
+func rebuildLogger(ws *os.File) {
+	core := zapcore.NewCore(newEncoder(), zapcore.Lock(ws), logLevel)
 	logger := zap.New(
-		zapcore.NewTee(stdoutCore, ring),
+		zapcore.NewTee(core, ring),
 		zap.AddCaller(),
 		zap.AddCallerSkip(1), // skip the wrapper functions in this package
 	)
-
 	zap.ReplaceGlobals(logger)
 }
+
+// ToStderr routes structured logs to stderr. CLI commands call this so that
+// stdout carries only the command's machine-readable output (e.g. a
+// `caesium receipt get` JSON receipt that gets piped into `caesium verify`).
+// The server does NOT use this — it logs to stdout and captures C-library
+// stderr separately (see CaptureStderr), where routing logs to stderr would
+// feed the capture pipe back into the logger.
+func ToStderr() { rebuildLogger(os.Stderr) }
+
+// ToStdout routes structured logs to stdout (the server default). Used to
+// restore stdout logging before the server installs its stderr capture.
+func ToStdout() { rebuildLogger(os.Stdout) }
 
 func jsonConfig() zapcore.EncoderConfig {
 	cfg := zap.NewProductionEncoderConfig()

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -96,7 +96,13 @@ func capture(logFunc func(string, ...interface{}), msg string, kv ...interface{}
 // (re)built INSIDE fn so it locks onto the swapped fd.
 func captureFD(fd **os.File, fn func()) string {
 	orig := *fd
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	if err != nil || r == nil || w == nil {
+		// Don't assign a nil *os.File to the global fd — a later write would
+		// nil-panic in unrelated code. Run fn against the original fd instead.
+		fn()
+		return ""
+	}
 	*fd = w
 	fn()
 	_ = w.Close()

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -3,6 +3,8 @@ package log
 import (
 	"bufio"
 	"bytes"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,6 +89,50 @@ func capture(logFunc func(string, ...interface{}), msg string, kv ...interface{}
 	zap.ReplaceGlobals(oldLogger.Desugar())
 
 	return buffer.String()
+}
+
+// captureFD redirects the given *os.File (os.Stdout or os.Stderr) to a pipe for
+// the duration of fn and returns whatever was written to it. The logger must be
+// (re)built INSIDE fn so it locks onto the swapped fd.
+func captureFD(fd **os.File, fn func()) string {
+	orig := *fd
+	r, w, _ := os.Pipe()
+	*fd = w
+	fn()
+	_ = w.Close()
+	*fd = orig
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	_ = r.Close()
+	return buf.String()
+}
+
+// TestOutputRoutingKeepsStdoutClean is the regression for the CLI log
+// contamination bug: a log line written under the default (stderr) routing must
+// NOT land on stdout, so machine-readable command output (e.g. a
+// `caesium receipt get` JSON receipt) stays parseable. ToStdout restores the
+// server's stdout routing.
+func (s *LogTestSuite) TestOutputRoutingKeepsStdoutClean() {
+	s.Require().NoError(SetLevel("info"))
+	defer ToStderr() // restore the package default for other tests
+
+	// Default routing (stderr): the line appears on stderr, never on stdout.
+	var onStderr string
+	onStdout := captureFD(&os.Stdout, func() {
+		onStderr = captureFD(&os.Stderr, func() {
+			ToStderr()
+			Info("routing probe alpha")
+		})
+	})
+	s.Contains(onStderr, "routing probe alpha", "log should be on stderr")
+	s.NotContains(onStdout, "routing probe alpha", "stdout must stay clean for machine output")
+
+	// ToStdout routing (server): the line appears on stdout.
+	onStdout2 := captureFD(&os.Stdout, func() {
+		ToStdout()
+		Info("routing probe beta")
+	})
+	s.Contains(onStdout2, "routing probe beta", "ToStdout should route logs to stdout")
 }
 
 func TestLogTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes two defects found by **driving the data-plane-memory features against a real running server** (the post-merge verification pass) — neither was caught by green CI, because both are end-to-end wiring gaps that unit tests papered over.

### 1. CLI logs contaminated stdout → broke the receipt audit workflow
`caesium receipt get`'s help documents committing the receipt and later running `caesium verify <file>`. That round-trip was broken: a **package-`init()` debug line** (`callback handlers registered`) was written to **stdout**, so `receipt get > file` produced a file with two top-level JSON values and `verify` failed with *"invalid character '{' after top-level value."*

**Fix:** default the structured logger to **stderr** (covers `init()`-time logs, which run before `main()`), and have the server's `start` restore stdout *before* `CaptureStderr` redirects fd 2 through its capture pipe — routing logs to stderr there would feed the pipe back into the logger in a loop. Adds `pkg/log.ToStderr`/`ToStdout` + an fd-routing regression test.

### 2. `/lineage/impact` cross-job query was permanently empty
The "what breaks if this table changes" query returned `downstream: []` for everything. Two gaps:
- **(a)** the lineage mapper never recovered a task's **step name** or declared **input/output schemas** from the task record, so datasets fell back to the task UUID and **no input datasets** were emitted (the only mechanism that creates graph edges);
- **(b)** **nothing ever persisted rows** to the `lineage_datasets` table the query reads — `handleEvent` only *emitted* OpenLineage events. (C2's unit tests passed only because they inserted synthetic rows by hand.)

**Fix:** `enrichTaskPayload` (resolves name + schemas from the task, mirroring the existing `jobRecord` DB-lookup pattern) and `persistTaskDatasets` (upserts the bounded dataset graph on terminal task events, keyed on `(task_run, namespace, name, direction)`). Best-effort: any failure leaves the graph unchanged rather than disrupting emission. Adds an **end-to-end impact regression that drives the real mapper persist path**, not hand-seeded rows.

## Verified end-to-end against a live server (not just CI)

```
# Fix 1 — clean round-trip, no log-stripping:
$ caesium receipt get --job-id … --run-id … > r.json && caesium verify r.json
OK: run … matches the committed receipt (digest f0de02d1…)

# Fix 2 — impact now returns the downstream consumer:
$ curl '…/v1/lineage/impact?namespace=caesium&name=lineage-schema.extract.output'
{ "downstream": [ { "dataset_name": "lineage-schema.transform.output", "job_alias": "lineage-schema", "depth": 0 } ] }
```
Also confirmed the server still logs to stdout (no regression) and `verify`'s degraded path still refuses unverifiable runs.

## Test plan
- [x] `just lint` → 0 issues
- [x] `just unit-test` → green (new: `TestMapperPersistsAndLinksImpact`, `TestOutputRoutingKeepsStdoutClean`)
- [x] End-to-end against a live `caesium start` server (both fixes observed working)

## Notes / follow-ups
- Lineage features require `CAESIUM_OPEN_LINEAGE_ENABLED=true` (off by default) — unchanged here.
- Input datasets derive from declared `inputSchema`/`outputSchema` (the data-contract path); auto-deriving inputs from predecessor outputs (so impact works without declarations) is a reasonable future enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
