### PR TITLE
Add causal run-diff read-side core (data-plane-memory-ii W1-α)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -319,7 +319,7 @@ substrate that shipped in data-plane-memory A2. It also unblocks Stream B's
 `--diff` output. Honest scope, enforced in the rendered output: cache-bust
 attribution only — hand value-level row/column diffs to dbt/Datafold.
 
-- [ ] A1. Add the run-diff read-side core: given two run IDs of the same job,
+- [x] A1. Add the run-diff read-side core: given two run IDs of the same job,
       pair terminal (latest-attempt) task-runs by task name and diff each pair's
       persisted `HashInput` blob via `DiffHashInputBlobs`, assembling a `RunDiff`
       (per-task verdict + `[]FieldChange` + run-level param/trigger deltas and a
@@ -329,6 +329,11 @@ attribution only — hand value-level row/column diffs to dbt/Datafold.
       struct.
       Files: new `internal/run/rundiff.go`, new `internal/run/rundiff_test.go`;
       reuses `internal/run/whydiff.go` (read-only).
+      Note: W1-alpha landed `Store.DiffRuns` with JSON-ready `RunDiff`/task
+      verdict structs, latest-terminal-attempt pairing by task name, run-level
+      trigger/param deltas, added/removed task sets, and focused run-package
+      unit coverage for changed params, identical inputs, topology drift, and
+      degraded blobs.
 - [ ] A2. Expose `GET /v1/jobs/:id/runs/diff?left=<run>&right=<run>` returning the
       `RunDiff` as JSON. **Validate both `left` and `right` belong to `:id` — this
       is the security boundary, not just input hygiene.** Scope middleware only

--- a/internal/run/rundiff.go
+++ b/internal/run/rundiff.go
@@ -1,0 +1,301 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// RunDiffVerdict is the per-task verdict for an explicit left -> right run
+// comparison.
+type RunDiffVerdict string
+
+const (
+	// RunDiffVerdictWouldCacheHit means the compared task HashInput blobs carry
+	// the same identity hash; relative to the left run, the right run would have
+	// cache-hit.
+	RunDiffVerdictWouldCacheHit RunDiffVerdict = "WOULD_CACHE_HIT"
+	// RunDiffVerdictReran means the compared task HashInput blobs differ; the
+	// field changes explain why the right-side task re-ran relative to the left.
+	RunDiffVerdictReran RunDiffVerdict = "RERAN"
+	// RunDiffVerdictDegraded means the task pair could not be diffed
+	// field-by-field because one side's persisted blob is missing or degraded.
+	RunDiffVerdictDegraded RunDiffVerdict = "DEGRADED"
+)
+
+// RunDiff is the machine-readable, read-side diff of two runs of the same job.
+// It is cache-bust attribution only: it compares persisted HashInput blobs and
+// trigger/run params, not row- or column-level data values.
+type RunDiff struct {
+	JobID      uuid.UUID `json:"jobId"`
+	LeftRunID  uuid.UUID `json:"leftRunId"`
+	RightRunID uuid.UUID `json:"rightRunId"`
+
+	LeftStatus  Status `json:"leftStatus"`
+	RightStatus Status `json:"rightStatus"`
+
+	LeftTrigger  WhyTrigger `json:"leftTrigger"`
+	RightTrigger WhyTrigger `json:"rightTrigger"`
+
+	TriggerChanges []FieldChange `json:"triggerChanges,omitempty"`
+	ParamChanges   []FieldChange `json:"paramChanges,omitempty"`
+	Tasks          []RunDiffTask `json:"tasks"`
+	TasksAdded     []string      `json:"tasksAdded,omitempty"`
+	TasksRemoved   []string      `json:"tasksRemoved,omitempty"`
+	GeneratedAt    time.Time     `json:"generatedAt"`
+}
+
+// RunDiffTask is one paired task-name comparison in a RunDiff.
+type RunDiffTask struct {
+	TaskName string `json:"taskName"`
+
+	LeftTaskRunID  uuid.UUID `json:"leftTaskRunId"`
+	RightTaskRunID uuid.UUID `json:"rightTaskRunId"`
+	LeftTaskID     uuid.UUID `json:"leftTaskId"`
+	RightTaskID    uuid.UUID `json:"rightTaskId"`
+
+	LeftStatus   TaskStatus `json:"leftStatus"`
+	RightStatus  TaskStatus `json:"rightStatus"`
+	LeftAttempt  int        `json:"leftAttempt"`
+	RightAttempt int        `json:"rightAttempt"`
+	LeftHash     string     `json:"leftHash,omitempty"`
+	RightHash    string     `json:"rightHash,omitempty"`
+
+	Verdict   RunDiffVerdict `json:"verdict"`
+	HashEqual bool           `json:"hashEqual"`
+	Changes   []FieldChange  `json:"changes,omitempty"`
+	Degraded  string         `json:"degraded,omitempty"`
+}
+
+var (
+	// ErrRunDiffJobMismatch is returned when either run does not belong to the
+	// requested job, or the two runs are from different jobs.
+	ErrRunDiffJobMismatch = errors.New("run: run diff job mismatch")
+)
+
+// DiffRuns compares the latest terminal task-runs in rightRunID against
+// leftRunID for one job. It pairs rows by task name, diffs each pair's
+// persisted HashInput blob via DiffHashInputBlobs, and returns a JSON-ready
+// read model for API/CLI layers to render.
+//
+// Pairing considers terminal task-runs only (Succeeded/Failed/Skipped/Cached).
+// A task with no terminal task-run on one side is treated as absent there and
+// reported in TasksAdded/TasksRemoved; this read model is intended for two
+// completed runs, where every task has a terminal attempt.
+func (s *Store) DiffRuns(ctx context.Context, jobID, leftRunID, rightRunID uuid.UUID) (*RunDiff, error) {
+	db := s.db.WithContext(ctx)
+
+	leftRun, err := loadRunDiffRun(db, leftRunID)
+	if err != nil {
+		return nil, err
+	}
+	rightRun, err := loadRunDiffRun(db, rightRunID)
+	if err != nil {
+		return nil, err
+	}
+	if leftRun.JobID != jobID || rightRun.JobID != jobID || leftRun.JobID != rightRun.JobID {
+		return nil, fmt.Errorf("%w: left run job=%s right run job=%s requested job=%s",
+			ErrRunDiffJobMismatch, leftRun.JobID, rightRun.JobID, jobID)
+	}
+
+	leftTasks, err := s.latestTerminalTaskRunsByName(ctx, leftRunID)
+	if err != nil {
+		return nil, err
+	}
+	rightTasks, err := s.latestTerminalTaskRunsByName(ctx, rightRunID)
+	if err != nil {
+		return nil, err
+	}
+
+	leftTrigger := s.loadTrigger(ctx, leftRun)
+	rightTrigger := s.loadTrigger(ctx, rightRun)
+
+	out := &RunDiff{
+		JobID:          jobID,
+		LeftRunID:      leftRunID,
+		RightRunID:     rightRunID,
+		LeftStatus:     Status(leftRun.Status),
+		RightStatus:    Status(rightRun.Status),
+		LeftTrigger:    leftTrigger,
+		RightTrigger:   rightTrigger,
+		TriggerChanges: diffRunTriggers(leftTrigger, rightTrigger),
+		ParamChanges:   diffStringMap("params", leftTrigger.Params, rightTrigger.Params),
+		GeneratedAt:    time.Now().UTC(),
+	}
+
+	for _, taskName := range sortedTaskNames(leftTasks, rightTasks) {
+		leftTask, leftOK := leftTasks[taskName]
+		rightTask, rightOK := rightTasks[taskName]
+		switch {
+		case !leftOK:
+			out.TasksAdded = append(out.TasksAdded, taskName)
+		case !rightOK:
+			out.TasksRemoved = append(out.TasksRemoved, taskName)
+		default:
+			out.Tasks = append(out.Tasks, diffRunTask(taskName, leftTask.TaskRun, rightTask.TaskRun))
+		}
+	}
+
+	return out, nil
+}
+
+type runDiffTaskRunRow struct {
+	models.TaskRun
+	TaskName string
+}
+
+func loadRunDiffRun(db *gorm.DB, runID uuid.UUID) (*models.JobRun, error) {
+	var run models.JobRun
+	if err := db.First(&run, "id = ?", runID).Error; err != nil {
+		return nil, err
+	}
+	return &run, nil
+}
+
+func (s *Store) latestTerminalTaskRunsByName(ctx context.Context, runID uuid.UUID) (map[string]runDiffTaskRunRow, error) {
+	var rows []runDiffTaskRunRow
+	if err := s.db.WithContext(ctx).
+		Table("task_runs").
+		Select("task_runs.*, tasks.name AS task_name").
+		Joins("JOIN tasks ON tasks.id = task_runs.task_id").
+		Where("task_runs.job_run_id = ? AND task_runs.status IN ?", runID, terminalTaskStatuses()).
+		Order("tasks.name ASC, task_runs.attempt ASC, task_runs.terminal_sequence ASC, task_runs.updated_at ASC, task_runs.id ASC").
+		Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]runDiffTaskRunRow, len(rows))
+	for _, row := range rows {
+		if current, ok := byName[row.TaskName]; !ok || laterTerminalTaskRun(row.TaskRun, current.TaskRun) {
+			byName[row.TaskName] = row
+		}
+	}
+	return byName, nil
+}
+
+func terminalTaskStatuses() []string {
+	return []string{
+		string(TaskStatusSucceeded),
+		string(TaskStatusFailed),
+		string(TaskStatusSkipped),
+		string(TaskStatusCached),
+	}
+}
+
+func laterTerminalTaskRun(candidate, current models.TaskRun) bool {
+	if candidate.Attempt != current.Attempt {
+		return candidate.Attempt > current.Attempt
+	}
+	if candidate.TerminalSequence != current.TerminalSequence {
+		return candidate.TerminalSequence > current.TerminalSequence
+	}
+	if !sameOptionalTime(candidate.CompletedAt, current.CompletedAt) {
+		return optionalTimeAfter(candidate.CompletedAt, current.CompletedAt)
+	}
+	if !candidate.UpdatedAt.Equal(current.UpdatedAt) {
+		return candidate.UpdatedAt.After(current.UpdatedAt)
+	}
+	if !candidate.CreatedAt.Equal(current.CreatedAt) {
+		return candidate.CreatedAt.After(current.CreatedAt)
+	}
+	return candidate.ID.String() > current.ID.String()
+}
+
+func sameOptionalTime(a, b *time.Time) bool {
+	switch {
+	case a == nil && b == nil:
+		return true
+	case a == nil || b == nil:
+		return false
+	default:
+		return a.Equal(*b)
+	}
+}
+
+func optionalTimeAfter(a, b *time.Time) bool {
+	switch {
+	case a == nil:
+		return false
+	case b == nil:
+		return true
+	default:
+		return a.After(*b)
+	}
+}
+
+func sortedTaskNames(left, right map[string]runDiffTaskRunRow) []string {
+	seen := make(map[string]struct{}, len(left)+len(right))
+	for name := range left {
+		seen[name] = struct{}{}
+	}
+	for name := range right {
+		seen[name] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func diffRunTask(taskName string, left, right models.TaskRun) RunDiffTask {
+	base := RunDiffTask{
+		TaskName:       taskName,
+		LeftTaskRunID:  left.ID,
+		RightTaskRunID: right.ID,
+		LeftTaskID:     left.TaskID,
+		RightTaskID:    right.TaskID,
+		LeftStatus:     TaskStatus(left.Status),
+		RightStatus:    TaskStatus(right.Status),
+		LeftAttempt:    left.Attempt,
+		RightAttempt:   right.Attempt,
+		LeftHash:       left.Hash,
+		RightHash:      right.Hash,
+	}
+
+	diff, err := DiffHashInputBlobs(right.HashInputBlob, left.HashInputBlob)
+	if err != nil {
+		// A decode failure on one task's persisted blob must not abort the
+		// whole run diff; degrade just this task, mirroring why's per-task
+		// degraded handling.
+		base.Verdict = RunDiffVerdictDegraded
+		base.Degraded = fmt.Sprintf("decode hash-input blob: %v", err)
+		return base
+	}
+
+	base.Verdict = classifyRunDiffVerdict(diff)
+	base.HashEqual = diff.HashEqual
+	base.Changes = diff.Changes
+	base.Degraded = diff.Degraded
+	return base
+}
+
+func classifyRunDiffVerdict(diff *BlobDiff) RunDiffVerdict {
+	if diff == nil || diff.Degraded != "" {
+		return RunDiffVerdictDegraded
+	}
+	if diff.HashEqual {
+		return RunDiffVerdictWouldCacheHit
+	}
+	return RunDiffVerdictReran
+}
+
+func diffRunTriggers(left, right WhyTrigger) []FieldChange {
+	var changes []FieldChange
+	addScalar := func(field, before, after string) {
+		if before != after {
+			changes = append(changes, FieldChange{Field: field, Kind: fieldScalar, Before: before, After: after})
+		}
+	}
+
+	addScalar("trigger.type", left.Type, right.Type)
+	addScalar("trigger.alias", left.Alias, right.Alias)
+	return changes
+}

--- a/internal/run/rundiff.go
+++ b/internal/run/rundiff.go
@@ -126,6 +126,7 @@ func (s *Store) DiffRuns(ctx context.Context, jobID, leftRunID, rightRunID uuid.
 		RightTrigger:   rightTrigger,
 		TriggerChanges: diffRunTriggers(leftTrigger, rightTrigger),
 		ParamChanges:   diffStringMap("params", leftTrigger.Params, rightTrigger.Params),
+		Tasks:          make([]RunDiffTask, 0),
 		GeneratedAt:    time.Now().UTC(),
 	}
 
@@ -260,6 +261,10 @@ func diffRunTask(taskName string, left, right models.TaskRun) RunDiffTask {
 		RightHash:      right.Hash,
 	}
 
+	// DiffHashInputBlobs(subject, baseline): right is the subject (newer/after),
+	// left the baseline (older/before), so the resulting FieldChanges read
+	// Before=left, After=right — matching RunDiff's left→right framing. Do not
+	// swap these to match the left,right parameter order.
 	diff, err := DiffHashInputBlobs(right.HashInputBlob, left.HashInputBlob)
 	if err != nil {
 		// A decode failure on one task's persisted blob must not abort the

--- a/internal/run/rundiff_test.go
+++ b/internal/run/rundiff_test.go
@@ -284,6 +284,7 @@ func seedRunDiffTask(t *testing.T, db *gorm.DB, jobID uuid.UUID, name string) uu
 func seedRunDiffTaskRun(t *testing.T, db *gorm.DB, runID, taskID uuid.UUID, attempt int, input cache.HashInput, status string, blobOverride []byte) uuid.UUID {
 	t.Helper()
 
+	id := uuid.New()
 	now := time.Now().UTC().Add(time.Duration(attempt) * time.Second)
 	blob := blobOverride
 	if blob == nil {
@@ -291,7 +292,7 @@ func seedRunDiffTaskRun(t *testing.T, db *gorm.DB, runID, taskID uuid.UUID, atte
 	}
 	hash := input.Compute()
 	require.NoError(t, db.Create(&models.TaskRun{
-		ID:               uuid.New(),
+		ID:               id,
 		JobRunID:         runID,
 		TaskID:           taskID,
 		AtomID:           uuid.New(),
@@ -310,7 +311,7 @@ func seedRunDiffTaskRun(t *testing.T, db *gorm.DB, runID, taskID uuid.UUID, atte
 		CreatedAt:        now,
 		UpdatedAt:        now,
 	}).Error)
-	return taskID
+	return id
 }
 
 func mustJSON(t *testing.T, v any) datatypes.JSON {

--- a/internal/run/rundiff_test.go
+++ b/internal/run/rundiff_test.go
@@ -1,0 +1,335 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/cache"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+func TestDiffRuns_RunParamChangeSurfacesOnTask(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	taskID := seedRunDiffTask(t, db, jobID, "load")
+	leftRunID := seedRunDiffRun(t, db, jobID, time.Now().UTC(), "cron", "nightly", map[string]string{"region": "us"})
+	rightRunID := seedRunDiffRun(t, db, jobID, time.Now().UTC().Add(time.Hour), "cron", "nightly", map[string]string{"region": "eu"})
+
+	leftHI := cache.HashInput{TaskName: "load", Image: "alpine:3.23", RunParams: map[string]string{"region": "us"}}
+	rightHI := cache.HashInput{TaskName: "load", Image: "alpine:3.23", RunParams: map[string]string{"region": "eu"}}
+	seedRunDiffTaskRun(t, db, leftRunID, taskID, 1, leftHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, taskID, 1, rightHI, string(TaskStatusSucceeded), nil)
+
+	diff, err := store.DiffRuns(ctx, jobID, leftRunID, rightRunID)
+	require.NoError(t, err)
+	require.Len(t, diff.Tasks, 1)
+	require.Equal(t, RunDiffVerdictReran, diff.Tasks[0].Verdict)
+
+	taskChange, ok := findChange(diff.Tasks[0].Changes, "runParams.region")
+	require.True(t, ok, "expected task-level run param change, got %+v", diff.Tasks[0].Changes)
+	require.Equal(t, "us", taskChange.Before)
+	require.Equal(t, "eu", taskChange.After)
+
+	paramChange, ok := findChange(diff.ParamChanges, "params.region")
+	require.True(t, ok, "expected run-level param change, got %+v", diff.ParamChanges)
+	require.Equal(t, "us", paramChange.Before)
+	require.Equal(t, "eu", paramChange.After)
+}
+
+func TestDiffRuns_IdenticalInputsWouldCacheHit(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	extractID := seedRunDiffTask(t, db, jobID, "extract")
+	loadID := seedRunDiffTask(t, db, jobID, "load")
+	base := time.Now().UTC()
+	leftRunID := seedRunDiffRun(t, db, jobID, base, "manual", "", map[string]string{"batch": "42"})
+	rightRunID := seedRunDiffRun(t, db, jobID, base.Add(time.Hour), "manual", "", map[string]string{"batch": "42"})
+
+	extractHI := cache.HashInput{TaskName: "extract", Image: "alpine:3.23", RunParams: map[string]string{"batch": "42"}}
+	loadHI := cache.HashInput{
+		TaskName: "load",
+		Image:    "alpine:3.23",
+		PredecessorOutputs: map[string]map[string]string{
+			"extract": {"rows": "10"},
+		},
+		RunParams: map[string]string{"batch": "42"},
+	}
+	seedRunDiffTaskRun(t, db, leftRunID, extractID, 1, extractHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, leftRunID, loadID, 1, loadHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, extractID, 1, extractHI, string(TaskStatusCached), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, loadID, 1, loadHI, string(TaskStatusCached), nil)
+
+	diff, err := store.DiffRuns(ctx, jobID, leftRunID, rightRunID)
+	require.NoError(t, err)
+	require.Empty(t, diff.TasksAdded)
+	require.Empty(t, diff.TasksRemoved)
+	require.Empty(t, diff.ParamChanges)
+	require.Len(t, diff.Tasks, 2)
+	for _, task := range diff.Tasks {
+		require.Equal(t, RunDiffVerdictWouldCacheHit, task.Verdict, "task=%s", task.TaskName)
+		require.True(t, task.HashEqual, "task=%s", task.TaskName)
+		require.Empty(t, task.Changes, "task=%s", task.TaskName)
+		require.Empty(t, task.Degraded, "task=%s", task.TaskName)
+	}
+}
+
+func TestDiffRuns_TasksAddedAndRemoved(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	sharedID := seedRunDiffTask(t, db, jobID, "shared")
+	oldID := seedRunDiffTask(t, db, jobID, "old")
+	newID := seedRunDiffTask(t, db, jobID, "new")
+	base := time.Now().UTC()
+	leftRunID := seedRunDiffRun(t, db, jobID, base, "manual", "", nil)
+	rightRunID := seedRunDiffRun(t, db, jobID, base.Add(time.Hour), "manual", "", nil)
+
+	sharedHI := cache.HashInput{TaskName: "shared", Image: "alpine:3.23"}
+	oldHI := cache.HashInput{TaskName: "old", Image: "alpine:3.23"}
+	newHI := cache.HashInput{TaskName: "new", Image: "alpine:3.23"}
+	seedRunDiffTaskRun(t, db, leftRunID, sharedID, 1, sharedHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, sharedID, 1, sharedHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, leftRunID, oldID, 1, oldHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, newID, 1, newHI, string(TaskStatusSucceeded), nil)
+
+	diff, err := store.DiffRuns(ctx, jobID, leftRunID, rightRunID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"new"}, diff.TasksAdded)
+	require.Equal(t, []string{"old"}, diff.TasksRemoved)
+	require.Len(t, diff.Tasks, 1)
+	require.Equal(t, "shared", diff.Tasks[0].TaskName)
+}
+
+func TestDiffRuns_DegradedBlobDoesNotStopRestOfDiff(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	goodID := seedRunDiffTask(t, db, jobID, "good")
+	degradedID := seedRunDiffTask(t, db, jobID, "degraded")
+	base := time.Now().UTC()
+	leftRunID := seedRunDiffRun(t, db, jobID, base, "manual", "", nil)
+	rightRunID := seedRunDiffRun(t, db, jobID, base.Add(time.Hour), "manual", "", nil)
+
+	goodHI := cache.HashInput{TaskName: "good", Image: "alpine:3.23"}
+	degradedHI := cache.HashInput{TaskName: "degraded", Image: "alpine:3.23"}
+	versionMismatchBlob := withBlobVersion(t, blobBytes(t, degradedHI), 999)
+
+	seedRunDiffTaskRun(t, db, leftRunID, goodID, 1, goodHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, goodID, 1, goodHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, leftRunID, degradedID, 1, degradedHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, degradedID, 1, degradedHI, string(TaskStatusSucceeded), versionMismatchBlob)
+
+	diff, err := store.DiffRuns(ctx, jobID, leftRunID, rightRunID)
+	require.NoError(t, err)
+	require.Len(t, diff.Tasks, 2)
+
+	byName := map[string]RunDiffTask{}
+	for _, task := range diff.Tasks {
+		byName[task.TaskName] = task
+	}
+	require.Equal(t, RunDiffVerdictWouldCacheHit, byName["good"].Verdict)
+	require.Empty(t, byName["good"].Degraded)
+	require.Equal(t, RunDiffVerdictDegraded, byName["degraded"].Verdict)
+	require.Contains(t, byName["degraded"].Degraded, "blob version mismatch")
+}
+
+func TestDiffRuns_UsesLatestTerminalAttemptByTaskName(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	taskID := seedRunDiffTask(t, db, jobID, "retrying")
+	base := time.Now().UTC()
+	leftRunID := seedRunDiffRun(t, db, jobID, base, "manual", "", nil)
+	rightRunID := seedRunDiffRun(t, db, jobID, base.Add(time.Hour), "manual", "", nil)
+
+	oldAttemptHI := cache.HashInput{TaskName: "retrying", Image: "busybox:1.36.1"}
+	latestHI := cache.HashInput{TaskName: "retrying", Image: "alpine:3.23"}
+	seedRunDiffTaskRun(t, db, leftRunID, taskID, 1, latestHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, taskID, 1, oldAttemptHI, string(TaskStatusFailed), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, taskID, 2, latestHI, string(TaskStatusSucceeded), nil)
+
+	diff, err := store.DiffRuns(ctx, jobID, leftRunID, rightRunID)
+	require.NoError(t, err)
+	require.Len(t, diff.Tasks, 1)
+	require.Equal(t, 2, diff.Tasks[0].RightAttempt)
+	require.Equal(t, RunDiffVerdictWouldCacheHit, diff.Tasks[0].Verdict)
+}
+
+func TestDiffRuns_CorruptBlobDegradesOnlyThatTask(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	goodID := seedRunDiffTask(t, db, jobID, "good")
+	corruptID := seedRunDiffTask(t, db, jobID, "corrupt")
+	base := time.Now().UTC()
+	leftRunID := seedRunDiffRun(t, db, jobID, base, "manual", "", nil)
+	rightRunID := seedRunDiffRun(t, db, jobID, base.Add(time.Hour), "manual", "", nil)
+
+	goodHI := cache.HashInput{TaskName: "good", Image: "alpine:3.23"}
+	corruptHI := cache.HashInput{TaskName: "corrupt", Image: "alpine:3.23"}
+
+	seedRunDiffTaskRun(t, db, leftRunID, goodID, 1, goodHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, goodID, 1, goodHI, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, leftRunID, corruptID, 1, corruptHI, string(TaskStatusSucceeded), nil)
+	// A non-empty, non-JSON persisted blob makes DiffHashInputBlobs return a
+	// decode error (distinct from the missing/oversized/version-mismatch
+	// degrade paths). It must degrade only this task, not abort the run diff.
+	seedRunDiffTaskRun(t, db, rightRunID, corruptID, 1, corruptHI, string(TaskStatusSucceeded), []byte("}{ not valid json"))
+
+	diff, err := store.DiffRuns(ctx, jobID, leftRunID, rightRunID)
+	require.NoError(t, err)
+	require.Len(t, diff.Tasks, 2)
+
+	byName := map[string]RunDiffTask{}
+	for _, task := range diff.Tasks {
+		byName[task.TaskName] = task
+	}
+	require.Equal(t, RunDiffVerdictWouldCacheHit, byName["good"].Verdict)
+	require.Empty(t, byName["good"].Degraded)
+	require.Equal(t, RunDiffVerdictDegraded, byName["corrupt"].Verdict)
+	require.Contains(t, byName["corrupt"].Degraded, "decode hash-input blob")
+}
+
+func TestDiffRuns_TriggerChangeSurfaces(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+
+	jobID := uuid.New()
+	taskID := seedRunDiffTask(t, db, jobID, "load")
+	base := time.Now().UTC()
+	leftRunID := seedRunDiffRun(t, db, jobID, base, "cron", "nightly", nil)
+	rightRunID := seedRunDiffRun(t, db, jobID, base.Add(time.Hour), "manual", "adhoc", nil)
+
+	hi := cache.HashInput{TaskName: "load", Image: "alpine:3.23"}
+	seedRunDiffTaskRun(t, db, leftRunID, taskID, 1, hi, string(TaskStatusSucceeded), nil)
+	seedRunDiffTaskRun(t, db, rightRunID, taskID, 1, hi, string(TaskStatusSucceeded), nil)
+
+	diff, err := store.DiffRuns(ctx, jobID, leftRunID, rightRunID)
+	require.NoError(t, err)
+
+	typeChange, ok := findChange(diff.TriggerChanges, "trigger.type")
+	require.True(t, ok, "expected trigger.type change, got %+v", diff.TriggerChanges)
+	require.Equal(t, "cron", typeChange.Before)
+	require.Equal(t, "manual", typeChange.After)
+
+	aliasChange, ok := findChange(diff.TriggerChanges, "trigger.alias")
+	require.True(t, ok, "expected trigger.alias change, got %+v", diff.TriggerChanges)
+	require.Equal(t, "nightly", aliasChange.Before)
+	require.Equal(t, "adhoc", aliasChange.After)
+}
+
+func seedRunDiffRun(t *testing.T, db *gorm.DB, jobID uuid.UUID, startedAt time.Time, triggerType, triggerAlias string, params map[string]string) uuid.UUID {
+	t.Helper()
+
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:           runID,
+		JobID:        jobID,
+		Status:       string(StatusSucceeded),
+		TriggerType:  triggerType,
+		TriggerAlias: triggerAlias,
+		Params:       mustJSON(t, params),
+		StartedAt:    startedAt,
+		CreatedAt:    startedAt,
+		UpdatedAt:    startedAt,
+	}).Error)
+	return runID
+}
+
+func seedRunDiffTask(t *testing.T, db *gorm.DB, jobID uuid.UUID, name string) uuid.UUID {
+	t.Helper()
+
+	taskID := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.Task{
+		ID:        taskID,
+		JobID:     jobID,
+		AtomID:    uuid.New(),
+		Name:      name,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	return taskID
+}
+
+func seedRunDiffTaskRun(t *testing.T, db *gorm.DB, runID, taskID uuid.UUID, attempt int, input cache.HashInput, status string, blobOverride []byte) uuid.UUID {
+	t.Helper()
+
+	now := time.Now().UTC().Add(time.Duration(attempt) * time.Second)
+	blob := blobOverride
+	if blob == nil {
+		blob = blobBytes(t, input)
+	}
+	hash := input.Compute()
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID:               uuid.New(),
+		JobRunID:         runID,
+		TaskID:           taskID,
+		AtomID:           uuid.New(),
+		Engine:           models.AtomEngineDocker,
+		Image:            input.Image,
+		Command:          `["echo"]`,
+		Status:           status,
+		Attempt:          attempt,
+		MaxAttempts:      attempt,
+		CacheEnabled:     true,
+		Hash:             hash,
+		HashInputBlob:    datatypes.JSON(blob),
+		TerminalSequence: int64(attempt),
+		StartedAt:        &now,
+		CompletedAt:      &now,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}).Error)
+	return taskID
+}
+
+func mustJSON(t *testing.T, v any) datatypes.JSON {
+	t.Helper()
+	if v == nil {
+		return nil
+	}
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return datatypes.JSON(data)
+}
+
+func withBlobVersion(t *testing.T, blob []byte, version int) []byte {
+	t.Helper()
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(blob, &raw))
+	raw["blobVersion"] = version
+	out, err := json.Marshal(raw)
+	require.NoError(t, err)
+	return out
+}


### PR DESCRIPTION
## Summary
- New `internal/run/rundiff.go` (`Store.DiffRuns`): pairs the latest **terminal** task-runs of two runs of the same job by task name and diffs each pair's persisted `HashInput` blob, **reusing the existing `whydiff.go` differ verbatim** (`DiffHashInputBlobs`/`BlobDiff`/`FieldChange`) — not a fork.
- Returns a JSON-ready `RunDiff`: per-task verdict (`RERAN` / `WOULD_CACHE_HIT` / `DEGRADED`) + field changes, run-level param/trigger deltas, and the tasks-added/removed set.
- **Cache-bust attribution only** (which step/output changed and why a task re-ran); value-level row/column diffs are explicitly out of scope (dbt/Datafold).
- Degrades gracefully per task: a missing / oversized / version-mismatched / **corrupt** blob marks just that task `DEGRADED` and continues the rest of the diff.
- Implements item **A1** (read-side core). The REST endpoint (A2), CLI (A3), and integration scenario (A4) are follow-on items in Stream A.

## Test plan
- [x] just lint (orchestrator)
- [x] just unit-test (orchestrator) — incl. new cases: run-param diff, identical/would-cache-hit, tasks added/removed, latest-terminal-attempt, version-mismatch degrade, **corrupt-blob degrade**, **trigger-delta**
- [ ] just integration-test — pre-merge gate (A1 is internal; the end-to-end driver lands with A3/A4)
- Opus adversarial review (4 lenses) → 2 confirmed fixes applied (degrade-on-corrupt-blob robustness + trigger-delta/corrupt-blob test coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)