### PR TITLE
Add end-to-end CI coverage for data-plane features + fix caesium why stdout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,28 @@ caesium job apply --path jobs/          # Deploy to server
 - Aim for meaningful coverage on core packages; keep tests deterministic and hermetic.
 - Generate coverage locally with `just unit-test` (writes `coverage.txt`).
 
+### End-to-end coverage is the gate (drive the real surface)
+"Green CI" must mean the feature works, not that internal functions pass on
+synthetic inputs. A unit test that hand-seeds DB rows, mocks a clock, or
+import-and-calls an internal function proves the function — never the wiring.
+Several data-plane features shipped green-but-hollow this way (the lineage
+impact query never persisted rows; `caesium why --json` / `caesium receipt get`
+wrote machine output to stderr). So:
+
+- **Every new CLI command and REST query ships with an integration test in
+  `test/` that drives it through its real surface** — invoke the CLI binary
+  (`s.runCLI*`) or hit the HTTP endpoint against the live server, and assert on
+  observed output. Not a unit test on the internal handler.
+- **For machine-readable CLI output (`--json`, receipts), assert stdout is
+  clean and parseable, capturing stdout SEPARATELY from stderr** (`runCLIStdout`,
+  not the stream-merging `runCLIRaw`). Log lines and cobra `cmd.Print*` both
+  leak to the wrong stream; a merged capture hides it.
+- **If a feature is config-gated** (e.g. lineage needs
+  `CAESIUM_OPEN_LINEAGE_ENABLED=true`), enable it on the integration server in
+  `just integration-up` so the path actually executes in CI.
+- A new `cmd/` subcommand or `api/rest/controller` endpoint with no
+  corresponding `test/` integration scenario should block review.
+
 ## Commit & Pull Request Guidelines
 - Commits: concise, imperative subject (50–72 chars). Example: `Add HTTP triggers for jobs (#51)`.
 - PRs: include a clear summary, linked issues, test evidence (logs or output), and docs updates when behavior/UI/CLI changes.

--- a/cmd/why/why.go
+++ b/cmd/why/why.go
@@ -108,23 +108,27 @@ var Cmd = &cobra.Command{
 			return fmt.Errorf("why failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
 		}
 
+		// NOTE: write machine-readable output via cmd.OutOrStdout(), NOT
+		// cmd.Print/Println — cobra's Print* helpers go to stderr, which would
+		// leave `--json` output unusable for piping (e.g. into `caesium verify`).
+		stdout := cmd.OutOrStdout()
 		if whyJSON {
 			// Re-indent for readability; fall back to the raw body if it isn't
 			// JSON (it always should be).
 			var out interface{}
 			if err := json.Unmarshal(body, &out); err != nil {
-				cmd.Print(string(body))
+				_, _ = fmt.Fprint(stdout, string(body))
 				return nil
 			}
 			pretty, _ := json.MarshalIndent(out, "", "  ")
-			cmd.Println(string(pretty))
+			_, _ = fmt.Fprintln(stdout, string(pretty))
 			return nil
 		}
 
 		var exp explanation
 		if err := json.Unmarshal(body, &exp); err != nil {
 			// Unknown shape — just print what we got.
-			cmd.Print(string(body))
+			_, _ = fmt.Fprint(stdout, string(body))
 			return nil
 		}
 		renderTable(cmd, &exp)
@@ -133,10 +137,13 @@ var Cmd = &cobra.Command{
 }
 
 func renderTable(cmd *cobra.Command, exp *explanation) {
-	cmd.Println(exp.Summary)
-	cmd.Println()
+	// All rendered output goes to stdout (cobra's cmd.Print* would route to
+	// stderr, splitting the report across streams).
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, exp.Summary)
+	_, _ = fmt.Fprintln(out)
 
-	tw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintf(tw, "TASK\t%s\n", exp.TaskName)
 	_, _ = fmt.Fprintf(tw, "VERDICT\t%s\n", exp.Verdict)
 	_, _ = fmt.Fprintf(tw, "STATUS\t%s\n", exp.Status)
@@ -163,23 +170,23 @@ func renderTable(cmd *cobra.Command, exp *explanation) {
 		return
 	}
 	if exp.Diff.Degraded != "" {
-		cmd.Println()
-		cmd.Printf("note: %s\n", exp.Diff.Degraded)
+		_, _ = fmt.Fprintln(out)
+		_, _ = fmt.Fprintf(out, "note: %s\n", exp.Diff.Degraded)
 		return
 	}
 	if len(exp.Diff.Changes) == 0 {
-		cmd.Println()
+		_, _ = fmt.Fprintln(out)
 		if exp.Diff.HashEqual {
-			cmd.Println("All hashed inputs are identical (no discriminating field).")
+			_, _ = fmt.Fprintln(out, "All hashed inputs are identical (no discriminating field).")
 		} else {
-			cmd.Println("No discriminating input field found.")
+			_, _ = fmt.Fprintln(out, "No discriminating input field found.")
 		}
 		return
 	}
 
-	cmd.Println()
-	cmd.Printf("Discriminating fields (%d):\n", len(exp.Diff.Changes))
-	dw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(out)
+	_, _ = fmt.Fprintf(out, "Discriminating fields (%d):\n", len(exp.Diff.Changes))
+	dw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(dw, "FIELD\tCHANGE\tBEFORE\tAFTER")
 	for _, ch := range exp.Diff.Changes {
 		before, after := ch.Before, ch.After

--- a/justfile
+++ b/justfile
@@ -226,6 +226,8 @@ integration-up: build-test
         -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
         -e CAESIUM_LOG_LEVEL=debug \
         -e CAESIUM_DATABASE_SHARDS=4 \
+        -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
+        -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         {{ local_image_ref }}:{{ tag }}-test start
 
 lint: builder-full

--- a/test/data_plane_e2e_test.go
+++ b/test/data_plane_e2e_test.go
@@ -24,7 +24,10 @@ import (
 // runCLIStdout runs the CLI capturing stdout and stderr SEPARATELY, returning
 // stdout only. The shared runCLIRaw helper merges the streams (CombinedOutput),
 // which is precisely why no existing test could detect log lines leaking onto
-// stdout and corrupting machine-readable command output.
+// stdout and corrupting machine-readable command output. On failure the
+// returned error carries stderr so the cause is visible in CI (the command's
+// own diagnostics go to stderr, which the stdout-only return would otherwise
+// drop).
 func (s *IntegrationTestSuite) runCLIStdout(args ...string) (string, error) {
 	s.T().Helper()
 	cmd := exec.CommandContext(s.T().Context(), s.cliPath, args...)
@@ -33,8 +36,10 @@ func (s *IntegrationTestSuite) runCLIStdout(args ...string) (string, error) {
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return stdout.String(), err
+	if err := cmd.Run(); err != nil {
+		return stdout.String(), fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
 }
 
 // whyExplanation mirrors the fields of the `caesium why --json` output that the
@@ -53,6 +58,9 @@ type whyExplanation struct {
 // CACHE_MISS when a run param changes.
 func (s *IntegrationTestSuite) TestCaesiumWhyExplainsHitAndMiss() {
 	alias := fmt.Sprintf("e2e-why-%d", time.Now().UnixNano())
+	// NOTE: do NOT set a step-level `engine:` — writeJobManifest/injectEngine
+	// inserts the runtime engine (docker/podman/kubernetes) per CI tier, and a
+	// hardcoded engine would duplicate that key. Caching is enabled job-wide.
 	manifest := fmt.Sprintf(`apiVersion: v1
 kind: Job
 metadata:
@@ -62,9 +70,7 @@ metadata:
 trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
 steps:
   - name: produce
-    engine: docker
     image: alpine:3.23
-    cache: true
     command: ["sh","-c","echo '##caesium::output {\"rows\": \"100\"}'"]
 `, alias)
 	dir := s.writeJobManifest(manifest)
@@ -123,9 +129,7 @@ metadata:
 trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
 steps:
   - name: produce
-    engine: docker
     image: alpine:3.23
-    cache: true
     command: ["sh","-c","echo '##caesium::output {\"rows\": \"1\"}'"]
 `, alias)
 	dir := s.writeJobManifest(manifest)
@@ -143,17 +147,25 @@ steps:
 	s.Require().NoError(err, "receipt get failed:\n%s", receipt)
 	s.Require().True(json.Valid([]byte(receipt)), "receipt get stdout was not clean JSON (log contamination):\n%s", receipt)
 
-	// Commit the receipt and verify it — the documented audit workflow.
+	// Commit the receipt and verify it — the documented audit workflow. verify
+	// writes its verdict (OK / UNVERIFIABLE) to stdout; a parse failure would
+	// surface as a cobra error on stderr (carried in err here). Capturing the
+	// streams separately avoids a stray stderr log line matching the verdict.
 	receiptFile := filepath.Join(dir, "receipt.json")
 	s.Require().NoError(os.WriteFile(receiptFile, []byte(receipt), 0o644))
-	out, err := s.runCLIRaw("verify", receiptFile, "--server", s.caesiumURL)
-	s.NotContains(out, "invalid character", "verify must parse the committed receipt file, not choke on contamination:\n%s", out)
-	if err != nil {
-		// A degraded (unpinned) run legitimately exits non-zero as UNVERIFIABLE;
-		// the contamination bug instead produced a parse error, asserted above.
-		s.Contains(out, "UNVERIFIABLE", "verify failed for a reason other than a degraded run:\n%s", out)
+	vout, verr := s.runCLIStdout("verify", receiptFile, "--server", s.caesiumURL)
+	diag := vout
+	if verr != nil {
+		diag += "\n" + verr.Error()
+	}
+	s.NotContains(diag, "invalid character", "verify must parse the committed receipt file, not choke on contamination:\n%s", diag)
+	if verr != nil {
+		// A degraded (unpinned) run legitimately exits non-zero as UNVERIFIABLE
+		// (the verdict is still on stdout); the contamination bug would instead
+		// produce the parse error asserted against above.
+		s.Contains(vout, "UNVERIFIABLE", "verify failed for a reason other than a degraded run:\n%s", diag)
 	} else {
-		s.Contains(out, "OK", "verify of a pinned run should report a match:\n%s", out)
+		s.Contains(vout, "OK", "verify of a pinned run should report a match:\n%s", vout)
 	}
 }
 
@@ -163,11 +175,20 @@ type impactResult struct {
 	} `json:"downstream"`
 }
 
-// TestLineageImpactReturnsDownstream verifies the cross-job impact query
-// end-to-end: a producer→consumer pipeline (linked via declared schemas)
-// populates the persisted lineage graph so /lineage/impact returns the
-// downstream consumer. Requires OPEN_LINEAGE enabled on the integration server
-// (set in `just integration-up`).
+// TestLineageImpactReturnsDownstream verifies the impact query end-to-end: a
+// producer→consumer pipeline (linked via declared schemas) populates the
+// persisted lineage graph so /lineage/impact returns the downstream consumer.
+// The original bug was that the graph was never persisted at all, so this query
+// returned empty regardless of topology; here it must traverse a real edge.
+//
+// This exercises a within-job producer→consumer edge. The impact BFS is
+// job-agnostic (it joins datasets by namespace+name), so it spans jobs whenever
+// two jobs share a dataset identity — but the schema-derived dataset name is
+// currently job-scoped (`<alias>.<step>.output`), so genuine cross-job linkage
+// needs a shared-dataset reference and is tracked as a follow-up.
+//
+// Requires OPEN_LINEAGE enabled on the integration server (set in
+// `just integration-up`).
 func (s *IntegrationTestSuite) TestLineageImpactReturnsDownstream() {
 	alias := fmt.Sprintf("e2e-lineage-%d", time.Now().UnixNano())
 	manifest := fmt.Sprintf(`apiVersion: v1
@@ -177,13 +198,11 @@ metadata:
 trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
 steps:
   - name: extract
-    engine: docker
     image: alpine:3.23
     outputSchema: { type: object, properties: { rows: { type: string } } }
     command: ["sh","-c","echo '##caesium::output {\"rows\": \"1\"}'"]
     next: transform
   - name: transform
-    engine: docker
     image: alpine:3.23
     inputSchema: { extract: { properties: { rows: { type: string } } } }
     outputSchema: { type: object, properties: { clean: { type: string } } }
@@ -206,6 +225,9 @@ steps:
 	deadline := time.Now().Add(30 * time.Second)
 	var res impactResult
 	for {
+		if s.T().Context().Err() != nil {
+			break // test cancelled/timed out — stop hitting the server
+		}
 		res = impactResult{}
 		s.getJSON("/v1/lineage/impact?namespace=caesium&name="+rootName, &res)
 		if len(res.Downstream) > 0 || time.Now().After(deadline) {

--- a/test/data_plane_e2e_test.go
+++ b/test/data_plane_e2e_test.go
@@ -1,0 +1,224 @@
+//go:build integration
+
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// These scenarios drive the data-plane-memory features (caesium why,
+// reproducibility receipt + verify, and the cross-job lineage impact query)
+// through their REAL surfaces against the live integration server. They exist
+// because the original ship of those features passed CI on unit tests over
+// synthetic state while the end-to-end paths were hollow (the impact query
+// never persisted rows; the receipt CLI contaminated stdout). Each assertion
+// here would have turned those bugs red.
+
+// runCLIStdout runs the CLI capturing stdout and stderr SEPARATELY, returning
+// stdout only. The shared runCLIRaw helper merges the streams (CombinedOutput),
+// which is precisely why no existing test could detect log lines leaking onto
+// stdout and corrupting machine-readable command output.
+func (s *IntegrationTestSuite) runCLIStdout(args ...string) (string, error) {
+	s.T().Helper()
+	cmd := exec.CommandContext(s.T().Context(), s.cliPath, args...)
+	cmd.Dir = s.projectRoot
+	cmd.Env = os.Environ()
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), err
+}
+
+// whyExplanation mirrors the fields of the `caesium why --json` output that the
+// assertions below read.
+type whyExplanation struct {
+	Verdict string `json:"verdict"`
+	Diff    *struct {
+		Changes []struct {
+			Field string `json:"field"`
+		} `json:"changes"`
+	} `json:"diff"`
+}
+
+// TestCaesiumWhyExplainsHitAndMiss verifies the EXPLAIN feature end-to-end:
+// `caesium why` reports CACHE_HIT when inputs are unchanged and a field-level
+// CACHE_MISS when a run param changes.
+func (s *IntegrationTestSuite) TestCaesiumWhyExplainsHitAndMiss() {
+	alias := fmt.Sprintf("e2e-why-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  cache:
+    enabled: true
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: produce
+    engine: docker
+    image: alpine:3.23
+    cache: true
+    command: ["sh","-c","echo '##caesium::output {\"rows\": \"100\"}'"]
+`, alias)
+	dir := s.writeJobManifest(manifest)
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	// Run #1 (cold) then run #2 (same inputs → cache hit on the cacheable step).
+	run1 := s.triggerRun(job.ID)
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, run1, 90*time.Second).Status)
+	run2 := s.triggerRun(job.ID)
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, run2, 90*time.Second).Status)
+
+	hit := s.parseWhy(job.ID, run2, "produce")
+	s.Equal("CACHE_HIT", hit.Verdict, "second run of an unchanged step must be a cache hit")
+
+	// Run #3 with a changed run param → cache miss attributable to that field.
+	run3 := s.triggerRunWithParams(job.ID, map[string]string{"scenario": "changed"})
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, run3, 90*time.Second).Status)
+	miss := s.parseWhy(job.ID, run3, "produce")
+	s.Equal("CACHE_MISS", miss.Verdict, "a changed run param must produce a cache miss")
+	s.Require().NotNil(miss.Diff, "a miss vs a prior run must carry a field-level diff")
+	foundParam := false
+	for _, c := range miss.Diff.Changes {
+		if strings.HasPrefix(c.Field, "runParams.") {
+			foundParam = true
+		}
+	}
+	s.True(foundParam, "the changed run param must appear as a discriminating field, got %+v", miss.Diff.Changes)
+}
+
+func (s *IntegrationTestSuite) parseWhy(jobID, runID, task string) whyExplanation {
+	s.T().Helper()
+	out, err := s.runCLIStdout("why", runID, "--job-id", jobID, "--task", task, "--json", "--server", s.caesiumURL)
+	s.Require().NoError(err, "caesium why failed:\n%s", out)
+	s.Require().True(json.Valid([]byte(out)), "caesium why --json stdout was not valid JSON (log contamination?):\n%s", out)
+	var exp whyExplanation
+	s.Require().NoError(json.Unmarshal([]byte(out), &exp))
+	return exp
+}
+
+// TestReproducibilityReceiptRoundTrip verifies the REPRODUCE feature end-to-end
+// AND guards the documented `receipt get > file` → `verify file` workflow: the
+// receipt printed to stdout must be clean JSON (no leaked log lines), and the
+// committed file must verify against the run's persisted state.
+func (s *IntegrationTestSuite) TestReproducibilityReceiptRoundTrip() {
+	alias := fmt.Sprintf("e2e-receipt-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  cache:
+    enabled: true
+    pinDigests: true
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: produce
+    engine: docker
+    image: alpine:3.23
+    cache: true
+    command: ["sh","-c","echo '##caesium::output {\"rows\": \"1\"}'"]
+`, alias)
+	dir := s.writeJobManifest(manifest)
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	runID := s.triggerRun(job.ID)
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, runID, 90*time.Second).Status)
+
+	// `receipt get` stdout MUST be clean JSON — this is the regression for log
+	// lines leaking onto stdout and breaking the round-trip.
+	receipt, err := s.runCLIStdout("receipt", "get", "--job-id", job.ID, "--run-id", runID, "--server", s.caesiumURL)
+	s.Require().NoError(err, "receipt get failed:\n%s", receipt)
+	s.Require().True(json.Valid([]byte(receipt)), "receipt get stdout was not clean JSON (log contamination):\n%s", receipt)
+
+	// Commit the receipt and verify it — the documented audit workflow.
+	receiptFile := filepath.Join(dir, "receipt.json")
+	s.Require().NoError(os.WriteFile(receiptFile, []byte(receipt), 0o644))
+	out, err := s.runCLIRaw("verify", receiptFile, "--server", s.caesiumURL)
+	s.NotContains(out, "invalid character", "verify must parse the committed receipt file, not choke on contamination:\n%s", out)
+	if err != nil {
+		// A degraded (unpinned) run legitimately exits non-zero as UNVERIFIABLE;
+		// the contamination bug instead produced a parse error, asserted above.
+		s.Contains(out, "UNVERIFIABLE", "verify failed for a reason other than a degraded run:\n%s", out)
+	} else {
+		s.Contains(out, "OK", "verify of a pinned run should report a match:\n%s", out)
+	}
+}
+
+type impactResult struct {
+	Downstream []struct {
+		DatasetName string `json:"dataset_name"`
+	} `json:"downstream"`
+}
+
+// TestLineageImpactReturnsDownstream verifies the cross-job impact query
+// end-to-end: a producer→consumer pipeline (linked via declared schemas)
+// populates the persisted lineage graph so /lineage/impact returns the
+// downstream consumer. Requires OPEN_LINEAGE enabled on the integration server
+// (set in `just integration-up`).
+func (s *IntegrationTestSuite) TestLineageImpactReturnsDownstream() {
+	alias := fmt.Sprintf("e2e-lineage-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: extract
+    engine: docker
+    image: alpine:3.23
+    outputSchema: { type: object, properties: { rows: { type: string } } }
+    command: ["sh","-c","echo '##caesium::output {\"rows\": \"1\"}'"]
+    next: transform
+  - name: transform
+    engine: docker
+    image: alpine:3.23
+    inputSchema: { extract: { properties: { rows: { type: string } } } }
+    outputSchema: { type: object, properties: { clean: { type: string } } }
+    command: ["sh","-c","echo got $CAESIUM_OUTPUT_EXTRACT_ROWS; echo '##caesium::output {\"clean\": \"y\"}'"]
+    dependsOn: extract
+`, alias)
+	dir := s.writeJobManifest(manifest)
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	runID := s.triggerRun(job.ID)
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, runID, 90*time.Second).Status)
+
+	// Lineage persistence is driven asynchronously by the event subscriber, so
+	// poll the impact endpoint until the downstream edge appears.
+	rootName := alias + ".extract.output"
+	wantName := alias + ".transform.output"
+	deadline := time.Now().Add(30 * time.Second)
+	var res impactResult
+	for {
+		res = impactResult{}
+		s.getJSON("/v1/lineage/impact?namespace=caesium&name="+rootName, &res)
+		if len(res.Downstream) > 0 || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	s.Require().NotEmpty(res.Downstream, "impact query returned no downstream consumer for %s", rootName)
+	found := false
+	for _, n := range res.Downstream {
+		if n.DatasetName == wantName {
+			found = true
+		}
+	}
+	s.True(found, "expected %s downstream of %s, got %+v", wantName, rootName, res.Downstream)
+}

--- a/test/data_plane_e2e_test.go
+++ b/test/data_plane_e2e_test.go
@@ -224,10 +224,8 @@ steps:
 	wantName := alias + ".transform.output"
 	deadline := time.Now().Add(30 * time.Second)
 	var res impactResult
-	for {
-		if s.T().Context().Err() != nil {
-			break // test cancelled/timed out — stop hitting the server
-		}
+	// Loop while the test context is live (cancelled/timed-out → stop polling).
+	for s.T().Context().Err() == nil {
 		res = impactResult{}
 		s.getJSON("/v1/lineage/impact?namespace=caesium&name="+rootName, &res)
 		if len(res.Downstream) > 0 || time.Now().After(deadline) {


### PR DESCRIPTION
## Summary

Makes "green CI" actually mean **the feature works** for the data-plane-memory features, instead of "internal functions pass on synthetic inputs." Directly addresses how two (now three) end-to-end bugs shipped green.

> **Stacked on #225** (`fix/lineage-impact-and-cli-log-stdout`) — the lineage-impact and receipt scenarios assert the behavior #225 fixes, so this builds on that branch. GitHub will retarget this PR to `master` once #225 merges.

### What's added

**A — Integration scenarios that drive the real surface** (`test/data_plane_e2e_test.go`):
- `caesium why` — cache HIT, and a field-level CACHE_MISS attributing a changed run param.
- Reproducibility receipt → `verify` round-trip — asserts `receipt get` stdout is **clean JSON** and the committed file verifies.
- `/lineage/impact` — a producer→consumer (schema-linked) pipeline must return the downstream consumer (within-job edge; genuine cross-job linkage needs a shared dataset identity and is a tracked follow-up).
- New `runCLIStdout` helper captures **stdout separately** from stderr. The shared `runCLIRaw` uses `CombinedOutput()` (merged streams) — which is *precisely why* the original stdout-contamination bugs were invisible to every existing test.

**B — Config coverage** (`justfile`): enable `OPEN_LINEAGE` on the integration server so the lineage dataset/impact path actually executes in CI (it's off by default — so it had **zero** CI coverage before).

**C/D — Process guard** (`AGENTS.md`): a testing policy — new CLI commands and REST queries must ship an integration test driving their real surface; machine-readable output must be asserted on stdout captured separately; config-gated features must be enabled in CI. A new `cmd/` subcommand or controller endpoint with no `test/` scenario should block review.

### Bonus bug, caught by the new coverage

The `caesium why` scenario immediately failed — `why --json` produced **empty stdout**. Root cause: the command used cobra's `cmd.Print*`, which route to **stderr**, so `--json` was unusable for piping and the table was split across streams (same bug class as #225's logging fix). Fixed in `cmd/why/why.go` to write via `cmd.OutOrStdout()`; warnings stay on stderr. This is the coverage paying for itself on day one.

## Test plan
- [x] `just lint` → 0 issues
- [x] All three scenarios verified **green** against a live `just integration-up` server (with the why fix; they failed before it)
- [x] `go vet -tags=integration ./test/` clean

## Why this matters
Before: ~80 integration tests, **0** covering `caesium why` / `receipt` / `verify` / `/lineage/impact`, and lineage off in CI. The features were unit-tested on hand-seeded rows and mocked state — green CI proved the functions, never the wiring. This closes that gap for the shipped features and sets the policy to prevent recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

