### PR TITLE
Add caesium run diff CLI + e2e (data-plane-memory-ii W3-α)

### DIFF
--- a/cmd/run/diff.go
+++ b/cmd/run/diff.go
@@ -1,0 +1,264 @@
+package run
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+)
+
+const runDiffAPIKeyEnvVar = "CAESIUM_API_KEY"
+
+var (
+	diffJobID  string
+	diffServer string
+	diffAPIKey string
+	diffJSON   bool
+)
+
+type runDiffResponse struct {
+	JobID      string `json:"jobId"`
+	LeftRunID  string `json:"leftRunId"`
+	RightRunID string `json:"rightRunId"`
+
+	LeftStatus  string `json:"leftStatus"`
+	RightStatus string `json:"rightStatus"`
+
+	LeftTrigger  runDiffTrigger `json:"leftTrigger"`
+	RightTrigger runDiffTrigger `json:"rightTrigger"`
+
+	TriggerChanges []runDiffFieldChange `json:"triggerChanges,omitempty"`
+	ParamChanges   []runDiffFieldChange `json:"paramChanges,omitempty"`
+	Tasks          []runDiffTask        `json:"tasks"`
+	TasksAdded     []string             `json:"tasksAdded,omitempty"`
+	TasksRemoved   []string             `json:"tasksRemoved,omitempty"`
+}
+
+type runDiffTrigger struct {
+	Type   string            `json:"type"`
+	Alias  string            `json:"alias"`
+	Params map[string]string `json:"params"`
+}
+
+type runDiffTask struct {
+	TaskName string `json:"taskName"`
+
+	LeftStatus   string `json:"leftStatus"`
+	RightStatus  string `json:"rightStatus"`
+	LeftAttempt  int    `json:"leftAttempt"`
+	RightAttempt int    `json:"rightAttempt"`
+	LeftHash     string `json:"leftHash,omitempty"`
+	RightHash    string `json:"rightHash,omitempty"`
+
+	Verdict   string               `json:"verdict"`
+	HashEqual bool                 `json:"hashEqual"`
+	Changes   []runDiffFieldChange `json:"changes,omitempty"`
+	Degraded  string               `json:"degraded,omitempty"`
+}
+
+type runDiffFieldChange struct {
+	Field    string `json:"field"`
+	Kind     string `json:"kind"`
+	Before   string `json:"before"`
+	After    string `json:"after"`
+	Added    bool   `json:"added"`
+	Removed  bool   `json:"removed"`
+	Redacted bool   `json:"redacted"`
+}
+
+var diffCmd = &cobra.Command{
+	Use:   "diff <left-run> <right-run> --job-id <job-id>",
+	Short: "Diff two runs of the same job",
+	Long: "Diff two runs of the same job by asking the job-scoped run-diff REST " +
+		"endpoint for cache-bust attribution. Prints a per-task table by default, " +
+		"or machine-readable JSON with --json.",
+	Args: cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		leftRunID := strings.TrimSpace(args[0])
+		rightRunID := strings.TrimSpace(args[1])
+		if diffJobID == "" {
+			return fmt.Errorf("--job-id is required")
+		}
+
+		server := strings.TrimSuffix(diffServer, "/")
+		params := url.Values{}
+		params.Set("left", leftRunID)
+		params.Set("right", rightRunID)
+		reqURL := fmt.Sprintf("%s/v1/jobs/%s/runs/diff?%s", server, diffJobID, params.Encode())
+
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
+		if err != nil {
+			return err
+		}
+		if apiKey := resolveRunDiffAPIKey(cmd, diffAPIKey); apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, _ := io.ReadAll(resp.Body)
+		if resp.StatusCode >= http.StatusBadRequest {
+			return fmt.Errorf("run diff failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		stdout := cmd.OutOrStdout()
+		if diffJSON {
+			var out interface{}
+			if err := json.Unmarshal(body, &out); err != nil {
+				_, _ = fmt.Fprint(stdout, string(body))
+				return nil
+			}
+			pretty, _ := json.MarshalIndent(out, "", "  ")
+			_, _ = fmt.Fprintln(stdout, string(pretty))
+			return nil
+		}
+
+		var diff runDiffResponse
+		if err := json.Unmarshal(body, &diff); err != nil {
+			_, _ = fmt.Fprint(stdout, string(body))
+			return nil
+		}
+		renderRunDiffTable(cmd, &diff)
+		return nil
+	},
+}
+
+func renderRunDiffTable(cmd *cobra.Command, diff *runDiffResponse) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintf(out, "Run diff for job %s\n\n", diff.JobID)
+
+	summary := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintf(summary, "LEFT RUN\t%s\t%s\n", diff.LeftRunID, diff.LeftStatus)
+	_, _ = fmt.Fprintf(summary, "RIGHT RUN\t%s\t%s\n", diff.RightRunID, diff.RightStatus)
+	if trigger := formatRunDiffTrigger(diff.LeftTrigger); trigger != "" {
+		_, _ = fmt.Fprintf(summary, "LEFT TRIGGER\t%s\n", trigger)
+	}
+	if trigger := formatRunDiffTrigger(diff.RightTrigger); trigger != "" {
+		_, _ = fmt.Fprintf(summary, "RIGHT TRIGGER\t%s\n", trigger)
+	}
+	_ = summary.Flush()
+
+	renderRunDiffChanges(out, "Trigger changes", diff.TriggerChanges)
+	renderRunDiffChanges(out, "Run parameter changes", diff.ParamChanges)
+
+	if len(diff.TasksAdded) > 0 {
+		_, _ = fmt.Fprintf(out, "\nTasks added: %s\n", strings.Join(diff.TasksAdded, ", "))
+	}
+	if len(diff.TasksRemoved) > 0 {
+		_, _ = fmt.Fprintf(out, "\nTasks removed: %s\n", strings.Join(diff.TasksRemoved, ", "))
+	}
+
+	_, _ = fmt.Fprintln(out, "\nTasks:")
+	tasks := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tasks, "TASK\tVERDICT\tLEFT\tRIGHT\tCHANGES")
+	for _, task := range diff.Tasks {
+		_, _ = fmt.Fprintf(tasks, "%s\t%s\t%s\t%s\t%d\n",
+			task.TaskName,
+			task.Verdict,
+			formatRunDiffTaskStatus(task.LeftStatus, task.LeftAttempt),
+			formatRunDiffTaskStatus(task.RightStatus, task.RightAttempt),
+			len(task.Changes),
+		)
+	}
+	_ = tasks.Flush()
+
+	for _, task := range diff.Tasks {
+		if task.Degraded != "" {
+			_, _ = fmt.Fprintf(out, "\n%s degraded: %s\n", task.TaskName, task.Degraded)
+			continue
+		}
+		renderRunDiffChanges(out, task.TaskName+" changes", task.Changes)
+	}
+}
+
+func renderRunDiffChanges(out io.Writer, title string, changes []runDiffFieldChange) {
+	if len(changes) == 0 {
+		return
+	}
+
+	_, _ = fmt.Fprintf(out, "\n%s (%d):\n", title, len(changes))
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "FIELD\tCHANGE\tBEFORE\tAFTER")
+	for _, ch := range changes {
+		before, after := ch.Before, ch.After
+		if ch.Redacted {
+			if before != "" {
+				before += " (redacted)"
+			}
+			if after != "" {
+				after += " (redacted)"
+			}
+		}
+		_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+			ch.Field,
+			runDiffChangeLabel(ch),
+			dashRunDiffEmpty(before),
+			dashRunDiffEmpty(after),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func runDiffChangeLabel(ch runDiffFieldChange) string {
+	switch {
+	case ch.Added:
+		return "added"
+	case ch.Removed:
+		return "removed"
+	case ch.Kind == "structural":
+		return "changed (structural)"
+	default:
+		return "changed"
+	}
+}
+
+func formatRunDiffTrigger(trigger runDiffTrigger) string {
+	if trigger.Type == "" {
+		return ""
+	}
+	if trigger.Alias != "" {
+		return fmt.Sprintf("%s (%s)", trigger.Type, trigger.Alias)
+	}
+	return trigger.Type
+}
+
+func formatRunDiffTaskStatus(status string, attempt int) string {
+	if attempt <= 0 {
+		return status
+	}
+	return fmt.Sprintf("%s (attempt %d)", status, attempt)
+}
+
+func dashRunDiffEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func resolveRunDiffAPIKey(cmd *cobra.Command, flagValue string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: --api-key is visible in process listings; prefer %s\n", runDiffAPIKeyEnvVar)
+		return strings.TrimSpace(flagValue)
+	}
+	return strings.TrimSpace(os.Getenv(runDiffAPIKeyEnvVar))
+}
+
+func init() {
+	diffCmd.Flags().StringVar(&diffJobID, "job-id", "", "Job ID that owns both runs (required)")
+	diffCmd.Flags().StringVar(&diffServer, "server", "http://localhost:8080", "Caesium server base URL")
+	diffCmd.Flags().StringVar(&diffAPIKey, "api-key", "", "API key for authentication (prefer "+runDiffAPIKeyEnvVar+"; --api-key is visible in process listings)")
+	diffCmd.Flags().BoolVar(&diffJSON, "json", false, "Emit machine-readable JSON instead of a table")
+
+	Cmd.AddCommand(diffCmd)
+}

--- a/cmd/run/diff.go
+++ b/cmd/run/diff.go
@@ -90,7 +90,7 @@ var diffCmd = &cobra.Command{
 		params := url.Values{}
 		params.Set("left", leftRunID)
 		params.Set("right", rightRunID)
-		reqURL := fmt.Sprintf("%s/v1/jobs/%s/runs/diff?%s", server, diffJobID, params.Encode())
+		reqURL := fmt.Sprintf("%s/v1/jobs/%s/runs/diff?%s", server, url.PathEscape(diffJobID), params.Encode())
 
 		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
 		if err != nil {
@@ -106,7 +106,10 @@ var diffCmd = &cobra.Command{
 		}
 		defer func() { _ = resp.Body.Close() }()
 
-		body, _ := io.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("reading run diff response: %w", err)
+		}
 		if resp.StatusCode >= http.StatusBadRequest {
 			return fmt.Errorf("run diff failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
 		}
@@ -115,8 +118,7 @@ var diffCmd = &cobra.Command{
 		if diffJSON {
 			var out interface{}
 			if err := json.Unmarshal(body, &out); err != nil {
-				_, _ = fmt.Fprint(stdout, string(body))
-				return nil
+				return fmt.Errorf("run diff response was not valid JSON (status %d): %w", resp.StatusCode, err)
 			}
 			pretty, _ := json.MarshalIndent(out, "", "  ")
 			_, _ = fmt.Fprintln(stdout, string(pretty))
@@ -125,8 +127,7 @@ var diffCmd = &cobra.Command{
 
 		var diff runDiffResponse
 		if err := json.Unmarshal(body, &diff); err != nil {
-			_, _ = fmt.Fprint(stdout, string(body))
-			return nil
+			return fmt.Errorf("run diff response was not valid JSON (status %d): %w", resp.StatusCode, err)
 		}
 		renderRunDiffTable(cmd, &diff)
 		return nil

--- a/docs/design-data-plane-memory.md
+++ b/docs/design-data-plane-memory.md
@@ -81,7 +81,7 @@ Caesium uniquely computes a transitive content hash that folds in the **typed da
 | `caesium why` (field-level) | C2 (+ C3 for graph-change causation) | Scope to cache hit/miss, predecessor-hash change, param change — call it that, not "data causality" |
 | Reproducibility receipt / `verify` | **C1 first**, then C2 | **Shipped** (C1+C2 landed): `caesium receipt get` / `caesium verify` re-derive a content-addressed receipt and flag drift. An unpinned-tag task is marked **degraded/unverifiable** and never attested as reproducible — the silent-failure mode is surfaced, not suppressed. |
 | Quarantined what-if replay | C1, C2 (+ C5 for data-diff) | Re-run only hash-changed tasks; unchanged = provably-identical cache hits |
-| `caesium run diff` (causal) | C2 | Cache-bust attribution only; hand off value diffs to dbt/Datafold |
+| `caesium run diff` (causal) | C2 | **Shipped**: cache-bust attribution only; hand off value diffs to dbt/Datafold |
 | Value-verified skip ("Bazel for data") | C5 (+ C1) | Metadata-only skip exists today (shipped cache); value-verification needs C5 |
 | Cross-job impact analysis | C4 (+ C3) | Intra-DAG only until lineage datasets are populated |
 

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -432,7 +432,7 @@ attribution only — hand value-level row/column diffs to dbt/Datafold.
       endpoint against the live integration server, covering the happy diff body,
       missing-param 400s, static-route ordering, and both cross-job 404
       permutations for the handler-level run ownership boundary.
-- [ ] A3. Add the `caesium run diff <left-run> <right-run> --job-id <id> [--json]`
+- [x] A3. Add the `caesium run diff <left-run> <right-run> --job-id <id> [--json]`
       subcommand. **`--job-id` is required** (matching `caesium why`): the REST
       endpoint is job-scoped (`/v1/jobs/:id/runs/diff`), so the CLI cannot construct
       the URL from run ids alone without a brittle global jobs/runs scan — and that
@@ -444,7 +444,10 @@ attribution only — hand value-level row/column diffs to dbt/Datafold.
       Files: new `cmd/run/diff.go` (its own `func init()` calling
       `Cmd.AddCommand(diffCmd)` on the existing `run.Cmd`).
       Depends on: A2.
-- [ ] A4. Add an integration scenario driving `caesium run diff --json` end-to-end
+      Note: W3-alpha added `cmd/run/diff.go`, requiring `--job-id`, calling the
+      job-scoped REST endpoint, emitting clean JSON with `--json`, and rendering a
+      per-task human table through `cmd.OutOrStdout()` without cobra `cmd.Print*`.
+- [x] A4. Add an integration scenario driving `caesium run diff --json` end-to-end
       against the live server: two runs of a cacheable job differing by one run
       param, asserting the discriminating `runParams.*` field appears in the diff
       and that stdout is clean parseable JSON (captured via `runCLIStdout`, not the
@@ -460,6 +463,11 @@ attribution only — hand value-level row/column diffs to dbt/Datafold.
       Files: `test/data_plane_e2e_test.go` (add `TestRunDiffAttributesChangedField`
       + `TestRunDiffRejectsCrossScopeRunIDs`), `docs/design-data-plane-memory.md`.
       Depends on: A3.
+      Note: W3-alpha added `TestRunDiffAttributesChangedField` against the live CLI
+      and flipped the design-table row to shipped. The scoped-key cross-scope CLI
+      assertion is deferred to the auth-enabled integration harness; W2's
+      `test/rundiff_blame_e2e_test.go` already covers the handler-level cross-job
+      404 boundary under the current auth-disabled CI harness.
 
 ### Stream B — Quarantined what-if replay
 

--- a/test/data_plane_e2e_test.go
+++ b/test/data_plane_e2e_test.go
@@ -113,6 +113,40 @@ func (s *IntegrationTestSuite) parseWhy(jobID, runID, task string) whyExplanatio
 	return exp
 }
 
+// TestRunDiffAttributesChangedField verifies the causal run-diff CLI
+// end-to-end: the command drives the live REST endpoint, emits clean parseable
+// JSON on stdout, and names the changed run param as a task-level
+// discriminating field.
+func (s *IntegrationTestSuite) TestRunDiffAttributesChangedField() {
+	alias := fmt.Sprintf("e2e-rundiff-cli-%d", time.Now().UnixNano())
+	dir := s.writeJobManifest(runDiffManifest(alias))
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	run1 := s.triggerRunWithParams(job.ID, map[string]string{"flavor": "vanilla"})
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, run1, runTimeout).Status)
+	run2 := s.triggerRunWithParams(job.ID, map[string]string{"flavor": "chocolate"})
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, run2, runTimeout).Status)
+
+	out, err := s.runCLIStdout("run", "diff", run1, run2, "--job-id", job.ID, "--json", "--server", s.caesiumURL)
+	s.Require().NoError(err, "caesium run diff failed:\n%s", out)
+	s.Require().True(json.Valid([]byte(out)), "caesium run diff --json stdout was not valid JSON (log contamination?):\n%s", out)
+
+	var diff runDiffRESTResponse
+	s.Require().NoError(json.Unmarshal([]byte(out), &diff))
+	s.Equal(job.ID, diff.JobID)
+	s.Equal(run1, diff.LeftRunID)
+	s.Equal(run2, diff.RightRunID)
+	s.True(hasRunDiffChange(diff.ParamChanges, "params.flavor", "vanilla", "chocolate"),
+		"run-level param diff should include params.flavor, got %+v", diff.ParamChanges)
+	task := requireRunDiffTask(s, diff.Tasks, "render")
+	s.Equal("RERAN", task.Verdict)
+	s.True(hasRunDiffChange(task.Changes, "runParams.flavor", "vanilla", "chocolate"),
+		"task diff should include runParams.flavor, got %+v", task.Changes)
+}
+
 // TestReproducibilityReceiptRoundTrip verifies the REPRODUCE feature end-to-end
 // AND guards the documented `receipt get > file` → `verify file` workflow: the
 // receipt printed to stdout must be clean JSON (no leaked log lines), and the


### PR DESCRIPTION
## Summary
- Adds `caesium run diff <left-run> <right-run> --job-id <id> [--json]` (`cmd/run/diff.go`) over the shipped A2 endpoint. `--job-id` is **required** (the endpoint is job-scoped, matching `caesium why`); human-readable per-task table by default; machine JSON with `--json`.
- **Stdout discipline:** all output via `cmd.OutOrStdout()` — no cobra `cmd.Print*` (which leak to stderr and break `--json` piping). Errors return through `RunE` to stderr.
- **Integration coverage** (`test/data_plane_e2e_test.go`, `//go:build integration`): `TestRunDiffAttributesChangedField` drives the **real CLI** `--json` via `runCLIStdout` (stdout captured separately from stderr), asserts `json.Valid` on stdout, and checks the discriminating `runParams.*` field + the RERAN verdict.
- Flips the `run diff` design-doc feature-table row to shipped. Implements **A3 + A4**.
- The scoped-API-key cross-scope CLI assertion is deferred to the auth-enabled integration harness (CI runs `auth_mode=none`); the handler-level cross-job 404 boundary is already e2e-covered by the A2 REST test (`test/rundiff_blame_e2e_test.go`).

## Test plan
- [x] just lint (orchestrator)
- [x] just unit-test (orchestrator)
- [ ] just integration-test — CI runs the new CLI e2e
- Opus adversarial review (stdout-discipline + e2e-validity lenses): **clean** — confirmed the e2e is not green-but-hollow and `--json` doesn't leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)