### PR TITLE
Add caesium blame CLI + e2e (data-plane-memory-ii W3-β)

### DIFF
--- a/api/rest/controller/jobdef/apply.go
+++ b/api/rest/controller/jobdef/apply.go
@@ -3,23 +3,18 @@ package jobdef
 import (
 	"errors"
 	"net/http"
+	"strings"
 
-	"github.com/caesium-cloud/caesium/internal/jobdef"
+	jobdefsvc "github.com/caesium-cloud/caesium/api/rest/service/jobdef"
+	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/db"
-	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/labstack/echo/v5"
 )
 
-type ApplyRequest struct {
-	Definitions []schema.Definition `json:"definitions"`
-	Force       bool                `json:"force,omitempty"`
-	Prune       bool                `json:"prune,omitempty"`
-}
+type ApplyProvenance = jobdefsvc.ApplyProvenance
 
-type ApplyResponse struct {
-	Applied int `json:"applied"`
-	Pruned  int `json:"pruned,omitempty"`
-}
+type ApplyRequest = jobdefsvc.ApplyRequest
+type ApplyResponse = jobdefsvc.ApplyResponse
 
 func Apply(c *echo.Context) error {
 	var req ApplyRequest
@@ -30,10 +25,18 @@ func Apply(c *echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "definitions are required")
 	}
 
-	importer := jobdef.NewImporter(db.Connection())
+	importer := internaljobdef.NewImporter(db.Connection())
 	ctx := c.Request().Context()
 	applied := 0
 	aliases := make([]string, 0, len(req.Definitions))
+	prov, err := applyProvenanceFromRequest(req.Provenance)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	opts := &internaljobdef.ApplyOptions{
+		Force:      req.Force,
+		Provenance: prov,
+	}
 
 	for i := range req.Definitions {
 		def := &req.Definitions[i]
@@ -42,8 +45,8 @@ func Apply(c *echo.Context) error {
 		}
 
 		aliases = append(aliases, def.Metadata.Alias)
-		if _, err := importer.ApplyWithOptions(ctx, def, &jobdef.ApplyOptions{Force: req.Force}); err != nil {
-			if errors.Is(err, jobdef.ErrDuplicateJob) || errors.Is(err, jobdef.ErrProvenanceConflict) || errors.Is(err, jobdef.ErrJobRunning) {
+		if _, err := importer.ApplyWithOptions(ctx, def, opts); err != nil {
+			if errors.Is(err, internaljobdef.ErrDuplicateJob) || errors.Is(err, internaljobdef.ErrProvenanceConflict) || errors.Is(err, internaljobdef.ErrJobRunning) {
 				return echo.NewHTTPError(http.StatusConflict, err.Error())
 			}
 			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
@@ -55,7 +58,7 @@ func Apply(c *echo.Context) error {
 	if req.Prune {
 		count, err := importer.PruneMissing(ctx, aliases, nil)
 		if err != nil {
-			if errors.Is(err, jobdef.ErrJobRunning) {
+			if errors.Is(err, internaljobdef.ErrJobRunning) {
 				return echo.NewHTTPError(http.StatusConflict, err.Error())
 			}
 			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
@@ -64,4 +67,29 @@ func Apply(c *echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, ApplyResponse{Applied: applied, Pruned: pruned})
+}
+
+func applyProvenanceFromRequest(p *ApplyProvenance) (*internaljobdef.Provenance, error) {
+	if p == nil {
+		return nil, nil
+	}
+
+	prov := &internaljobdef.Provenance{
+		SourceID: strings.TrimSpace(p.SourceID),
+		Repo:     strings.TrimSpace(p.Repo),
+		Ref:      strings.TrimSpace(p.Ref),
+		Commit:   strings.TrimSpace(p.Commit),
+		Path:     strings.TrimSpace(p.Path),
+	}
+	if prov.SourceID == "" && prov.Repo == "" && prov.Ref == "" && prov.Commit == "" && prov.Path == "" {
+		return nil, nil
+	}
+	// A provenance record without a source_id is incoherent: it would stamp a
+	// commit/repo onto a snapshot while leaving the job's ownership empty (so a
+	// later plain apply could mutate it freely). Require source_id whenever any
+	// other provenance field is set.
+	if prov.SourceID == "" {
+		return nil, errors.New("provenance.source_id is required when any other provenance field is set")
+	}
+	return prov, nil
 }

--- a/api/rest/service/jobdef/apply.go
+++ b/api/rest/service/jobdef/apply.go
@@ -1,0 +1,33 @@
+package jobdef
+
+import schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+
+type ApplyRequest struct {
+	Definitions []schema.Definition `json:"definitions"`
+	Force       bool                `json:"force,omitempty"`
+	Prune       bool                `json:"prune,omitempty"`
+	Provenance  *ApplyProvenance    `json:"provenance,omitempty"`
+}
+
+// ApplyProvenance lets a non-git-sync apply (e.g. a CI/CD pipeline) record the
+// source it came from. SECURITY/TRUST BOUNDARY: unlike git-sync provenance —
+// which the server sets authoritatively from its own configuration — these
+// values are CLIENT-ASSERTED and NOT authenticated. SourceID is advisory
+// ownership only (an Operator who knows a git-sync SourceID could assert it; no
+// worse than the existing --force override, which the same RoleOperator already
+// has), and Commit is an unverified label that flows into dag_snapshot.git_commit
+// (so `caesium blame` attribution for an API-applied job reflects the asserted
+// commit, not a server-verified one). Treat blame as a tamper-evident audit
+// record only when provenance came from git-sync, not an API client.
+type ApplyProvenance struct {
+	SourceID string `json:"source_id,omitempty"`
+	Repo     string `json:"repo,omitempty"`
+	Ref      string `json:"ref,omitempty"`
+	Commit   string `json:"commit,omitempty"`
+	Path     string `json:"path,omitempty"`
+}
+
+type ApplyResponse struct {
+	Applied int `json:"applied"`
+	Pruned  int `json:"pruned,omitempty"`
+}

--- a/cmd/blame/blame.go
+++ b/cmd/blame/blame.go
@@ -1,0 +1,242 @@
+// Package blame implements `caesium blame <job>`: a read-side attribution view
+// over dag_snapshot history.
+package blame
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+const (
+	apiKeyEnvVar = "CAESIUM_API_KEY"
+	coverageNote = "Coverage: topology + image + command only. env/spec/retries/cache/schema/sla/triggerRules changes are not tracked."
+)
+
+var (
+	blameTask   string
+	blameFrom   string
+	blameTo     string
+	blameServer string
+	blameAPIKey string
+	blameJSON   bool
+)
+
+type result struct {
+	JobID      string            `json:"job_id"`
+	Coverage   string            `json:"coverage"`
+	FromCommit string            `json:"from_commit,omitempty"`
+	ToCommit   string            `json:"to_commit,omitempty"`
+	Tasks      []taskAttribution `json:"tasks"`
+	Edges      []edgeAttribution `json:"edges"`
+}
+
+type taskAttribution struct {
+	Element           taskElement `json:"element"`
+	IntroducingCommit string      `json:"introducing_commit"`
+	SnapshotID        string      `json:"snapshot_id"`
+}
+
+type taskElement struct {
+	Name    string   `json:"name"`
+	Image   string   `json:"image"`
+	Command []string `json:"command,omitempty"`
+}
+
+type edgeAttribution struct {
+	Element           edgeElement `json:"element"`
+	IntroducingCommit string      `json:"introducing_commit"`
+	SnapshotID        string      `json:"snapshot_id"`
+	ProvenanceCommit  string      `json:"provenance_commit,omitempty"`
+}
+
+type edgeElement struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+type jobSummary struct {
+	ID    string `json:"id"`
+	Alias string `json:"alias"`
+}
+
+// Cmd is the `caesium blame` command.
+var Cmd = &cobra.Command{
+	Use:   "blame <job-id-or-alias>",
+	Short: "Attribute DAG tasks and edges to their introducing snapshot",
+	Long: "Attribute each persisted DAG task and edge to the commit/snapshot that introduced its current form. " +
+		"By default prints a per-element table; with --json prints the server's machine-readable JSON result. " +
+		coverageNote,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		server := strings.TrimSuffix(blameServer, "/")
+		jobID, err := resolveJobID(cmd, server, strings.TrimSpace(args[0]))
+		if err != nil {
+			return err
+		}
+
+		params := url.Values{}
+		if blameTask != "" {
+			params.Set("task", blameTask)
+		}
+		if blameFrom != "" {
+			params.Set("from", blameFrom)
+		}
+		if blameTo != "" {
+			params.Set("to", blameTo)
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/jobs/%s/blame", server, url.PathEscape(jobID))
+		if encoded := params.Encode(); encoded != "" {
+			reqURL += "?" + encoded
+		}
+		body, err := get(cmd, reqURL, "blame")
+		if err != nil {
+			return err
+		}
+
+		stdout := cmd.OutOrStdout()
+		if blameJSON {
+			var out any
+			if err := json.Unmarshal(body, &out); err != nil {
+				_, writeErr := stdout.Write(body)
+				return writeErr
+			}
+			pretty, err := json.MarshalIndent(out, "", "  ")
+			if err != nil {
+				_, writeErr := stdout.Write(body)
+				return writeErr
+			}
+			_, _ = stdout.Write(pretty)
+			_, _ = fmt.Fprintln(stdout)
+			return nil
+		}
+
+		var res result
+		if err := json.Unmarshal(body, &res); err != nil {
+			_, writeErr := stdout.Write(body)
+			return writeErr
+		}
+		renderTable(cmd, &res)
+		return nil
+	},
+}
+
+func resolveJobID(cmd *cobra.Command, server, idOrAlias string) (string, error) {
+	if idOrAlias == "" {
+		return "", fmt.Errorf("job id or alias is required")
+	}
+	if _, err := uuid.Parse(idOrAlias); err == nil {
+		return idOrAlias, nil
+	}
+
+	body, err := get(cmd, server+"/v1/jobs", "job lookup")
+	if err != nil {
+		return "", err
+	}
+	var jobs []jobSummary
+	if err := json.Unmarshal(body, &jobs); err != nil {
+		return "", fmt.Errorf("job lookup returned invalid JSON: %w", err)
+	}
+	for _, job := range jobs {
+		if job.Alias == idOrAlias {
+			return job.ID, nil
+		}
+	}
+	return "", fmt.Errorf("job alias %q not found", idOrAlias)
+}
+
+func get(cmd *cobra.Command, reqURL, label string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := resolveAPIKey(cmd, blameAPIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("%s failed (%d): %s", label, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func renderTable(cmd *cobra.Command, res *result) {
+	out := cmd.OutOrStdout()
+	_, _ = fmt.Fprintln(out, coverageNote)
+	if res.Coverage != "" {
+		_, _ = fmt.Fprintf(out, "coverage: %s\n", res.Coverage)
+	}
+	if res.FromCommit != "" || res.ToCommit != "" {
+		_, _ = fmt.Fprintf(out, "range: %s..%s\n", dashIfEmpty(res.FromCommit), dashIfEmpty(res.ToCommit))
+	}
+	_, _ = fmt.Fprintln(out)
+
+	tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(tw, "TYPE\tELEMENT\tIMAGE/COMMAND\tINTRODUCING COMMIT\tSNAPSHOT\tPROVENANCE")
+	for _, task := range res.Tasks {
+		_, _ = fmt.Fprintf(tw, "task\t%s\t%s %s\t%s\t%s\t-\n",
+			task.Element.Name,
+			dashIfEmpty(task.Element.Image),
+			commandString(task.Element.Command),
+			dashIfEmpty(task.IntroducingCommit),
+			task.SnapshotID,
+		)
+	}
+	for _, edge := range res.Edges {
+		_, _ = fmt.Fprintf(tw, "edge\t%s -> %s\t-\t%s\t%s\t%s\n",
+			edge.Element.From,
+			edge.Element.To,
+			dashIfEmpty(edge.IntroducingCommit),
+			edge.SnapshotID,
+			dashIfEmpty(edge.ProvenanceCommit),
+		)
+	}
+	_ = tw.Flush()
+}
+
+func commandString(command []string) string {
+	if len(command) == 0 {
+		return "-"
+	}
+	return strings.Join(command, " ")
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func resolveAPIKey(cmd *cobra.Command, explicit string) string {
+	if v := strings.TrimSpace(explicit); v != "" {
+		cmd.PrintErrln(fmt.Sprintf("warning: --api-key is visible in process listings; prefer %s", apiKeyEnvVar))
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(apiKeyEnvVar))
+}
+
+func init() {
+	Cmd.Flags().StringVar(&blameTask, "task", "", "Limit blame to a task and adjacent edges")
+	Cmd.Flags().StringVar(&blameFrom, "from", "", "Start commit for attribution range")
+	Cmd.Flags().StringVar(&blameTo, "to", "", "End commit for attribution range")
+	Cmd.Flags().BoolVar(&blameJSON, "json", false, "Print machine-readable JSON")
+	Cmd.Flags().StringVar(&blameServer, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.Flags().StringVar(&blameAPIKey, "api-key", "", "API key bearer token (default: CAESIUM_API_KEY)")
+}

--- a/cmd/blame/blame.go
+++ b/cmd/blame/blame.go
@@ -87,6 +87,9 @@ var Cmd = &cobra.Command{
 		if blameTask != "" {
 			params.Set("task", blameTask)
 		}
+		if blameTo != "" && blameFrom == "" {
+			return fmt.Errorf("--to requires --from")
+		}
 		if blameFrom != "" {
 			params.Set("from", blameFrom)
 		}
@@ -107,13 +110,11 @@ var Cmd = &cobra.Command{
 		if blameJSON {
 			var out any
 			if err := json.Unmarshal(body, &out); err != nil {
-				_, writeErr := stdout.Write(body)
-				return writeErr
+				return fmt.Errorf("blame response was not valid JSON: %w", err)
 			}
 			pretty, err := json.MarshalIndent(out, "", "  ")
 			if err != nil {
-				_, writeErr := stdout.Write(body)
-				return writeErr
+				return fmt.Errorf("re-encoding blame JSON: %w", err)
 			}
 			_, _ = stdout.Write(pretty)
 			_, _ = fmt.Fprintln(stdout)
@@ -122,8 +123,7 @@ var Cmd = &cobra.Command{
 
 		var res result
 		if err := json.Unmarshal(body, &res); err != nil {
-			_, writeErr := stdout.Write(body)
-			return writeErr
+			return fmt.Errorf("blame response was not valid JSON: %w", err)
 		}
 		renderTable(cmd, &res)
 		return nil
@@ -169,7 +169,10 @@ func get(cmd *cobra.Command, reqURL, label string) ([]byte, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	body, _ := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s response: %w", label, err)
+	}
 	if resp.StatusCode >= http.StatusBadRequest {
 		return nil, fmt.Errorf("%s failed (%d): %s", label, resp.StatusCode, strings.TrimSpace(string(body)))
 	}

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"github.com/caesium-cloud/caesium/cmd/auth"
 	"github.com/caesium-cloud/caesium/cmd/backfill"
+	"github.com/caesium-cloud/caesium/cmd/blame"
 	"github.com/caesium-cloud/caesium/cmd/cache"
 	"github.com/caesium-cloud/caesium/cmd/dev"
 	"github.com/caesium-cloud/caesium/cmd/job"
@@ -18,6 +19,7 @@ import (
 var cmds = []*cobra.Command{
 	auth.Cmd,
 	backfill.Cmd,
+	blame.Cmd,
 	cache.Cmd,
 	dev.Cmd,
 	job.Cmd,

--- a/cmd/job/apply.go
+++ b/cmd/job/apply.go
@@ -12,17 +12,22 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/caesium-cloud/caesium/api/rest/controller/jobdef"
+	jobdefsvc "github.com/caesium-cloud/caesium/api/rest/service/jobdef"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
 
 var (
-	applyPaths  []string
-	applyServer string
-	applyForce  bool
-	applyPrune  bool
+	applyPaths              []string
+	applyServer             string
+	applyForce              bool
+	applyPrune              bool
+	applyProvenanceSourceID string
+	applyProvenanceRepo     string
+	applyProvenanceRef      string
+	applyProvenanceCommit   string
+	applyProvenancePath     string
 )
 
 var applyCmd = &cobra.Command{
@@ -40,7 +45,7 @@ var applyCmd = &cobra.Command{
 			return nil
 		}
 
-		if err := sendApplyRequest(cmd.Context(), strings.TrimSuffix(applyServer, "/"), defs, applyForce, applyPrune); err != nil {
+		if err := sendApplyRequest(cmd.Context(), strings.TrimSuffix(applyServer, "/"), defs, applyForce, applyPrune, applyProvenanceFromFlags()); err != nil {
 			return err
 		}
 
@@ -56,6 +61,11 @@ func init() {
 	applyCmd.Flags().StringVar(&applyServer, "server", "http://localhost:8080", "Caesium server base URL")
 	applyCmd.Flags().BoolVar(&applyForce, "force", false, "Override provenance ownership checks when applying definitions")
 	applyCmd.Flags().BoolVar(&applyPrune, "prune", false, "Retire active jobs that are missing from the supplied path set")
+	applyCmd.Flags().StringVar(&applyProvenanceSourceID, "provenance-source-id", "", "Record the source ID that produced the applied definitions")
+	applyCmd.Flags().StringVar(&applyProvenanceRepo, "provenance-repo", "", "Record the repository URL that produced the applied definitions")
+	applyCmd.Flags().StringVar(&applyProvenanceRef, "provenance-ref", "", "Record the repository ref that produced the applied definitions")
+	applyCmd.Flags().StringVar(&applyProvenanceCommit, "provenance-commit", "", "Record the commit that produced the applied definitions")
+	applyCmd.Flags().StringVar(&applyProvenancePath, "provenance-path", "", "Record the manifest path that produced the applied definitions")
 	Cmd.AddCommand(applyCmd)
 }
 
@@ -124,11 +134,26 @@ func appendDefinitions(path string, defs *[]schema.Definition) error {
 	return nil
 }
 
-func sendApplyRequest(ctx context.Context, server string, defs []schema.Definition, force, prune bool) error {
-	reqBody := jobdef.ApplyRequest{
+func applyProvenanceFromFlags() *jobdefsvc.ApplyProvenance {
+	prov := &jobdefsvc.ApplyProvenance{
+		SourceID: strings.TrimSpace(applyProvenanceSourceID),
+		Repo:     strings.TrimSpace(applyProvenanceRepo),
+		Ref:      strings.TrimSpace(applyProvenanceRef),
+		Commit:   strings.TrimSpace(applyProvenanceCommit),
+		Path:     strings.TrimSpace(applyProvenancePath),
+	}
+	if prov.SourceID == "" && prov.Repo == "" && prov.Ref == "" && prov.Commit == "" && prov.Path == "" {
+		return nil
+	}
+	return prov
+}
+
+func sendApplyRequest(ctx context.Context, server string, defs []schema.Definition, force, prune bool, provenance *jobdefsvc.ApplyProvenance) error {
+	reqBody := jobdefsvc.ApplyRequest{
 		Definitions: defs,
 		Force:       force,
 		Prune:       prune,
+		Provenance:  provenance,
 	}
 	payload, err := json.Marshal(reqBody)
 	if err != nil {

--- a/docs/caesium-job-llm-reference.md
+++ b/docs/caesium-job-llm-reference.md
@@ -318,9 +318,15 @@ caesium dev --once --path job.yaml      # Run job locally against Docker
 caesium dev --path job.yaml             # Watch mode — re-run on file save
 caesium job diff --path jobs/           # Preview creates/updates/deletes vs server
 caesium job apply --path jobs/          # Deploy definitions to running server
+caesium blame <job-id-or-alias>          # Attribute topology/image/command changes to commits/snapshots
 caesium test --path jobs/               # Full validation suite
 caesium test --scenario harness/        # Execute harness scenarios against the local runtime
 ```
+
+`caesium blame` is intentionally scoped to the data stored in `dag_snapshot`:
+topology, step image, and step command. It does not track behavior-only changes
+to `env`, `spec`/node selectors, `retries`, `cache`, schemas, `sla`, or
+`triggerRules`, so do not describe it as full behavior blame.
 
 ---
 

--- a/docs/design-data-plane-memory.md
+++ b/docs/design-data-plane-memory.md
@@ -82,6 +82,7 @@ Caesium uniquely computes a transitive content hash that folds in the **typed da
 | Reproducibility receipt / `verify` | **C1 first**, then C2 | **Shipped** (C1+C2 landed): `caesium receipt get` / `caesium verify` re-derive a content-addressed receipt and flag drift. An unpinned-tag task is marked **degraded/unverifiable** and never attested as reproducible — the silent-failure mode is surfaced, not suppressed. |
 | Quarantined what-if replay | C1, C2 (+ C5 for data-diff) | Re-run only hash-changed tasks; unchanged = provably-identical cache hits |
 | `caesium run diff` (causal) | C2 | Cache-bust attribution only; hand off value diffs to dbt/Datafold |
+| `caesium blame` (topology attribution) | C3 | **Shipped**: commit/snapshot blame over `dag_snapshot` for topology + image + command only; `env`/`spec`/`retries`/`cache`/schema/`sla`/`triggerRules` edits are intentionally untracked until the snapshot descriptor expands. |
 | Value-verified skip ("Bazel for data") | C5 (+ C1) | Metadata-only skip exists today (shipped cache); value-verification needs C5 |
 | Cross-job impact analysis | C4 (+ C3) | Intra-DAG only until lineage datasets are populated |
 

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -1093,7 +1093,7 @@ recorded here, out of scope, not promised.
       endpoint against the live integration server, covering topology-change
       attribution, task filtering, job scoping, unknown-task empty results, and
       unknown-commit 404 handling.
-- [ ] C3. Add the `caesium blame <job-id-or-alias> [--task t] [--from c] [--to c]
+- [x] C3. Add the `caesium blame <job-id-or-alias> [--task t] [--from c] [--to c]
       [--json]` top-level command: per-element table by default, machine JSON with
       `--json` via `cmd.OutOrStdout()`. The table/help text and the
       `docs/caesium-job-llm-reference.md`/blame docs must **state the coverage
@@ -1103,7 +1103,11 @@ recorded here, out of scope, not promised.
       Files: new `cmd/blame/`, append `blame.Cmd` to the `cmds` slice in
       `cmd/execute.go`, blame coverage note in the docs.
       Depends on: C2.
-- [ ] C4. Add an integration scenario: apply a job, then apply a topology change
+      Note: W3-beta added top-level `caesium blame`, alias/UUID resolution,
+      task/from/to/json flags, stdout-only JSON/table rendering via
+      `cmd.OutOrStdout()`, and the topology+image+command coverage caveat in
+      help, table output, and docs.
+- [x] C4. Add an integration scenario: apply a job, then apply a topology change
       (add an edge/step) that writes a second `dag_snapshot`, then drive
       `caesium blame --json` and assert the new element is attributed to the later
       snapshot/commit while the unchanged elements stay attributed to the first;
@@ -1134,6 +1138,12 @@ recorded here, out of scope, not promised.
       `provenance.commit` on apply so `--from`/`--to` are exercised end-to-end. The
       snapshot-identity attribution still holds internally, but the commit-range
       *surface* must be proven.
+      Note: W3-beta added `test/blame_test.go`, using a test apply helper over
+      `Importer.ApplyWithOptions` to stamp distinct `Provenance.Commit` values
+      into `dag_snapshot.git_commit`, then driving `caesium blame --json` via
+      `runCLIStdout`. The scenario covers addition, same-name image+command
+      mutation, delete-and-readd, env-only no-snapshot behavior, and commit-range
+      include/exclude assertions through `--from`/`--to`.
 
 ## Harness Strengthening
 

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -1138,12 +1138,14 @@ recorded here, out of scope, not promised.
       `provenance.commit` on apply so `--from`/`--to` are exercised end-to-end. The
       snapshot-identity attribution still holds internally, but the commit-range
       *surface* must be proven.
-      Note: W3-beta added `test/blame_test.go`, using a test apply helper over
-      `Importer.ApplyWithOptions` to stamp distinct `Provenance.Commit` values
-      into `dag_snapshot.git_commit`, then driving `caesium blame --json` via
-      `runCLIStdout`. The scenario covers addition, same-name image+command
-      mutation, delete-and-readd, env-only no-snapshot behavior, and commit-range
-      include/exclude assertions through `--from`/`--to`.
+      Note: W3-beta added `test/blame_test.go`; commit stamping now goes through
+      the apply API's optional `provenance` block (driven by
+      `caesium job apply --provenance-commit`, not an in-process importer) so the
+      server stamps distinct `dag_snapshot.git_commit` values before
+      `caesium blame --json` is driven via `runCLIStdout`. The scenario covers
+      addition, same-name image+command mutation, delete-and-readd, env-only
+      no-snapshot behavior, and commit-range include/exclude assertions through
+      `--from`/`--to`.
 
 ## Harness Strengthening
 

--- a/test/blame_test.go
+++ b/test/blame_test.go
@@ -3,15 +3,10 @@
 package test
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
+	"os"
 	"time"
-
-	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
-	"github.com/caesium-cloud/caesium/pkg/db"
-	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 )
 
 func (s *IntegrationTestSuite) TestBlameCLIAttributionAndCommitRanges() {
@@ -25,8 +20,8 @@ func (s *IntegrationTestSuite) TestBlameCLIAttributionAndCommitRanges() {
 		commit6 = "blame-cli-commit-6"
 	)
 
-	jobID := s.applyBlameManifestWithCommit(blameCLIV1(alias), commit1)
-	s.applyBlameManifestWithCommit(blameCLIV2(alias), commit2)
+	jobID := s.applyBlameManifestWithCommit(alias, blameCLIV1(alias), commit1)
+	s.applyBlameManifestWithCommit(alias, blameCLIV2(alias), commit2)
 
 	history := s.blameTopologyHistory(jobID)
 	s.Require().Len(history.Snapshots, 2, "topology addition should write a second dag_snapshot")
@@ -54,7 +49,7 @@ func (s *IntegrationTestSuite) TestBlameCLIAttributionAndCommitRanges() {
 	// Behavior-only edits are outside blame coverage. They update live runtime
 	// behavior but must not write a dag_snapshot or silently move attribution.
 	beforeBehaviorOnly := len(history.Snapshots)
-	s.applyBlameManifestWithCommit(blameCLIBehaviorOnly(alias), commit3)
+	s.applyBlameManifestWithCommit(alias, blameCLIBehaviorOnly(alias), commit3)
 	afterBehaviorOnly := s.blameTopologyHistory(jobID)
 	s.Len(afterBehaviorOnly.Snapshots, beforeBehaviorOnly, "env-only change must not write a dag_snapshot")
 	afterBehavior := s.runBlameJSON(alias)
@@ -68,8 +63,8 @@ func (s *IntegrationTestSuite) TestBlameCLIAttributionAndCommitRanges() {
 
 	// Delete-and-readd: the current descriptor is blamed on the re-adding
 	// snapshot, not its earliest-ever appearance.
-	s.applyBlameManifestWithCommit(blameCLIDeletePublish(alias), commit4)
-	s.applyBlameManifestWithCommit(blameCLIV2(alias), commit5)
+	s.applyBlameManifestWithCommit(alias, blameCLIDeletePublish(alias), commit4)
+	s.applyBlameManifestWithCommit(alias, blameCLIV2(alias), commit5)
 	afterReadd := s.runBlameJSON(alias)
 	s.Equal(commit5, requireBlameTask(s, afterReadd.Tasks, "publish").IntroducingCommit)
 	s.Equal(commit5, requireBlameEdge(s, afterReadd.Edges, "load", "publish").IntroducingCommit)
@@ -81,7 +76,7 @@ func (s *IntegrationTestSuite) TestBlameCLIAttributionAndCommitRanges() {
 
 	// Same-name descriptor mutation: changing load's image+command produces a
 	// new descriptor and must be blamed on the mutating commit.
-	s.applyBlameManifestWithCommit(blameCLIMutatedLoad(alias), commit6)
+	s.applyBlameManifestWithCommit(alias, blameCLIMutatedLoad(alias), commit6)
 	finalHistory := s.blameTopologyHistory(jobID)
 	s.Require().Len(finalHistory.Snapshots, 5, "addition, delete, re-add, and image/command mutation should produce five snapshots total")
 	mutated := s.runBlameJSON(alias)
@@ -92,28 +87,25 @@ func (s *IntegrationTestSuite) TestBlameCLIAttributionAndCommitRanges() {
 	s.Equal(commit1, requireBlameTask(s, mutated.Tasks, "extract").IntroducingCommit)
 }
 
-func (s *IntegrationTestSuite) applyBlameManifestWithCommit(manifest, commit string) string {
+func (s *IntegrationTestSuite) applyBlameManifestWithCommit(alias, manifest, commit string) string {
 	s.T().Helper()
 	time.Sleep(10 * time.Millisecond)
 
-	def, err := schema.Parse([]byte(strings.TrimSpace(s.injectEngine(manifest))))
-	s.Require().NoError(err)
+	dir := s.writeJobManifest(manifest)
+	defer os.RemoveAll(dir)
 
-	job, err := internaljobdef.NewImporter(db.Connection()).ApplyWithOptions(
-		context.Background(),
-		def,
-		&internaljobdef.ApplyOptions{
-			Provenance: &internaljobdef.Provenance{
-				SourceID: "integration-blame-cli",
-				Repo:     "https://example.invalid/caesium-integration.git",
-				Ref:      "refs/heads/integration",
-				Commit:   commit,
-				Path:     "jobs/" + def.Metadata.Alias + ".job.yaml",
-			},
-		},
+	s.runCLI(
+		"job", "apply",
+		"--path", dir,
+		"--server", s.caesiumURL,
+		"--provenance-source-id", "integration-blame-cli",
+		"--provenance-repo", "https://example.invalid/caesium-integration.git",
+		"--provenance-ref", "refs/heads/integration",
+		"--provenance-commit", commit,
+		"--provenance-path", "jobs/"+alias+".job.yaml",
 	)
-	s.Require().NoError(err)
-	return job.ID.String()
+
+	return s.requireJobByAlias(alias).ID
 }
 
 func (s *IntegrationTestSuite) runBlameJSON(job string, extraArgs ...string) blameRESTResponse {

--- a/test/blame_test.go
+++ b/test/blame_test.go
@@ -1,0 +1,263 @@
+//go:build integration
+
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+)
+
+func (s *IntegrationTestSuite) TestBlameCLIAttributionAndCommitRanges() {
+	alias := fmt.Sprintf("e2e-blame-cli-%d", time.Now().UnixNano())
+	const (
+		commit1 = "blame-cli-commit-1"
+		commit2 = "blame-cli-commit-2"
+		commit3 = "blame-cli-commit-3"
+		commit4 = "blame-cli-commit-4"
+		commit5 = "blame-cli-commit-5"
+		commit6 = "blame-cli-commit-6"
+	)
+
+	jobID := s.applyBlameManifestWithCommit(blameCLIV1(alias), commit1)
+	s.applyBlameManifestWithCommit(blameCLIV2(alias), commit2)
+
+	history := s.blameTopologyHistory(jobID)
+	s.Require().Len(history.Snapshots, 2, "topology addition should write a second dag_snapshot")
+
+	full := s.runBlameJSON(alias)
+	s.Equal(jobID, full.JobID)
+	s.Equal("topology+image+command", full.Coverage)
+	s.Equal(commit1, requireBlameTask(s, full.Tasks, "extract").IntroducingCommit)
+	s.Equal(commit1, requireBlameTask(s, full.Tasks, "load").IntroducingCommit)
+	s.Equal(commit2, requireBlameTask(s, full.Tasks, "publish").IntroducingCommit)
+	s.Equal(commit1, requireBlameEdge(s, full.Edges, "extract", "load").IntroducingCommit)
+	s.Equal(commit2, requireBlameEdge(s, full.Edges, "load", "publish").IntroducingCommit)
+
+	// Mandatory commit-range gate: exercise operator-facing --from/--to commit
+	// filters through the CLI against distinct GitCommit values stamped on apply.
+	laterOnly := s.runBlameJSON(alias, "--from", commit2, "--to", commit2)
+	s.Equal(commit2, laterOnly.FromCommit)
+	s.Equal(commit2, laterOnly.ToCommit)
+	s.True(hasBlameTask(laterOnly.Tasks, "publish"), "range covering only commit2 should include the added task")
+	s.False(hasBlameTask(laterOnly.Tasks, "extract"), "range covering only commit2 should exclude unchanged commit1 task")
+	s.False(hasBlameTask(laterOnly.Tasks, "load"), "range covering only commit2 should exclude unchanged commit1 task")
+	s.True(hasBlameEdge(laterOnly.Edges, "load", "publish"), "range covering only commit2 should include the added edge")
+	s.False(hasBlameEdge(laterOnly.Edges, "extract", "load"), "range covering only commit2 should exclude unchanged commit1 edge")
+
+	// Behavior-only edits are outside blame coverage. They update live runtime
+	// behavior but must not write a dag_snapshot or silently move attribution.
+	beforeBehaviorOnly := len(history.Snapshots)
+	s.applyBlameManifestWithCommit(blameCLIBehaviorOnly(alias), commit3)
+	afterBehaviorOnly := s.blameTopologyHistory(jobID)
+	s.Len(afterBehaviorOnly.Snapshots, beforeBehaviorOnly, "env-only change must not write a dag_snapshot")
+	afterBehavior := s.runBlameJSON(alias)
+	s.Equal("topology+image+command", afterBehavior.Coverage)
+	s.Equal(commit1, requireBlameTask(s, afterBehavior.Tasks, "extract").IntroducingCommit)
+	s.Equal(commit2, requireBlameTask(s, afterBehavior.Tasks, "publish").IntroducingCommit)
+	table, err := s.runCLIStdout("blame", alias, "--server", s.caesiumURL)
+	s.Require().NoError(err, "caesium blame table failed:\n%s", table)
+	s.Contains(table, "Coverage: topology + image + command only")
+	s.Contains(table, "env/spec/retries/cache/schema/sla/triggerRules changes are not tracked")
+
+	// Delete-and-readd: the current descriptor is blamed on the re-adding
+	// snapshot, not its earliest-ever appearance.
+	s.applyBlameManifestWithCommit(blameCLIDeletePublish(alias), commit4)
+	s.applyBlameManifestWithCommit(blameCLIV2(alias), commit5)
+	afterReadd := s.runBlameJSON(alias)
+	s.Equal(commit5, requireBlameTask(s, afterReadd.Tasks, "publish").IntroducingCommit)
+	s.Equal(commit5, requireBlameEdge(s, afterReadd.Edges, "load", "publish").IntroducingCommit)
+
+	readdOnly := s.runBlameJSON(alias, "--from", commit5, "--to", commit5)
+	s.True(hasBlameTask(readdOnly.Tasks, "publish"), "range covering only re-add commit should include publish")
+	s.False(hasBlameTask(readdOnly.Tasks, "extract"), "range covering only re-add commit should exclude unchanged extract")
+	s.True(hasBlameEdge(readdOnly.Edges, "load", "publish"), "range covering only re-add commit should include re-added edge")
+
+	// Same-name descriptor mutation: changing load's image+command produces a
+	// new descriptor and must be blamed on the mutating commit.
+	s.applyBlameManifestWithCommit(blameCLIMutatedLoad(alias), commit6)
+	finalHistory := s.blameTopologyHistory(jobID)
+	s.Require().Len(finalHistory.Snapshots, 5, "addition, delete, re-add, and image/command mutation should produce five snapshots total")
+	mutated := s.runBlameJSON(alias)
+	load := requireBlameTask(s, mutated.Tasks, "load")
+	s.Equal(commit6, load.IntroducingCommit)
+	s.Equal("busybox:1.36.1", load.Element.Image)
+	s.Equal([]string{"sh", "-c", "echo load-mutated"}, load.Element.Command)
+	s.Equal(commit1, requireBlameTask(s, mutated.Tasks, "extract").IntroducingCommit)
+}
+
+func (s *IntegrationTestSuite) applyBlameManifestWithCommit(manifest, commit string) string {
+	s.T().Helper()
+	time.Sleep(10 * time.Millisecond)
+
+	def, err := schema.Parse([]byte(strings.TrimSpace(s.injectEngine(manifest))))
+	s.Require().NoError(err)
+
+	job, err := internaljobdef.NewImporter(db.Connection()).ApplyWithOptions(
+		context.Background(),
+		def,
+		&internaljobdef.ApplyOptions{
+			Provenance: &internaljobdef.Provenance{
+				SourceID: "integration-blame-cli",
+				Repo:     "https://example.invalid/caesium-integration.git",
+				Ref:      "refs/heads/integration",
+				Commit:   commit,
+				Path:     "jobs/" + def.Metadata.Alias + ".job.yaml",
+			},
+		},
+	)
+	s.Require().NoError(err)
+	return job.ID.String()
+}
+
+func (s *IntegrationTestSuite) runBlameJSON(job string, extraArgs ...string) blameRESTResponse {
+	s.T().Helper()
+	args := []string{"blame", job, "--json", "--server", s.caesiumURL}
+	args = append(args, extraArgs...)
+	out, err := s.runCLIStdout(args...)
+	s.Require().NoError(err, "caesium blame --json failed:\n%s", out)
+	s.Require().True(json.Valid([]byte(out)), "caesium blame --json stdout was not valid JSON (log contamination?):\n%s", out)
+	var res blameRESTResponse
+	s.Require().NoError(json.Unmarshal([]byte(out), &res))
+	return res
+}
+
+func (s *IntegrationTestSuite) blameTopologyHistory(jobID string) topologyHistoryResponse {
+	s.T().Helper()
+	var history topologyHistoryResponse
+	s.getJSON(fmt.Sprintf("/v1/jobs/%s/topology/history", jobID), &history)
+	return history
+}
+
+func requireBlameEdge(s *IntegrationTestSuite, edges []blameEdgeResult, from, to string) blameEdgeResult {
+	s.T().Helper()
+	for _, edge := range edges {
+		if edge.Element.From == from && edge.Element.To == to {
+			return edge
+		}
+	}
+	s.T().Fatalf("blame edge %q -> %q not found in %+v", from, to, edges)
+	return blameEdgeResult{}
+}
+
+func hasBlameEdge(edges []blameEdgeResult, from, to string) bool {
+	for _, edge := range edges {
+		if edge.Element.From == from && edge.Element.To == to {
+			return true
+		}
+	}
+	return false
+}
+
+func blameCLIV1(alias string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: extract
+    image: alpine:3.23
+    command: ["sh","-c","echo extract"]
+    next: load
+  - name: load
+    image: alpine:3.23
+    command: ["sh","-c","echo load"]
+    dependsOn: extract
+`, alias)
+}
+
+func blameCLIV2(alias string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: extract
+    image: alpine:3.23
+    command: ["sh","-c","echo extract"]
+    next: load
+  - name: load
+    image: alpine:3.23
+    command: ["sh","-c","echo load"]
+    dependsOn: extract
+    next: publish
+  - name: publish
+    image: alpine:3.23
+    command: ["sh","-c","echo publish"]
+    dependsOn: load
+`, alias)
+}
+
+func blameCLIBehaviorOnly(alias string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: extract
+    image: alpine:3.23
+    env:
+      BLAME_BEHAVIOR_ONLY: changed
+    command: ["sh","-c","echo extract"]
+    next: load
+  - name: load
+    image: alpine:3.23
+    command: ["sh","-c","echo load"]
+    dependsOn: extract
+    next: publish
+  - name: publish
+    image: alpine:3.23
+    command: ["sh","-c","echo publish"]
+    dependsOn: load
+`, alias)
+}
+
+func blameCLIDeletePublish(alias string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: extract
+    image: alpine:3.23
+    command: ["sh","-c","echo extract"]
+    next: load
+  - name: load
+    image: alpine:3.23
+    command: ["sh","-c","echo load"]
+    dependsOn: extract
+`, alias)
+}
+
+func blameCLIMutatedLoad(alias string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: extract
+    image: alpine:3.23
+    command: ["sh","-c","echo extract"]
+    next: load
+  - name: load
+    image: busybox:1.36.1
+    command: ["sh","-c","echo load-mutated"]
+    dependsOn: extract
+    next: publish
+  - name: publish
+    image: alpine:3.23
+    command: ["sh","-c","echo publish"]
+    dependsOn: load
+`, alias)
+}

--- a/test/rundiff_blame_e2e_test.go
+++ b/test/rundiff_blame_e2e_test.go
@@ -36,10 +36,12 @@ type runDiffFieldChange struct {
 }
 
 type blameRESTResponse struct {
-	JobID    string            `json:"job_id"`
-	Coverage string            `json:"coverage"`
-	Tasks    []blameTaskResult `json:"tasks"`
-	Edges    []blameEdgeResult `json:"edges"`
+	JobID      string            `json:"job_id"`
+	Coverage   string            `json:"coverage"`
+	FromCommit string            `json:"from_commit,omitempty"`
+	ToCommit   string            `json:"to_commit,omitempty"`
+	Tasks      []blameTaskResult `json:"tasks"`
+	Edges      []blameEdgeResult `json:"edges"`
 }
 
 type blameTaskResult struct {


### PR DESCRIPTION
## Summary
- Adds the top-level `caesium blame <job-id-or-alias> [--task t] [--from c] [--to c] [--json]` (`cmd/blame/`, appended to `cmd/execute.go`'s `cmds`) over the shipped C2 endpoint. Per-element table by default; machine JSON via `cmd.OutOrStdout()`.
- **Honest coverage caveat** surfaced in the command help, `docs/caesium-job-llm-reference.md`, and the output: blame attributes **topology + image + command** only; `env`/`spec`/`retries`/`cache`/schema/`sla`/`triggerRules` edits are untracked (so it never reads as full behavior blame).
- **Integration coverage** (`test/blame_test.go`, `//go:build integration`): ordinary addition; (a) same-name image/command mutation → mutating snapshot; (b) delete-and-readd → re-adding snapshot; (c) behavior-only `env` change → **no new snapshot + caveat present**; and (d) the **mandatory commit-range gate** — **distinct `GitCommit`s stamped per apply**, driving `blame --from/--to` through the **real CLI** (`runCLIStdout`) and asserting both **inclusion and exclusion** of the expected snapshots (not a snapshot-id fallback).
- Flips the `blame` design-doc row to shipped. Implements **C3 + C4**.

## Test plan
- [x] just lint (orchestrator)
- [x] just unit-test (orchestrator)
- [ ] just integration-test — CI runs the new blame e2e (incl. the commit-range gate)
- Opus adversarial review (xhigh commit-range lens): **clean** — confirmed the commit-range test is genuinely exercised (real provenance commits + inclusion/exclusion) and `--json` is clean. Aligned `resolveAPIKey` with the `why.go` template; pinned `busybox:1.36.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)