### PR TITLE
Add lineage impact assertion to harness scenarios

### DIFF
--- a/docs/caesium-job-llm-reference.md
+++ b/docs/caesium-job-llm-reference.md
@@ -338,6 +338,7 @@ Supported assertions:
 - `expect.lineage.totalEvents`: exact emitted OpenLineage event count
 - `expect.lineage.eventTypes`: exact OpenLineage event-type counts (`START`, `COMPLETE`, `FAIL`, `ABORT`)
 - `expect.lineage.jobNames`: required OpenLineage job names present in the emitted stream
+- `expect.lineage.impact[]`: assertions over the **persisted** dataset graph (what the `/lineage/impact` query reads), not just the emitted events. Each entry sets `dataset` (the root dataset name, e.g. `<job-alias>.<step>.output`), a `downstream` list of dataset names that must be reachable from it, an optional `maxDepth` (0 = unbounded), and an optional `namespace` (defaults to the harness namespace). Catches the class of bug where datasets are emitted but never stored, so impact comes back empty.
 
 Example with observability assertions:
 
@@ -367,6 +368,10 @@ scenarios:
           COMPLETE: 4
         jobNames:
           - nightly-etl
+        impact:
+          - dataset: nightly-etl.extract.output
+            downstream:
+              - nightly-etl.transform.output
 ```
 
 ---

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -75,12 +75,13 @@ func Execute(ctx context.Context, scenario ResolvedScenario) (*Result, error) {
 			}
 
 			lineage.RegisterMetrics()
+			obs.db = db // for impact assertions over the persisted dataset graph
 
 			bus := event.New()
 			store.SetBus(bus)
 
 			transport := &recordingTransport{}
-			subscriber := lineage.NewSubscriber(bus, transport, "caesium-harness", db)
+			subscriber := lineage.NewSubscriber(bus, transport, harnessNamespace, db)
 			subscriber.SetTransportName("harness")
 
 			lineageCtx, cancel := context.WithCancel(ctx)
@@ -127,7 +128,7 @@ func Execute(ctx context.Context, scenario ResolvedScenario) (*Result, error) {
 		MetricObservations: metricObservations,
 		LineageEvents:      lineageEvents,
 	}
-	result.Failures = evaluateScenario(scenario, runResult, execErr, metricObservations, lineageEvents, lineageErr)
+	result.Failures = evaluateScenario(ctx, obs.db, scenario, runResult, execErr, metricObservations, lineageEvents, lineageErr)
 	return result, nil
 }
 
@@ -137,11 +138,16 @@ type placeholderState struct {
 	TaskIDs  map[string]uuid.UUID
 }
 
+// harnessNamespace is the OpenLineage namespace datasets are recorded under
+// when the harness runs a scenario; impact assertions default to it.
+const harnessNamespace = "caesium-harness"
+
 type observabilityCapture struct {
 	baselines        map[int]float64
 	lineageTransport *recordingTransport
 	lineageCancel    context.CancelFunc
 	lineageErrCh     chan error
+	db               *gorm.DB // set when lineage is enabled; used by impact assertions
 }
 
 func (o *observabilityCapture) finish(runResult *localrun.RunResult) ([]lineage.RunEvent, error) {
@@ -196,6 +202,8 @@ func (t *recordingTransport) Events() []lineage.RunEvent {
 }
 
 func evaluateScenario(
+	ctx context.Context,
+	db *gorm.DB,
 	scenario ResolvedScenario,
 	runResult *localrun.RunResult,
 	execErr error,
@@ -310,8 +318,46 @@ func evaluateScenario(
 				failures = append(failures, fmt.Sprintf("lineage jobNames: expected %q to appear", jobName))
 			}
 		}
+
+		// Impact assertions query the PERSISTED dataset graph (what
+		// /lineage/impact reads), proving datasets are not just emitted but
+		// stored and linked.
+		for _, imp := range expect.Lineage.Impact {
+			failures = append(failures, evaluateImpact(ctx, db, imp)...)
+		}
 	}
 
+	return failures
+}
+
+// evaluateImpact runs the cross-job impact query for one expectation and reports
+// any expected downstream dataset that is missing from the result.
+func evaluateImpact(ctx context.Context, db *gorm.DB, imp ImpactExpectation) []string {
+	if db == nil {
+		return []string{fmt.Sprintf("lineage impact[%s]: no database available (is lineage enabled?)", imp.Dataset)}
+	}
+	ns := imp.Namespace
+	if ns == "" {
+		ns = harnessNamespace
+	}
+	res, err := lineage.QueryImpact(ctx, db, ns, imp.Dataset, imp.MaxDepth)
+	if err != nil {
+		return []string{fmt.Sprintf("lineage impact[%s]: query failed: %v", imp.Dataset, err)}
+	}
+	got := make(map[string]struct{}, len(res.Downstream))
+	for _, node := range res.Downstream {
+		got[node.DatasetName] = struct{}{}
+	}
+	var failures []string
+	for _, want := range imp.Downstream {
+		if _, ok := got[want]; !ok {
+			names := make([]string, 0, len(res.Downstream))
+			for _, node := range res.Downstream {
+				names = append(names, node.DatasetName)
+			}
+			failures = append(failures, fmt.Sprintf("lineage impact[%s]: expected downstream %q, got %v", imp.Dataset, want, names))
+		}
+	}
 	return failures
 }
 

--- a/internal/harness/runner_test.go
+++ b/internal/harness/runner_test.go
@@ -1,0 +1,85 @@
+package harness
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// seedImpactGraph builds a minimal persisted lineage graph in an in-memory DB:
+// a producer task_run with an `output` dataset and a consumer task_run that
+// declares the same dataset as `input` and emits its own `output` — exactly the
+// shape QueryImpact traverses.
+func seedImpactGraph(t *testing.T, ns string) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(models.All...))
+
+	triggerID := uuid.New()
+	require.NoError(t, db.Create(&models.Trigger{ID: triggerID, Type: models.TriggerTypeCron}).Error)
+	job := &models.Job{ID: uuid.New(), Alias: "harness-job", TriggerID: triggerID}
+	require.NoError(t, db.Create(job).Error)
+	jobRun := &models.JobRun{ID: uuid.New(), JobID: job.ID, TriggerID: triggerID, Status: "succeeded", StartedAt: time.Now().UTC()}
+	require.NoError(t, db.Create(jobRun).Error)
+
+	mkTaskRun := func() *models.TaskRun {
+		atomID := uuid.New()
+		require.NoError(t, db.Create(&models.Atom{ID: atomID, Engine: models.AtomEngineDocker, Image: "alpine:3.23"}).Error)
+		tr := &models.TaskRun{
+			ID: uuid.New(), JobRunID: jobRun.ID, TaskID: uuid.New(), AtomID: atomID,
+			Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: "[]", Status: "succeeded", Attempt: 1,
+		}
+		require.NoError(t, db.Create(tr).Error)
+		return tr
+	}
+	mkDataset := func(tr *models.TaskRun, name, direction string) {
+		require.NoError(t, db.Create(&models.LineageDataset{
+			ID: uuid.New(), TaskRunID: tr.ID, Namespace: ns, Name: name,
+			Direction: direction, FacetSummary: datatypes.JSON([]byte("{}")), CreatedAt: time.Now().UTC(),
+		}).Error)
+	}
+
+	producer := mkTaskRun()
+	mkDataset(producer, "harness-job.extract.output", "output")
+	consumer := mkTaskRun()
+	mkDataset(consumer, "harness-job.extract.output", "input")
+	mkDataset(consumer, "harness-job.transform.output", "output")
+	return db
+}
+
+func TestEvaluateImpactPassesWhenDownstreamPresent(t *testing.T) {
+	db := seedImpactGraph(t, harnessNamespace)
+	failures := evaluateImpact(context.Background(), db, ImpactExpectation{
+		Dataset:    "harness-job.extract.output",
+		Downstream: []string{"harness-job.transform.output"},
+	})
+	require.Empty(t, failures, "expected the downstream consumer to be found")
+}
+
+func TestEvaluateImpactFailsWhenDownstreamMissing(t *testing.T) {
+	db := seedImpactGraph(t, harnessNamespace)
+	failures := evaluateImpact(context.Background(), db, ImpactExpectation{
+		Dataset:    "harness-job.extract.output",
+		Downstream: []string{"harness-job.nonexistent.output"},
+	})
+	require.Len(t, failures, 1)
+	require.Contains(t, failures[0], "expected downstream")
+	require.Contains(t, failures[0], "harness-job.transform.output", "failure should list what WAS found")
+}
+
+func TestEvaluateImpactFailsWithoutDatabase(t *testing.T) {
+	failures := evaluateImpact(context.Background(), nil, ImpactExpectation{
+		Dataset:    "x",
+		Downstream: []string{"y"},
+	})
+	require.Len(t, failures, 1)
+	require.Contains(t, failures[0], "no database available")
+}

--- a/internal/harness/scenario.go
+++ b/internal/harness/scenario.go
@@ -68,9 +68,27 @@ type MetricExpectation struct {
 
 // LineageExpectation describes emitted OpenLineage assertions.
 type LineageExpectation struct {
-	TotalEvents *int           `yaml:"totalEvents,omitempty"`
-	EventTypes  map[string]int `yaml:"eventTypes,omitempty"`
-	JobNames    []string       `yaml:"jobNames,omitempty"`
+	TotalEvents *int                `yaml:"totalEvents,omitempty"`
+	EventTypes  map[string]int      `yaml:"eventTypes,omitempty"`
+	JobNames    []string            `yaml:"jobNames,omitempty"`
+	Impact      []ImpactExpectation `yaml:"impact,omitempty"`
+}
+
+// ImpactExpectation asserts the persisted lineage graph (the data the
+// /lineage/impact query reads), not just the emitted events: that a root
+// dataset reaches the expected downstream consumers. This catches regressions
+// where datasets are emitted but never persisted, so impact comes back empty.
+type ImpactExpectation struct {
+	// Dataset is the root dataset name whose downstream impact is queried
+	// (e.g. "<job-alias>.<step>.output").
+	Dataset string `yaml:"dataset"`
+	// Namespace overrides the dataset namespace; defaults to the harness
+	// namespace when empty.
+	Namespace string `yaml:"namespace,omitempty"`
+	// MaxDepth bounds the downstream BFS (0 = unbounded).
+	MaxDepth int `yaml:"maxDepth,omitempty"`
+	// Downstream lists dataset names that must appear in the impact result.
+	Downstream []string `yaml:"downstream"`
 }
 
 // ResolvedScenario is a validated scenario with its source location.
@@ -253,6 +271,18 @@ func (s *Scenario) Validate() error {
 			}
 			if count < 0 {
 				return fmt.Errorf("expect.lineage.eventTypes[%q] must be >= 0", eventType)
+			}
+		}
+		for i := range s.Expect.Lineage.Impact {
+			imp := &s.Expect.Lineage.Impact[i]
+			if strings.TrimSpace(imp.Dataset) == "" {
+				return fmt.Errorf("expect.lineage.impact[%d].dataset is required", i)
+			}
+			if len(imp.Downstream) == 0 {
+				return fmt.Errorf("expect.lineage.impact[%d] must list at least one downstream dataset", i)
+			}
+			if imp.MaxDepth < 0 {
+				return fmt.Errorf("expect.lineage.impact[%d].maxDepth must be >= 0", i)
 			}
 		}
 	}

--- a/internal/harness/scenario_test.go
+++ b/internal/harness/scenario_test.go
@@ -51,6 +51,85 @@ scenarios:
 	require.Equal(t, "harness-job", def.Metadata.Alias)
 }
 
+func TestCollectScenariosParsesImpactExpectation(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "job.job.yaml"), []byte(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: harness-job
+trigger:
+  type: cron
+  configuration:
+    cron: "*/5 * * * *"
+steps:
+  - name: hello
+    image: alpine:3.23
+    command: ["echo", "hello"]
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "impact.scenario.yaml"), []byte(`
+apiVersion: v1
+kind: Harness
+scenarios:
+  - name: impact
+    path: ./job.job.yaml
+    expect:
+      lineage:
+        impact:
+          - dataset: harness-job.extract.output
+            maxDepth: 2
+            downstream:
+              - harness-job.transform.output
+`), 0o644))
+
+	scenarios, err := CollectScenarios([]string{dir})
+	require.NoError(t, err)
+	require.Len(t, scenarios, 1)
+	imp := scenarios[0].Scenario.Expect.Lineage.Impact
+	require.Len(t, imp, 1)
+	require.Equal(t, "harness-job.extract.output", imp[0].Dataset)
+	require.Equal(t, 2, imp[0].MaxDepth)
+	require.Equal(t, []string{"harness-job.transform.output"}, imp[0].Downstream)
+}
+
+func TestCollectScenariosRejectsImpactWithoutDataset(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.scenario.yaml"), []byte(`
+apiVersion: v1
+kind: Harness
+scenarios:
+  - name: bad
+    path: ./job.job.yaml
+    expect:
+      lineage:
+        impact:
+          - downstream: [x]
+`), 0o644))
+
+	_, err := CollectScenarios([]string{dir})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "impact[0].dataset is required")
+}
+
+func TestCollectScenariosRejectsImpactWithoutDownstream(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.scenario.yaml"), []byte(`
+apiVersion: v1
+kind: Harness
+scenarios:
+  - name: bad
+    path: ./job.job.yaml
+    expect:
+      lineage:
+        impact:
+          - dataset: a.b.output
+`), 0o644))
+
+	_, err := CollectScenarios([]string{dir})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must list at least one downstream dataset")
+}
+
 func TestCollectScenariosRejectsDuplicateTaskExpectations(t *testing.T) {
 	dir := t.TempDir()
 	scenarioPath := filepath.Join(dir, "broken.scenario.yaml")


### PR DESCRIPTION
Closes out the "C" piece of the end-to-end CI coverage framework: a declarative way to assert the **persisted lineage graph** (what `/lineage/impact` reads) from a `.scenario.yaml`, so the impact path is regression-covered without bespoke Go in every test.

## What's added
`expect.lineage.impact[]` on the Harness kind. Each entry runs `lineage.QueryImpact` against the harness DB after a scenario run and asserts the expected downstream datasets are reachable from a root dataset:

```yaml
expect:
  lineage:
    impact:
      - dataset: nightly-etl.extract.output
        downstream:
          - nightly-etl.transform.output
        maxDepth: 2        # optional, 0 = unbounded
        namespace: ...     # optional, defaults to the harness namespace
```

This asserts the **persisted** graph, not just emitted events — catching the class of bug (fixed in #225) where datasets are emitted but never stored, so impact comes back empty.

## Changes
- `scenario.go`: `ImpactExpectation` type + validation (`dataset` and at least one `downstream` required; `maxDepth >= 0`).
- `runner.go`: capture the harness DB when lineage is enabled, thread it + `ctx` into `evaluateScenario`, evaluate each impact expectation via `QueryImpact`.
- Tests: scenario parse/validation + `evaluateImpact` over a seeded in-memory dataset graph (pass when downstream present, fail when missing, fail when no DB).
- Docs: `expect.lineage.impact` documented in the harness reference with an example.

The "CLI output" half of the original C idea intentionally stays in the integration suite — the harness executes jobs in-process and doesn't invoke the CLI, so CLI-surface assertions belong there (per the testing policy added in the e2e-coverage PR).

## Test plan
- [x] `just lint` → 0 issues
- [x] `go test ./internal/harness/` → green (3 new evaluateImpact + 3 new parse/validation tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)