### PR TITLE
Resolve /v1/lineage/impact scope semantics (data-plane-memory-ii W2-γ)

### DIFF
--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -123,7 +123,7 @@ func Auth(d AuthDeps) echo.MiddlewareFunc {
 			scopeContext, err := authorizeScope(c, d.Service, principal.Scope, routePath)
 			if err != nil {
 				if he, ok := err.(*echo.HTTPError); ok && he.Code == http.StatusForbidden {
-					return denyAccess(c, d.Auditor, principal.Subject, principal.Role, routePath, "insufficient_scope", required)
+					return denyAccessWithMessage(c, d.Auditor, principal.Subject, principal.Role, routePath, "insufficient_scope", required, forbiddenMessage(he))
 				}
 				return err
 			}
@@ -246,6 +246,19 @@ func denyAccess(
 	reason string,
 	required models.Role,
 ) error {
+	return denyAccessWithMessage(c, auditor, actor, keyRole, routePath, reason, required, "insufficient permissions")
+}
+
+func denyAccessWithMessage(
+	c *echo.Context,
+	auditor *auth.AuditLogger,
+	actor string,
+	keyRole models.Role,
+	routePath string,
+	reason string,
+	required models.Role,
+	message string,
+) error {
 	metrics.AuthRequestsTotal.WithLabelValues("denied", string(keyRole), c.Request().Method, routePath).Inc()
 
 	metadata := map[string]interface{}{
@@ -266,7 +279,16 @@ func denyAccess(
 		Outcome:  auth.OutcomeDenied,
 		Metadata: metadata,
 	}))
-	return echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+	return echo.NewHTTPError(http.StatusForbidden, message)
+}
+
+func forbiddenMessage(err *echo.HTTPError) string {
+	// echo/v5 HTTPError.Message is a concrete string (not interface{} as in v4),
+	// so read it directly rather than type-asserting.
+	if err != nil && err.Message != "" {
+		return err.Message
+	}
+	return "insufficient permissions"
 }
 
 func logSuccessfulAction(

--- a/api/middleware/auth_scope.go
+++ b/api/middleware/auth_scope.go
@@ -17,7 +17,10 @@ import (
 // ContextKeyAllowedJobAliases stores the scoped job aliases available to list endpoints.
 const ContextKeyAllowedJobAliases = "auth.allowed_job_aliases"
 
-const lineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
+// LineageImpactScopedDenyMessage is the 403 reason returned to a scoped principal
+// on the global, cross-job /v1/lineage/impact route. Exported so the auth and
+// integration tests assert against the single source of truth.
+const LineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
 
 type scopeAuditContext struct {
 	jobAliases []string
@@ -81,7 +84,7 @@ func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routeP
 		return state, nil
 	case "/v1/lineage/impact":
 		if c.Request().Method == http.MethodGet {
-			return nil, echo.NewHTTPError(http.StatusForbidden, lineageImpactScopedDenyMessage)
+			return nil, echo.NewHTTPError(http.StatusForbidden, LineageImpactScopedDenyMessage)
 		}
 	}
 

--- a/api/middleware/auth_scope.go
+++ b/api/middleware/auth_scope.go
@@ -17,6 +17,8 @@ import (
 // ContextKeyAllowedJobAliases stores the scoped job aliases available to list endpoints.
 const ContextKeyAllowedJobAliases = "auth.allowed_job_aliases"
 
+const lineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
+
 type scopeAuditContext struct {
 	jobAliases []string
 }
@@ -77,6 +79,10 @@ func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routeP
 		}
 		state.jobAliases = aliases
 		return state, nil
+	case "/v1/lineage/impact":
+		if c.Request().Method == http.MethodGet {
+			return nil, echo.NewHTTPError(http.StatusForbidden, lineageImpactScopedDenyMessage)
+		}
 	}
 
 	if strings.HasPrefix(routePath, "/v1/jobs/:id") {

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -18,8 +18,6 @@ import (
 	"gorm.io/gorm"
 )
 
-const lineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
-
 func setupAuth(t *testing.T) (*gorm.DB, *auth.Service, *auth.AuditLogger, *auth.RateLimiter, string) {
 	t.Helper()
 
@@ -798,7 +796,7 @@ func TestMiddlewareLineageImpactRejectsScopedViewerWithSpecificMessage(t *testin
 	he, ok := err.(*echo.HTTPError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusForbidden, he.Code)
-	require.Equal(t, lineageImpactScopedDenyMessage, he.Message)
+	require.Equal(t, authmw.LineageImpactScopedDenyMessage, he.Message)
 }
 
 func TestGetAuthKeyReturnsNilWhenNotSet(t *testing.T) {

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -18,6 +18,8 @@ import (
 	"gorm.io/gorm"
 )
 
+const lineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
+
 func setupAuth(t *testing.T) (*gorm.DB, *auth.Service, *auth.AuditLogger, *auth.RateLimiter, string) {
 	t.Helper()
 
@@ -753,6 +755,50 @@ func TestMiddlewareScopedGlobalRouteRejected(t *testing.T) {
 	he, ok := err.(*echo.HTTPError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestMiddlewareLineageImpactAllowsUnscopedViewer(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleViewer, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/lineage/impact", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/lineage/impact", Method: http.MethodGet},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareLineageImpactRejectsScopedViewerWithSpecificMessage(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleViewer, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/lineage/impact", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/lineage/impact", Method: http.MethodGet},
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+	require.Equal(t, lineageImpactScopedDenyMessage, he.Message)
 }
 
 func TestGetAuthKeyReturnsNilWhenNotSet(t *testing.T) {

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -1175,7 +1175,7 @@ behavior must be deliberate, not an accident of the fall-through.
       Note: H-1+H-2 fix shipped code and are independent of A/B/C; given no users
       this is low-urgency, but they can land as a small standalone PR whenever
       convenient — see the cover note on PR #229.
-- [ ] H-3. Resolve `/v1/lineage/impact` scope semantics — the cross-job leak. The
+- [x] H-3. Resolve `/v1/lineage/impact` scope semantics — the cross-job leak. The
       impact query is **global and intentionally cross-job** (it traverses dataset
       edges across jobs), but scope enforcement currently 403s every scoped
       principal on it (fall-through). A role-only backfill therefore leaves scoped
@@ -1197,6 +1197,11 @@ behavior must be deliberate, not an accident of the fall-through.
       authorize a `run_id`-scoped subscription, deny scoped keys an unfiltered global
       stream. Resolve it with the same `authorizeScope`-case approach; B2 owns the
       runtime change and B6(12) the test, but the scope decision is coordinated here.
+      Note (W2-gamma): Implemented option (a), requiring an unscoped principal for
+      the global impact traversal. Scoped keys now hit an explicit
+      `authorizeScope` deny for `GET /v1/lineage/impact` with the message
+      "lineage impact is a global cross-job query and requires an unscoped
+      principal"; unscoped viewer-or-higher principals continue to the controller.
 - [ ] H-4. **(Optional, nice-to-have)** Stand up a true **distributed** integration
       tier so B6's worker-isolation assertion can also run end-to-end, not only as
       the B6(7) direct `internal/worker` unit test. Add a CI/justfile target (or

--- a/docs/open_lineage.md
+++ b/docs/open_lineage.md
@@ -64,6 +64,8 @@ Run-level events (DAG start/complete/fail) continue to emit empty `Inputs`/`Outp
 
 A bounded summary of each task's dataset graph is also persisted in dqlite via the `lineage_datasets` table (namespace, name, direction, and a small facet digest) to support future cross-job impact queries — full facets are emitted only to the configured transport backend.
 
+`GET /v1/lineage/impact` is a global cross-job traversal over that persisted graph. In v1, job-scoped API keys are denied on this endpoint; use an unscoped API key with viewer-or-higher role until alias-filtered impact traversal is implemented.
+
 ## Configuration
 
 The integration is controlled entirely via environment variables. It is disabled by default.

--- a/test/lineage_scope_test.go
+++ b/test/lineage_scope_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	lineagectrl "github.com/caesium-cloud/caesium/api/rest/controller/lineage"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+const lineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
+
+func TestLineageImpactScopeRequiresUnscopedPrincipal(t *testing.T) {
+	t.Setenv("CAESIUM_DATABASE_PATH", t.TempDir())
+	t.Setenv("CAESIUM_DATABASE_SHARDS", "1")
+	t.Setenv("CAESIUM_DATABASE_STANDBYS", "0")
+	t.Setenv("CAESIUM_NODE_ADDRESS", freeLoopbackAddress(t))
+	t.Setenv("CAESIUM_AUTH_KEY_HASH_SECRET", "0123456789abcdef0123456789abcdef")
+	require.NoError(t, env.Process())
+	require.NoError(t, db.Migrate())
+
+	conn := db.Connection()
+	authSvc := iauth.NewService(conn, iauth.WithKeyHashSecret(env.Variables().AuthKeyHashSecret))
+	auditor := iauth.NewAuditLogger(conn)
+	limiter := iauth.NewRateLimiter(10, time.Minute)
+
+	unscoped, err := authSvc.CreateKey(&iauth.CreateKeyRequest{
+		Role:      models.RoleViewer,
+		CreatedBy: "integration-test",
+	})
+	require.NoError(t, err)
+	scoped, err := authSvc.CreateKey(&iauth.CreateKeyRequest{
+		Role:      models.RoleViewer,
+		Scope:     &models.KeyScope{Jobs: []string{"alpha"}},
+		CreatedBy: "integration-test",
+	})
+	require.NoError(t, err)
+
+	e := echo.New()
+	protected := e.Group("/v1")
+	protected.Use(authmw.Auth(authmw.AuthDeps{
+		Service: authSvc,
+		Auditor: auditor,
+		Limiter: limiter,
+	}))
+	protected.GET("/lineage/impact", lineagectrl.Impact)
+
+	server := httptest.NewServer(e)
+	defer server.Close()
+
+	target := server.URL + "/v1/lineage/impact?namespace=caesium&name=missing"
+
+	status, body := getWithBearer(t, target, scoped.Plaintext)
+	require.Equal(t, http.StatusForbidden, status, body)
+	require.Contains(t, body, lineageImpactScopedDenyMessage)
+
+	status, body = getWithBearer(t, target, unscoped.Plaintext)
+	require.Equal(t, http.StatusOK, status, body)
+
+	var result struct {
+		RootNamespace string `json:"root_namespace"`
+		RootName      string `json:"root_name"`
+		Downstream    []any  `json:"downstream"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &result))
+	require.Equal(t, "caesium", result.RootNamespace)
+	require.Equal(t, "missing", result.RootName)
+	require.Empty(t, result.Downstream)
+}
+
+func getWithBearer(t *testing.T, target, token string) (int, string) {
+	t.Helper()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	return resp.StatusCode, string(body)
+}
+
+func freeLoopbackAddress(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	return ln.Addr().String()
+}

--- a/test/lineage_scope_test.go
+++ b/test/lineage_scope_test.go
@@ -3,6 +3,7 @@
 package test
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net"
@@ -100,7 +101,8 @@ func getWithBearer(t *testing.T, target, token string) (int, string) {
 func freeLoopbackAddress(t *testing.T) string {
 	t.Helper()
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	var lc net.ListenConfig
+	ln, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer ln.Close()
 	return ln.Addr().String()

--- a/test/lineage_scope_test.go
+++ b/test/lineage_scope_test.go
@@ -22,8 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const lineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
-
 func TestLineageImpactScopeRequiresUnscopedPrincipal(t *testing.T) {
 	t.Setenv("CAESIUM_DATABASE_PATH", t.TempDir())
 	t.Setenv("CAESIUM_DATABASE_SHARDS", "1")
@@ -66,7 +64,7 @@ func TestLineageImpactScopeRequiresUnscopedPrincipal(t *testing.T) {
 
 	status, body := getWithBearer(t, target, scoped.Plaintext)
 	require.Equal(t, http.StatusForbidden, status, body)
-	require.Contains(t, body, lineageImpactScopedDenyMessage)
+	require.Contains(t, body, authmw.LineageImpactScopedDenyMessage)
 
 	status, body = getWithBearer(t, target, unscoped.Plaintext)
 	require.Equal(t, http.StatusOK, status, body)


### PR DESCRIPTION
## Summary
- `/v1/lineage/impact` is a **global, intentionally cross-job** query, but `authorizeScope` previously denied every scoped API key via the generic fall-through — so scoped keys couldn't use impact at all, and the naive "loosen scope" fix would leak datasets from jobs the key isn't scoped to.
- Implements **option (a)** (the lean pre-alpha choice): an explicit `authorizeScope` case for `GET /v1/lineage/impact` that **denies scoped principals with a clear, specific message** (`requires an unscoped principal`) while unscoped/admin principals pass. The deny is intentional and documented (`docs/open_lineage.md`), not an accident of the fall-through.
- Tests: middleware unit assertions (scoped denied / unscoped allowed) + a `test/` integration scenario (`//go:build integration`).
- Implements item **H-3**. (Alias-filtered traversal — option (b) — is recorded as the correct long-term enhancement.)

## Test plan
- [x] just lint (orchestrator)
- [x] just unit-test (orchestrator)
- [ ] just integration-test — pre-merge gate (CI runs it)
- Opus adversarial review (xhigh, scope-security lens): caught + fixed a compile-breaking `echo.HTTPError.Message` type assertion (echo v5 made it a concrete string); deduped a redundant unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)