### PR TITLE
Add RBAC policy completeness guard over auth-middleware routes (data-plane-memory-ii W2-β)

### DIFF
--- a/api/auth_rbac_policy_completeness_test.go
+++ b/api/auth_rbac_policy_completeness_test.go
@@ -1,0 +1,98 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"testing"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	"github.com/caesium-cloud/caesium/api/rest/bind"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthMiddlewareMountedRoutesHaveRBACPolicy(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, env.Process())
+	})
+
+	t.Setenv("CAESIUM_AUTH_MODE", "api-key")
+	t.Setenv("CAESIUM_AUTH_OIDC_ENABLED", "true")
+	t.Setenv("CAESIUM_AUTH_SAML_ENABLED", "true")
+	t.Setenv("CAESIUM_AUTH_LDAP_ENABLED", "true")
+	t.Setenv("CAESIUM_LOG_CONSOLE_ENABLED", "true")
+	t.Setenv("CAESIUM_DATABASE_CONSOLE_ENABLED", "true")
+	require.NoError(t, env.Process())
+
+	vars := env.Variables()
+	e := echo.New()
+	authSvc := iauth.NewService(nil)
+	sessions := iauth.NewSessionStore(nil)
+	providers := SSOProviders{
+		OIDC: routeOnlyRedirectProvider{name: "oidc"},
+		SAML: routeOnlyRedirectProvider{name: "saml"},
+		LDAP: routeOnlyCredentialProvider{name: "ldap"},
+	}
+
+	e.GET("/health", Health)
+	e.GET("/auth/status", authStatus(vars))
+	registerSSORoutes(e, vars, authSvc, nil, nil, sessions, nil, providers)
+	registerMetrics(e, vars, authSvc, nil, nil, sessions)
+	bind.All(e.Group("/v1"), nil, authSvc, nil, nil, sessions)
+
+	mounted := make(map[string]struct{})
+	var missing []string
+	for _, route := range e.Router().Routes() {
+		if authmw.IsPublicAuthPath(route.Path) {
+			continue
+		}
+
+		path := authmw.NormalizeRoutePath(route.Path)
+		key := route.Method + " " + path
+		mounted[key] = struct{}{}
+		if _, ok := iauth.RequiredRole(route.Method, path); !ok {
+			missing = append(missing, key)
+		}
+	}
+
+	require.Contains(t, mounted, "GET /metrics")
+	require.Contains(t, mounted, "GET /auth/whoami")
+	require.Contains(t, mounted, "GET /v1/events")
+	require.Contains(t, mounted, "GET /v1/auth/keys")
+	require.Contains(t, mounted, "GET /v1/logs/level")
+	require.Contains(t, mounted, "GET /v1/database/schema")
+
+	sort.Strings(missing)
+	require.Empty(t, missing, "auth-middleware mounted routes missing endpointPolicy entries")
+}
+
+type routeOnlyRedirectProvider struct {
+	name string
+}
+
+func (p routeOnlyRedirectProvider) Name() string {
+	return p.name
+}
+
+func (p routeOnlyRedirectProvider) Begin(http.ResponseWriter, *http.Request, string) (string, error) {
+	return "", nil
+}
+
+func (p routeOnlyRedirectProvider) Complete(*http.Request) (*iauth.ExternalIdentity, error) {
+	return nil, nil
+}
+
+type routeOnlyCredentialProvider struct {
+	name string
+}
+
+func (p routeOnlyCredentialProvider) Name() string {
+	return p.name
+}
+
+func (p routeOnlyCredentialProvider) Authenticate(context.Context, string, string) (*iauth.ExternalIdentity, error) {
+	return nil, nil
+}

--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -29,6 +29,20 @@ var skipPaths = map[string]bool{
 	"/health": true,
 }
 
+var publicAuthPaths = map[string]bool{
+	"/auth/status":            true,
+	"/auth/sso/oidc/login":    true,
+	"/auth/sso/oidc/callback": true,
+	"/auth/sso/saml/login":    true,
+	"/auth/sso/saml/acs":      true,
+	"/auth/sso/saml/metadata": true,
+	"/auth/sso/ldap/login":    true,
+}
+
+var publicAuthPathPrefixes = []string{
+	"/v1/hooks/",
+}
+
 // AuthDeps bundles the dependencies the auth middleware needs.
 type AuthDeps struct {
 	Service    *auth.Service
@@ -46,7 +60,7 @@ func Auth(d AuthDeps) echo.MiddlewareFunc {
 			path := c.Request().URL.Path
 
 			// Skip auth for explicitly public paths.
-			if skipPaths[path] {
+			if IsPublicAuthPath(path) {
 				return next(c)
 			}
 
@@ -163,16 +177,37 @@ func extractBearerToken(c *echo.Context) (string, bool) {
 	return token, false
 }
 
+// IsPublicAuthPath reports whether path is intentionally reachable without the
+// Auth middleware enforcing credentials. Keep RBAC completeness tests on this
+// helper so their public-route exclusions match the middleware.
+func IsPublicAuthPath(path string) bool {
+	if skipPaths[path] || publicAuthPaths[path] {
+		return true
+	}
+	for _, prefix := range publicAuthPathPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// NormalizeRoutePath returns the policy lookup path used by RBAC for Echo route
+// patterns or raw request paths.
+func NormalizeRoutePath(path string) string {
+	path = uuidPattern.ReplaceAllString(path, ":id")
+	return namedParamPattern.ReplaceAllString(path, ":id")
+}
+
 // normalisePath returns the Echo route pattern (with :param placeholders)
-// so RBAC policy lookup works for parametric routes. Falls back to replacing
+// so RBAC policy lookup works for parametric routes. Falls back to normalising
 // UUID segments in the raw path.
 func normalisePath(c *echo.Context) string {
-	ri := c.RouteInfo()
-	path := ri.Path
+	path := c.RouteInfo().Path
 	if path == "" {
-		path = uuidPattern.ReplaceAllString(c.Request().URL.Path, ":id")
+		path = c.Request().URL.Path
 	}
-	return namedParamPattern.ReplaceAllString(path, ":id")
+	return NormalizeRoutePath(path)
 }
 
 // tokenPrefix returns a safe display prefix for logging, never the full key.

--- a/api/rest/controller/event/stream.go
+++ b/api/rest/controller/event/stream.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/event"
@@ -15,15 +16,20 @@ import (
 )
 
 type Controller struct {
-	bus   event.Bus
-	store *event.Store
+	bus       event.Bus
+	storeOnce sync.Once
+	store     *event.Store
 }
 
 func New(bus event.Bus) *Controller {
-	return &Controller{
-		bus:   bus,
-		store: event.NewStore(db.Connection()),
-	}
+	return &Controller{bus: bus}
+}
+
+func (ctrl *Controller) persistentStore() *event.Store {
+	ctrl.storeOnce.Do(func() {
+		ctrl.store = event.NewStore(db.Connection())
+	})
+	return ctrl.store
 }
 
 func (ctrl *Controller) Stream(c *echo.Context) error {
@@ -62,14 +68,14 @@ func (ctrl *Controller) Stream(c *echo.Context) error {
 	}
 	flusher.Flush()
 
-	if ctrl.store != nil {
-		latestBeforeCatchup, err := ctrl.store.LatestSequence(ctx)
+	if store := ctrl.persistentStore(); store != nil {
+		latestBeforeCatchup, err := store.LatestSequence(ctx)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "failed to read event cursor").Wrap(err)
 		}
 
 		for {
-			backlog, err := ctrl.store.ListSince(ctx, lastSent, 500, filter)
+			backlog, err := store.ListSince(ctx, lastSent, 500, filter)
 			if err != nil {
 				return echo.NewHTTPError(http.StatusInternalServerError, "failed to read event backlog").Wrap(err)
 			}

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -1144,7 +1144,7 @@ behavior must be deliberate, not an accident of the fall-through.
       `DELETE /v1/notifications/policies/:id`, `POST /v1/jobdefs/lint`, and
       `POST /v1/jobdefs/diff`; `GET /v1/lineage/impact` has only its Viewer
       role backfilled here and remains pending H-3 scope semantics.
-- [ ] H-2. Add the **completeness guard**: a test asserting every route registered
+- [x] H-2. Add the **completeness guard**: a test asserting every route registered
       under `bind.go`'s `Protected()` group has an `endpointPolicy` entry, so a new
       authenticated route without a policy fails CI instead of 403-ing at runtime.
       This is what makes A2/B4/C2's entries non-optional. It must land **after**
@@ -1175,6 +1175,9 @@ behavior must be deliberate, not an accident of the fall-through.
       Note: H-1+H-2 fix shipped code and are independent of A/B/C; given no users
       this is low-urgency, but they can land as a small standalone PR whenever
       convenient — see the cover note on PR #229.
+      Note (W2-β): guard covers all authed routes (Protected + auth, minus
+      public); shared normalization helper; comprehensive scope integration
+      tests deferred to the auth-enabled integration harness.
 - [ ] H-3. Resolve `/v1/lineage/impact` scope semantics — the cross-job leak. The
       impact query is **global and intentionally cross-job** (it traverses dataset
       edges across jobs), but scope enforcement currently 403s every scoped


### PR DESCRIPTION
## Summary
- Adds `api/auth_rbac_policy_completeness_test.go` — a unit guard that registers the **full router** (`bind.All` + SSO + metrics) and asserts **every auth-middleware-mounted route has an `endpointPolicy` entry**. A future authenticated route shipped without a policy now fails CI instead of silently 403-ing (`unknown_route`) at runtime. Covers `/v1/auth/*` too, not just `Protected()`.
- Extracts shared `NormalizeRoutePath` + `IsPublicAuthPath` helpers into `api/middleware` so the guard's path normalization + public-route exclusion stay in lockstep with the real middleware (no duplicated regex to drift).
- Makes the `/events` stream controller's store **lazy** (`sync.Once`) so route registration no longer eagerly opens a dqlite connection — the guard runs hermetically in `just unit-test`.
- Implements item **H-2** (the completeness guard). Comprehensive scoped allow/deny integration tests are **deferred** to the auth-enabled integration harness (which A4/C4/B6 also require) — the in-process scope test was removed as it poisoned the global DB singleton.

## Test plan
- [x] just lint (orchestrator)
- [x] just unit-test (orchestrator) — the guard passes hermetically
- [ ] just integration-test — CI
- Two Opus review passes: first flagged the guard missed `/v1/auth/*` and the fragile scope test; the fix's comprehensive guard then needed a hermetic-DB fix (lazy event store), now resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)