### PR TITLE
Add quarantine runtime plumbing (data-plane-memory-ii W4-α)

### DIFF
--- a/api/middleware/auth_scope.go
+++ b/api/middleware/auth_scope.go
@@ -22,6 +22,11 @@ const ContextKeyAllowedJobAliases = "auth.allowed_job_aliases"
 // integration tests assert against the single source of truth.
 const LineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
 
+// EventsScopedDenyMessage is returned when a scoped principal attempts to open
+// the global event stream without a run_id filter. Scoped event subscriptions
+// must resolve to one run owner before any events are streamed.
+const EventsScopedDenyMessage = "event stream requires an in-scope run_id for scoped principals"
+
 type scopeAuditContext struct {
 	jobAliases []string
 }
@@ -85,6 +90,29 @@ func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routeP
 	case "/v1/lineage/impact":
 		if c.Request().Method == http.MethodGet {
 			return nil, echo.NewHTTPError(http.StatusForbidden, LineageImpactScopedDenyMessage)
+		}
+	case "/v1/events":
+		if c.Request().Method == http.MethodGet {
+			runIDRaw := strings.TrimSpace(c.QueryParam("run_id"))
+			if runIDRaw == "" {
+				return nil, echo.NewHTTPError(http.StatusForbidden, EventsScopedDenyMessage)
+			}
+			runID, err := uuid.Parse(runIDRaw)
+			if err != nil {
+				return nil, echo.NewHTTPError(http.StatusBadRequest, "invalid run_id")
+			}
+			jobAlias, err := svc.JobAliasByRunID(c.Request().Context(), runID)
+			if err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					return nil, echo.ErrNotFound
+				}
+				return nil, echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+			}
+			if !auth.CheckScope(scopeJSON, jobAlias) {
+				return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+			}
+			state.jobAliases = []string{jobAlias}
+			return state, nil
 		}
 	}
 

--- a/api/rest/controller/event/stream.go
+++ b/api/rest/controller/event/stream.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -9,20 +10,29 @@ import (
 	"sync"
 	"time"
 
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
 )
 
 type Controller struct {
 	bus       event.Bus
 	storeOnce sync.Once
 	store     *event.Store
+	authSvc   *iauth.Service
 }
 
 func New(bus event.Bus) *Controller {
 	return &Controller{bus: bus}
+}
+
+func (ctrl *Controller) WithAuthService(svc *iauth.Service) *Controller {
+	ctrl.authSvc = svc
+	return ctrl
 }
 
 func (ctrl *Controller) persistentStore() *event.Store {
@@ -35,7 +45,7 @@ func (ctrl *Controller) persistentStore() *event.Store {
 func (ctrl *Controller) Stream(c *echo.Context) error {
 	ctx := c.Request().Context()
 
-	filter, err := buildFilter(c)
+	filter, err := ctrl.buildFilter(c)
 	if err != nil {
 		return err
 	}
@@ -135,7 +145,7 @@ func (ctrl *Controller) Stream(c *echo.Context) error {
 	}
 }
 
-func buildFilter(c *echo.Context) (event.Filter, error) {
+func (ctrl *Controller) buildFilter(c *echo.Context) (event.Filter, error) {
 	filter := event.Filter{}
 
 	if jobIDStr := c.QueryParam("job_id"); jobIDStr != "" {
@@ -152,6 +162,10 @@ func buildFilter(c *echo.Context) (event.Filter, error) {
 			return filter, echo.NewHTTPError(http.StatusBadRequest, "invalid run_id")
 		}
 		filter.RunID = id
+		if err := ctrl.authorizeRunQuarantineAccess(c, id); err != nil {
+			return filter, err
+		}
+		filter.IncludeQuarantine = true
 	}
 
 	if typesStr := c.QueryParam("types"); typesStr != "" {
@@ -165,6 +179,29 @@ func buildFilter(c *echo.Context) (event.Filter, error) {
 	}
 
 	return filter, nil
+}
+
+func (ctrl *Controller) authorizeRunQuarantineAccess(c *echo.Context, runID uuid.UUID) error {
+	principal := authmw.GetPrincipal(c)
+	if principal == nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+
+	svc := ctrl.authSvc
+	if svc == nil {
+		svc = iauth.NewService(db.Connection())
+	}
+	jobAlias, err := svc.JobAliasByRunID(c.Request().Context(), runID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	if !iauth.CheckScope(principal.Scope, jobAlias) {
+		return echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+	}
+	return nil
 }
 
 func parseLastSequence(c *echo.Context) (uint64, error) {

--- a/api/rest/controller/event/stream_test.go
+++ b/api/rest/controller/event/stream_test.go
@@ -1,0 +1,96 @@
+package event
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestBuildFilterIncludesQuarantineOnlyForAccessibleRun(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		testutil.CloseDB(db)
+	})
+
+	runID := seedEventStreamRun(t, db, "alpha")
+	scopeJSON, err := json.Marshal(models.KeyScope{Jobs: []string{"alpha"}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events?run_id="+runID.String(), nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	c.Set(authmw.ContextKeyPrincipal, &iauth.Principal{Role: models.RoleViewer, Scope: scopeJSON})
+
+	filter, err := New(nil).WithAuthService(iauth.NewService(db)).buildFilter(c)
+	require.NoError(t, err)
+	require.Equal(t, runID, filter.RunID)
+	require.True(t, filter.IncludeQuarantine)
+}
+
+func TestBuildFilterRejectsQuarantineForOutOfScopeRun(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		testutil.CloseDB(db)
+	})
+
+	runID := seedEventStreamRun(t, db, "alpha")
+	scopeJSON, err := json.Marshal(models.KeyScope{Jobs: []string{"beta"}})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/events?run_id="+runID.String(), nil)
+	rec := httptest.NewRecorder()
+	c := echo.New().NewContext(req, rec)
+	c.Set(authmw.ContextKeyPrincipal, &iauth.Principal{Role: models.RoleViewer, Scope: scopeJSON})
+
+	filter, err := New(nil).WithAuthService(iauth.NewService(db)).buildFilter(c)
+	require.Error(t, err)
+	require.False(t, filter.IncludeQuarantine)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, httpErr.Code)
+}
+
+func seedEventStreamRun(t *testing.T, db *gorm.DB, alias string) uuid.UUID {
+	t.Helper()
+
+	now := time.Now().UTC()
+	trigger := &models.Trigger{
+		ID:        uuid.New(),
+		Alias:     alias + "-trigger",
+		Type:      models.TriggerTypeCron,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	require.NoError(t, db.Create(trigger).Error)
+
+	job := &models.Job{
+		ID:        uuid.New(),
+		Alias:     alias,
+		TriggerID: trigger.ID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	require.NoError(t, db.Create(job).Error)
+
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:        runID,
+		JobID:     job.ID,
+		Status:    "running",
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	return runID
+}

--- a/api/rest/service/stats/stats.go
+++ b/api/rest/service/stats/stats.go
@@ -109,17 +109,17 @@ func (s *Service) Summary(window string) (*StatsResponse, error) {
 	// Recent runs (always 24h as per spec KPI)
 	recentSince := time.Now().UTC().Add(-24 * time.Hour)
 	s.db.WithContext(s.ctx).Model(&models.JobRun{}).
-		Where("started_at >= ?", recentSince).
+		Where("started_at >= ? AND quarantine IS NOT TRUE", recentSince).
 		Count(&resp.Jobs.RecentRuns)
 
 	// Success rate in window
 	var totalCompleted int64
 	var totalSucceeded int64
 	s.db.WithContext(s.ctx).Model(&models.JobRun{}).
-		Where("status IN ? AND started_at >= ?", []string{"succeeded", "failed"}, since).
+		Where("status IN ? AND started_at >= ? AND quarantine IS NOT TRUE", []string{"succeeded", "failed"}, since).
 		Count(&totalCompleted)
 	s.db.WithContext(s.ctx).Model(&models.JobRun{}).
-		Where("status = ? AND started_at >= ?", "succeeded", since).
+		Where("status = ? AND started_at >= ? AND quarantine IS NOT TRUE", "succeeded", since).
 		Count(&totalSucceeded)
 	if totalCompleted > 0 {
 		resp.Jobs.SuccessRate = float64(totalSucceeded) / float64(totalCompleted)
@@ -128,8 +128,8 @@ func (s *Service) Summary(window string) (*StatsResponse, error) {
 	// Average duration in window
 	var avgResult struct{ Avg float64 }
 	s.db.WithContext(s.ctx).Model(&models.JobRun{}).
-		Select("AVG(" + durExpr + ") as avg").
-		Where("completed_at IS NOT NULL AND started_at >= ?", since).
+		Select("AVG("+durExpr+") as avg").
+		Where("completed_at IS NOT NULL AND started_at >= ? AND quarantine IS NOT TRUE", since).
 		Scan(&avgResult)
 	resp.Jobs.AvgDurationSeconds = avgResult.Avg
 
@@ -142,7 +142,7 @@ func (s *Service) Summary(window string) (*StatsResponse, error) {
 	var failRows []failRow
 	s.db.WithContext(s.ctx).Model(&models.JobRun{}).
 		Select("job_id, COUNT(*) as failure_count, MAX(completed_at) as last_failure").
-		Where("status = ? AND started_at >= ?", "failed", since).
+		Where("status = ? AND started_at >= ? AND quarantine IS NOT TRUE", "failed", since).
 		Group("job_id").
 		Order("failure_count DESC").
 		Limit(5).
@@ -168,7 +168,7 @@ func (s *Service) Summary(window string) (*StatsResponse, error) {
 		Select("job_runs.job_id, tasks.name as atom_name, COUNT(*) as failure_count").
 		Joins("JOIN job_runs ON job_runs.id = task_runs.job_run_id").
 		Joins("JOIN tasks ON tasks.id = task_runs.task_id").
-		Where("task_runs.status = ? AND job_runs.started_at >= ?", "failed", since).
+		Where("task_runs.status = ? AND job_runs.started_at >= ? AND task_runs.quarantine IS NOT TRUE AND job_runs.quarantine IS NOT TRUE", "failed", since).
 		Group("job_runs.job_id, tasks.name").
 		Order("failure_count DESC").
 		Limit(5).
@@ -191,8 +191,8 @@ func (s *Service) Summary(window string) (*StatsResponse, error) {
 	}
 	var slowRows []slowRow
 	s.db.WithContext(s.ctx).Model(&models.JobRun{}).
-		Select("job_id, AVG(" + durExpr + ") as avg").
-		Where("completed_at IS NOT NULL AND started_at >= ?", since).
+		Select("job_id, AVG("+durExpr+") as avg").
+		Where("completed_at IS NOT NULL AND started_at >= ? AND quarantine IS NOT TRUE", since).
 		Group("job_id").
 		Order("avg DESC").
 		Limit(5).
@@ -229,7 +229,7 @@ func (s *Service) Summary(window string) (*StatsResponse, error) {
 
 	s.db.WithContext(s.ctx).Model(&models.JobRun{}).
 		Select(pointExpr+" as point, COUNT(*) as run_count, SUM(CASE WHEN status = 'succeeded' THEN 1 ELSE 0 END) as succ").
-		Where("started_at >= ? AND status IN ?", since, []string{"succeeded", "failed"}).
+		Where("started_at >= ? AND status IN ? AND quarantine IS NOT TRUE", since, []string{"succeeded", "failed"}).
 		Group("point").
 		Order("point ASC").
 		Scan(&trendData)

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -640,7 +640,7 @@ write, lineage emit, or callback.
       Note (W1-beta): Added `docs/design-quarantined-replay.md` with the
       fail-closed replay safety model, producer/metric/envelope audits grounded in
       source grep, plus the required top-level README index entry.
-- [ ] B2. Add quarantine to the run model **and propagate it to both executors**.
+- [x] B2. Add quarantine to the run model **and propagate it to both executors**.
       An additive `Quarantine bool` (and a captured override-params blob) on
       `JobRun`, **plus a `Quarantine bool` on `TaskRun`** threaded scheduler→worker
       the same way `ResolvedImageDigest` is (so the distributed worker sees it
@@ -778,6 +778,30 @@ write, lineage emit, or callback.
       short-circuit; suppress before increment), and
       `internal/jobdef/secret/` (the `ResolveWithIdentity` provider-aware identity
       API + env/k8s/vault impls). The complete surface comes from B1's audit.
+      Note (W4-alpha): Landed the additive `JobRun`/`TaskRun`/`ExecutionEvent`
+      quarantine markers, nullable unique `ReplayFingerprint`, replay override blob,
+      event-bus marker/filtering, default `quarantine IS NOT TRUE` stats/run/event
+      filters, run-level propagation to task rows, per-TaskRun execution descriptors,
+      provider-aware `ResolveWithIdentity`, and quarantine suppression across local
+      executor callbacks/cache publication, distributed worker cache publication,
+      notification subscriber/watcher, OpenLineage subscriber/mapper, `/events`
+      backlog/live stream, dispatch/complete/worker metrics, and run/task/cache/retry
+      metrics. B3 still owns constructing quarantined replay runs, replay-safe
+      pre-dispatch enforcement, baseline-cache-absent failure, descriptor-based
+      replay reconstruction, and user-facing replay errors; B4 still owns the durable
+      reservation state machine around `ReplayFingerprint`; B6 still owns the full
+      end-to-end notification/SLA/lineage integration scenarios.
+      Review-fix note (W4-alpha, 2026-06-25): closed the security review blockers:
+      `run_started` now carries the quarantine marker through both `Start` paths;
+      Vault KV-v2 version pinning uses `ReadWithDataWithContext` query data instead
+      of appending `?version=` to the logical path; dispatch metric visibility reads
+      the already-loaded `TaskRun.Quarantine` and defaults to emit when marker
+      context is unavailable; empty task-registration batches observe zero; the v1
+      descriptor no longer exposes unpopulated large-ref or redundant violation
+      behavior fields; `/events?run_id=...` authorizes the run owner before
+      including quarantined events; and descriptor/quarantine/notification guard
+      tests were added. Side-effect/event/cache/lineage/callback suppression remains
+      fail-closed.
       Depends on: B1.
 - [ ] B3. Implement the replay construction + dispatch path: from a baseline run +
       `--set` overrides, build a quarantined `JobRun` and dispatch it through the

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -794,14 +794,25 @@ write, lineage emit, or callback.
       Review-fix note (W4-alpha, 2026-06-25): closed the security review blockers:
       `run_started` now carries the quarantine marker through both `Start` paths;
       Vault KV-v2 version pinning uses `ReadWithDataWithContext` query data instead
-      of appending `?version=` to the logical path; dispatch metric visibility reads
-      the already-loaded `TaskRun.Quarantine` and defaults to emit when marker
-      context is unavailable; empty task-registration batches observe zero; the v1
+      of appending `?version=` to the logical path; dispatch metric visibility
+      defaults to emit when marker context is unavailable; empty task-registration
+      batches observe zero; the v1
       descriptor no longer exposes unpopulated large-ref or redundant violation
       behavior fields; `/events?run_id=...` authorizes the run owner before
       including quarantined events; and descriptor/quarantine/notification guard
       tests were added. Side-effect/event/cache/lineage/callback suppression remains
       fail-closed.
+      Review-fix note (W4-alpha, 2026-06-25, perf/concurrency): made dispatch
+      completion metric quarantine checks lazy and memoized, with missing task rows
+      intentionally defaulting to metric emit only; collapsed batch event
+      quarantine stamping from per-event SELECTs into per-run/per-task grouped
+      lookups that still abort the transaction on lookup errors; removed the
+      redundant Vault KV-v2 current-version re-read while preserving version-N
+      HMAC identity capture with canonical integer version strings; and made
+      `execution_descriptor` mutations compare-and-swap against the prior JSON so
+      concurrent descriptor writers retry instead of clobbering each other. No
+      side-effect, event, cache, lineage, callback, or notification suppression was
+      made fail-open.
       Depends on: B1.
 - [ ] B3. Implement the replay construction + dispatch path: from a baseline run +
       `--set` overrides, build a quarantined `JobRun` and dispatch it through the

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -431,10 +431,16 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
+	metricQuarantined := h.completeMetricQuarantined(ctx, req.RunID, req.TaskID)
+	recordRejected := func(reason string) {
+		if !metricQuarantined {
+			metrics.CompleteRejectedTotal.WithLabelValues(reason).Inc()
+		}
+	}
 
 	// Rule 5: validate status vocabulary.
 	if !ValidCompleteStatuses[req.Status] {
-		metrics.CompleteRejectedTotal.WithLabelValues(ReasonInvalidStatus).Inc()
+		recordRejected(ReasonInvalidStatus)
 		writeJSON(w, http.StatusConflict, ErrorResponse{
 			Code:    ReasonInvalidStatus,
 			Message: fmt.Sprintf("invalid status %q; must be one of {succeeded, failed, cached}", req.Status),
@@ -446,7 +452,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 	// ownership (owner_node, expiry) and generation in memory.
 	lease, err := h.leaseStore.GetLease(ctx, req.RunID)
 	if err != nil {
-		metrics.CompleteRejectedTotal.WithLabelValues(ReasonMissingRun).Inc()
+		recordRejected(ReasonMissingRun)
 		writeJSON(w, http.StatusConflict, ErrorResponse{
 			Code:    ReasonMissingRun,
 			Message: "run lease not found",
@@ -454,7 +460,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if lease.OwnerNode != h.nodeID || lease.LeaseExpiresAt.Before(time.Now().UTC()) {
-		metrics.CompleteRejectedTotal.WithLabelValues(ReasonNotOwner).Inc()
+		recordRejected(ReasonNotOwner)
 		writeJSON(w, http.StatusConflict, ErrorResponse{
 			Code:    ReasonNotOwner,
 			Message: "this node does not currently own the run",
@@ -462,7 +468,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if lease.Generation != req.OwnerGeneration {
-		metrics.CompleteRejectedTotal.WithLabelValues(ReasonStaleGeneration).Inc()
+		recordRejected(ReasonStaleGeneration)
 		writeJSON(w, http.StatusConflict, ErrorResponse{
 			Code:    ReasonStaleGeneration,
 			Message: fmt.Sprintf("owner generation mismatch: expected %d, got %d", lease.Generation, req.OwnerGeneration),
@@ -481,11 +487,11 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		)
 		if omErr != nil {
 			if dqlite.IsContentionError(omErr) {
-				h.rejectRetryable(w, req, omErr)
+				h.rejectRetryable(w, req, omErr, metricQuarantined)
 				return
 			}
 			if errors.Is(omErr, run.ErrTaskClaimMismatch) {
-				metrics.CompleteRejectedTotal.WithLabelValues(ReasonWrongWorker).Inc()
+				recordRejected(ReasonWrongWorker)
 				writeJSON(w, http.StatusConflict, ErrorResponse{
 					Code:    ReasonWrongWorker,
 					Message: "task claimed_by mismatch or task not in running state",
@@ -520,7 +526,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 			applyErr = h.store.FailTaskClaimed(req.RunID, req.TaskID, fmt.Errorf("%s", req.Error), req.WorkerNode)
 		}
 		if applyErr == run.ErrTaskClaimMismatch {
-			metrics.CompleteRejectedTotal.WithLabelValues(ReasonWrongWorker).Inc()
+			recordRejected(ReasonWrongWorker)
 			writeJSON(w, http.StatusConflict, ErrorResponse{
 				Code:    ReasonWrongWorker,
 				Message: "task claimed_by mismatch or task not in running state",
@@ -529,7 +535,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		}
 		if applyErr != nil {
 			if dqlite.IsContentionError(applyErr) {
-				h.rejectRetryable(w, req, applyErr)
+				h.rejectRetryable(w, req, applyErr, metricQuarantined)
 				return
 			}
 			log.Error("complete: apply failed",
@@ -549,7 +555,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		source := run.CacheHitSource{RunID: req.RunID}
 		applyErr := h.store.CacheHitTaskClaimed(req.RunID, req.TaskID, source, req.Result, req.WorkerNode, req.Outputs, req.BranchSelections)
 		if applyErr == run.ErrTaskClaimMismatch {
-			metrics.CompleteRejectedTotal.WithLabelValues(ReasonWrongWorker).Inc()
+			recordRejected(ReasonWrongWorker)
 			writeJSON(w, http.StatusConflict, ErrorResponse{
 				Code:    ReasonWrongWorker,
 				Message: "task claimed_by mismatch or task not in running state",
@@ -558,7 +564,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		}
 		if applyErr != nil {
 			if dqlite.IsContentionError(applyErr) {
-				h.rejectRetryable(w, req, applyErr)
+				h.rejectRetryable(w, req, applyErr, metricQuarantined)
 				return
 			}
 			log.Error("complete: CacheHitTaskClaimed failed",
@@ -577,13 +583,31 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, CompleteResponse{Accepted: true})
 }
 
+func (h *Handler) completeMetricQuarantined(ctx context.Context, runID, taskID uuid.UUID) bool {
+	if h.store == nil {
+		return false
+	}
+	quarantined, err := h.store.TaskQuarantine(ctx, runID, taskID)
+	if err != nil {
+		log.Warn("complete: failed to read task quarantine marker; emitting complete metrics",
+			"run_id", runID,
+			"task_id", taskID,
+			"error", err,
+		)
+		return false
+	}
+	return quarantined
+}
+
 // rejectRetryable answers a completion the owner could not apply because of
 // transient dqlite contention.  It returns 503 (not 409) so the worker knows
 // the request is safe to re-send once the leader's contention clears, and logs
 // at warn rather than error because this is expected under burst load and is
 // not a lost completion unless the worker exhausts its own retries.
-func (h *Handler) rejectRetryable(w http.ResponseWriter, req CompleteRequest, applyErr error) {
-	metrics.CompleteRetryableTotal.WithLabelValues(ReasonContention).Inc()
+func (h *Handler) rejectRetryable(w http.ResponseWriter, req CompleteRequest, applyErr error, quarantined bool) {
+	if !quarantined {
+		metrics.CompleteRetryableTotal.WithLabelValues(ReasonContention).Inc()
+	}
 	log.Warn("complete: transient contention, asking worker to retry",
 		"run_id", req.RunID,
 		"task_id", req.TaskID,

--- a/internal/dispatch/dispatch.go
+++ b/internal/dispatch/dispatch.go
@@ -34,6 +34,7 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 // Rejection reason labels for caesium_complete_rejected_total.
@@ -431,9 +432,11 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ctx := r.Context()
-	metricQuarantined := h.completeMetricQuarantined(ctx, req.RunID, req.TaskID)
+	metricQuarantined := sync.OnceValue(func() bool {
+		return h.completeMetricQuarantined(ctx, req.RunID, req.TaskID)
+	})
 	recordRejected := func(reason string) {
-		if !metricQuarantined {
+		if !metricQuarantined() {
 			metrics.CompleteRejectedTotal.WithLabelValues(reason).Inc()
 		}
 	}
@@ -487,7 +490,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		)
 		if omErr != nil {
 			if dqlite.IsContentionError(omErr) {
-				h.rejectRetryable(w, req, omErr, metricQuarantined)
+				h.rejectRetryable(w, req, omErr, metricQuarantined())
 				return
 			}
 			if errors.Is(omErr, run.ErrTaskClaimMismatch) {
@@ -535,7 +538,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		}
 		if applyErr != nil {
 			if dqlite.IsContentionError(applyErr) {
-				h.rejectRetryable(w, req, applyErr, metricQuarantined)
+				h.rejectRetryable(w, req, applyErr, metricQuarantined())
 				return
 			}
 			log.Error("complete: apply failed",
@@ -564,7 +567,7 @@ func (h *Handler) HandleComplete(w http.ResponseWriter, r *http.Request) {
 		}
 		if applyErr != nil {
 			if dqlite.IsContentionError(applyErr) {
-				h.rejectRetryable(w, req, applyErr, metricQuarantined)
+				h.rejectRetryable(w, req, applyErr, metricQuarantined())
 				return
 			}
 			log.Error("complete: CacheHitTaskClaimed failed",
@@ -589,11 +592,18 @@ func (h *Handler) completeMetricQuarantined(ctx context.Context, runID, taskID u
 	}
 	quarantined, err := h.store.TaskQuarantine(ctx, runID, taskID)
 	if err != nil {
-		log.Warn("complete: failed to read task quarantine marker; emitting complete metrics",
-			"run_id", runID,
-			"task_id", taskID,
-			"error", err,
-		)
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			log.Debug("complete: task quarantine marker not found; emitting complete metrics",
+				"run_id", runID,
+				"task_id", taskID,
+			)
+		} else {
+			log.Warn("complete: failed to read task quarantine marker; emitting complete metrics",
+				"run_id", runID,
+				"task_id", taskID,
+				"error", err,
+			)
+		}
 		return false
 	}
 	return quarantined

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -228,12 +228,14 @@ func (l *DispatchLoop) tick(ctx context.Context) {
 		log.Warn("dispatch loop: peer discovery failed", "error", err)
 		// Distinct from no_peers (empty list = normal bootstrap) so dashboards
 		// can alert on real RPC failures separately.
+		// This run-set-wide control-plane metric has no per-task quarantine context.
 		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonPeerDiscoveryError).Inc()
 		return
 	}
 	// Normalise peers to {nodeID, baseURL} pairs; include self in the rotation.
 	peers := l.buildPeers(rawPeers)
 	if len(peers) == 0 {
+		// This run-set-wide control-plane metric has no per-task quarantine context.
 		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNoPeers).Inc()
 		return
 	}
@@ -332,7 +334,7 @@ func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, generat
 		go func(p peer, req DispatchRequest) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			l.postOne(ctx, runID, p, req)
+			l.postOne(ctx, runID, p, req, task.Quarantine)
 		}(p, req)
 	}
 	wg.Wait()
@@ -390,14 +392,14 @@ func (l *DispatchLoop) dispatchRunInMemory(ctx context.Context, runID uuid.UUID,
 		go func(p peer, req DispatchRequest) {
 			defer wg.Done()
 			defer func() { <-sem }()
-			l.postOne(ctx, runID, p, req)
+			l.postOne(ctx, runID, p, req, false)
 		}(p, req)
 	}
 	wg.Wait()
 }
 
 // postOne does the actual HTTP call + metric/log accounting for one dispatch.
-func (l *DispatchLoop) postOne(ctx context.Context, runID uuid.UUID, p peer, req DispatchRequest) {
+func (l *DispatchLoop) postOne(ctx context.Context, runID uuid.UUID, p peer, req DispatchRequest, quarantined bool) {
 	dispatchURL := p.baseURL + "/internal/dispatch"
 	accepted, postErr := PostDispatch(ctx, dispatchURL, l.cfg.Token, req)
 	if postErr != nil {
@@ -414,7 +416,9 @@ func (l *DispatchLoop) postOne(ctx context.Context, runID uuid.UUID, p peer, req
 			"cooldown", peerBenchCooldown,
 			"error", postErr,
 		)
-		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNetworkError).Inc()
+		if !quarantined {
+			metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonNetworkError).Inc()
+		}
 		return
 	}
 	if !accepted {
@@ -423,10 +427,14 @@ func (l *DispatchLoop) postOne(ctx context.Context, runID uuid.UUID, p peer, req
 			"task_id", req.TaskID,
 			"peer", p.nodeID,
 		)
-		metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonWorkerRejected).Inc()
+		if !quarantined {
+			metrics.DispatchRejectedTotal.WithLabelValues(DispatchReasonWorkerRejected).Inc()
+		}
 		return
 	}
-	metrics.DispatchSentTotal.Inc()
+	if !quarantined {
+		metrics.DispatchSentTotal.Inc()
+	}
 	// In-memory mode: record the dispatch in the owner's RunState so the task
 	// leaves the ready queue and becomes running (re-dispatched on lease expiry).
 	if l.cfg.OwnerManager != nil {

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -42,20 +42,22 @@ const (
 
 // Event represents a system event.
 type Event struct {
-	Sequence  uint64          `json:"sequence,omitempty"`
-	Type      Type            `json:"type"`
-	JobID     uuid.UUID       `json:"job_id,omitempty"`
-	RunID     uuid.UUID       `json:"run_id,omitempty"`
-	TaskID    uuid.UUID       `json:"task_id,omitempty"`
-	Timestamp time.Time       `json:"timestamp"`
-	Payload   json.RawMessage `json:"payload,omitempty"`
+	Sequence   uint64          `json:"sequence,omitempty"`
+	Type       Type            `json:"type"`
+	JobID      uuid.UUID       `json:"job_id,omitempty"`
+	RunID      uuid.UUID       `json:"run_id,omitempty"`
+	TaskID     uuid.UUID       `json:"task_id,omitempty"`
+	Timestamp  time.Time       `json:"timestamp"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+	Quarantine bool            `json:"quarantine,omitempty"`
 }
 
 // Filter defines criteria for receiving events.
 type Filter struct {
-	JobID uuid.UUID
-	RunID uuid.UUID
-	Types []Type
+	JobID             uuid.UUID
+	RunID             uuid.UUID
+	Types             []Type
+	IncludeQuarantine bool
 }
 
 // Bus defines the event bus interface.
@@ -110,6 +112,9 @@ func (b *bus) Subscribe(ctx context.Context, filter Filter) (<-chan Event, error
 }
 
 func (b *bus) matches(filter Filter, e Event) bool {
+	if e.Quarantine && !filter.IncludeQuarantine {
+		return false
+	}
 	if filter.JobID != uuid.Nil && filter.JobID != e.JobID {
 		return false
 	}

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -116,6 +116,25 @@ func TestFilterByRunID(t *testing.T) {
 	noRecv(t, ch)
 }
 
+func TestQuarantinedEventsExcludedByDefault(t *testing.T) {
+	b := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	defaultCh, err := b.Subscribe(ctx, Filter{})
+	require.NoError(t, err)
+	includeCh, err := b.Subscribe(ctx, Filter{IncludeQuarantine: true})
+	require.NoError(t, err)
+
+	evt := Event{Type: TypeRunStarted, RunID: uuid.New(), Quarantine: true, Timestamp: time.Now()}
+	b.Publish(evt)
+
+	noRecv(t, defaultCh)
+	got := recv(t, includeCh)
+	assert.True(t, got.Quarantine)
+	assert.Equal(t, evt.RunID, got.RunID)
+}
+
 func TestFilterCombination(t *testing.T) {
 	b := New()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/event/store.go
+++ b/internal/event/store.go
@@ -41,6 +41,7 @@ func (s *Store) AppendTx(tx *gorm.DB, evt *Event) error {
 		RunID:              uuidPtr(evt.RunID),
 		TaskID:             uuidPtr(evt.TaskID),
 		Payload:            []byte(evt.Payload),
+		Quarantine:         evt.Quarantine,
 		BusDispatchPending: true,
 		CreatedAt:          evt.Timestamp,
 	}
@@ -81,6 +82,7 @@ func (s *Store) AppendBatchTx(tx *gorm.DB, evts []*Event) error {
 			RunID:              uuidPtr(evt.RunID),
 			TaskID:             uuidPtr(evt.TaskID),
 			Payload:            []byte(evt.Payload),
+			Quarantine:         evt.Quarantine,
 			BusDispatchPending: true,
 			CreatedAt:          ts,
 		}
@@ -118,6 +120,9 @@ func (s *Store) ListSince(ctx context.Context, after uint64, limit int, filter F
 		Where("sequence > ?", after).
 		Order("sequence ASC").
 		Limit(limit)
+	if !filter.IncludeQuarantine {
+		query = query.Where("quarantine IS NOT TRUE")
+	}
 
 	if filter.JobID != uuid.Nil {
 		query = query.Where("job_id = ?", filter.JobID)
@@ -165,12 +170,13 @@ func modelToEvent(row models.ExecutionEvent) Event {
 		payload = json.RawMessage(row.Payload)
 	}
 	return Event{
-		Sequence:  row.Sequence,
-		Type:      Type(row.Type),
-		JobID:     derefUUID(row.JobID),
-		RunID:     derefUUID(row.RunID),
-		TaskID:    derefUUID(row.TaskID),
-		Timestamp: row.CreatedAt,
-		Payload:   payload,
+		Sequence:   row.Sequence,
+		Type:       Type(row.Type),
+		JobID:      derefUUID(row.JobID),
+		RunID:      derefUUID(row.RunID),
+		TaskID:     derefUUID(row.TaskID),
+		Timestamp:  row.CreatedAt,
+		Payload:    payload,
+		Quarantine: row.Quarantine,
 	}
 }

--- a/internal/event/store_test.go
+++ b/internal/event/store_test.go
@@ -70,6 +70,33 @@ func TestAppendTxMarksEventPendingBusDispatch(t *testing.T) {
 	require.NoError(t, s.db.First(&row, "sequence = ?", evt.Sequence).Error)
 	require.True(t, row.BusDispatchPending)
 	require.Nil(t, row.BusDispatchedAt)
+	require.False(t, row.Quarantine)
+}
+
+func TestListSinceExcludesQuarantineByDefault(t *testing.T) {
+	s := openStore(t)
+	ctx := context.Background()
+	runID := uuid.New()
+
+	events := []Event{
+		{Type: TypeRunStarted, JobID: uuid.New(), RunID: runID},
+		{Type: TypeTaskStarted, JobID: uuid.New(), RunID: runID, Quarantine: true},
+	}
+	for i := range events {
+		tx := s.db.Begin()
+		require.NoError(t, s.AppendTx(tx, &events[i]))
+		require.NoError(t, tx.Commit().Error)
+	}
+
+	defaultRows, err := s.ListSince(ctx, 0, 10, Filter{RunID: runID})
+	require.NoError(t, err)
+	require.Len(t, defaultRows, 1)
+	require.False(t, defaultRows[0].Quarantine)
+
+	includeRows, err := s.ListSince(ctx, 0, 10, Filter{RunID: runID, IncludeQuarantine: true})
+	require.NoError(t, err)
+	require.Len(t, includeRows, 2)
+	require.True(t, includeRows[1].Quarantine)
 }
 
 func TestPublishAndMarkBusDispatchedPublishesAndMarksEvent(t *testing.T) {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -392,12 +392,16 @@ func (j *job) Run(ctx context.Context) error {
 	}
 
 	runID := snapshot.ID
+	runQuarantined := snapshot.Quarantine
 	ctx = run.WithContext(ctx, runID)
 
 	var runErr error
 	defer func() {
 		if err := store.Complete(runID, runErr); err != nil {
 			log.Error("run completion persistence failure", "run_id", runID, "error", err)
+		}
+		if runQuarantined {
+			return
 		}
 		dispatchCtx := context.WithoutCancel(ctx)
 		if err := j.dispatchRunCallbacks(dispatchCtx, j.id, runID, runErr); err != nil {
@@ -575,9 +579,11 @@ func (j *job) Run(ctx context.Context) error {
 	taskOutcomes := make(map[uuid.UUID]run.TaskStatus, len(tasks))
 	taskOutputs := make(map[uuid.UUID]map[string]string, len(tasks))
 	taskHashes := make(map[uuid.UUID]string, len(tasks))
+	taskQuarantine := make(map[uuid.UUID]bool, len(tasks))
 	terminalTasks := 0
 
 	for _, taskState := range currentRun.Tasks {
+		taskQuarantine[taskState.ID] = taskState.Quarantine || runQuarantined
 		indegree[taskState.ID] = taskState.OutstandingPredecessors
 		switch taskState.Status {
 		case run.TaskStatusSucceeded, run.TaskStatusCached:
@@ -691,9 +697,18 @@ func (j *job) Run(ctx context.Context) error {
 		log.Info("running atom", "job_id", j.id, "task_id", taskID, "image", runner.image, "cmd", runner.command, "attempt", attempt)
 
 		spec := runner.spec
-		spec, err := jobdefruntime.ResolveContainerSpecSecrets(taskCtx, secretResolver, spec)
+		spec, secretIdentities, err := jobdefruntime.ResolveContainerSpecSecretsWithIdentities(taskCtx, secretResolver, spec)
 		if err != nil {
 			return "", nil, nil, nil, err
+		}
+		if len(secretIdentities) > 0 {
+			refs := make([]models.TaskExecutionSecretRef, 0, len(secretIdentities))
+			for _, resolved := range secretIdentities {
+				refs = append(refs, run.SecretIdentityDescriptorRef(resolved.EnvKey, resolved.Ref, resolved.Identity))
+			}
+			if err := store.UpdateTaskExecutionDescriptorSecretRefs(runID, taskID, refs); err != nil {
+				log.Warn("failed to persist task execution descriptor secret identity", "task_id", taskID, "error", err)
+			}
 		}
 		if len(paramEnv) > 0 || len(extraEnv) > 0 {
 			merged := make(map[string]string, len(spec.Env)+len(paramEnv)+len(extraEnv))
@@ -799,8 +814,10 @@ func (j *job) Run(ctx context.Context) error {
 
 		// Build predecessor output env vars for this task.
 		predOutputs := make(map[string]map[string]string)
+		predOutputsByID := make(map[uuid.UUID]map[string]string)
 		for _, predID := range predecessors[taskID] {
 			if outputs, ok := taskOutputs[predID]; ok && len(outputs) > 0 {
+				predOutputsByID[predID] = outputs
 				stepName := ""
 				if t := tasksByID[predID]; t != nil {
 					stepName = t.Name
@@ -814,6 +831,7 @@ func (j *job) Run(ctx context.Context) error {
 		outputEnv := pkgtask.BuildOutputEnv(predOutputs)
 
 		taskModel := tasksByID[taskID]
+		taskQuarantined := taskQuarantine[taskID] || runQuarantined
 
 		// Cache check — attempt to bypass container execution.
 		var cacheCfg jobdefschema.CacheConfig
@@ -852,9 +870,11 @@ func (j *job) Run(ctx context.Context) error {
 
 			// Collect predecessor hashes.
 			var predHashes []string
+			predHashByID := make(map[uuid.UUID]string)
 			for _, predID := range predecessors[taskID] {
 				if h, ok := taskHashes[predID]; ok {
 					predHashes = append(predHashes, h)
+					predHashByID[predID] = h
 				}
 			}
 
@@ -902,13 +922,18 @@ func (j *job) Run(ctx context.Context) error {
 			if err := store.SetTaskHashWithBlob(runID, taskID, inputHash, resolvedImageDigest, hashInputBlob); err != nil {
 				log.Warn("failed to persist task hash", "task", taskName, "error", err)
 			}
+			if err := store.UpdateTaskExecutionDescriptorInputs(runID, taskID, predOutputsByID, predHashByID, inputHash, resolvedImageDigest, hashInputBlob); err != nil {
+				log.Warn("failed to persist task execution descriptor inputs", "task", taskName, "error", err)
+			}
 
 			entry, found, err := cacheStore.Get(inputHash)
 			switch {
 			case err != nil:
 				log.Warn("cache lookup failed", "task", taskName, "error", err)
 			case found:
-				metrics.TaskCacheHitsTotal.WithLabelValues(j.alias, taskName).Inc()
+				if !taskQuarantined {
+					metrics.TaskCacheHitsTotal.WithLabelValues(j.alias, taskName).Inc()
+				}
 				log.Info("cache hit", "task", taskName, "hash", inputHash[:12])
 
 				cacheResult, cacheErr := store.CacheHitTask(runID, taskID, run.CacheHitSource{
@@ -934,7 +959,9 @@ func (j *job) Run(ctx context.Context) error {
 					return skipped, nil
 				}
 			default:
-				metrics.TaskCacheMissesTotal.WithLabelValues(j.alias, taskName).Inc()
+				if !taskQuarantined {
+					metrics.TaskCacheMissesTotal.WithLabelValues(j.alias, taskName).Inc()
+				}
 			}
 		}
 
@@ -983,55 +1010,60 @@ func (j *job) Run(ctx context.Context) error {
 						taskName = taskModel.Name
 					}
 
-					// Value-verified short-circuit (D2): this task re-executed
-					// because its OWN identity hash (inputHash) changed. If it
-					// produced output byte-identical to a prior successful run,
-					// present that prior run's identity to downstream consumers so
-					// a downstream whose only changed input was this step stays a
-					// cache hit instead of re-running. The substitution only
-					// happens when content equality is PROVEN (see
-					// cache.EquivalentPriorHash); on any uncertainty it returns
-					// inputHash unchanged (re-run downstream — always safe). The
-					// proof reads priors filtered to exclude inputHash, so the
-					// order relative to the Put below does not matter.
-					effectiveHash := inputHash
-					if priors, priorErr := cacheStore.PriorEntriesByTask(j.id, taskName, inputHash); priorErr != nil {
-						log.Warn("short-circuit: failed to load prior entries", "task", taskName, "error", priorErr)
+					if taskQuarantined {
+						taskHashes[taskID] = inputHash
+						log.Info("quarantined task skipped cache publication", "task", taskName, "hash", inputHash[:12])
 					} else {
-						effectiveHash = cache.EquivalentPriorHash(inputHash, output, priors)
-					}
-					// taskHashes drives the in-memory predHashes a downstream task
-					// folds into its own key; storing the effective (possibly
-					// prior) identity is what stops the cascade locally.
-					taskHashes[taskID] = effectiveHash
-					if effectiveHash != inputHash {
-						metrics.TaskCacheShortCircuitsTotal.WithLabelValues(j.alias, taskName).Inc()
-						log.Info("value-verified short-circuit", "task", taskName, "new_hash", inputHash[:12], "effective_hash", effectiveHash[:12])
-						if scErr := store.SetTaskEffectiveHash(runID, taskID, effectiveHash); scErr != nil {
-							log.Warn("short-circuit: failed to persist effective hash", "task", taskName, "error", scErr)
+						// Value-verified short-circuit (D2): this task re-executed
+						// because its OWN identity hash (inputHash) changed. If it
+						// produced output byte-identical to a prior successful run,
+						// present that prior run's identity to downstream consumers so
+						// a downstream whose only changed input was this step stays a
+						// cache hit instead of re-running. The substitution only
+						// happens when content equality is PROVEN (see
+						// cache.EquivalentPriorHash); on any uncertainty it returns
+						// inputHash unchanged (re-run downstream — always safe). The
+						// proof reads priors filtered to exclude inputHash, so the
+						// order relative to the Put below does not matter.
+						effectiveHash := inputHash
+						if priors, priorErr := cacheStore.PriorEntriesByTask(j.id, taskName, inputHash); priorErr != nil {
+							log.Warn("short-circuit: failed to load prior entries", "task", taskName, "error", priorErr)
+						} else {
+							effectiveHash = cache.EquivalentPriorHash(inputHash, output, priors)
 						}
-					}
+						// taskHashes drives the in-memory predHashes a downstream task
+						// folds into its own key; storing the effective (possibly
+						// prior) identity is what stops the cascade locally.
+						taskHashes[taskID] = effectiveHash
+						if effectiveHash != inputHash {
+							metrics.TaskCacheShortCircuitsTotal.WithLabelValues(j.alias, taskName).Inc()
+							log.Info("value-verified short-circuit", "task", taskName, "new_hash", inputHash[:12], "effective_hash", effectiveHash[:12])
+							if scErr := store.SetTaskEffectiveHash(runID, taskID, effectiveHash); scErr != nil {
+								log.Warn("short-circuit: failed to persist effective hash", "task", taskName, "error", scErr)
+							}
+						}
 
-					var expiresAt *time.Time
-					if cacheCfg.TTL > 0 {
-						t := time.Now().Add(cacheCfg.TTL)
-						expiresAt = &t
-					}
-					if putErr := cacheStore.Put(&cache.Entry{
-						Hash:                inputHash,
-						JobID:               j.id,
-						TaskName:            taskName,
-						Result:              result,
-						Output:              output,
-						BranchSelections:    branchNames,
-						RunID:               runID,
-						TaskRunID:           taskID,
-						ResolvedImageDigest: resolvedImageDigest,
-						HashInputBlob:       hashInputBlob,
-						CreatedAt:           time.Now(),
-						ExpiresAt:           expiresAt,
-					}); putErr != nil {
-						log.Warn("failed to store cache entry", "task", taskName, "error", putErr)
+						var expiresAt *time.Time
+						if cacheCfg.TTL > 0 {
+							t := time.Now().Add(cacheCfg.TTL)
+							expiresAt = &t
+						}
+						if putErr := cacheStore.Put(&cache.Entry{
+							Hash:                inputHash,
+							JobID:               j.id,
+							TaskName:            taskName,
+							Result:              result,
+							Output:              output,
+							BranchSelections:    branchNames,
+							RunID:               runID,
+							TaskRunID:           taskID,
+							ResolvedImageDigest: resolvedImageDigest,
+							HashInputBlob:       hashInputBlob,
+							CreatedAt:           time.Now(),
+							ExpiresAt:           expiresAt,
+						}); putErr != nil {
+							log.Warn("failed to store cache entry", "task", taskName, "error", putErr)
+						}
 					}
 				}
 
@@ -1056,7 +1088,9 @@ func (j *job) Run(ctx context.Context) error {
 
 			log.Info("retrying task", "job_id", j.id, "task_id", taskID, "attempt", attempt, "next_attempt", attempt+1, "delay", delay, "error", lastErr)
 
-			metrics.TaskRetriesTotal.WithLabelValues(j.alias, taskID.String(), strconv.Itoa(attempt)).Inc()
+			if !taskQuarantined {
+				metrics.TaskRetriesTotal.WithLabelValues(j.alias, taskID.String(), strconv.Itoa(attempt)).Inc()
+			}
 
 			if err := store.RetryTask(runID, taskID, attempt+1); err != nil {
 				log.Error("failed to persist task retry state", "run_id", runID, "task_id", taskID, "error", err)

--- a/internal/jobdef/git/git_sync_test.go
+++ b/internal/jobdef/git/git_sync_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/caesium-cloud/caesium/internal/jobdef"
 	jobdiff "github.com/caesium-cloud/caesium/internal/jobdef/diff"
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/go-git/go-git/v5"
@@ -520,10 +521,15 @@ func (s *GitSyncSuite) commit(repoDir string, files map[string]string) {
 type staticResolver map[string]string
 
 func (sr staticResolver) Resolve(_ context.Context, ref string) (string, error) {
+	value, _, err := sr.ResolveWithIdentity(context.Background(), ref)
+	return value, err
+}
+
+func (sr staticResolver) ResolveWithIdentity(_ context.Context, ref string) (string, secret.Identity, error) {
 	if val, ok := sr[ref]; ok {
-		return val, nil
+		return val, secret.Identity{Provider: "env", Ref: ref, Verifiable: false, UnverifiableReason: "test stub"}, nil
 	}
-	return "", fmt.Errorf("secret %q not found", ref)
+	return "", secret.Identity{}, fmt.Errorf("secret %q not found", ref)
 }
 
 func mustGeneratePrivateKey(tb testing.TB) string {

--- a/internal/jobdef/lint/secret_test.go
+++ b/internal/jobdef/lint/secret_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/stretchr/testify/suite"
 )
@@ -61,8 +62,13 @@ type fakeResolver struct {
 }
 
 func (f *fakeResolver) Resolve(_ context.Context, ref string) (string, error) {
+	value, _, err := f.ResolveWithIdentity(context.Background(), ref)
+	return value, err
+}
+
+func (f *fakeResolver) ResolveWithIdentity(_ context.Context, ref string) (string, secret.Identity, error) {
 	if err, ok := f.responses[ref]; ok {
-		return "", err
+		return "", secret.Identity{}, err
 	}
-	return "", nil
+	return "", secret.Identity{Provider: "env", Ref: ref, Verifiable: false, UnverifiableReason: "test stub"}, nil
 }

--- a/internal/jobdef/runtime/config.go
+++ b/internal/jobdef/runtime/config.go
@@ -19,7 +19,11 @@ type Watch struct {
 
 // BuildSecretResolver constructs the resolver chain based on environment variables.
 func BuildSecretResolver(vars env.Environment) (*secret.MultiResolver, error) {
-	cfg := secret.Config{EnableEnv: vars.JobdefSecretsEnableEnv}
+	cfg := secret.Config{
+		EnableEnv:           vars.JobdefSecretsEnableEnv,
+		IdentityHMACKeys:    vars.JobdefSecretsIdentityHMACKeys,
+		IdentityHMACCurrent: vars.JobdefSecretsIdentityHMACKeyID,
+	}
 
 	if vars.JobdefSecretsEnableKubernetes || vars.JobdefSecretsKubeConfig != "" || vars.JobdefSecretsKubeNamespace != "default" {
 		cfg.Kubernetes = &secret.KubernetesConfig{

--- a/internal/jobdef/runtime/spec.go
+++ b/internal/jobdef/runtime/spec.go
@@ -9,29 +9,50 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/container"
 )
 
+// ResolvedSecretIdentity is the identity metadata captured for one resolved
+// environment secret reference.
+type ResolvedSecretIdentity struct {
+	EnvKey   string
+	Ref      string
+	Identity secret.Identity
+}
+
 // ResolveContainerSpecSecrets resolves secret:// values in the step-declared
 // environment at container-create time. It leaves non-secret values unchanged
 // and returns a copied spec so callers do not mutate cached atom specs.
 func ResolveContainerSpecSecrets(ctx context.Context, resolver secret.Resolver, spec container.Spec) (container.Spec, error) {
+	resolved, _, err := ResolveContainerSpecSecretsWithIdentities(ctx, resolver, spec)
+	return resolved, err
+}
+
+// ResolveContainerSpecSecretsWithIdentities resolves secret:// values and
+// returns the provider identity for every resolved secret reference.
+func ResolveContainerSpecSecretsWithIdentities(ctx context.Context, resolver secret.Resolver, spec container.Spec) (container.Spec, []ResolvedSecretIdentity, error) {
 	if len(spec.Env) == 0 {
-		return spec, nil
+		return spec, nil, nil
 	}
 
 	resolved := make(map[string]string, len(spec.Env))
+	identities := make([]ResolvedSecretIdentity, 0)
 	for key, value := range spec.Env {
 		if !strings.HasPrefix(value, "secret://") {
 			resolved[key] = value
 			continue
 		}
 		if resolver == nil {
-			return container.Spec{}, fmt.Errorf("resolve env %s: no secret resolver configured for %s", key, value)
+			return container.Spec{}, nil, fmt.Errorf("resolve env %s: no secret resolver configured for %s", key, value)
 		}
-		secretValue, err := resolver.Resolve(ctx, value)
+		secretValue, identity, err := resolver.ResolveWithIdentity(ctx, value)
 		if err != nil {
-			return container.Spec{}, fmt.Errorf("resolve env %s from %s: %w", key, value, err)
+			return container.Spec{}, nil, fmt.Errorf("resolve env %s from %s: %w", key, value, err)
 		}
 		resolved[key] = secretValue
+		identities = append(identities, ResolvedSecretIdentity{
+			EnvKey:   key,
+			Ref:      value,
+			Identity: identity,
+		})
 	}
 	spec.Env = resolved
-	return spec, nil
+	return spec, identities, nil
 }

--- a/internal/jobdef/secret/env.go
+++ b/internal/jobdef/secret/env.go
@@ -18,13 +18,19 @@ func NewEnvResolver() *EnvResolver {
 }
 
 // Resolve implements the Resolver interface.
-func (r *EnvResolver) Resolve(_ context.Context, ref string) (string, error) {
+func (r *EnvResolver) Resolve(ctx context.Context, ref string) (string, error) {
+	value, _, err := r.ResolveWithIdentity(ctx, ref)
+	return value, err
+}
+
+// ResolveWithIdentity implements the Resolver interface.
+func (r *EnvResolver) ResolveWithIdentity(_ context.Context, ref string) (string, Identity, error) {
 	reference, err := Parse(ref)
 	if err != nil {
-		return "", err
+		return "", Identity{}, err
 	}
 	if reference.Provider != providerEnv {
-		return "", fmt.Errorf("env resolver cannot handle provider %q", reference.Provider)
+		return "", Identity{}, fmt.Errorf("env resolver cannot handle provider %q", reference.Provider)
 	}
 
 	name := reference.Query.Get("name")
@@ -34,13 +40,19 @@ func (r *EnvResolver) Resolve(_ context.Context, ref string) (string, error) {
 
 	name = strings.TrimSpace(name)
 	if name == "" {
-		return "", fmt.Errorf("env secret %q requires a name", ref)
+		return "", Identity{}, fmt.Errorf("env secret %q requires a name", ref)
 	}
 
 	value, ok := os.LookupEnv(name)
 	if !ok {
-		return "", fmt.Errorf("environment variable %s not set", name)
+		return "", Identity{}, fmt.Errorf("environment variable %s not set", name)
 	}
 
-	return value, nil
+	return value, Identity{
+		Provider:           providerEnv,
+		Ref:                ref,
+		Name:               name,
+		Verifiable:         false,
+		UnverifiableReason: "environment variables have no provider version identity",
+	}, nil
 }

--- a/internal/jobdef/secret/env_test.go
+++ b/internal/jobdef/secret/env_test.go
@@ -27,6 +27,17 @@ func (s *EnvResolverSuite) TestResolveDirectVariable() {
 	s.Equal("abc123", value)
 }
 
+func (s *EnvResolverSuite) TestResolveWithIdentityIsUnverifiable() {
+	s.T().Setenv("EXAMPLE_TOKEN", "abc123")
+	value, identity, err := s.resolver.ResolveWithIdentity(context.Background(), "secret://env/EXAMPLE_TOKEN")
+	s.Require().NoError(err)
+	s.Equal("abc123", value)
+	s.False(identity.Verifiable)
+	s.Equal("env", identity.Provider)
+	s.Equal("EXAMPLE_TOKEN", identity.Name)
+	s.NotEmpty(identity.UnverifiableReason)
+}
+
 func (s *EnvResolverSuite) TestResolveSegmentsJoin() {
 	s.T().Setenv("APP_DB_PASSWORD", "s3cr3t")
 	value, err := s.resolver.Resolve(context.Background(), "secret://env/APP/DB/PASSWORD")

--- a/internal/jobdef/secret/factory.go
+++ b/internal/jobdef/secret/factory.go
@@ -2,14 +2,20 @@ package secret
 
 // Config defines which providers should be available in a MultiResolver.
 type Config struct {
-	EnableEnv  bool
-	Kubernetes *KubernetesConfig
-	Vault      *VaultConfig
+	EnableEnv           bool
+	Kubernetes          *KubernetesConfig
+	Vault               *VaultConfig
+	IdentityHMACKeys    string
+	IdentityHMACCurrent string
 }
 
 // NewConfiguredResolver builds a MultiResolver using the supplied provider configuration.
 func NewConfiguredResolver(cfg Config) (*MultiResolver, error) {
 	providers := map[string]Resolver{}
+	keyring, err := ParseIdentityKeyring(cfg.IdentityHMACCurrent, cfg.IdentityHMACKeys)
+	if err != nil {
+		return nil, err
+	}
 
 	if cfg.EnableEnv {
 		providers[providerEnv] = NewEnvResolver()
@@ -23,6 +29,7 @@ func NewConfiguredResolver(cfg Config) (*MultiResolver, error) {
 	}
 
 	if cfg.Vault != nil {
+		cfg.Vault.IdentityKeyring = keyring
 		resolver, err := NewVaultResolver(*cfg.Vault)
 		if err != nil {
 			return nil, err

--- a/internal/jobdef/secret/identity.go
+++ b/internal/jobdef/secret/identity.go
@@ -1,0 +1,112 @@
+package secret
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// IdentityKeyring holds versioned server-side keys used only for baseline
+// secret identity HMACs. The key id, not the key bytes, is persisted.
+type IdentityKeyring struct {
+	currentKeyID string
+	keys         map[string][]byte
+}
+
+// NewIdentityKeyring validates and builds a versioned identity-HMAC keyring.
+func NewIdentityKeyring(currentKeyID string, keys map[string][]byte) (*IdentityKeyring, error) {
+	currentKeyID = strings.TrimSpace(currentKeyID)
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	copied := make(map[string][]byte, len(keys))
+	for id, key := range keys {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return nil, errors.New("secret identity key id cannot be empty")
+		}
+		if len(key) == 0 {
+			return nil, fmt.Errorf("secret identity key %q cannot be empty", id)
+		}
+		copied[id] = append([]byte(nil), key...)
+	}
+	if currentKeyID == "" {
+		if len(copied) == 1 {
+			for id := range copied {
+				currentKeyID = id
+			}
+		} else {
+			return nil, errors.New("secret identity current key id is required when multiple keys are configured")
+		}
+	}
+	if _, ok := copied[currentKeyID]; !ok {
+		return nil, fmt.Errorf("secret identity current key %q is not in the keyring", currentKeyID)
+	}
+	return &IdentityKeyring{currentKeyID: currentKeyID, keys: copied}, nil
+}
+
+// ParseIdentityKeyring parses a comma-separated id=value list. Values may be
+// raw strings, base64:<data>, or hex:<data>.
+func ParseIdentityKeyring(currentKeyID, raw string) (*IdentityKeyring, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	keys := map[string][]byte{}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		id, value, ok := strings.Cut(part, "=")
+		if !ok {
+			id, value, ok = strings.Cut(part, ":")
+		}
+		if !ok {
+			return nil, fmt.Errorf("secret identity key %q must be id=value", part)
+		}
+		id = strings.TrimSpace(id)
+		value = strings.TrimSpace(value)
+		key, err := decodeIdentityKey(value)
+		if err != nil {
+			return nil, fmt.Errorf("secret identity key %q: %w", id, err)
+		}
+		keys[id] = key
+	}
+	return NewIdentityKeyring(currentKeyID, keys)
+}
+
+func decodeIdentityKey(value string) ([]byte, error) {
+	if strings.HasPrefix(value, "base64:") {
+		decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, "base64:"))
+		if err != nil {
+			return nil, err
+		}
+		return decoded, nil
+	}
+	if strings.HasPrefix(value, "hex:") {
+		decoded, err := hex.DecodeString(strings.TrimPrefix(value, "hex:"))
+		if err != nil {
+			return nil, err
+		}
+		return decoded, nil
+	}
+	return []byte(value), nil
+}
+
+func (k *IdentityKeyring) CurrentHMAC(value []byte) (keyID, digest string, ok bool) {
+	if k == nil || k.currentKeyID == "" {
+		return "", "", false
+	}
+	key, ok := k.keys[k.currentKeyID]
+	if !ok || len(key) == 0 {
+		return "", "", false
+	}
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(value)
+	return k.currentKeyID, hex.EncodeToString(mac.Sum(nil)), true
+}

--- a/internal/jobdef/secret/kubernetes.go
+++ b/internal/jobdef/secret/kubernetes.go
@@ -52,39 +52,53 @@ func NewKubernetesResolverWithClient(client kubernetes.Interface, namespace stri
 
 // Resolve implements the Resolver interface.
 func (r *KubernetesResolver) Resolve(ctx context.Context, ref string) (string, error) {
+	value, _, err := r.ResolveWithIdentity(ctx, ref)
+	return value, err
+}
+
+// ResolveWithIdentity implements the Resolver interface.
+func (r *KubernetesResolver) ResolveWithIdentity(ctx context.Context, ref string) (string, Identity, error) {
 	reference, err := Parse(ref)
 	if err != nil {
-		return "", err
+		return "", Identity{}, err
 	}
 	if reference.Provider != providerKubernetes && reference.Provider != "kubernetes" {
-		return "", fmt.Errorf("kubernetes resolver cannot handle provider %q", reference.Provider)
+		return "", Identity{}, fmt.Errorf("kubernetes resolver cannot handle provider %q", reference.Provider)
 	}
 
 	namespace, name, key, err := r.parseReference(reference)
 	if err != nil {
-		return "", err
+		return "", Identity{}, err
 	}
 
 	client, err := r.clientset()
 	if err != nil {
-		return "", err
+		return "", Identity{}, err
 	}
 
 	secret, err := client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return "", fmt.Errorf("load kubernetes secret %s/%s: %w", namespace, name, err)
+		return "", Identity{}, fmt.Errorf("load kubernetes secret %s/%s: %w", namespace, name, err)
 	}
 
 	if secret.Data == nil {
-		return "", fmt.Errorf("kubernetes secret %s/%s has no data", namespace, name)
+		return "", Identity{}, fmt.Errorf("kubernetes secret %s/%s has no data", namespace, name)
 	}
 
 	value, ok := secret.Data[key]
 	if !ok {
-		return "", fmt.Errorf("kubernetes secret %s/%s missing key %s", namespace, name, key)
+		return "", Identity{}, fmt.Errorf("kubernetes secret %s/%s missing key %s", namespace, name, key)
 	}
 
-	return string(value), nil
+	return string(value), Identity{
+		Provider:        providerKubernetes,
+		Ref:             ref,
+		Namespace:       namespace,
+		Name:            name,
+		Key:             key,
+		ResourceVersion: secret.ResourceVersion,
+		Verifiable:      secret.ResourceVersion != "",
+	}, nil
 }
 
 func (r *KubernetesResolver) parseReference(ref *Reference) (namespace, name, key string, err error) {

--- a/internal/jobdef/secret/kubernetes_test.go
+++ b/internal/jobdef/secret/kubernetes_test.go
@@ -20,14 +20,19 @@ func TestKubernetesResolverSuite(t *testing.T) {
 
 func (s *KubernetesResolverSuite) TestResolveDefaultNamespace() {
 	client := fake.NewClientset(&corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: "git-creds", Namespace: "jobs"},
+		ObjectMeta: metav1.ObjectMeta{Name: "git-creds", Namespace: "jobs", ResourceVersion: "42"},
 		Data:       map[string][]byte{"password": []byte("hunter2")},
 	})
 
 	r := NewKubernetesResolverWithClient(client, "jobs")
-	value, err := r.Resolve(context.Background(), "secret://k8s/git-creds/password")
+	value, identity, err := r.ResolveWithIdentity(context.Background(), "secret://k8s/git-creds/password")
 	s.Require().NoError(err)
 	s.Equal("hunter2", value)
+	s.True(identity.Verifiable)
+	s.Equal("42", identity.ResourceVersion)
+	s.Equal("jobs", identity.Namespace)
+	s.Equal("git-creds", identity.Name)
+	s.Equal("password", identity.Key)
 }
 
 func (s *KubernetesResolverSuite) TestResolveExplicitNamespace() {

--- a/internal/jobdef/secret/multi.go
+++ b/internal/jobdef/secret/multi.go
@@ -47,22 +47,28 @@ func (m *MultiResolver) Providers() []string {
 
 // Resolve locates the provider-specific resolver and delegates the call.
 func (m *MultiResolver) Resolve(ctx context.Context, ref string) (string, error) {
+	value, _, err := m.ResolveWithIdentity(ctx, ref)
+	return value, err
+}
+
+// ResolveWithIdentity locates the provider-specific resolver and delegates the call.
+func (m *MultiResolver) ResolveWithIdentity(ctx context.Context, ref string) (string, Identity, error) {
 	if strings.TrimSpace(ref) == "" {
-		return "", errors.New("secret reference is empty")
+		return "", Identity{}, errors.New("secret reference is empty")
 	}
 	if m == nil {
-		return "", errors.New("secret resolver is not configured")
+		return "", Identity{}, errors.New("secret resolver is not configured")
 	}
 
 	refInfo, err := Parse(ref)
 	if err != nil {
-		return "", err
+		return "", Identity{}, err
 	}
 
 	resolver, ok := m.providers[refInfo.Provider]
 	if !ok || resolver == nil {
-		return "", fmt.Errorf("secret provider %q not configured", refInfo.Provider)
+		return "", Identity{}, fmt.Errorf("secret provider %q not configured", refInfo.Provider)
 	}
 
-	return resolver.Resolve(ctx, ref)
+	return resolver.ResolveWithIdentity(ctx, ref)
 }

--- a/internal/jobdef/secret/multi_test.go
+++ b/internal/jobdef/secret/multi_test.go
@@ -14,11 +14,16 @@ type stubResolver struct {
 }
 
 func (s *stubResolver) Resolve(_ context.Context, ref string) (string, error) {
+	value, _, err := s.ResolveWithIdentity(context.Background(), ref)
+	return value, err
+}
+
+func (s *stubResolver) ResolveWithIdentity(_ context.Context, ref string) (string, Identity, error) {
 	s.ref = ref
 	if s.err != nil {
-		return "", s.err
+		return "", Identity{}, s.err
 	}
-	return s.value, nil
+	return s.value, Identity{Provider: "env", Ref: ref, Verifiable: false, UnverifiableReason: "test stub"}, nil
 }
 
 type MultiResolverSuite struct {

--- a/internal/jobdef/secret/resolver.go
+++ b/internal/jobdef/secret/resolver.go
@@ -2,7 +2,25 @@ package secret
 
 import "context"
 
+// Identity describes the provider-specific baseline identity for a resolved
+// secret reference. It never contains the secret value.
+type Identity struct {
+	Provider           string            `json:"provider"`
+	Ref                string            `json:"ref"`
+	Version            string            `json:"version,omitempty"`
+	ResourceVersion    string            `json:"resourceVersion,omitempty"`
+	Namespace          string            `json:"namespace,omitempty"`
+	Name               string            `json:"name,omitempty"`
+	Key                string            `json:"key,omitempty"`
+	KeyID              string            `json:"keyId,omitempty"`
+	HMACSHA256         string            `json:"hmacSha256,omitempty"`
+	Verifiable         bool              `json:"verifiable"`
+	UnverifiableReason string            `json:"unverifiableReason,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+}
+
 // Resolver resolves a secret reference into a concrete value.
 type Resolver interface {
 	Resolve(ctx context.Context, ref string) (string, error)
+	ResolveWithIdentity(ctx context.Context, ref string) (string, Identity, error)
 }

--- a/internal/jobdef/secret/vault.go
+++ b/internal/jobdef/secret/vault.go
@@ -2,9 +2,12 @@ package secret
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
+	"strconv"
 	"strings"
 
 	vault "github.com/hashicorp/vault/api"
@@ -121,14 +124,7 @@ func (r *VaultResolver) ResolveWithIdentity(ctx context.Context, ref string) (st
 		return "", Identity{}, fmt.Errorf("vault secret %s missing field %s", path, field)
 	}
 
-	versionedSecret, err := r.logical.ReadWithDataWithContext(ctx, path, map[string][]string{"version": {version}})
-	if err != nil {
-		return "", Identity{}, fmt.Errorf("read vault secret %s version %s: %w", path, version, err)
-	}
-	if versionedSecret == nil {
-		return "", Identity{}, fmt.Errorf("vault secret %s version %s not found", path, version)
-	}
-	value, ok := extractVaultField(versionedSecret, field)
+	value, ok := extractVaultField(secret, field)
 	if !ok {
 		return "", Identity{}, fmt.Errorf("vault secret %s version %s missing field %s", path, version, field)
 	}
@@ -200,7 +196,67 @@ func vaultKVv2Version(secret *vault.Secret) string {
 		return ""
 	}
 	if version, ok := metadata["version"]; ok {
-		return strings.TrimSpace(fmt.Sprintf("%v", version))
+		return canonicalVaultVersionString(version)
 	}
 	return ""
+}
+
+func canonicalVaultVersionString(version any) string {
+	switch v := version.(type) {
+	case json.Number:
+		if i, err := v.Int64(); err == nil {
+			return strconv.FormatInt(i, 10)
+		}
+		if f, err := v.Float64(); err == nil {
+			return canonicalVaultFloatVersion(f)
+		}
+	case float64:
+		return canonicalVaultFloatVersion(v)
+	case float32:
+		return canonicalVaultFloatVersion(float64(v))
+	case int:
+		return strconv.Itoa(v)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(v, 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case string:
+		return canonicalVaultStringVersion(v)
+	}
+	return ""
+}
+
+func canonicalVaultStringVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return ""
+	}
+	if i, err := strconv.ParseInt(version, 10, 64); err == nil {
+		return strconv.FormatInt(i, 10)
+	}
+	if f, err := strconv.ParseFloat(version, 64); err == nil {
+		return canonicalVaultFloatVersion(f)
+	}
+	return ""
+}
+
+func canonicalVaultFloatVersion(version float64) string {
+	if math.IsNaN(version) || math.IsInf(version, 0) || math.Trunc(version) != version {
+		return ""
+	}
+	return strconv.FormatInt(int64(version), 10)
 }

--- a/internal/jobdef/secret/vault.go
+++ b/internal/jobdef/secret/vault.go
@@ -14,20 +14,23 @@ const providerVault = "vault"
 
 type vaultLogical interface {
 	ReadWithContext(ctx context.Context, path string) (*vault.Secret, error)
+	ReadWithDataWithContext(ctx context.Context, path string, data map[string][]string) (*vault.Secret, error)
 }
 
 // VaultConfig describes how to connect to a Vault cluster.
 type VaultConfig struct {
-	Address       string
-	Token         string
-	Namespace     string
-	CACertPath    string
-	TLSSkipVerify bool
+	Address         string
+	Token           string
+	Namespace       string
+	CACertPath      string
+	TLSSkipVerify   bool
+	IdentityKeyring *IdentityKeyring
 }
 
 // VaultResolver reads secrets from HashiCorp Vault logical paths.
 type VaultResolver struct {
-	logical vaultLogical
+	logical         vaultLogical
+	identityKeyring *IdentityKeyring
 }
 
 // NewVaultResolver builds a resolver using the provided configuration.
@@ -57,7 +60,7 @@ func NewVaultResolver(cfg VaultConfig) (*VaultResolver, error) {
 		client.SetNamespace(ns)
 	}
 
-	return &VaultResolver{logical: client.Logical()}, nil
+	return &VaultResolver{logical: client.Logical(), identityKeyring: cfg.IdentityKeyring}, nil
 }
 
 // NewVaultResolverWithLogical constructs a resolver with a preconfigured logical client (useful in tests).
@@ -65,21 +68,93 @@ func NewVaultResolverWithLogical(logical vaultLogical) *VaultResolver {
 	return &VaultResolver{logical: logical}
 }
 
+// NewVaultResolverWithLogicalAndKeyring constructs a test resolver with an
+// identity keyring.
+func NewVaultResolverWithLogicalAndKeyring(logical vaultLogical, keyring *IdentityKeyring) *VaultResolver {
+	return &VaultResolver{logical: logical, identityKeyring: keyring}
+}
+
 // Resolve implements the Resolver interface.
 func (r *VaultResolver) Resolve(ctx context.Context, ref string) (string, error) {
+	value, _, err := r.ResolveWithIdentity(ctx, ref)
+	return value, err
+}
+
+// ResolveWithIdentity implements the Resolver interface.
+func (r *VaultResolver) ResolveWithIdentity(ctx context.Context, ref string) (string, Identity, error) {
 	reference, err := Parse(ref)
 	if err != nil {
-		return "", err
+		return "", Identity{}, err
 	}
 	if reference.Provider != providerVault {
-		return "", fmt.Errorf("vault resolver cannot handle provider %q", reference.Provider)
+		return "", Identity{}, fmt.Errorf("vault resolver cannot handle provider %q", reference.Provider)
 	}
 
 	if r.logical == nil {
-		return "", errors.New("vault logical client not configured")
+		return "", Identity{}, errors.New("vault logical client not configured")
 	}
 
-	field := strings.TrimSpace(reference.Query.Get("field"))
+	path, field, err := parseVaultPathField(reference)
+	if err != nil {
+		return "", Identity{}, err
+	}
+
+	secret, err := r.logical.ReadWithContext(ctx, path)
+	if err != nil {
+		return "", Identity{}, fmt.Errorf("read vault secret %s: %w", path, err)
+	}
+	if secret == nil {
+		return "", Identity{}, fmt.Errorf("vault secret %s not found", path)
+	}
+
+	version := vaultKVv2Version(secret)
+	if version == "" {
+		if value, ok := extractVaultField(secret, field); ok {
+			return value, Identity{
+				Provider:           providerVault,
+				Ref:                ref,
+				Verifiable:         false,
+				UnverifiableReason: "vault secret response has no KV-v2 metadata.version",
+				Metadata:           map[string]string{"path": path, "field": field},
+			}, nil
+		}
+		return "", Identity{}, fmt.Errorf("vault secret %s missing field %s", path, field)
+	}
+
+	versionedSecret, err := r.logical.ReadWithDataWithContext(ctx, path, map[string][]string{"version": {version}})
+	if err != nil {
+		return "", Identity{}, fmt.Errorf("read vault secret %s version %s: %w", path, version, err)
+	}
+	if versionedSecret == nil {
+		return "", Identity{}, fmt.Errorf("vault secret %s version %s not found", path, version)
+	}
+	value, ok := extractVaultField(versionedSecret, field)
+	if !ok {
+		return "", Identity{}, fmt.Errorf("vault secret %s version %s missing field %s", path, version, field)
+	}
+
+	identity := Identity{
+		Provider: providerVault,
+		Ref:      ref,
+		Version:  version,
+		Metadata: map[string]string{
+			"path":  path,
+			"field": field,
+		},
+	}
+	if keyID, digest, ok := r.identityKeyring.CurrentHMAC([]byte(value)); ok {
+		identity.KeyID = keyID
+		identity.HMACSHA256 = digest
+		identity.Verifiable = true
+	} else {
+		identity.Verifiable = false
+		identity.UnverifiableReason = "vault identity HMAC keyring is not configured"
+	}
+	return value, identity, nil
+}
+
+func parseVaultPathField(reference *Reference) (path, field string, err error) {
+	field = strings.TrimSpace(reference.Query.Get("field"))
 	segments := slices.Clone(reference.Segments)
 
 	if field == "" && len(segments) >= 2 {
@@ -87,27 +162,14 @@ func (r *VaultResolver) Resolve(ctx context.Context, ref string) (string, error)
 		segments = segments[:len(segments)-1]
 	}
 
-	path := strings.Join(segments, "/")
+	path = strings.Join(segments, "/")
 	if path == "" {
-		return "", fmt.Errorf("vault secret %q missing path", ref)
+		return "", "", fmt.Errorf("vault secret %q missing path", reference.Raw)
 	}
 	if field == "" {
-		return "", fmt.Errorf("vault secret %q missing field (provide ?field= or include as final path segment)", ref)
+		return "", "", fmt.Errorf("vault secret %q missing field (provide ?field= or include as final path segment)", reference.Raw)
 	}
-
-	secret, err := r.logical.ReadWithContext(ctx, path)
-	if err != nil {
-		return "", fmt.Errorf("read vault secret %s: %w", path, err)
-	}
-	if secret == nil {
-		return "", fmt.Errorf("vault secret %s not found", path)
-	}
-
-	if value, ok := extractVaultField(secret, field); ok {
-		return value, nil
-	}
-
-	return "", fmt.Errorf("vault secret %s missing field %s", path, field)
+	return path, field, nil
 }
 
 func extractVaultField(secret *vault.Secret, field string) (string, bool) {
@@ -127,4 +189,18 @@ func extractVaultField(secret *vault.Secret, field string) (string, bool) {
 	}
 
 	return "", false
+}
+
+func vaultKVv2Version(secret *vault.Secret) string {
+	if secret == nil || secret.Data == nil {
+		return ""
+	}
+	metadata, ok := secret.Data["metadata"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	if version, ok := metadata["version"]; ok {
+		return strings.TrimSpace(fmt.Sprintf("%v", version))
+	}
+	return ""
 }

--- a/internal/jobdef/secret/vault_test.go
+++ b/internal/jobdef/secret/vault_test.go
@@ -2,6 +2,9 @@ package secret
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"testing"
 
@@ -10,13 +13,37 @@ import (
 )
 
 type fakeLogical struct {
-	response *vault.Secret
-	err      error
-	lastPath string
+	response     *vault.Secret
+	responses    map[string]*vault.Secret
+	err          error
+	lastPath     string
+	paths        []string
+	dataRequests []logicalDataRequest
+}
+
+type logicalDataRequest struct {
+	path string
+	data map[string][]string
 }
 
 func (f *fakeLogical) ReadWithContext(_ context.Context, path string) (*vault.Secret, error) {
 	f.lastPath = path
+	f.paths = append(f.paths, path)
+	if f.responses != nil {
+		return f.responses[path], f.err
+	}
+	return f.response, f.err
+}
+
+func (f *fakeLogical) ReadWithDataWithContext(_ context.Context, path string, data map[string][]string) (*vault.Secret, error) {
+	copied := make(map[string][]string, len(data))
+	for k, values := range data {
+		copied[k] = append([]string(nil), values...)
+	}
+	f.dataRequests = append(f.dataRequests, logicalDataRequest{path: path, data: copied})
+	if f.responses != nil {
+		return f.responses[path], f.err
+	}
 	return f.response, f.err
 }
 
@@ -37,6 +64,36 @@ func (s *VaultResolverSuite) TestResolveKVv2() {
 	s.Require().NoError(err)
 	s.Equal("abc", value)
 	s.Equal("secret/data/path", rest.lastPath)
+}
+
+func (s *VaultResolverSuite) TestResolveWithIdentityKVv2PinsVersionAndHMACsValue() {
+	keyring, err := NewIdentityKeyring("k1", map[string][]byte{"k1": []byte("server-key")})
+	s.Require().NoError(err)
+	rest := &fakeLogical{responses: map[string]*vault.Secret{
+		"secret/data/path": {
+			Data: map[string]any{
+				"data":     map[string]any{"token": "abc"},
+				"metadata": map[string]any{"version": 7},
+			},
+		},
+	}}
+	r := NewVaultResolverWithLogicalAndKeyring(rest, keyring)
+
+	value, identity, err := r.ResolveWithIdentity(context.Background(), "secret://vault/secret/data/path?field=token")
+	s.Require().NoError(err)
+	s.Equal("abc", value)
+	s.Equal([]string{"secret/data/path"}, rest.paths)
+	s.Require().Len(rest.dataRequests, 1)
+	s.Equal("secret/data/path", rest.dataRequests[0].path)
+	s.Equal([]string{"7"}, rest.dataRequests[0].data["version"])
+	s.True(identity.Verifiable)
+	s.Equal("vault", identity.Provider)
+	s.Equal("7", identity.Version)
+	s.Equal("k1", identity.KeyID)
+
+	mac := hmac.New(sha256.New, []byte("server-key"))
+	_, _ = mac.Write([]byte("abc"))
+	s.Equal(hex.EncodeToString(mac.Sum(nil)), identity.HMACSHA256)
 }
 
 func (s *VaultResolverSuite) TestResolveFieldAsSegment() {

--- a/internal/jobdef/secret/vault_test.go
+++ b/internal/jobdef/secret/vault_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -83,9 +84,7 @@ func (s *VaultResolverSuite) TestResolveWithIdentityKVv2PinsVersionAndHMACsValue
 	s.Require().NoError(err)
 	s.Equal("abc", value)
 	s.Equal([]string{"secret/data/path"}, rest.paths)
-	s.Require().Len(rest.dataRequests, 1)
-	s.Equal("secret/data/path", rest.dataRequests[0].path)
-	s.Equal([]string{"7"}, rest.dataRequests[0].data["version"])
+	s.Empty(rest.dataRequests, "current-version identity must use the first Vault read instead of re-reading version N")
 	s.True(identity.Verifiable)
 	s.Equal("vault", identity.Provider)
 	s.Equal("7", identity.Version)
@@ -94,6 +93,21 @@ func (s *VaultResolverSuite) TestResolveWithIdentityKVv2PinsVersionAndHMACsValue
 	mac := hmac.New(sha256.New, []byte("server-key"))
 	_, _ = mac.Write([]byte("abc"))
 	s.Equal(hex.EncodeToString(mac.Sum(nil)), identity.HMACSHA256)
+}
+
+func (s *VaultResolverSuite) TestResolveWithIdentityCanonicalizesNumericVersion() {
+	keyring, err := NewIdentityKeyring("k1", map[string][]byte{"k1": []byte("server-key")})
+	s.Require().NoError(err)
+	rest := &fakeLogical{response: &vault.Secret{Data: map[string]any{
+		"data":     map[string]any{"token": "abc"},
+		"metadata": map[string]any{"version": json.Number("7.0")},
+	}}}
+	r := NewVaultResolverWithLogicalAndKeyring(rest, keyring)
+
+	_, identity, err := r.ResolveWithIdentity(context.Background(), "secret://vault/secret/data/path?field=token")
+	s.Require().NoError(err)
+	s.Equal("7", identity.Version)
+	s.Empty(rest.dataRequests)
 }
 
 func (s *VaultResolverSuite) TestResolveFieldAsSegment() {

--- a/internal/lineage/mapper.go
+++ b/internal/lineage/mapper.go
@@ -95,6 +95,10 @@ func newMapper(namespace string, db *gorm.DB) *mapper {
 }
 
 func (m *mapper) mapEvent(evt event.Event) (*RunEvent, error) {
+	if evt.Quarantine {
+		return nil, nil
+	}
+
 	switch evt.Type {
 	case event.TypeRunStarted:
 		return m.mapRunStart(evt)

--- a/internal/lineage/mapper_test.go
+++ b/internal/lineage/mapper_test.go
@@ -78,6 +78,26 @@ func TestMapRunStart(t *testing.T) {
 	}
 }
 
+func TestMapQuarantinedEventReturnsNil(t *testing.T) {
+	m := newMapper("caesium-test", nil)
+	payload := testJobRunPayload()
+
+	olEvent, err := m.mapEvent(event.Event{
+		Type:       event.TypeRunStarted,
+		JobID:      payload.JobID,
+		RunID:      payload.ID,
+		Timestamp:  time.Now().UTC(),
+		Payload:    mustMarshal(t, payload),
+		Quarantine: true,
+	})
+	if err != nil {
+		t.Fatalf("mapEvent: %v", err)
+	}
+	if olEvent != nil {
+		t.Fatalf("quarantined event mapped to OpenLineage event: %+v", olEvent)
+	}
+}
+
 func TestMapRunComplete(t *testing.T) {
 	m := newMapper("caesium-test", nil)
 	payload := testJobRunPayload()

--- a/internal/lineage/subscriber.go
+++ b/internal/lineage/subscriber.go
@@ -71,6 +71,15 @@ func (s *Subscriber) StartWithReady(ctx context.Context, ready chan<- struct{}) 
 }
 
 func (s *Subscriber) handleEvent(ctx context.Context, evt event.Event) {
+	if evt.Quarantine {
+		log.Debug("lineage: dropping quarantined event",
+			"event_type", string(evt.Type),
+			"run_id", evt.RunID,
+			"task_id", evt.TaskID,
+		)
+		return
+	}
+
 	olEvent, err := s.mapper.mapEvent(evt)
 	if err != nil {
 		log.Error("lineage: failed to map event",

--- a/internal/models/execution_event.go
+++ b/internal/models/execution_event.go
@@ -13,6 +13,7 @@ type ExecutionEvent struct {
 	RunID              *uuid.UUID `gorm:"type:uuid;index" json:"run_id,omitempty"`
 	TaskID             *uuid.UUID `gorm:"type:uuid;index" json:"task_id,omitempty"`
 	Payload            []byte     `gorm:"type:json" json:"payload,omitempty"`
+	Quarantine         bool       `gorm:"not null;default:false;index" json:"quarantine"`
 	BusDispatchPending bool       `gorm:"not null;default:false;index" json:"bus_dispatch_pending"`
 	BusDispatchedAt    *time.Time `gorm:"index" json:"bus_dispatched_at,omitempty"`
 	CreatedAt          time.Time  `gorm:"not null;index" json:"created_at"`

--- a/internal/models/run.go
+++ b/internal/models/run.go
@@ -3,30 +3,37 @@ package models
 import (
 	"time"
 
+	"github.com/caesium-cloud/caesium/pkg/container"
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
 )
 
 type JobRun struct {
-	ID            uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
-	JobID         uuid.UUID      `gorm:"type:uuid;index;not null" json:"job_id"`
-	Job           Job            `gorm:"constraint:OnDelete:CASCADE" json:"-"`
-	BackfillID    *uuid.UUID     `gorm:"type:uuid;index" json:"backfill_id,omitempty"`
-	Backfill      *Backfill      `gorm:"constraint:OnDelete:SET NULL" json:"-"`
-	TriggerID     uuid.UUID      `gorm:"type:uuid;index" json:"trigger_id"`
-	TriggerType   string         `gorm:"type:text" json:"trigger_type"`
-	TriggerAlias  string         `gorm:"type:text" json:"trigger_alias"`
-	Status        string         `gorm:"type:text;index;not null" json:"status"`
-	Error         string         `json:"error,omitempty"`
-	Params        datatypes.JSON `gorm:"type:json" json:"params,omitempty"`
-	StartedAt     time.Time      `gorm:"not null" json:"started_at"`
-	CompletedAt   *time.Time     `json:"completed_at,omitempty"`
-	CreatedAt     time.Time      `gorm:"not null" json:"created_at"`
-	UpdatedAt     time.Time      `gorm:"not null" json:"updated_at"`
-	Tasks         []*TaskRun     `gorm:"foreignKey:JobRunID;constraint:OnDelete:CASCADE" json:"tasks,omitempty"`
-	CacheHits     int            `gorm:"-" json:"cache_hits"`
-	ExecutedTasks int            `gorm:"-" json:"executed_tasks"`
-	TotalTasks    int            `gorm:"-" json:"total_tasks"`
+	ID           uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	JobID        uuid.UUID      `gorm:"type:uuid;index;not null" json:"job_id"`
+	Job          Job            `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	BackfillID   *uuid.UUID     `gorm:"type:uuid;index" json:"backfill_id,omitempty"`
+	Backfill     *Backfill      `gorm:"constraint:OnDelete:SET NULL" json:"-"`
+	TriggerID    uuid.UUID      `gorm:"type:uuid;index" json:"trigger_id"`
+	TriggerType  string         `gorm:"type:text" json:"trigger_type"`
+	TriggerAlias string         `gorm:"type:text" json:"trigger_alias"`
+	Status       string         `gorm:"type:text;index;not null" json:"status"`
+	Error        string         `json:"error,omitempty"`
+	Params       datatypes.JSON `gorm:"type:json" json:"params,omitempty"`
+	Quarantine   bool           `gorm:"not null;default:false;index" json:"quarantine"`
+	// ReplayFingerprint is the scoped, server-derived idempotency fingerprint
+	// for quarantined replay creation. It is nullable so ordinary runs do not
+	// participate in the unique index.
+	ReplayFingerprint *string        `gorm:"type:text;uniqueIndex:idx_job_runs_replay_fingerprint" json:"replay_fingerprint,omitempty"`
+	ReplayOverrides   datatypes.JSON `gorm:"type:json" json:"replay_overrides,omitempty"`
+	StartedAt         time.Time      `gorm:"not null" json:"started_at"`
+	CompletedAt       *time.Time     `json:"completed_at,omitempty"`
+	CreatedAt         time.Time      `gorm:"not null" json:"created_at"`
+	UpdatedAt         time.Time      `gorm:"not null" json:"updated_at"`
+	Tasks             []*TaskRun     `gorm:"foreignKey:JobRunID;constraint:OnDelete:CASCADE" json:"tasks,omitempty"`
+	CacheHits         int            `gorm:"-" json:"cache_hits"`
+	ExecutedTasks     int            `gorm:"-" json:"executed_tasks"`
+	TotalTasks        int            `gorm:"-" json:"total_tasks"`
 }
 
 type TaskRun struct {
@@ -62,6 +69,7 @@ type TaskRun struct {
 	Result           string         `json:"result,omitempty"`
 	Output           datatypes.JSON `gorm:"type:json" json:"output,omitempty"`
 	BranchSelections datatypes.JSON `gorm:"type:json" json:"branch_selections,omitempty"`
+	Quarantine       bool           `gorm:"not null;default:false;index" json:"quarantine"`
 	CacheHit         bool           `gorm:"not null;default:false" json:"cache_hit"`
 	CacheEnabled     bool           `gorm:"not null;default:false" json:"-"`
 	CacheTTL         time.Duration  `gorm:"not null;default:0" json:"-"`
@@ -100,6 +108,7 @@ type TaskRun struct {
 	SchemaValidation string `gorm:"type:text;not null;default:''" json:"-"`
 	// SchemaViolations stores any output schema violations detected at runtime.
 	SchemaViolations        datatypes.JSON `gorm:"type:json" json:"schema_violations,omitempty"`
+	ExecutionDescriptor     datatypes.JSON `gorm:"type:json" json:"-"`
 	LogText                 string         `gorm:"type:text" json:"-"`
 	LogTruncated            bool           `gorm:"not null;default:false" json:"-"`
 	Error                   string         `json:"error,omitempty"`
@@ -123,6 +132,125 @@ type TaskRun struct {
 	CompletedAt      *time.Time `json:"completed_at,omitempty"`
 	CreatedAt        time.Time  `gorm:"not null" json:"created_at"`
 	UpdatedAt        time.Time  `gorm:"not null" json:"updated_at"`
+}
+
+const TaskExecutionDescriptorSchemaVersion = 1
+
+// TaskExecutionDescriptor is the immutable, per-TaskRun runtime envelope used
+// by quarantined replay. Secret values are never stored; secret refs are
+// recorded with provider identity metadata. Large object/reference capture is
+// out of scope for descriptor schema v1 and must be added explicitly in a later
+// schema version before replay can depend on those refs.
+type TaskExecutionDescriptor struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	CapturedAt    time.Time `json:"capturedAt"`
+
+	Baseline TaskExecutionBaseline `json:"baseline"`
+	DAG      TaskExecutionDAG      `json:"dag"`
+	Run      TaskExecutionRun      `json:"run"`
+	Runtime  TaskExecutionRuntime  `json:"runtime"`
+	Timing   TaskExecutionTiming   `json:"timing"`
+	Cache    TaskExecutionCache    `json:"cache"`
+	Schema   TaskExecutionSchema   `json:"schema"`
+	Job      TaskExecutionJob      `json:"job"`
+
+	ContainerSpec  container.Spec            `json:"containerSpec"`
+	KubernetesSpec *container.KubernetesSpec `json:"kubernetesSpec,omitempty"`
+	SecretRefs     []TaskExecutionSecretRef  `json:"secretRefs,omitempty"`
+}
+
+type TaskExecutionBaseline struct {
+	JobID               uuid.UUID `json:"jobId"`
+	JobAlias            string    `json:"jobAlias"`
+	TaskID              uuid.UUID `json:"taskId"`
+	TaskName            string    `json:"taskName"`
+	AtomID              uuid.UUID `json:"atomId"`
+	BaselineRunID       uuid.UUID `json:"baselineRunId"`
+	TriggerID           uuid.UUID `json:"triggerId,omitempty"`
+	TriggerType         string    `json:"triggerType,omitempty"`
+	TriggerAlias        string    `json:"triggerAlias,omitempty"`
+	ReplaySafe          bool      `json:"replaySafe"`
+	Quarantine          bool      `json:"quarantine"`
+	ComputedHash        string    `json:"computedHash,omitempty"`
+	EffectiveHash       string    `json:"effectiveHash,omitempty"`
+	HashInputBlobStored bool      `json:"hashInputBlobStored,omitempty"`
+}
+
+type TaskExecutionDAG struct {
+	Predecessors               []TaskExecutionEdgeRef          `json:"predecessors,omitempty"`
+	Successors                 []TaskExecutionEdgeRef          `json:"successors,omitempty"`
+	TriggerRule                string                          `json:"triggerRule,omitempty"`
+	BranchBehavior             string                          `json:"branchBehavior,omitempty"`
+	EdgeMode                   string                          `json:"edgeMode,omitempty"`
+	TaskPosition               int                             `json:"taskPosition"`
+	OutstandingPredecessors    int                             `json:"outstandingPredecessors"`
+	PredecessorOutputs         map[uuid.UUID]map[string]string `json:"predecessorOutputs,omitempty"`
+	PredecessorEffectiveHashes map[uuid.UUID]string            `json:"predecessorEffectiveHashes,omitempty"`
+}
+
+type TaskExecutionEdgeRef struct {
+	TaskID   uuid.UUID `json:"taskId"`
+	TaskName string    `json:"taskName,omitempty"`
+}
+
+type TaskExecutionRun struct {
+	Params map[string]string `json:"params,omitempty"`
+}
+
+type TaskExecutionRuntime struct {
+	Engine              AtomEngine        `json:"engine"`
+	Image               string            `json:"image"`
+	ResolvedImageDigest string            `json:"resolvedImageDigest,omitempty"`
+	Command             []string          `json:"command,omitempty"`
+	CommandRaw          string            `json:"commandRaw,omitempty"`
+	WorkDir             string            `json:"workdir,omitempty"`
+	TaskType            string            `json:"taskType,omitempty"`
+	NodeSelector        map[string]string `json:"nodeSelector,omitempty"`
+	RetryCount          int               `json:"retryCount"`
+	RetryDelay          time.Duration     `json:"retryDelay"`
+	RetryBackoff        bool              `json:"retryBackoff"`
+}
+
+type TaskExecutionTiming struct {
+	TaskTimeout time.Duration `json:"taskTimeout"`
+	RunTimeout  time.Duration `json:"runTimeout"`
+}
+
+type TaskExecutionCache struct {
+	Enabled             bool          `json:"enabled"`
+	TTL                 time.Duration `json:"ttl"`
+	Version             int           `json:"version"`
+	PinDigests          bool          `json:"pinDigests"`
+	DigestTTL           time.Duration `json:"digestTTL"`
+	ComputedHash        string        `json:"computedHash,omitempty"`
+	EffectiveHash       string        `json:"effectiveHash,omitempty"`
+	HashInputBlobStored bool          `json:"hashInputBlobStored,omitempty"`
+}
+
+type TaskExecutionSchema struct {
+	InputSchema  datatypes.JSON `json:"inputSchema,omitempty"`
+	OutputSchema datatypes.JSON `json:"outputSchema,omitempty"`
+	// ValidationMode fully determines violation behavior in descriptor schema v1.
+	ValidationMode string `json:"validationMode,omitempty"`
+}
+
+type TaskExecutionJob struct {
+	MaxParallelTasks int               `json:"maxParallelTasks"`
+	Labels           map[string]string `json:"labels,omitempty"`
+	Annotations      map[string]string `json:"annotations,omitempty"`
+	SLA              datatypes.JSON    `json:"sla,omitempty"`
+	CacheDefaults    datatypes.JSON    `json:"cacheDefaults,omitempty"`
+	TriggerConfig    datatypes.JSONMap `json:"triggerConfig,omitempty"`
+}
+
+type TaskExecutionSecretRef struct {
+	Ref                string            `json:"ref"`
+	EnvKey             string            `json:"envKey,omitempty"`
+	Provider           string            `json:"provider,omitempty"`
+	Identity           datatypes.JSONMap `json:"identity,omitempty"`
+	Verifiable         bool              `json:"verifiable"`
+	UnverifiableReason string            `json:"unverifiableReason,omitempty"`
+	IdentityCapturedAt *time.Time        `json:"identityCapturedAt,omitempty"`
 }
 
 // TaskCache stores cached task results keyed by identity hash.

--- a/internal/models/run_quarantine_test.go
+++ b/internal/models/run_quarantine_test.go
@@ -1,0 +1,59 @@
+package models_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuarantineColumnsDefaultFalse(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	now := time.Now().UTC()
+	runID := uuid.New()
+	taskID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:        runID,
+		JobID:     uuid.New(),
+		Status:    "running",
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID:        uuid.New(),
+		JobRunID:  runID,
+		TaskID:    taskID,
+		AtomID:    uuid.New(),
+		Engine:    models.AtomEngineDocker,
+		Image:     "alpine:3.23",
+		Command:   `["true"]`,
+		Status:    "pending",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.ExecutionEvent{
+		Type:      "run_started",
+		RunID:     &runID,
+		TaskID:    &taskID,
+		CreatedAt: now,
+	}).Error)
+
+	var jobRun models.JobRun
+	require.NoError(t, db.First(&jobRun, "id = ?", runID).Error)
+	require.False(t, jobRun.Quarantine)
+	require.Nil(t, jobRun.ReplayFingerprint)
+
+	var taskRun models.TaskRun
+	require.NoError(t, db.First(&taskRun, "job_run_id = ? AND task_id = ?", runID, taskID).Error)
+	require.False(t, taskRun.Quarantine)
+
+	var evt models.ExecutionEvent
+	require.NoError(t, db.First(&evt, "run_id = ? AND task_id = ?", runID, taskID).Error)
+	require.False(t, evt.Quarantine)
+}

--- a/internal/notification/subscriber.go
+++ b/internal/notification/subscriber.go
@@ -25,9 +25,9 @@ var notifiableTypes = []event.Type{
 // Subscriber listens to the event bus and dispatches notifications
 // through matching policies and channels.
 type Subscriber struct {
-	bus      event.Bus
-	db       *gorm.DB
-	senders  map[models.ChannelType]Sender
+	bus     event.Bus
+	db      *gorm.DB
+	senders map[models.ChannelType]Sender
 }
 
 // NewSubscriber creates a notification subscriber.
@@ -77,6 +77,15 @@ func (s *Subscriber) StartWithReady(ctx context.Context, ready chan<- struct{}) 
 }
 
 func (s *Subscriber) handleEvent(ctx context.Context, evt event.Event) {
+	if evt.Quarantine {
+		log.Debug("notification: dropping quarantined event",
+			"event_type", string(evt.Type),
+			"run_id", evt.RunID,
+			"task_id", evt.TaskID,
+		)
+		return
+	}
+
 	// Record failure/alert metrics.
 	recordEventMetric(evt)
 
@@ -380,4 +389,3 @@ func ChannelConfigMap(ch models.NotificationChannel) (map[string]interface{}, er
 	}
 	return m, nil
 }
-

--- a/internal/notification/subscriber_test.go
+++ b/internal/notification/subscriber_test.go
@@ -1,0 +1,36 @@
+package notification
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	metrictestutil "github.com/caesium-cloud/caesium/internal/metrics/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscriberDropsQuarantinedEventsBeforeMetrics(t *testing.T) {
+	TaskFailuresTotal.Reset()
+
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		testutil.CloseDB(db)
+	})
+
+	sub := &Subscriber{db: db}
+	sub.handleEvent(context.Background(), event.Event{
+		Type:       event.TypeTaskFailed,
+		Payload:    mustJSON(map[string]string{"job_alias": "pipeline"}),
+		Quarantine: true,
+	})
+
+	require.Equal(t, 0.0, metrictestutil.CounterValue(t, TaskFailuresTotal, "pipeline"))
+
+	sub.handleEvent(context.Background(), event.Event{
+		Type:    event.TypeTaskFailed,
+		Payload: mustJSON(map[string]string{"job_alias": "pipeline"}),
+	})
+
+	require.Equal(t, 1.0, metrictestutil.CounterValue(t, TaskFailuresTotal, "pipeline"))
+}

--- a/internal/notification/watcher.go
+++ b/internal/notification/watcher.go
@@ -86,7 +86,7 @@ func (w *Watcher) scanRunningRuns(ctx context.Context, now time.Time) {
 	var runs []models.JobRun
 	if err := w.db.WithContext(ctx).
 		Preload("Job").
-		Where("status = ?", "running").
+		Where("status = ? AND quarantine IS NOT TRUE", "running").
 		Find(&runs).Error; err != nil {
 		log.Error("notification watcher: failed to query running runs", "error", err)
 		return
@@ -210,7 +210,7 @@ func (w *Watcher) scanCompletedBySLA(ctx context.Context, now time.Time) {
 	if err := w.db.WithContext(ctx).
 		Model(&models.JobRun{}).
 		Select("job_id, MAX(completed_at) AS latest_compl").
-		Where("job_id IN ? AND status = ? AND completed_at >= ?",
+		Where("job_id IN ? AND status = ? AND completed_at >= ? AND quarantine IS NOT TRUE",
 			jobIDs, "succeeded", earliestWindow).
 		Group("job_id").
 		Find(&rows).Error; err != nil {

--- a/internal/run/descriptor.go
+++ b/internal/run/descriptor.go
@@ -1,0 +1,53 @@
+package run
+
+import (
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"gorm.io/datatypes"
+)
+
+// SecretIdentityDescriptorRef converts a resolved secret identity into the
+// immutable TaskRun descriptor shape. It intentionally omits the secret value.
+func SecretIdentityDescriptorRef(envKey, ref string, identity secret.Identity) models.TaskExecutionSecretRef {
+	capturedAt := time.Now().UTC()
+	if ref == "" {
+		ref = identity.Ref
+	}
+	provider := identity.Provider
+	metadata := datatypes.JSONMap{}
+	if identity.Version != "" {
+		metadata["version"] = identity.Version
+	}
+	if identity.ResourceVersion != "" {
+		metadata["resourceVersion"] = identity.ResourceVersion
+	}
+	if identity.Namespace != "" {
+		metadata["namespace"] = identity.Namespace
+	}
+	if identity.Name != "" {
+		metadata["name"] = identity.Name
+	}
+	if identity.Key != "" {
+		metadata["key"] = identity.Key
+	}
+	if identity.KeyID != "" {
+		metadata["keyId"] = identity.KeyID
+	}
+	if identity.HMACSHA256 != "" {
+		metadata["hmacSha256"] = identity.HMACSHA256
+	}
+	for k, v := range identity.Metadata {
+		metadata[k] = v
+	}
+	return models.TaskExecutionSecretRef{
+		Ref:                ref,
+		EnvKey:             envKey,
+		Provider:           provider,
+		Identity:           metadata,
+		Verifiable:         identity.Verifiable,
+		UnverifiableReason: identity.UnverifiableReason,
+		IdentityCapturedAt: &capturedAt,
+	}
+}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -252,21 +253,37 @@ func (s *Store) stampEventQuarantineTx(tx *gorm.DB, evt *event.Event) error {
 	// Event quarantine stamping is deliberately fail-closed: a missing marker
 	// aborts the transaction instead of leaking an outward event as production.
 	if evt.TaskID != uuid.Nil {
-		var taskRun models.TaskRun
-		if err := tx.Select("quarantine").
-			Where("job_run_id = ? AND task_id = ?", evt.RunID, evt.TaskID).
-			First(&taskRun).Error; err != nil {
+		quarantined, err := s.taskEventQuarantineTx(tx, evt.RunID, evt.TaskID)
+		if err != nil {
 			return fmt.Errorf("run: stamp event quarantine from task run: %w", err)
 		}
-		evt.Quarantine = taskRun.Quarantine
+		evt.Quarantine = quarantined
 		return nil
 	}
-	var jobRun models.JobRun
-	if err := tx.Select("quarantine").First(&jobRun, "id = ?", evt.RunID).Error; err != nil {
+	quarantined, err := s.runEventQuarantineTx(tx, evt.RunID)
+	if err != nil {
 		return fmt.Errorf("run: stamp event quarantine from job run: %w", err)
 	}
-	evt.Quarantine = jobRun.Quarantine
+	evt.Quarantine = quarantined
 	return nil
+}
+
+func (s *Store) runEventQuarantineTx(tx *gorm.DB, runID uuid.UUID) (bool, error) {
+	var jobRun models.JobRun
+	if err := tx.Select("quarantine").First(&jobRun, "id = ?", runID).Error; err != nil {
+		return false, err
+	}
+	return jobRun.Quarantine, nil
+}
+
+func (s *Store) taskEventQuarantineTx(tx *gorm.DB, runID, taskID uuid.UUID) (bool, error) {
+	var taskRun models.TaskRun
+	if err := tx.Select("quarantine").
+		Where("job_run_id = ? AND task_id = ?", runID, taskID).
+		First(&taskRun).Error; err != nil {
+		return false, err
+	}
+	return taskRun.Quarantine, nil
 }
 
 func (s *Store) DB() *gorm.DB {
@@ -421,27 +438,46 @@ func (s *Store) mutateTaskExecutionDescriptor(runID, taskID uuid.UUID, mutate fu
 		return nil
 	}
 
-	var taskRun models.TaskRun
-	if err := s.db.Select("execution_descriptor").Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&taskRun).Error; err != nil {
-		return err
-	}
-	desc := models.TaskExecutionDescriptor{
-		SchemaVersion: models.TaskExecutionDescriptorSchemaVersion,
-		CapturedAt:    time.Now().UTC(),
-	}
-	if len(taskRun.ExecutionDescriptor) > 0 {
-		if err := json.Unmarshal(taskRun.ExecutionDescriptor, &desc); err != nil {
-			return fmt.Errorf("run: decode task execution descriptor: %w", err)
+	for attempt := 0; attempt <= len(storeBusyRetryBackoffs); attempt++ {
+		var taskRun models.TaskRun
+		if err := s.db.Select("execution_descriptor").Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&taskRun).Error; err != nil {
+			return err
+		}
+		previous := append([]byte(nil), taskRun.ExecutionDescriptor...)
+		desc := models.TaskExecutionDescriptor{
+			SchemaVersion: models.TaskExecutionDescriptorSchemaVersion,
+			CapturedAt:    time.Now().UTC(),
+		}
+		if len(previous) > 0 {
+			if err := json.Unmarshal(previous, &desc); err != nil {
+				return fmt.Errorf("run: decode task execution descriptor: %w", err)
+			}
+		}
+		mutate(&desc)
+		encoded, err := json.Marshal(&desc)
+		if err != nil {
+			return fmt.Errorf("run: encode task execution descriptor: %w", err)
+		}
+		if bytes.Equal(previous, encoded) {
+			return nil
+		}
+
+		update := s.db.Model(&models.TaskRun{}).
+			Where("job_run_id = ? AND task_id = ?", runID, taskID)
+		if len(previous) == 0 {
+			update = update.Where("(execution_descriptor IS NULL OR execution_descriptor = '')")
+		} else {
+			update = update.Where("execution_descriptor = ?", string(previous))
+		}
+		result := update.Update("execution_descriptor", datatypes.JSON(encoded))
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected > 0 {
+			return nil
 		}
 	}
-	mutate(&desc)
-	encoded, err := json.Marshal(&desc)
-	if err != nil {
-		return fmt.Errorf("run: encode task execution descriptor: %w", err)
-	}
-	return s.db.Model(&models.TaskRun{}).
-		Where("job_run_id = ? AND task_id = ?", runID, taskID).
-		Update("execution_descriptor", datatypes.JSON(encoded)).Error
+	return fmt.Errorf("run: update task execution descriptor: concurrent mutation did not settle")
 }
 
 func mergeDescriptorSecretRefs(existing, updates []models.TaskExecutionSecretRef) []models.TaskExecutionSecretRef {
@@ -1792,10 +1828,8 @@ func (s *Store) appendBatchEventsTx(tx *gorm.DB, evts []*event.Event, pendingEve
 	if s.eventStore == nil || len(evts) == 0 {
 		return nil
 	}
-	for _, evt := range evts {
-		if err := s.stampEventQuarantineTx(tx, evt); err != nil {
-			return err
-		}
+	if err := s.stampBatchEventQuarantineTx(tx, evts); err != nil {
+		return err
 	}
 	if err := s.eventStore.AppendBatchTx(tx, evts); err != nil {
 		return err
@@ -1805,6 +1839,92 @@ func (s *Store) appendBatchEventsTx(tx *gorm.DB, evts []*event.Event, pendingEve
 		*pendingEvents = append(*pendingEvents, *e)
 	}
 	return nil
+}
+
+type eventQuarantineKey struct {
+	runID  uuid.UUID
+	taskID uuid.UUID
+}
+
+func (s *Store) stampBatchEventQuarantineTx(tx *gorm.DB, evts []*event.Event) error {
+	runIDs := make(map[uuid.UUID]struct{})
+	taskIDsByRun := make(map[uuid.UUID]map[uuid.UUID]struct{})
+	for _, evt := range evts {
+		if tx == nil || evt == nil || evt.RunID == uuid.Nil {
+			continue
+		}
+		runIDs[evt.RunID] = struct{}{}
+		if evt.TaskID == uuid.Nil {
+			continue
+		}
+		if taskIDsByRun[evt.RunID] == nil {
+			taskIDsByRun[evt.RunID] = make(map[uuid.UUID]struct{})
+		}
+		taskIDsByRun[evt.RunID][evt.TaskID] = struct{}{}
+	}
+	if len(runIDs) == 0 {
+		return nil
+	}
+
+	runQuarantine := make(map[uuid.UUID]bool, len(runIDs))
+	var runRows []struct {
+		ID         uuid.UUID
+		Quarantine bool
+	}
+	if err := tx.Model(&models.JobRun{}).
+		Select("id", "quarantine").
+		Where("id IN ?", uuidSetValues(runIDs)).
+		Find(&runRows).Error; err != nil {
+		return fmt.Errorf("run: stamp event quarantine from job run batch: %w", err)
+	}
+	for _, row := range runRows {
+		runQuarantine[row.ID] = row.Quarantine
+	}
+	if len(runQuarantine) != len(runIDs) {
+		return fmt.Errorf("run: stamp event quarantine from job run batch: %w", gorm.ErrRecordNotFound)
+	}
+
+	taskQuarantine := make(map[eventQuarantineKey]bool)
+	for runID, taskIDs := range taskIDsByRun {
+		ids := uuidSetValues(taskIDs)
+		var taskRows []struct {
+			JobRunID   uuid.UUID
+			TaskID     uuid.UUID
+			Quarantine bool
+		}
+		if err := tx.Model(&models.TaskRun{}).
+			Select("job_run_id", "task_id", "quarantine").
+			Where("job_run_id = ? AND task_id IN ?", runID, ids).
+			Find(&taskRows).Error; err != nil {
+			return fmt.Errorf("run: stamp event quarantine from task run batch: %w", err)
+		}
+		for _, row := range taskRows {
+			taskQuarantine[eventQuarantineKey{runID: row.JobRunID, taskID: row.TaskID}] = row.Quarantine
+		}
+		if len(taskRows) != len(ids) {
+			return fmt.Errorf("run: stamp event quarantine from task run batch: %w", gorm.ErrRecordNotFound)
+		}
+	}
+
+	for _, evt := range evts {
+		if evt == nil || evt.RunID == uuid.Nil {
+			continue
+		}
+		quarantined := runQuarantine[evt.RunID]
+		if evt.TaskID != uuid.Nil {
+			quarantined = quarantined || taskQuarantine[eventQuarantineKey{runID: evt.RunID, taskID: evt.TaskID}]
+		}
+		evt.Quarantine = quarantined
+	}
+	return nil
+}
+
+func uuidSetValues(set map[uuid.UUID]struct{}) []uuid.UUID {
+	values := make([]uuid.UUID, 0, len(set))
+	for id := range set {
+		values = append(values, id)
+	}
+	return values
 }
 
 func (s *Store) markTaskSkippedTx(tx *gorm.DB, runID, taskID uuid.UUID, reason string, pendingEvents *[]event.Event, counts *dbWriteCounts) (bool, error) {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"math/rand/v2"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/container"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/caesium-cloud/caesium/pkg/env"
@@ -118,6 +120,7 @@ type TaskRun struct {
 	Output                  map[string]string         `json:"output,omitempty"`
 	SchemaViolations        []pkgtask.SchemaViolation `json:"schema_violations,omitempty"`
 	BranchSelections        []string                  `json:"branch_selections,omitempty"`
+	Quarantine              bool                      `json:"quarantine"`
 	CacheHit                bool                      `json:"cache_hit"`
 	ReplaySafe              bool                      `json:"replay_safe"`
 	CacheOriginRunID        *uuid.UUID                `json:"cache_origin_run_id,omitempty"`
@@ -141,6 +144,7 @@ type JobRun struct {
 	TriggerAlias  string            `json:"trigger_alias,omitempty"`
 	Status        Status            `json:"status"`
 	Params        map[string]string `json:"params,omitempty"`
+	Quarantine    bool              `json:"quarantine"`
 	StartedAt     time.Time         `json:"started_at"`
 	CompletedAt   *time.Time        `json:"completed_at,omitempty"`
 	CreatedAt     time.Time         `json:"created_at"`
@@ -235,7 +239,34 @@ func (s *Store) RecordEventTx(tx *gorm.DB, evt *event.Event) error {
 	if evt == nil || s.eventStore == nil {
 		return nil
 	}
+	if err := s.stampEventQuarantineTx(tx, evt); err != nil {
+		return err
+	}
 	return s.eventStore.AppendTx(tx, evt)
+}
+
+func (s *Store) stampEventQuarantineTx(tx *gorm.DB, evt *event.Event) error {
+	if tx == nil || evt == nil || evt.RunID == uuid.Nil {
+		return nil
+	}
+	// Event quarantine stamping is deliberately fail-closed: a missing marker
+	// aborts the transaction instead of leaking an outward event as production.
+	if evt.TaskID != uuid.Nil {
+		var taskRun models.TaskRun
+		if err := tx.Select("quarantine").
+			Where("job_run_id = ? AND task_id = ?", evt.RunID, evt.TaskID).
+			First(&taskRun).Error; err != nil {
+			return fmt.Errorf("run: stamp event quarantine from task run: %w", err)
+		}
+		evt.Quarantine = taskRun.Quarantine
+		return nil
+	}
+	var jobRun models.JobRun
+	if err := tx.Select("quarantine").First(&jobRun, "id = ?", evt.RunID).Error; err != nil {
+		return fmt.Errorf("run: stamp event quarantine from job run: %w", err)
+	}
+	evt.Quarantine = jobRun.Quarantine
+	return nil
 }
 
 func (s *Store) DB() *gorm.DB {
@@ -309,6 +340,41 @@ func (s *Store) SetTaskHashWithBlob(runID, taskID uuid.UUID, hash, resolvedImage
 		Updates(updates).Error
 }
 
+func (s *Store) UpdateTaskExecutionDescriptorInputs(runID, taskID uuid.UUID, predecessorOutputs map[uuid.UUID]map[string]string, predecessorHashes map[uuid.UUID]string, computedHash, resolvedImageDigest string, hashInputBlob []byte) error {
+	return s.mutateTaskExecutionDescriptor(runID, taskID, func(desc *models.TaskExecutionDescriptor) {
+		desc.CapturedAt = time.Now().UTC()
+		if desc.SchemaVersion == 0 {
+			desc.SchemaVersion = models.TaskExecutionDescriptorSchemaVersion
+		}
+		desc.DAG.PredecessorOutputs = predecessorOutputs
+		desc.DAG.PredecessorEffectiveHashes = predecessorHashes
+		if computedHash != "" {
+			desc.Baseline.ComputedHash = computedHash
+			desc.Cache.ComputedHash = computedHash
+		}
+		if resolvedImageDigest != "" {
+			desc.Runtime.ResolvedImageDigest = resolvedImageDigest
+		}
+		if len(hashInputBlob) > 0 {
+			desc.Baseline.HashInputBlobStored = true
+			desc.Cache.HashInputBlobStored = true
+		}
+	})
+}
+
+func (s *Store) UpdateTaskExecutionDescriptorSecretRefs(runID, taskID uuid.UUID, refs []models.TaskExecutionSecretRef) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	return s.mutateTaskExecutionDescriptor(runID, taskID, func(desc *models.TaskExecutionDescriptor) {
+		desc.CapturedAt = time.Now().UTC()
+		if desc.SchemaVersion == 0 {
+			desc.SchemaVersion = models.TaskExecutionDescriptorSchemaVersion
+		}
+		desc.SecretRefs = mergeDescriptorSecretRefs(desc.SecretRefs, refs)
+	})
+}
+
 // SetTaskEffectiveHash records the proven-equivalent prior identity a task
 // presents to its downstream consumers when a value-verified short-circuit was
 // proven (design Component 5 / D2). It writes ONLY the effective_hash column;
@@ -322,9 +388,81 @@ func (s *Store) SetTaskEffectiveHash(runID, taskID uuid.UUID, effectiveHash stri
 	if effectiveHash == "" {
 		return nil
 	}
+	if err := s.mutateTaskExecutionDescriptor(runID, taskID, func(desc *models.TaskExecutionDescriptor) {
+		desc.Baseline.EffectiveHash = effectiveHash
+		desc.Cache.EffectiveHash = effectiveHash
+	}); err != nil {
+		log.Warn("failed to update task execution descriptor effective hash", "run_id", runID, "task_id", taskID, "error", err)
+	}
 	return s.db.Model(&models.TaskRun{}).
 		Where("job_run_id = ? AND task_id = ?", runID, taskID).
 		Update("effective_hash", effectiveHash).Error
+}
+
+func (s *Store) TaskQuarantine(ctx context.Context, runID, taskID uuid.UUID) (bool, error) {
+	var row struct {
+		TaskQuarantine bool
+		RunQuarantine  bool
+	}
+	err := s.db.WithContext(ctx).
+		Table("task_runs").
+		Select("task_runs.quarantine AS task_quarantine, job_runs.quarantine AS run_quarantine").
+		Joins("join job_runs on job_runs.id = task_runs.job_run_id").
+		Where("task_runs.job_run_id = ? AND task_runs.task_id = ?", runID, taskID).
+		Take(&row).Error
+	if err != nil {
+		return false, err
+	}
+	return row.TaskQuarantine || row.RunQuarantine, nil
+}
+
+func (s *Store) mutateTaskExecutionDescriptor(runID, taskID uuid.UUID, mutate func(*models.TaskExecutionDescriptor)) error {
+	if mutate == nil {
+		return nil
+	}
+
+	var taskRun models.TaskRun
+	if err := s.db.Select("execution_descriptor").Where("job_run_id = ? AND task_id = ?", runID, taskID).First(&taskRun).Error; err != nil {
+		return err
+	}
+	desc := models.TaskExecutionDescriptor{
+		SchemaVersion: models.TaskExecutionDescriptorSchemaVersion,
+		CapturedAt:    time.Now().UTC(),
+	}
+	if len(taskRun.ExecutionDescriptor) > 0 {
+		if err := json.Unmarshal(taskRun.ExecutionDescriptor, &desc); err != nil {
+			return fmt.Errorf("run: decode task execution descriptor: %w", err)
+		}
+	}
+	mutate(&desc)
+	encoded, err := json.Marshal(&desc)
+	if err != nil {
+		return fmt.Errorf("run: encode task execution descriptor: %w", err)
+	}
+	return s.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", runID, taskID).
+		Update("execution_descriptor", datatypes.JSON(encoded)).Error
+}
+
+func mergeDescriptorSecretRefs(existing, updates []models.TaskExecutionSecretRef) []models.TaskExecutionSecretRef {
+	if len(existing) == 0 {
+		return append([]models.TaskExecutionSecretRef(nil), updates...)
+	}
+	merged := append([]models.TaskExecutionSecretRef(nil), existing...)
+	index := make(map[string]int, len(merged))
+	for i, ref := range merged {
+		index[ref.EnvKey+"\x00"+ref.Ref] = i
+	}
+	for _, ref := range updates {
+		key := ref.EnvKey + "\x00" + ref.Ref
+		if i, ok := index[key]; ok {
+			merged[i] = ref
+			continue
+		}
+		index[key] = len(merged)
+		merged = append(merged, ref)
+	}
+	return merged
 }
 
 func (s *Store) Start(jobID uuid.UUID, triggerID *uuid.UUID, params ...map[string]string) (*JobRun, error) {
@@ -369,11 +507,12 @@ func (s *Store) Start(jobID uuid.UUID, triggerID *uuid.UUID, params ...map[strin
 				}
 
 				evt := event.Event{
-					Type:      event.TypeRunStarted,
-					JobID:     jobID,
-					RunID:     model.ID,
-					Timestamp: time.Now().UTC(),
-					Payload:   payload,
+					Type:       event.TypeRunStarted,
+					JobID:      jobID,
+					RunID:      model.ID,
+					Timestamp:  time.Now().UTC(),
+					Payload:    payload,
+					Quarantine: model.Quarantine,
 				}
 				if err := s.eventStore.AppendTx(tx, &evt); err != nil {
 					return err
@@ -415,10 +554,12 @@ func (s *Store) Start(jobID uuid.UUID, triggerID *uuid.UUID, params ...map[strin
 		}
 	}
 
-	metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
-	s.startedMu.Lock()
-	s.startedRuns[model.ID] = struct{}{}
-	s.startedMu.Unlock()
+	if !model.Quarantine {
+		metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
+		s.startedMu.Lock()
+		s.startedRuns[model.ID] = struct{}{}
+		s.startedMu.Unlock()
+	}
 
 	run, err := s.loadRun(model.ID)
 	return run, err
@@ -467,11 +608,12 @@ func (s *Store) StartForBackfill(jobID, backfillID uuid.UUID, params map[string]
 				}
 
 				evt := event.Event{
-					Type:      event.TypeRunStarted,
-					JobID:     jobID,
-					RunID:     model.ID,
-					Timestamp: time.Now().UTC(),
-					Payload:   payload,
+					Type:       event.TypeRunStarted,
+					JobID:      jobID,
+					RunID:      model.ID,
+					Timestamp:  time.Now().UTC(),
+					Payload:    payload,
+					Quarantine: model.Quarantine,
 				}
 				if err := s.eventStore.AppendTx(tx, &evt); err != nil {
 					return err
@@ -507,10 +649,12 @@ func (s *Store) StartForBackfill(jobID, backfillID uuid.UUID, params map[string]
 		}
 	}
 
-	metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
-	s.startedMu.Lock()
-	s.startedRuns[model.ID] = struct{}{}
-	s.startedMu.Unlock()
+	if !model.Quarantine {
+		metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
+		s.startedMu.Lock()
+		s.startedRuns[model.ID] = struct{}{}
+		s.startedMu.Unlock()
+	}
 
 	return s.loadRun(model.ID)
 }
@@ -524,8 +668,8 @@ func (s *Store) RegisterTask(runID uuid.UUID, task *models.Task, atom *models.At
 }
 
 func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error {
-	metrics.TaskRegisterBatchSize.Observe(float64(len(inputs)))
 	if len(inputs) == 0 {
+		metrics.TaskRegisterBatchSize.Observe(0)
 		return nil
 	}
 
@@ -543,14 +687,17 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 	}
 
 	var jobRun models.JobRun
-	if err := s.db.Select("job_id").First(&jobRun, "id = ?", runID).Error; err != nil {
+	if err := s.db.Select("id", "job_id", "params", "trigger_id", "trigger_type", "trigger_alias", "quarantine").First(&jobRun, "id = ?", runID).Error; err != nil {
 		return fmt.Errorf("run: job run %s not found: %w", runID, err)
 	}
 	jobID := jobRun.JobID
+	if !jobRun.Quarantine {
+		metrics.TaskRegisterBatchSize.Observe(float64(len(inputs)))
+	}
 
 	var job models.Job
 	jobFound := true
-	if err := s.db.Select("id", "schema_validation", "cache_config", "replay_safe").First(&job, "id = ?", jobID).Error; err != nil {
+	if err := s.db.Select("id", "alias", "labels", "annotations", "schema_validation", "cache_config", "replay_safe", "max_parallel_tasks", "task_timeout", "run_timeout", "sla").First(&job, "id = ?", jobID).Error; err != nil {
 		if !errors.Is(err, gorm.ErrRecordNotFound) {
 			return err
 		}
@@ -627,6 +774,20 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 				if jobFound && job.ReplaySafe {
 					replaySafe = true
 				}
+				descriptor, descriptorErr := s.initialTaskExecutionDescriptorTx(
+					tx,
+					jobRun,
+					job,
+					jobFound,
+					task,
+					atom,
+					input.OutstandingPredecessors,
+					resolvedCache,
+					replaySafe,
+				)
+				if descriptorErr != nil {
+					return descriptorErr
+				}
 
 				records = append(records, models.TaskRun{
 					ID:                      uuid.New(),
@@ -649,15 +810,18 @@ func (s *Store) RegisterTasks(runID uuid.UUID, inputs []RegisterTaskInput) error
 					CacheDigestTTL:          resolvedCache.DigestTTL,
 					OutputSchema:            append(datatypes.JSON(nil), task.OutputSchema...),
 					SchemaValidation:        schemaValidation,
+					Quarantine:              jobRun.Quarantine,
+					ExecutionDescriptor:     descriptor,
 				})
 
 				if input.OutstandingPredecessors == 0 && s.eventStore != nil {
 					readyEvents = append(readyEvents, event.Event{
-						Type:      event.TypeTaskReady,
-						JobID:     jobID,
-						RunID:     runID,
-						TaskID:    task.ID,
-						Timestamp: time.Now().UTC(),
+						Type:       event.TypeTaskReady,
+						JobID:      jobID,
+						RunID:      runID,
+						TaskID:     task.ID,
+						Timestamp:  time.Now().UTC(),
+						Quarantine: jobRun.Quarantine,
 					})
 				}
 			}
@@ -706,6 +870,7 @@ func executionEventRecord(evt event.Event) models.ExecutionEvent {
 	record := models.ExecutionEvent{
 		Type:               string(evt.Type),
 		Payload:            []byte(evt.Payload),
+		Quarantine:         evt.Quarantine,
 		BusDispatchPending: true,
 		CreatedAt:          evt.Timestamp,
 	}
@@ -722,6 +887,262 @@ func executionEventRecord(evt event.Event) models.ExecutionEvent {
 		record.TaskID = &taskID
 	}
 	return record
+}
+
+func (s *Store) initialTaskExecutionDescriptorTx(
+	tx *gorm.DB,
+	jobRun models.JobRun,
+	job models.Job,
+	jobFound bool,
+	task *models.Task,
+	atom *models.Atom,
+	outstanding int,
+	cacheCfg jobdefschema.CacheConfig,
+	replaySafe bool,
+) (datatypes.JSON, error) {
+	if task == nil || atom == nil {
+		return nil, errors.New("run: descriptor requires task and atom")
+	}
+
+	spec := atom.ContainerSpec()
+	trigger := models.Trigger{}
+	if jobRun.TriggerID != uuid.Nil {
+		_ = tx.Select("id", "type", "alias", "configuration").First(&trigger, "id = ?", jobRun.TriggerID).Error
+	}
+
+	predecessors, successors, edgeMode, err := s.taskDescriptorEdgesTx(tx, *task)
+	if err != nil {
+		return nil, err
+	}
+
+	triggerRule := normalizedTriggerRule(task.TriggerRule)
+	taskType := task.Type
+	if taskType == "" {
+		taskType = "task"
+	}
+
+	runParams := decodeRunParams(jobRun.Params)
+	command := atom.Cmd()
+	if len(command) == 0 && atom.Command != "" {
+		command = []string{atom.Command}
+	}
+
+	jobAlias := ""
+	jobLabels := map[string]string(nil)
+	jobAnnotations := map[string]string(nil)
+	var jobSLA datatypes.JSON
+	var jobCache datatypes.JSON
+	var triggerConfig datatypes.JSONMap
+	maxParallel := 0
+	taskTimeout := time.Duration(0)
+	runTimeout := time.Duration(0)
+	schemaValidation := ""
+	if jobFound {
+		jobAlias = job.Alias
+		jobLabels = jsonmap.ToStringMap(job.Labels)
+		jobAnnotations = jsonmap.ToStringMap(job.Annotations)
+		jobSLA = append(datatypes.JSON(nil), job.SLA...)
+		jobCache = append(datatypes.JSON(nil), job.CacheConfig...)
+		maxParallel = job.MaxParallelTasks
+		taskTimeout = job.TaskTimeout
+		runTimeout = job.RunTimeout
+		schemaValidation = job.SchemaValidation
+	}
+	if strings.TrimSpace(trigger.Configuration) != "" {
+		_ = json.Unmarshal([]byte(trigger.Configuration), &triggerConfig)
+	}
+
+	descriptor := models.TaskExecutionDescriptor{
+		SchemaVersion: models.TaskExecutionDescriptorSchemaVersion,
+		CapturedAt:    time.Now().UTC(),
+		Baseline: models.TaskExecutionBaseline{
+			JobID:         jobRun.JobID,
+			JobAlias:      jobAlias,
+			TaskID:        task.ID,
+			TaskName:      task.Name,
+			AtomID:        atom.ID,
+			BaselineRunID: jobRun.ID,
+			TriggerID:     jobRun.TriggerID,
+			TriggerType:   firstNonEmpty(jobRun.TriggerType, string(trigger.Type)),
+			TriggerAlias:  firstNonEmpty(jobRun.TriggerAlias, trigger.Alias),
+			ReplaySafe:    replaySafe,
+			Quarantine:    jobRun.Quarantine,
+		},
+		DAG: models.TaskExecutionDAG{
+			Predecessors:            predecessors,
+			Successors:              successors,
+			TriggerRule:             triggerRule,
+			BranchBehavior:          taskType,
+			EdgeMode:                edgeMode,
+			TaskPosition:            task.Position,
+			OutstandingPredecessors: outstanding,
+		},
+		Run: models.TaskExecutionRun{
+			Params: runParams,
+		},
+		Runtime: models.TaskExecutionRuntime{
+			Engine:       atom.Engine,
+			Image:        atom.Image,
+			Command:      command,
+			CommandRaw:   atom.Command,
+			WorkDir:      spec.WorkDir,
+			TaskType:     taskType,
+			NodeSelector: jsonmap.ToStringMap(task.NodeSelector),
+			RetryCount:   task.Retries,
+			RetryDelay:   task.RetryDelay,
+			RetryBackoff: task.RetryBackoff,
+		},
+		Timing: models.TaskExecutionTiming{
+			TaskTimeout: taskTimeout,
+			RunTimeout:  runTimeout,
+		},
+		Cache: models.TaskExecutionCache{
+			Enabled:    cacheCfg.Enabled,
+			TTL:        cacheCfg.TTL,
+			Version:    cacheCfg.Version,
+			PinDigests: cacheCfg.PinDigests,
+			DigestTTL:  cacheCfg.DigestTTL,
+		},
+		Schema: models.TaskExecutionSchema{
+			InputSchema:    append(datatypes.JSON(nil), task.InputSchema...),
+			OutputSchema:   append(datatypes.JSON(nil), task.OutputSchema...),
+			ValidationMode: schemaValidation,
+		},
+		Job: models.TaskExecutionJob{
+			MaxParallelTasks: maxParallel,
+			Labels:           jobLabels,
+			Annotations:      jobAnnotations,
+			SLA:              jobSLA,
+			CacheDefaults:    jobCache,
+			TriggerConfig:    triggerConfig,
+		},
+		ContainerSpec:  spec,
+		KubernetesSpec: spec.Kubernetes,
+		SecretRefs:     descriptorSecretRefs(spec),
+	}
+
+	encoded, err := json.Marshal(&descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("run: marshal task execution descriptor: %w", err)
+	}
+	return datatypes.JSON(encoded), nil
+}
+
+func (s *Store) taskDescriptorEdgesTx(tx *gorm.DB, task models.Task) ([]models.TaskExecutionEdgeRef, []models.TaskExecutionEdgeRef, string, error) {
+	var edgeCount int64
+	if err := tx.Model(&models.TaskEdge{}).Where("job_id = ?", task.JobID).Count(&edgeCount).Error; err != nil {
+		return nil, nil, "", err
+	}
+	mode := "explicit"
+	if edgeCount == 0 {
+		mode = "implicit_sequential"
+	}
+
+	predecessors := make([]models.TaskExecutionEdgeRef, 0)
+	successors := make([]models.TaskExecutionEdgeRef, 0)
+	if mode == "explicit" {
+		var predEdges []models.TaskEdge
+		if err := tx.Where("to_task_id = ?", task.ID).Find(&predEdges).Error; err != nil {
+			return nil, nil, "", err
+		}
+		for _, edge := range predEdges {
+			ref, err := taskEdgeRefTx(tx, edge.FromTaskID)
+			if err != nil {
+				return nil, nil, "", err
+			}
+			predecessors = append(predecessors, ref)
+		}
+		var succEdges []models.TaskEdge
+		if err := tx.Where("from_task_id = ?", task.ID).Find(&succEdges).Error; err != nil {
+			return nil, nil, "", err
+		}
+		for _, edge := range succEdges {
+			ref, err := taskEdgeRefTx(tx, edge.ToTaskID)
+			if err != nil {
+				return nil, nil, "", err
+			}
+			successors = append(successors, ref)
+		}
+		return predecessors, successors, mode, nil
+	}
+
+	var prev models.Task
+	if err := tx.
+		Where("job_id = ? AND (position < ? OR (position = ? AND created_at < ?))", task.JobID, task.Position, task.Position, task.CreatedAt).
+		Order("position DESC").
+		Order("created_at DESC").
+		First(&prev).Error; err == nil {
+		predecessors = append(predecessors, models.TaskExecutionEdgeRef{TaskID: prev.ID, TaskName: prev.Name})
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil, "", err
+	}
+	var next models.Task
+	if err := tx.
+		Where("job_id = ? AND (position > ? OR (position = ? AND created_at > ?))", task.JobID, task.Position, task.Position, task.CreatedAt).
+		Order("position ASC").
+		Order("created_at ASC").
+		First(&next).Error; err == nil {
+		successors = append(successors, models.TaskExecutionEdgeRef{TaskID: next.ID, TaskName: next.Name})
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil, "", err
+	}
+	return predecessors, successors, mode, nil
+}
+
+func taskEdgeRefTx(tx *gorm.DB, taskID uuid.UUID) (models.TaskExecutionEdgeRef, error) {
+	var task models.Task
+	if err := tx.Select("id", "name").First(&task, "id = ?", taskID).Error; err != nil {
+		return models.TaskExecutionEdgeRef{}, err
+	}
+	return models.TaskExecutionEdgeRef{TaskID: task.ID, TaskName: task.Name}, nil
+}
+
+func decodeRunParams(raw datatypes.JSON) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var params map[string]string
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil
+	}
+	return params
+}
+
+func descriptorSecretRefs(spec container.Spec) []models.TaskExecutionSecretRef {
+	if len(spec.Env) == 0 {
+		return nil
+	}
+	refs := make([]models.TaskExecutionSecretRef, 0)
+	keys := make([]string, 0, len(spec.Env))
+	for key := range spec.Env {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		ref := strings.TrimSpace(spec.Env[key])
+		if !strings.HasPrefix(ref, "secret://") {
+			continue
+		}
+		refs = append(refs, models.TaskExecutionSecretRef{
+			Ref:        ref,
+			EnvKey:     key,
+			Verifiable: false,
+			// The pre-exec descriptor only knows the secret reference; the
+			// provider identity is finalized after executeAtom/executeTask
+			// resolves the value at container-create time.
+			UnverifiableReason: "secret identity not resolved yet",
+		})
+	}
+	return refs
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
@@ -1332,6 +1753,9 @@ func (s *Store) appendTaskReadyEventTx(tx *gorm.DB, runID, taskID uuid.UUID, pen
 		TaskID:    taskID,
 		Timestamp: time.Now().UTC(),
 	}
+	if err := s.stampEventQuarantineTx(tx, &evt); err != nil {
+		return err
+	}
 	if err := s.eventStore.AppendTx(tx, &evt); err != nil {
 		return err
 	}
@@ -1367,6 +1791,11 @@ func (s *Store) batchDecrementPredecessorsTx(tx *gorm.DB, runID uuid.UUID, succe
 func (s *Store) appendBatchEventsTx(tx *gorm.DB, evts []*event.Event, pendingEvents *[]event.Event, counts *dbWriteCounts) error {
 	if s.eventStore == nil || len(evts) == 0 {
 		return nil
+	}
+	for _, evt := range evts {
+		if err := s.stampEventQuarantineTx(tx, evt); err != nil {
+			return err
+		}
 	}
 	if err := s.eventStore.AppendBatchTx(tx, evts); err != nil {
 		return err
@@ -1530,12 +1959,14 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 			if err := taskQuery.First(&taskRun).Error; err == nil {
 				var jobRun models.JobRun
 				if err := tx.First(&jobRun, "id = ?", runID).Error; err == nil {
-					jobID := jobRun.JobID.String()
-					engine := string(taskRun.Engine)
-					metrics.TaskRunsTotal.WithLabelValues(jobID, taskID.String(), engine, string(status)).Inc()
-					if taskRun.StartedAt != nil {
-						duration := now.Sub(*taskRun.StartedAt).Seconds()
-						metrics.TaskRunDurationSeconds.WithLabelValues(jobID, engine, string(status)).Observe(duration)
+					if !taskRun.Quarantine && !jobRun.Quarantine {
+						jobID := jobRun.JobID.String()
+						engine := string(taskRun.Engine)
+						metrics.TaskRunsTotal.WithLabelValues(jobID, taskID.String(), engine, string(status)).Inc()
+						if taskRun.StartedAt != nil {
+							duration := now.Sub(*taskRun.StartedAt).Seconds()
+							metrics.TaskRunDurationSeconds.WithLabelValues(jobID, engine, string(status)).Observe(duration)
+						}
 					}
 				}
 			} else if enforceClaim && errors.Is(err, gorm.ErrRecordNotFound) {
@@ -1802,12 +2233,14 @@ func (s *Store) CompleteTaskOwner(
 			if err := tq.First(&taskRun).Error; err == nil {
 				var jobRun models.JobRun
 				if err := tx.First(&jobRun, "id = ?", runID).Error; err == nil {
-					jobID := jobRun.JobID.String()
-					engine := string(taskRun.Engine)
-					metrics.TaskRunsTotal.WithLabelValues(jobID, taskID.String(), engine, string(status)).Inc()
-					if taskRun.StartedAt != nil {
-						metrics.TaskRunDurationSeconds.WithLabelValues(jobID, engine, string(status)).
-							Observe(now.Sub(*taskRun.StartedAt).Seconds())
+					if !taskRun.Quarantine && !jobRun.Quarantine {
+						jobID := jobRun.JobID.String()
+						engine := string(taskRun.Engine)
+						metrics.TaskRunsTotal.WithLabelValues(jobID, taskID.String(), engine, string(status)).Inc()
+						if taskRun.StartedAt != nil {
+							metrics.TaskRunDurationSeconds.WithLabelValues(jobID, engine, string(status)).
+								Observe(now.Sub(*taskRun.StartedAt).Seconds())
+						}
 					}
 				}
 			} else if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -2051,12 +2484,14 @@ func (s *Store) failTask(runID, taskID uuid.UUID, failure error, claimedBy strin
 	if err := taskQuery.First(&taskRun).Error; err == nil {
 		var jobRun models.JobRun
 		if err := s.db.First(&jobRun, "id = ?", runID).Error; err == nil {
-			jobID := jobRun.JobID.String()
-			engine := string(taskRun.Engine)
-			metrics.TaskRunsTotal.WithLabelValues(jobID, taskID.String(), engine, string(TaskStatusFailed)).Inc()
-			if taskRun.StartedAt != nil {
-				duration := now.Sub(*taskRun.StartedAt).Seconds()
-				metrics.TaskRunDurationSeconds.WithLabelValues(jobID, engine, string(TaskStatusFailed)).Observe(duration)
+			if !taskRun.Quarantine && !jobRun.Quarantine {
+				jobID := jobRun.JobID.String()
+				engine := string(taskRun.Engine)
+				metrics.TaskRunsTotal.WithLabelValues(jobID, taskID.String(), engine, string(TaskStatusFailed)).Inc()
+				if taskRun.StartedAt != nil {
+					duration := now.Sub(*taskRun.StartedAt).Seconds()
+					metrics.TaskRunDurationSeconds.WithLabelValues(jobID, engine, string(TaskStatusFailed)).Observe(duration)
+				}
 			}
 		}
 	} else if enforceClaim && errors.Is(err, gorm.ErrRecordNotFound) {
@@ -2266,12 +2701,14 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 		pendingEvents []event.Event
 		jobID         uuid.UUID
 		startedAt     time.Time
+		quarantine    bool
 	)
 	err := withStoreBusyRetry(func() error {
 		attemptEvents := make([]event.Event, 0, 2)
 		var (
-			attemptJobID     uuid.UUID
-			attemptStartedAt time.Time
+			attemptJobID      uuid.UUID
+			attemptStartedAt  time.Time
+			attemptQuarantine bool
 		)
 		txErr := s.db.Transaction(func(tx *gorm.DB) error {
 			// Idempotency guard: skip if the run is already terminal.  Run-owner
@@ -2296,11 +2733,12 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 			// Read jobID + startedAt inside the same retried transaction so the
 			// post-commit metrics/gauge bookkeeping always has them.
 			var jr models.JobRun
-			if err := tx.Select("job_id", "started_at").First(&jr, "id = ?", runID).Error; err != nil {
+			if err := tx.Select("job_id", "started_at", "quarantine").First(&jr, "id = ?", runID).Error; err != nil {
 				return err
 			}
 			attemptJobID = jr.JobID
 			attemptStartedAt = jr.StartedAt
+			attemptQuarantine = jr.Quarantine
 
 			if s.eventStore != nil {
 				loaded, loadErr := s.loadRunWithDB(tx, runID)
@@ -2318,11 +2756,12 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 				}
 
 				completionEvent := event.Event{
-					Type:      eventType,
-					JobID:     loaded.JobID,
-					RunID:     runID,
-					Timestamp: now,
-					Payload:   payload,
+					Type:       eventType,
+					JobID:      loaded.JobID,
+					RunID:      runID,
+					Timestamp:  now,
+					Payload:    payload,
+					Quarantine: loaded.Quarantine || attemptQuarantine,
 				}
 				if err := s.eventStore.AppendTx(tx, &completionEvent); err != nil {
 					return err
@@ -2330,11 +2769,12 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 				attemptEvents = append(attemptEvents, completionEvent)
 
 				terminalEvent := event.Event{
-					Type:      event.TypeRunTerminal,
-					JobID:     loaded.JobID,
-					RunID:     runID,
-					Timestamp: now,
-					Payload:   payload,
+					Type:       event.TypeRunTerminal,
+					JobID:      loaded.JobID,
+					RunID:      runID,
+					Timestamp:  now,
+					Payload:    payload,
+					Quarantine: loaded.Quarantine || attemptQuarantine,
 				}
 				if err := s.eventStore.AppendTx(tx, &terminalEvent); err != nil {
 					return err
@@ -2348,6 +2788,7 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 			pendingEvents = attemptEvents
 			jobID = attemptJobID
 			startedAt = attemptStartedAt
+			quarantine = attemptQuarantine
 		}
 		return txErr
 	})
@@ -2364,7 +2805,6 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 	// completion write has committed, so retries don't double-count. jobID and
 	// startedAt are guaranteed populated because the transaction succeeded.
 	jobIDStr := jobID.String()
-	metrics.JobRunsTotal.WithLabelValues(jobIDStr, string(status)).Inc()
 	// Only decrement the active gauge if this process incremented it.
 	s.startedMu.Lock()
 	_, started := s.startedRuns[runID]
@@ -2372,10 +2812,13 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 		delete(s.startedRuns, runID)
 	}
 	s.startedMu.Unlock()
-	if started {
-		metrics.JobsActive.WithLabelValues(jobIDStr).Dec()
+	if !quarantine {
+		metrics.JobRunsTotal.WithLabelValues(jobIDStr, string(status)).Inc()
+		if started {
+			metrics.JobsActive.WithLabelValues(jobIDStr).Dec()
+		}
+		metrics.JobRunDurationSeconds.WithLabelValues(jobIDStr, string(status)).Observe(now.Sub(startedAt).Seconds())
 	}
-	metrics.JobRunDurationSeconds.WithLabelValues(jobIDStr, string(status)).Observe(now.Sub(startedAt).Seconds())
 
 	s.publishEvents(pendingEvents...)
 	return nil
@@ -2402,7 +2845,7 @@ func (s *Store) ResetInFlightTasks(runID uuid.UUID) error {
 
 func (s *Store) FindRunning(jobID uuid.UUID) (*JobRun, error) {
 	var model models.JobRun
-	err := s.db.Where("job_id = ? AND status = ?", jobID, string(StatusRunning)).
+	err := s.db.Where("job_id = ? AND status = ? AND quarantine IS NOT TRUE", jobID, string(StatusRunning)).
 		Order("started_at DESC").
 		First(&model).Error
 	if err != nil {
@@ -2427,7 +2870,7 @@ func (s *Store) List(jobID uuid.UUID) ([]*JobRun, error) {
 		Select("job_runs.*, jobs.alias as job_alias, triggers.type as trigger_type, triggers.alias as trigger_alias").
 		Joins("join jobs on jobs.id = job_runs.job_id").
 		Joins("left join triggers on triggers.id = job_runs.trigger_id").
-		Where("job_runs.job_id = ?", jobID).
+		Where("job_runs.job_id = ? AND job_runs.quarantine IS NOT TRUE", jobID).
 		Order("job_runs.started_at ASC").
 		Preload("Tasks").
 		Scan(&results).Error
@@ -2453,7 +2896,7 @@ func (s *Store) List(jobID uuid.UUID) ([]*JobRun, error) {
 
 func (s *Store) Latest(jobID uuid.UUID) (*JobRun, error) {
 	var model models.JobRun
-	err := s.db.Where("job_id = ?", jobID).
+	err := s.db.Where("job_id = ? AND quarantine IS NOT TRUE", jobID).
 		Order("started_at DESC").
 		First(&model).Error
 	if err != nil {
@@ -2468,7 +2911,7 @@ func (s *Store) Latest(jobID uuid.UUID) (*JobRun, error) {
 func (s *Store) LatestSuccessfulCronRun(jobID uuid.UUID) (*JobRun, error) {
 	var model models.JobRun
 	err := s.db.
-		Where("job_id = ? AND status = ? AND trigger_type = ?", jobID, string(StatusSucceeded), "cron").
+		Where("job_id = ? AND status = ? AND trigger_type = ? AND quarantine IS NOT TRUE", jobID, string(StatusSucceeded), "cron").
 		Order("started_at DESC").
 		First(&model).Error
 	if err != nil {
@@ -2535,6 +2978,7 @@ func (s *Store) convertRunModelWithDB(conn *gorm.DB, model *models.JobRun) (*Job
 		JobID:      model.JobID,
 		BackfillID: model.BackfillID,
 		Status:     Status(model.Status),
+		Quarantine: model.Quarantine,
 		StartedAt:  model.StartedAt,
 		CreatedAt:  model.CreatedAt,
 		UpdatedAt:  model.UpdatedAt,
@@ -2604,6 +3048,7 @@ func convertRunTaskModel(model *models.TaskRun) *TaskRun {
 		CreatedAt:               model.CreatedAt,
 		UpdatedAt:               model.UpdatedAt,
 		CacheHit:                model.CacheHit || TaskStatus(model.Status) == TaskStatusCached,
+		Quarantine:              model.Quarantine,
 		ReplaySafe:              model.ReplaySafe,
 	}
 
@@ -2731,12 +3176,13 @@ func (s *Store) recordTaskEventTx(db *gorm.DB, eventType event.Type, runID, task
 	}
 
 	evt := event.Event{
-		Type:      eventType,
-		JobID:     jobRun.JobID,
-		RunID:     runID,
-		TaskID:    taskID,
-		Timestamp: time.Now().UTC(),
-		Payload:   payload,
+		Type:       eventType,
+		JobID:      jobRun.JobID,
+		RunID:      runID,
+		TaskID:     taskID,
+		Timestamp:  time.Now().UTC(),
+		Payload:    payload,
+		Quarantine: taskRun.Quarantine || jobRun.Quarantine,
 	}
 	if s.eventStore != nil {
 		if err := s.eventStore.AppendTx(db, &evt); err != nil {
@@ -2934,6 +3380,52 @@ func (s *Store) PredecessorOutputs(runID, taskID uuid.UUID) (map[string]map[stri
 	return result, nil
 }
 
+// PredecessorDescriptorInputs returns predecessor outputs and effective hashes
+// keyed by predecessor task id for immutable execution-descriptor capture.
+func (s *Store) PredecessorDescriptorInputs(runID, taskID uuid.UUID) (map[uuid.UUID]map[string]string, map[uuid.UUID]string, error) {
+	var edges []models.TaskEdge
+	if err := s.db.Where("to_task_id = ?", taskID).Find(&edges).Error; err != nil {
+		return nil, nil, err
+	}
+	if len(edges) == 0 {
+		return nil, nil, nil
+	}
+
+	predTaskIDs := make([]uuid.UUID, len(edges))
+	for i, edge := range edges {
+		predTaskIDs[i] = edge.FromTaskID
+	}
+
+	var taskRuns []models.TaskRun
+	if err := s.db.
+		Select("task_id", "output", "hash", "effective_hash", "status").
+		Where("job_run_id = ? AND task_id IN ?", runID, predTaskIDs).
+		Find(&taskRuns).Error; err != nil {
+		return nil, nil, err
+	}
+
+	outputs := make(map[uuid.UUID]map[string]string, len(taskRuns))
+	hashes := make(map[uuid.UUID]string, len(taskRuns))
+	for _, taskRun := range taskRuns {
+		if len(taskRun.Output) > 0 {
+			var output map[string]string
+			if err := json.Unmarshal(taskRun.Output, &output); err == nil && len(output) > 0 {
+				outputs[taskRun.TaskID] = output
+			}
+		}
+		if taskRun.Status == string(TaskStatusSucceeded) || taskRun.Status == string(TaskStatusCached) {
+			hash := taskRun.Hash
+			if taskRun.EffectiveHash != "" {
+				hash = taskRun.EffectiveHash
+			}
+			if hash != "" {
+				hashes[taskRun.TaskID] = hash
+			}
+		}
+	}
+	return outputs, hashes, nil
+}
+
 // PredecessorHashes returns the execution hashes recorded on predecessor task
 // runs that completed successfully in the current run. This keeps distributed
 // cache hashing aligned with local execution, including transitive cache hits.
@@ -3006,6 +3498,7 @@ func effectiveTaskHash(hash, effectiveHash string) string {
 func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 	pendingEvents := make([]event.Event, 0, 2)
 	var jobID uuid.UUID
+	var quarantine bool
 	var counts dbWriteCounts
 
 	err := s.db.Transaction(func(tx *gorm.DB) error {
@@ -3018,6 +3511,7 @@ func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 			return fmt.Errorf("can only retry runs in terminal state, current: %s", jobRun.Status)
 		}
 		jobID = jobRun.JobID
+		quarantine = jobRun.Quarantine
 
 		// 2. Reset the job run status to running.
 		if err := tx.Model(&jobRun).Updates(map[string]interface{}{
@@ -3112,11 +3606,12 @@ func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 				return marshalErr
 			}
 			evt := event.Event{
-				Type:      event.TypeRunRetried,
-				JobID:     jobRun.JobID,
-				RunID:     runID,
-				Timestamp: time.Now().UTC(),
-				Payload:   payload,
+				Type:       event.TypeRunRetried,
+				JobID:      jobRun.JobID,
+				RunID:      runID,
+				Timestamp:  time.Now().UTC(),
+				Payload:    payload,
+				Quarantine: jobRun.Quarantine,
 			}
 			if err := s.eventStore.AppendTx(tx, &evt); err != nil {
 				return err
@@ -3133,11 +3628,13 @@ func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 	counts.commit()
 	s.publishEvents(pendingEvents...)
 
-	// Track this run in the active set so Complete() will decrement the gauge.
-	s.startedMu.Lock()
-	s.startedRuns[runID] = struct{}{}
-	s.startedMu.Unlock()
-	metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
+	if !quarantine {
+		// Track this run in the active set so Complete() will decrement the gauge.
+		s.startedMu.Lock()
+		s.startedRuns[runID] = struct{}{}
+		s.startedMu.Unlock()
+		metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
+	}
 
 	return s.loadRun(runID)
 }

--- a/internal/run/store_test.go
+++ b/internal/run/store_test.go
@@ -1,14 +1,19 @@
 package run
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/lineage"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/container"
 	"github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/google/uuid"
 	"github.com/mattn/go-sqlite3"
@@ -16,6 +21,308 @@ import (
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
+
+type recordingLineageTransport struct {
+	mu     sync.Mutex
+	events []lineage.RunEvent
+}
+
+func (t *recordingLineageTransport) Emit(_ context.Context, evt lineage.RunEvent) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, evt)
+	return nil
+}
+
+func (t *recordingLineageTransport) Close() error {
+	return nil
+}
+
+func (t *recordingLineageTransport) Count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.events)
+}
+
+func TestStartQuarantinedRunStartedEventCarriesMarker(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		testutil.CloseDB(db)
+	})
+
+	store := NewStore(db)
+	bus := event.New()
+	store.SetBus(bus)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	published, err := bus.Subscribe(ctx, event.Filter{
+		Types:             []event.Type{event.TypeRunStarted},
+		IncludeQuarantine: true,
+	})
+	require.NoError(t, err)
+
+	transport := &recordingLineageTransport{}
+	lineageReady := make(chan struct{})
+	lineageDone := make(chan error, 1)
+	go func() {
+		lineageDone <- lineage.NewSubscriber(bus, transport, "caesium-test", db).StartWithReady(ctx, lineageReady)
+	}()
+	select {
+	case <-lineageReady:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for lineage subscriber")
+	}
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-lineageDone:
+			require.NoError(t, err)
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for lineage subscriber shutdown")
+		}
+	})
+
+	const callbackName = "test:quarantine_job_run_before_create"
+	require.NoError(t, db.Callback().Create().Before("gorm:create").Register(callbackName, func(tx *gorm.DB) {
+		if tx.Statement.Schema != nil && tx.Statement.Schema.Table == "job_runs" {
+			tx.Statement.SetColumn("Quarantine", true)
+		}
+	}))
+	t.Cleanup(func() {
+		_ = db.Callback().Create().Remove(callbackName)
+	})
+
+	runRecord, err := store.Start(uuid.New(), nil)
+	require.NoError(t, err)
+	require.True(t, runRecord.Quarantine)
+
+	var persisted models.ExecutionEvent
+	require.NoError(t, db.First(&persisted, "run_id = ? AND type = ?", runRecord.ID, string(event.TypeRunStarted)).Error)
+	require.True(t, persisted.Quarantine)
+
+	select {
+	case got := <-published:
+		require.Equal(t, event.TypeRunStarted, got.Type)
+		require.Equal(t, runRecord.ID, got.RunID)
+		require.True(t, got.Quarantine)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for published run_started event")
+	}
+
+	require.Equal(t, 0, transport.Count(), "lineage transport must not receive quarantined run_started")
+}
+
+func TestTaskExecutionDescriptorCaptureCoversContainerSpecFields(t *testing.T) {
+	descriptorType := reflect.TypeOf(models.TaskExecutionDescriptor{})
+
+	containerField, ok := descriptorType.FieldByName("ContainerSpec")
+	require.True(t, ok, "descriptor must carry the runtime container spec")
+	require.Equal(t, reflect.TypeOf(container.Spec{}), containerField.Type)
+
+	kubernetesField, ok := descriptorType.FieldByName("KubernetesSpec")
+	require.True(t, ok, "descriptor must carry the Kubernetes workload identity spec")
+	require.Equal(t, reflect.TypeOf((*container.KubernetesSpec)(nil)), kubernetesField.Type)
+
+	// These explicit lists intentionally force a descriptor review when either
+	// container carrier grows, even though v1 currently stores the structs whole.
+	require.ElementsMatch(t,
+		[]string{"Env", "WorkDir", "Mounts", "ResolvedVolumeMounts", "Kubernetes"},
+		exportedFieldNames(reflect.TypeOf(container.Spec{})),
+	)
+	require.ElementsMatch(t,
+		[]string{"ServiceAccountName", "PodAnnotations", "AutomountServiceAccountToken", "QueueName"},
+		exportedFieldNames(reflect.TypeOf(container.KubernetesSpec{})),
+	)
+}
+
+func exportedFieldNames(rt reflect.Type) []string {
+	names := make([]string, 0, rt.NumField())
+	for i := 0; i < rt.NumField(); i++ {
+		field := rt.Field(i)
+		if field.IsExported() {
+			names = append(names, field.Name)
+		}
+	}
+	return names
+}
+
+func TestRegisterTaskPersistsInitialExecutionDescriptorEnvelope(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		testutil.CloseDB(db)
+	})
+
+	store := NewStore(db)
+	now := time.Now().UTC()
+
+	trigger := &models.Trigger{
+		ID:            uuid.New(),
+		Alias:         "descriptor-trigger",
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"cron":"0 * * * *","timezone":"UTC"}`,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	require.NoError(t, db.Create(trigger).Error)
+
+	job := &models.Job{
+		ID:               uuid.New(),
+		Alias:            "descriptor-job",
+		TriggerID:        trigger.ID,
+		Labels:           datatypes.JSONMap{"team": "data"},
+		Annotations:      datatypes.JSONMap{"owner": "etl"},
+		MaxParallelTasks: 4,
+		TaskTimeout:      2 * time.Minute,
+		RunTimeout:       10 * time.Minute,
+		SLA:              datatypes.JSON(`{"completedBy":"09:00"}`),
+		SchemaValidation: jobdef.SchemaValidationFail,
+		ReplaySafe:       true,
+		CacheConfig:      datatypes.JSON(`{"ttl":"1h","version":3,"pinDigests":true,"digestTTL":"5m"}`),
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	require.NoError(t, db.Create(job).Error)
+
+	runRecord, err := store.Start(job.ID, &trigger.ID, map[string]string{"logical_date": "2026-06-25"})
+	require.NoError(t, err)
+
+	automount := false
+	spec := container.Spec{
+		Env: map[string]string{
+			"API_TOKEN": "secret://env/API_TOKEN",
+			"MODE":      "batch",
+		},
+		WorkDir: "/workspace",
+		Mounts: []container.Mount{{
+			Type:     container.MountTypeBind,
+			Source:   "/data/in",
+			Target:   "/input",
+			ReadOnly: true,
+		}},
+		ResolvedVolumeMounts: []container.VolumeMount{{
+			Name:     "scratch",
+			Type:     container.VolumeMountTypePVC,
+			Source:   "scratch-pvc",
+			Target:   "/scratch",
+			ReadOnly: false,
+			SubPath:  "runs",
+		}},
+		Kubernetes: &container.KubernetesSpec{
+			ServiceAccountName:           "replay-runner",
+			PodAnnotations:               map[string]string{"sidecar.istio.io/inject": "false"},
+			AutomountServiceAccountToken: &automount,
+			QueueName:                    "etl-high",
+		},
+	}
+	specJSON, err := json.Marshal(spec)
+	require.NoError(t, err)
+
+	atom := &models.Atom{
+		ID:        uuid.New(),
+		Engine:    models.AtomEngineKubernetes,
+		Image:     "busybox:1.36.1",
+		Command:   `["sh","-c","echo hi"]`,
+		Spec:      specJSON,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	require.NoError(t, db.Create(atom).Error)
+
+	task := &models.Task{
+		ID:           uuid.New(),
+		JobID:        job.ID,
+		AtomID:       atom.ID,
+		Name:         "load",
+		Position:     7,
+		Type:         "task",
+		NodeSelector: datatypes.JSONMap{"disk": "ssd"},
+		Retries:      2,
+		RetryDelay:   30 * time.Second,
+		RetryBackoff: true,
+		InputSchema:  datatypes.JSON(`{"extract":{"type":"object","required":["path"]}}`),
+		OutputSchema: datatypes.JSON(`{"type":"object","required":["rows"]}`),
+		ReplaySafe:   true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	require.NoError(t, db.Create(task).Error)
+
+	require.NoError(t, store.RegisterTask(runRecord.ID, task, atom, 1))
+
+	var persisted models.TaskRun
+	require.NoError(t, db.First(&persisted, "job_run_id = ? AND task_id = ?", runRecord.ID, task.ID).Error)
+
+	var descriptor models.TaskExecutionDescriptor
+	require.NoError(t, json.Unmarshal(persisted.ExecutionDescriptor, &descriptor))
+
+	require.Equal(t, models.TaskExecutionDescriptorSchemaVersion, descriptor.SchemaVersion)
+	require.Equal(t, job.ID, descriptor.Baseline.JobID)
+	require.Equal(t, job.Alias, descriptor.Baseline.JobAlias)
+	require.Equal(t, task.ID, descriptor.Baseline.TaskID)
+	require.Equal(t, task.Name, descriptor.Baseline.TaskName)
+	require.Equal(t, atom.ID, descriptor.Baseline.AtomID)
+	require.Equal(t, runRecord.ID, descriptor.Baseline.BaselineRunID)
+	require.Equal(t, trigger.ID, descriptor.Baseline.TriggerID)
+	require.Equal(t, string(models.TriggerTypeCron), descriptor.Baseline.TriggerType)
+	require.Equal(t, trigger.Alias, descriptor.Baseline.TriggerAlias)
+	require.True(t, descriptor.Baseline.ReplaySafe)
+	require.False(t, descriptor.Baseline.Quarantine)
+	require.Equal(t, map[string]string{"logical_date": "2026-06-25"}, descriptor.Run.Params)
+
+	require.Equal(t, models.AtomEngineKubernetes, descriptor.Runtime.Engine)
+	require.Equal(t, atom.Image, descriptor.Runtime.Image)
+	require.Equal(t, []string{"sh", "-c", "echo hi"}, descriptor.Runtime.Command)
+	require.Equal(t, atom.Command, descriptor.Runtime.CommandRaw)
+	require.Equal(t, "/workspace", descriptor.Runtime.WorkDir)
+	require.Equal(t, "task", descriptor.Runtime.TaskType)
+	require.Equal(t, map[string]string{"disk": "ssd"}, descriptor.Runtime.NodeSelector)
+	require.Equal(t, 2, descriptor.Runtime.RetryCount)
+	require.Equal(t, 30*time.Second, descriptor.Runtime.RetryDelay)
+	require.True(t, descriptor.Runtime.RetryBackoff)
+
+	require.Equal(t, 2*time.Minute, descriptor.Timing.TaskTimeout)
+	require.Equal(t, 10*time.Minute, descriptor.Timing.RunTimeout)
+	require.True(t, descriptor.Cache.Enabled)
+	require.Equal(t, time.Hour, descriptor.Cache.TTL)
+	require.Equal(t, 3, descriptor.Cache.Version)
+	require.True(t, descriptor.Cache.PinDigests)
+	require.Equal(t, 5*time.Minute, descriptor.Cache.DigestTTL)
+
+	require.JSONEq(t, string(task.InputSchema), string(descriptor.Schema.InputSchema))
+	require.JSONEq(t, string(task.OutputSchema), string(descriptor.Schema.OutputSchema))
+	require.Equal(t, jobdef.SchemaValidationFail, descriptor.Schema.ValidationMode)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(persisted.ExecutionDescriptor, &raw))
+	schemaRaw, ok := raw["schema"].(map[string]any)
+	require.True(t, ok)
+	require.NotContains(t, schemaRaw, "violationBehavior")
+
+	require.Equal(t, 4, descriptor.Job.MaxParallelTasks)
+	require.Equal(t, map[string]string{"team": "data"}, descriptor.Job.Labels)
+	require.Equal(t, map[string]string{"owner": "etl"}, descriptor.Job.Annotations)
+	require.JSONEq(t, string(job.SLA), string(descriptor.Job.SLA))
+	require.JSONEq(t, string(job.CacheConfig), string(descriptor.Job.CacheDefaults))
+	require.Equal(t, "UTC", descriptor.Job.TriggerConfig["timezone"])
+
+	require.Equal(t, spec.Env, descriptor.ContainerSpec.Env)
+	require.Equal(t, spec.WorkDir, descriptor.ContainerSpec.WorkDir)
+	require.Equal(t, spec.Mounts, descriptor.ContainerSpec.Mounts)
+	require.Equal(t, spec.ResolvedVolumeMounts, descriptor.ContainerSpec.ResolvedVolumeMounts)
+	require.NotNil(t, descriptor.KubernetesSpec)
+	require.Equal(t, "replay-runner", descriptor.KubernetesSpec.ServiceAccountName)
+	require.Equal(t, map[string]string{"sidecar.istio.io/inject": "false"}, descriptor.KubernetesSpec.PodAnnotations)
+	require.NotNil(t, descriptor.KubernetesSpec.AutomountServiceAccountToken)
+	require.False(t, *descriptor.KubernetesSpec.AutomountServiceAccountToken)
+	require.Equal(t, "etl-high", descriptor.KubernetesSpec.QueueName)
+
+	require.Len(t, descriptor.SecretRefs, 1)
+	require.Equal(t, "API_TOKEN", descriptor.SecretRefs[0].EnvKey)
+	require.Equal(t, "secret://env/API_TOKEN", descriptor.SecretRefs[0].Ref)
+	require.False(t, descriptor.SecretRefs[0].Verifiable)
+	require.Contains(t, descriptor.SecretRefs[0].UnverifiableReason, "not resolved yet")
+}
 
 func TestStorePersistsRunState(t *testing.T) {
 	db := testutil.OpenTestDB(t)

--- a/internal/run/store_test.go
+++ b/internal/run/store_test.go
@@ -324,6 +324,53 @@ func TestRegisterTaskPersistsInitialExecutionDescriptorEnvelope(t *testing.T) {
 	require.Contains(t, descriptor.SecretRefs[0].UnverifiableReason, "not resolved yet")
 }
 
+func TestTaskExecutionDescriptorMutationRetriesConcurrentChange(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	runID, taskID := registerSingleTaskRun(t, store, db)
+
+	// mutateTaskExecutionDescriptor uses optimistic CAS-with-retry (no enclosing
+	// transaction). Under real concurrency, two writers adding distinct secret
+	// refs must BOTH survive: when one writer's conditional UPDATE misses (the
+	// row changed since its read), it re-reads and re-merges rather than
+	// clobbering. Drive that with two goroutines released together to maximize
+	// interleaving — a synthetic re-entrant callback would deadlock SQLite's
+	// single writer.
+	refs := []models.TaskExecutionSecretRef{
+		{Ref: "secret://env/API_TOKEN", EnvKey: "API_TOKEN", Provider: "env", Verifiable: false},
+		{Ref: "secret://env/DB_PASSWORD", EnvKey: "DB_PASSWORD", Provider: "env", Verifiable: false},
+	}
+	var wg sync.WaitGroup
+	errs := make([]error, len(refs))
+	start := make(chan struct{})
+	for i := range refs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			errs[i] = store.UpdateTaskExecutionDescriptorSecretRefs(runID, taskID, []models.TaskExecutionSecretRef{refs[i]})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	for _, err := range errs {
+		require.NoError(t, err)
+	}
+
+	var persisted models.TaskRun
+	require.NoError(t, db.Select("execution_descriptor").First(&persisted, "job_run_id = ? AND task_id = ?", runID, taskID).Error)
+	var descriptor models.TaskExecutionDescriptor
+	require.NoError(t, json.Unmarshal(persisted.ExecutionDescriptor, &descriptor))
+	envKeys := make(map[string]bool)
+	for _, r := range descriptor.SecretRefs {
+		envKeys[r.EnvKey] = true
+	}
+	require.True(t, envKeys["API_TOKEN"], "API_TOKEN ref lost to a concurrent descriptor write")
+	require.True(t, envKeys["DB_PASSWORD"], "DB_PASSWORD ref lost to a concurrent descriptor write")
+}
+
 func TestStorePersistsRunState(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() {
@@ -780,6 +827,52 @@ func TestRegisterTasksReturnsMissingJobRunError(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "job run")
+}
+
+func TestBatchEventQuarantineStampUsesRunAndTaskMarkers(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	runID, taskA := registerSingleTaskRun(t, store, db)
+	var taskRunA models.TaskRun
+	require.NoError(t, db.First(&taskRunA, "job_run_id = ? AND task_id = ?", runID, taskA).Error)
+	var jobRun models.JobRun
+	require.NoError(t, db.First(&jobRun, "id = ?", runID).Error)
+
+	now := time.Now().UTC()
+	atom := &models.Atom{ID: uuid.New(), Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["echo","b"]`, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(atom).Error)
+	taskB := &models.Task{ID: uuid.New(), JobID: jobRun.JobID, AtomID: atom.ID, Name: "batch-b", CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(taskB).Error)
+	require.NoError(t, store.RegisterTask(runID, taskB, atom, 0))
+
+	require.NoError(t, db.Model(&models.JobRun{}).Where("id = ?", runID).Update("quarantine", true).Error)
+	runMarked := []*event.Event{
+		{Type: event.TypeRunStarted, RunID: runID},
+		{Type: event.TypeTaskReady, RunID: runID, TaskID: taskA},
+		{Type: event.TypeTaskReady, RunID: runID, TaskID: taskB.ID},
+	}
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return store.stampBatchEventQuarantineTx(tx, runMarked)
+	}))
+	for _, evt := range runMarked {
+		require.True(t, evt.Quarantine, "run-level quarantine should mark every batch event")
+	}
+
+	require.NoError(t, db.Model(&models.JobRun{}).Where("id = ?", runID).Update("quarantine", false).Error)
+	require.NoError(t, db.Model(&models.TaskRun{}).Where("job_run_id = ? AND task_id = ?", runID, taskA).Update("quarantine", true).Error)
+	taskMarked := []*event.Event{
+		{Type: event.TypeRunStarted, RunID: runID},
+		{Type: event.TypeTaskReady, RunID: runID, TaskID: taskA},
+		{Type: event.TypeTaskReady, RunID: runID, TaskID: taskB.ID},
+	}
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return store.stampBatchEventQuarantineTx(tx, taskMarked)
+	}))
+	require.False(t, taskMarked[0].Quarantine)
+	require.True(t, taskMarked[1].Quarantine)
+	require.False(t, taskMarked[2].Quarantine)
 }
 
 func TestWithStoreBusyRetryRetriesSQLiteContention(t *testing.T) {

--- a/internal/trigger/http/http_test.go
+++ b/internal/trigger/http/http_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -24,6 +25,14 @@ type stubSecretResolver struct {
 
 func (s stubSecretResolver) Resolve(ctx context.Context, ref string) (string, error) {
 	return s.resolve(ctx, ref)
+}
+
+func (s stubSecretResolver) ResolveWithIdentity(ctx context.Context, ref string) (string, secret.Identity, error) {
+	value, err := s.resolve(ctx, ref)
+	if err != nil {
+		return "", secret.Identity{}, err
+	}
+	return value, secret.Identity{Provider: "env", Ref: ref, Verifiable: false, UnverifiableReason: "test stub"}, nil
 }
 
 func TestNewParsesConfiguration(t *testing.T) {

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -151,7 +151,9 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 		return nil, err
 	}
 	if claimed != nil {
-		metrics.WorkerClaimsTotal.WithLabelValues(c.nodeID).Inc()
+		if !claimed.Quarantine {
+			metrics.WorkerClaimsTotal.WithLabelValues(c.nodeID).Inc()
+		}
 		metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 		metrics.DBStatementsTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
 		counts.commit()
@@ -355,11 +357,13 @@ func nodeSelectorIteratorSQL(dialect, jsonExpr string) string {
 func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 	start := time.Now()
 	defer func() {
+		// Control-plane node-load series: intentionally includes replay work and
+		// is not a run-health input.
 		metrics.ReclaimDurationSeconds.Observe(time.Since(start).Seconds())
 	}()
 
 	pendingEvents := make([]event.Event, 0, 8)
-	var reclaimedCount int64
+	var productionReclaimedCount int64
 	var counts dbWriteCounts
 	err := withBusyRetry(ctx, c.busyRetryBackoffs, func() error {
 		if err := ctx.Err(); err != nil {
@@ -369,7 +373,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 		now := time.Now().UTC()
 		counts.reset()
 		attemptEvents := make([]event.Event, 0, 8)
-		var attemptReclaimedCount int64
+		var attemptProductionReclaimedCount int64
 
 		err := c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 			runningRunIDs := tx.Model(&models.JobRun{}).
@@ -425,7 +429,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 						continue
 					}
 					var jobRun models.JobRun
-					if err := tx.Select("job_id").First(&jobRun, "id = ?", taskRun.JobRunID).Error; err != nil {
+					if err := tx.Select("job_id", "quarantine").First(&jobRun, "id = ?", taskRun.JobRunID).Error; err != nil {
 						return err
 					}
 					jobRunByID[taskRun.JobRunID] = jobRun
@@ -435,6 +439,10 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				eventRecords := make([]models.ExecutionEvent, 0, len(expired)*2)
 				for _, taskRun := range expired {
 					jobRun := jobRunByID[taskRun.JobRunID]
+					quarantined := taskRun.Quarantine || jobRun.Quarantine
+					if !quarantined {
+						attemptProductionReclaimedCount++
+					}
 					jobIDPtr := &jobRun.JobID
 					runIDCopy := taskRun.JobRunID
 					taskIDCopy := taskRun.TaskID
@@ -444,6 +452,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 							JobID:              jobIDPtr,
 							RunID:              &runIDCopy,
 							TaskID:             &taskIDCopy,
+							Quarantine:         quarantined,
 							BusDispatchPending: true,
 							CreatedAt:          now,
 						},
@@ -452,6 +461,7 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 							JobID:              jobIDPtr,
 							RunID:              &runIDCopy,
 							TaskID:             &taskIDCopy,
+							Quarantine:         quarantined,
 							BusDispatchPending: true,
 							CreatedAt:          now,
 						},
@@ -466,28 +476,28 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 				for i := range eventRecords {
 					rec := &eventRecords[i]
 					attemptEvents = append(attemptEvents, event.Event{
-						Sequence:  rec.Sequence,
-						Type:      event.Type(rec.Type),
-						JobID:     derefUUID(rec.JobID),
-						RunID:     derefUUID(rec.RunID),
-						TaskID:    derefUUID(rec.TaskID),
-						Timestamp: rec.CreatedAt,
+						Sequence:   rec.Sequence,
+						Type:       event.Type(rec.Type),
+						JobID:      derefUUID(rec.JobID),
+						RunID:      derefUUID(rec.RunID),
+						TaskID:     derefUUID(rec.TaskID),
+						Quarantine: rec.Quarantine,
+						Timestamp:  rec.CreatedAt,
 					})
 				}
 			}
-			attemptReclaimedCount = result.RowsAffected
 			return nil
 		})
 		if err == nil {
 			pendingEvents = attemptEvents
-			reclaimedCount = attemptReclaimedCount
+			productionReclaimedCount = attemptProductionReclaimedCount
 		}
 		return err
 	}, c.observeBusyRetry)
 	if err == nil {
 		counts.commit()
-		if reclaimedCount > 0 {
-			metrics.WorkerLeaseExpirationsTotal.WithLabelValues(c.nodeID).Add(float64(reclaimedCount))
+		if productionReclaimedCount > 0 {
+			metrics.WorkerLeaseExpirationsTotal.WithLabelValues(c.nodeID).Add(float64(productionReclaimedCount))
 		}
 		c.store.PublishEvents(pendingEvents...)
 	}
@@ -495,6 +505,8 @@ func (c *Claimer) ReclaimExpired(ctx context.Context) error {
 }
 
 func (c *Claimer) observeBusyRetry(error) {
+	// Control-plane node-load series: intentionally includes replay work and is
+	// not a run-health input.
 	metrics.WorkerClaimContentionTotal.WithLabelValues(c.nodeID).Inc()
 }
 

--- a/internal/worker/completion_sink.go
+++ b/internal/worker/completion_sink.go
@@ -175,7 +175,9 @@ func (s *ownerSink) send(ctx context.Context, taskRun *models.TaskRun, req dispa
 				// The owner fenced the completion (stale generation, wrong
 				// worker, etc.).  This is not a transport error; the owner
 				// deliberately rejected it.
-				metrics.CompleteReportFailedTotal.WithLabelValues("owner_rejected").Inc()
+				if !taskRun.Quarantine {
+					metrics.CompleteReportFailedTotal.WithLabelValues("owner_rejected").Inc()
+				}
 				log.Warn("dispatched task: owner rejected completion",
 					"run_id", req.RunID,
 					"task_id", req.TaskID,
@@ -205,7 +207,9 @@ func (s *ownerSink) send(ctx context.Context, taskRun *models.TaskRun, req dispa
 		if errors.Is(err, dispatch.ErrOwnerBusy) {
 			reason = "owner_busy"
 		}
-		metrics.CompleteReportFailedTotal.WithLabelValues(reason).Inc()
+		if !taskRun.Quarantine {
+			metrics.CompleteReportFailedTotal.WithLabelValues(reason).Inc()
+		}
 		log.Error("dispatched task: failed to report completion to owner",
 			"run_id", req.RunID,
 			"task_id", req.TaskID,

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -167,6 +167,10 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		if predHashErr != nil {
 			log.Warn("cache: failed to query predecessor hashes", "task_id", taskRun.TaskID, "error", predHashErr)
 		}
+		descriptorPredOutputs, descriptorPredHashes, descriptorErr := e.store.PredecessorDescriptorInputs(taskRun.JobRunID, taskRun.TaskID)
+		if descriptorErr != nil {
+			log.Warn("cache: failed to query predecessor descriptor inputs", "task_id", taskRun.TaskID, "error", descriptorErr)
+		}
 
 		// Build merged env for hashing, excluding volatile per-run vars.
 		mergedEnv := make(map[string]string, len(atomSpec.Env))
@@ -219,6 +223,9 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		if err := e.store.SetTaskHashWithBlob(taskRun.JobRunID, taskRun.TaskID, cacheHash, resolvedImageDigest, hashInputBlob); err != nil {
 			log.Warn("cache: failed to persist task hash", "task_id", taskRun.TaskID, "hash", cacheHash, "error", err)
 		}
+		if err := e.store.UpdateTaskExecutionDescriptorInputs(taskRun.JobRunID, taskRun.TaskID, descriptorPredOutputs, descriptorPredHashes, cacheHash, resolvedImageDigest, hashInputBlob); err != nil {
+			log.Warn("cache: failed to persist task execution descriptor inputs", "task_id", taskRun.TaskID, "error", err)
+		}
 
 		if cacheStore != nil {
 			entry, found, getErr := cacheStore.Get(cacheHash)
@@ -238,7 +245,9 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 					log.Error("cache: failed to persist cache hit", "task_id", taskRun.TaskID, "error", err)
 					// Fall through to normal execution on persistence failure.
 				} else {
-					metrics.TaskCacheHitsTotal.WithLabelValues(cacheJobAlias, taskName).Inc()
+					if !taskRun.Quarantine {
+						metrics.TaskCacheHitsTotal.WithLabelValues(cacheJobAlias, taskName).Inc()
+					}
 					return
 				}
 			}
@@ -259,8 +268,10 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		execErr := e.executeTask(ctx, taskRun, sink, atomSpec, runParams, resolveJobAlias())
 		if execErr == nil {
 			// Store successful result in cache.
-			if cacheStore != nil && cacheHash != "" {
+			if cacheStore != nil && cacheHash != "" && !taskRun.Quarantine {
 				e.storeCacheEntry(cacheStore, cacheCfg, cacheHash, resolvedImageDigest, hashInputBlob, taskRun, resolveJobAlias())
+			} else if taskRun.Quarantine && cacheStore != nil && cacheHash != "" {
+				log.Info("quarantined worker task skipped cache publication", "task_id", taskRun.TaskID, "hash", cacheHash)
 			}
 			return
 		}
@@ -293,7 +304,9 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 
 		log.Info("retrying worker task", "run_id", taskRun.JobRunID, "task_id", taskRun.TaskID, "attempt", attempt, "next_attempt", attempt+1, "delay", delay, "error", lastErr)
 
-		metrics.TaskRetriesTotal.WithLabelValues(resolveJobAlias(), taskRun.TaskID.String(), strconv.Itoa(attempt)).Inc()
+		if !taskRun.Quarantine {
+			metrics.TaskRetriesTotal.WithLabelValues(resolveJobAlias(), taskRun.TaskID.String(), strconv.Itoa(attempt)).Inc()
+		}
 
 		if retryErr := e.store.RetryTaskClaimed(taskRun.JobRunID, taskRun.TaskID, attempt+1, taskRun.ClaimedBy); retryErr != nil {
 			if errors.Is(retryErr, run.ErrTaskClaimMismatch) {
@@ -417,9 +430,18 @@ func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskR
 		atomName = fmt.Sprintf("%s-attempt%d", atomName, taskRun.ClaimAttempt)
 	}
 
-	spec, err := jobdefruntime.ResolveContainerSpecSecrets(taskCtx, e.secretResolver, atomSpec)
+	spec, secretIdentities, err := jobdefruntime.ResolveContainerSpecSecretsWithIdentities(taskCtx, e.secretResolver, atomSpec)
 	if err != nil {
 		return err
+	}
+	if len(secretIdentities) > 0 {
+		refs := make([]models.TaskExecutionSecretRef, 0, len(secretIdentities))
+		for _, resolved := range secretIdentities {
+			refs = append(refs, run.SecretIdentityDescriptorRef(resolved.EnvKey, resolved.Ref, resolved.Identity))
+		}
+		if err := e.store.UpdateTaskExecutionDescriptorSecretRefs(taskRun.JobRunID, taskRun.TaskID, refs); err != nil {
+			log.Warn("failed to persist worker task execution descriptor secret identity", "task_id", taskRun.TaskID, "error", err)
+		}
 	}
 
 	predOutputs, predErr := e.store.PredecessorOutputs(taskRun.JobRunID, taskRun.TaskID)
@@ -525,6 +547,11 @@ func (e *runtimeExecutor) runSchemaValidation(taskRun *models.TaskRun, output ma
 
 // storeCacheEntry reads back the completed task run and stores the result in the cache.
 func (e *runtimeExecutor) storeCacheEntry(cacheStore *cache.Store, cacheCfg jobdefschema.CacheConfig, hash, resolvedImageDigest string, hashInputBlob []byte, taskRun *models.TaskRun, jobAlias string) {
+	if taskRun.Quarantine {
+		log.Info("quarantined worker task suppressed cache store entry", "task_id", taskRun.TaskID, "hash", hash)
+		return
+	}
+
 	// Read back the completed task run to get output and result.
 	var completed models.TaskRun
 	if err := e.store.DB().Where("job_run_id = ? AND task_id = ?", taskRun.JobRunID, taskRun.TaskID).First(&completed).Error; err != nil {

--- a/internal/worker/runtime_executor_test.go
+++ b/internal/worker/runtime_executor_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/atom"
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	jobdeftestutil "github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
@@ -303,6 +304,81 @@ func TestRuntimeExecutorAppliesAtomSpecSecretsParamsAndOutputs(t *testing.T) {
 	require.Equal(t, "/work/tf.plan", got.Env["CAESIUM_OUTPUT_EXTRACT_PLAN"])
 }
 
+func TestRuntimeExecutorQuarantinedTaskSkipsCacheWrite(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() {
+		jobdeftestutil.CloseDB(db)
+	})
+
+	store := run.NewStore(db)
+	now := time.Now().UTC()
+	trigger := &models.Trigger{ID: uuid.New(), Alias: "trigger", Type: models.TriggerTypeCron, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(trigger).Error)
+	job := &models.Job{ID: uuid.New(), Alias: "worker-quarantine-job", TriggerID: trigger.ID, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(job).Error)
+	atomModel := &models.Atom{
+		ID:        uuid.New(),
+		Engine:    models.AtomEngineDocker,
+		Image:     "alpine:3.23",
+		Command:   `["sh","-c","true"]`,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	require.NoError(t, db.Create(atomModel).Error)
+	task := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atomModel.ID, Name: "deploy", CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(task).Error)
+	jobRun := &models.JobRun{
+		ID:          uuid.New(),
+		JobID:       job.ID,
+		TriggerID:   trigger.ID,
+		TriggerType: string(trigger.Type),
+		Status:      string(run.StatusRunning),
+		Quarantine:  true,
+		StartedAt:   now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	require.NoError(t, db.Create(jobRun).Error)
+	taskRun := &models.TaskRun{
+		ID:           uuid.New(),
+		JobRunID:     jobRun.ID,
+		TaskID:       task.ID,
+		AtomID:       atomModel.ID,
+		Engine:       atomModel.Engine,
+		Image:        atomModel.Image,
+		Command:      atomModel.Command,
+		Status:       string(run.TaskStatusRunning),
+		ClaimedBy:    "node-a",
+		Attempt:      1,
+		MaxAttempts:  1,
+		CacheEnabled: true,
+		CacheVersion: 1,
+		Quarantine:   true,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	require.NoError(t, db.Create(taskRun).Error)
+
+	engine := &captureCreateEngine{}
+	executor := &runtimeExecutor{
+		store:     store,
+		localSink: NewLocalSink(store),
+		engineFactory: func(context.Context, models.AtomEngine) (atom.Engine, error) {
+			return engine, nil
+		},
+	}
+	executor.Execute(context.Background(), taskRun)
+
+	var cacheRows int64
+	require.NoError(t, db.Model(&models.TaskCache{}).Count(&cacheRows).Error)
+	require.Zero(t, cacheRows)
+
+	var persisted models.TaskRun
+	require.NoError(t, db.First(&persisted, "job_run_id = ? AND task_id = ?", jobRun.ID, task.ID).Error)
+	require.Equal(t, string(run.TaskStatusSucceeded), persisted.Status)
+	require.NotEmpty(t, persisted.Hash)
+}
+
 func seedSchemaValidationTaskRun(t *testing.T, schemaValidation string) (*models.TaskRun, *gorm.DB) {
 	t.Helper()
 
@@ -409,11 +485,16 @@ func persistedSchemaViolations(t *testing.T, db *gorm.DB, runID, taskID uuid.UUI
 type staticSecretResolver map[string]string
 
 func (r staticSecretResolver) Resolve(_ context.Context, ref string) (string, error) {
+	value, _, err := r.ResolveWithIdentity(context.Background(), ref)
+	return value, err
+}
+
+func (r staticSecretResolver) ResolveWithIdentity(_ context.Context, ref string) (string, secret.Identity, error) {
 	value, ok := r[ref]
 	if !ok {
-		return "", errors.New("missing secret")
+		return "", secret.Identity{}, errors.New("missing secret")
 	}
-	return value, nil
+	return value, secret.Identity{Provider: "env", Ref: ref, Verifiable: false, UnverifiableReason: "test stub"}, nil
 }
 
 type captureCreateEngine struct {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -527,8 +527,12 @@ func (w *Worker) renewRunLeasesNow(ctx context.Context) {
 	// Always publish the current owned-run count, even when zero, so the
 	// gauge accurately reflects the state instead of holding the last
 	// non-zero value indefinitely.
+	// Control-plane node-load series: intentionally includes replay work and is
+	// not a run-health input.
 	metrics.RunLeasesOwned.Set(float64(rowsAffected))
 	if rowsAffected > 0 {
+		// Control-plane node-load series: intentionally includes replay work and
+		// is not a run-health input.
 		metrics.RunLeaseRenewalsTotal.Inc()
 	}
 }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -66,59 +66,61 @@ func Variables() Environment {
 // Environment defines the environment variables used
 // by caesium.
 type Environment struct {
-	LogLevel                      string        `default:"info" split_words:"true"`
-	LogFormat                     string        `default:"json" split_words:"true"`
-	LogConsoleEnabled             bool          `default:"true" split_words:"true"`
-	Port                          int           `default:"8080"`
-	DockerHost                    string        `default:"" split_words:"true"`
-	KubernetesConfig              string        `default:"" split_words:"true"`
-	KubernetesNamespace           string        `default:"default" split_words:"true"`
-	PodmanURI                     string        `default:"" split_words:"true"`
-	NodeAddress                   string        `default:"127.0.0.1:9001" split_words:"true"`
-	NodeLabels                    string        `default:"" split_words:"true"`
-	DatabaseNodes                 []string      `default:"" split_words:"true"`
-	APIExternalURL                string        `envconfig:"API_EXTERNAL_URL" default:""`
-	DatabasePath                  string        `default:"/var/lib/caesium/dqlite" split_words:"true"`
-	DatabaseType                  string        `default:"internal" split_words:"true"`
-	DatabaseDSN                   string        `default:"host=postgres user=postgres password=postgres dbname=caesium port=5432 sslmode=disable" split_words:"true"`
-	DatabaseMaxOpenConns          int           `default:"4" split_words:"true"`
-	DatabaseMaxIdleConns          int           `default:"2" split_words:"true"`
-	DatabaseShards                int           `default:"1" split_words:"true"`
-	DatabaseVoters                int           `default:"3" split_words:"true"`
-	DatabaseStandbys              int           `default:"3" split_words:"true"`
-	DatabaseConsoleEnabled        bool          `default:"false" split_words:"true"`
-	ManualTriggerAPIKey           string        `envconfig:"MANUAL_TRIGGER_API_KEY" default:""`
-	MaxParallelTasks              int           `split_words:"true"`
-	TaskFailurePolicy             string        `default:"halt" split_words:"true"`
-	TaskTimeout                   time.Duration `default:"0" split_words:"true"`
-	ExecutionMode                 string        `default:"local" split_words:"true"`
-	WorkerEnabled                 bool          `default:"true" split_words:"true"`
-	WorkerPollInterval            time.Duration `default:"15s" split_words:"true"`
-	WorkerReclaimInterval         time.Duration `default:"30s" split_words:"true"`
-	WorkerLeaseTTL                time.Duration `default:"5m" split_words:"true"`
-	WorkerLeaseRenewInterval      time.Duration `default:"0" split_words:"true"`
-	WorkerPoolSize                int           `default:"4" split_words:"true"`
-	ShutdownGracePeriod           time.Duration `envconfig:"SHUTDOWN_GRACE_PERIOD" default:"30s"`
-	InternalWakeupToken           string        `default:"" split_words:"true"`
-	WakeupFanoutMode              string        `default:"full" split_words:"true"`
-	AtomPollInterval              time.Duration `default:"1s" split_words:"true"`
-	JobdefGitEnabled              bool          `envconfig:"JOBDEF_GIT_ENABLED" default:"false"`
-	JobdefGitOnce                 bool          `envconfig:"JOBDEF_GIT_ONCE" default:"false"`
-	JobdefGitInterval             time.Duration `envconfig:"JOBDEF_GIT_INTERVAL" default:"1m"`
-	JobdefGitSources              GitSources    `envconfig:"JOBDEF_GIT_SOURCES"`
-	JobdefSecretsEnableEnv        bool          `envconfig:"JOBDEF_SECRETS_ENABLE_ENV" default:"true"`
-	JobdefSecretsEnableKubernetes bool          `envconfig:"JOBDEF_SECRETS_ENABLE_KUBERNETES" default:"false"`
-	JobdefSecretsKubeConfig       string        `envconfig:"JOBDEF_SECRETS_KUBECONFIG"`
-	JobdefSecretsKubeNamespace    string        `envconfig:"JOBDEF_SECRETS_KUBE_NAMESPACE" default:"default"`
-	JobdefSecretsVaultAddress     string        `envconfig:"JOBDEF_SECRETS_VAULT_ADDRESS"`
-	JobdefSecretsVaultToken       string        `envconfig:"JOBDEF_SECRETS_VAULT_TOKEN"`
-	JobdefSecretsVaultNamespace   string        `envconfig:"JOBDEF_SECRETS_VAULT_NAMESPACE"`
-	JobdefSecretsVaultCACert      string        `envconfig:"JOBDEF_SECRETS_VAULT_CA_CERT"`
-	JobdefSecretsVaultSkipVerify  bool          `envconfig:"JOBDEF_SECRETS_VAULT_SKIP_VERIFY" default:"false"`
-	CacheEnabled                  bool          `default:"false" split_words:"true"`
-	CacheTTL                      time.Duration `default:"24h" split_words:"true"`
-	CachePruneInterval            time.Duration `default:"1h" split_words:"true"`
-	CacheMaxEntries               int           `default:"10000" split_words:"true"`
+	LogLevel                       string        `default:"info" split_words:"true"`
+	LogFormat                      string        `default:"json" split_words:"true"`
+	LogConsoleEnabled              bool          `default:"true" split_words:"true"`
+	Port                           int           `default:"8080"`
+	DockerHost                     string        `default:"" split_words:"true"`
+	KubernetesConfig               string        `default:"" split_words:"true"`
+	KubernetesNamespace            string        `default:"default" split_words:"true"`
+	PodmanURI                      string        `default:"" split_words:"true"`
+	NodeAddress                    string        `default:"127.0.0.1:9001" split_words:"true"`
+	NodeLabels                     string        `default:"" split_words:"true"`
+	DatabaseNodes                  []string      `default:"" split_words:"true"`
+	APIExternalURL                 string        `envconfig:"API_EXTERNAL_URL" default:""`
+	DatabasePath                   string        `default:"/var/lib/caesium/dqlite" split_words:"true"`
+	DatabaseType                   string        `default:"internal" split_words:"true"`
+	DatabaseDSN                    string        `default:"host=postgres user=postgres password=postgres dbname=caesium port=5432 sslmode=disable" split_words:"true"`
+	DatabaseMaxOpenConns           int           `default:"4" split_words:"true"`
+	DatabaseMaxIdleConns           int           `default:"2" split_words:"true"`
+	DatabaseShards                 int           `default:"1" split_words:"true"`
+	DatabaseVoters                 int           `default:"3" split_words:"true"`
+	DatabaseStandbys               int           `default:"3" split_words:"true"`
+	DatabaseConsoleEnabled         bool          `default:"false" split_words:"true"`
+	ManualTriggerAPIKey            string        `envconfig:"MANUAL_TRIGGER_API_KEY" default:""`
+	MaxParallelTasks               int           `split_words:"true"`
+	TaskFailurePolicy              string        `default:"halt" split_words:"true"`
+	TaskTimeout                    time.Duration `default:"0" split_words:"true"`
+	ExecutionMode                  string        `default:"local" split_words:"true"`
+	WorkerEnabled                  bool          `default:"true" split_words:"true"`
+	WorkerPollInterval             time.Duration `default:"15s" split_words:"true"`
+	WorkerReclaimInterval          time.Duration `default:"30s" split_words:"true"`
+	WorkerLeaseTTL                 time.Duration `default:"5m" split_words:"true"`
+	WorkerLeaseRenewInterval       time.Duration `default:"0" split_words:"true"`
+	WorkerPoolSize                 int           `default:"4" split_words:"true"`
+	ShutdownGracePeriod            time.Duration `envconfig:"SHUTDOWN_GRACE_PERIOD" default:"30s"`
+	InternalWakeupToken            string        `default:"" split_words:"true"`
+	WakeupFanoutMode               string        `default:"full" split_words:"true"`
+	AtomPollInterval               time.Duration `default:"1s" split_words:"true"`
+	JobdefGitEnabled               bool          `envconfig:"JOBDEF_GIT_ENABLED" default:"false"`
+	JobdefGitOnce                  bool          `envconfig:"JOBDEF_GIT_ONCE" default:"false"`
+	JobdefGitInterval              time.Duration `envconfig:"JOBDEF_GIT_INTERVAL" default:"1m"`
+	JobdefGitSources               GitSources    `envconfig:"JOBDEF_GIT_SOURCES"`
+	JobdefSecretsEnableEnv         bool          `envconfig:"JOBDEF_SECRETS_ENABLE_ENV" default:"true"`
+	JobdefSecretsEnableKubernetes  bool          `envconfig:"JOBDEF_SECRETS_ENABLE_KUBERNETES" default:"false"`
+	JobdefSecretsKubeConfig        string        `envconfig:"JOBDEF_SECRETS_KUBECONFIG"`
+	JobdefSecretsKubeNamespace     string        `envconfig:"JOBDEF_SECRETS_KUBE_NAMESPACE" default:"default"`
+	JobdefSecretsVaultAddress      string        `envconfig:"JOBDEF_SECRETS_VAULT_ADDRESS"`
+	JobdefSecretsVaultToken        string        `envconfig:"JOBDEF_SECRETS_VAULT_TOKEN"`
+	JobdefSecretsVaultNamespace    string        `envconfig:"JOBDEF_SECRETS_VAULT_NAMESPACE"`
+	JobdefSecretsVaultCACert       string        `envconfig:"JOBDEF_SECRETS_VAULT_CA_CERT"`
+	JobdefSecretsVaultSkipVerify   bool          `envconfig:"JOBDEF_SECRETS_VAULT_SKIP_VERIFY" default:"false"`
+	JobdefSecretsIdentityHMACKeys  string        `envconfig:"JOBDEF_SECRETS_IDENTITY_HMAC_KEYS" default:""`
+	JobdefSecretsIdentityHMACKeyID string        `envconfig:"JOBDEF_SECRETS_IDENTITY_HMAC_KEY_ID" default:""`
+	CacheEnabled                   bool          `default:"false" split_words:"true"`
+	CacheTTL                       time.Duration `default:"24h" split_words:"true"`
+	CachePruneInterval             time.Duration `default:"1h" split_words:"true"`
+	CacheMaxEntries                int           `default:"10000" split_words:"true"`
 	// CachePinDigests is the global default for resolving image tags to content
 	// digests and folding the digest (not the mutable tag) into the cache key.
 	// Off by default so steady-state runs pay no registry round-trip; a job or


### PR DESCRIPTION
## B2 — Quarantine runtime plumbing (the keystone safety item)

Makes a what-if **replay** run non-authoritative (no cache/lineage writes) and side-effect-free (reaches no outward channel) across **both** the local scheduler and the distributed worker. Built off the B1 safety memo (`docs/design-quarantined-replay.md`).

### What landed
- **3 marker carriers:** `Quarantine` on `JobRun` + `TaskRun` (`not null;default:false`, propagated onto every task run at registration); a `ReplayFingerprint` column; `event.Event.Quarantine` on the live bus (stamped at the lifecycle-event chokepoint + inline on `run_started`); a queryable `execution_events.quarantine` column.
- **Both executors** honor cache READS but skip cache-authoritative WRITES, authoritative lineage, and callbacks for quarantined runs (the distributed worker independently short-circuits before `storeCacheEntry`/lineage).
- **Every side-effect producer fail-closed-suppressed:** notification subscriber (before the alert metric), the timeout/SLA watcher, the OpenLineage subscriber (before `transport.Emit` and `lineage_datasets`), and `/events` SSE + backlog.
- **Observability isolation:** run.Store health metrics, notification counters, stats aggregates, and the **cron catch-up watermark** all exclude quarantined runs (`quarantine IS NOT TRUE`).
- **Immutable per-TaskRun execution descriptor** capturing the effective runtime envelope for B3 to replay.
- **Provider-aware secret `ResolveWithIdentity`** (vault KV-v2 version + keyring-versioned HMAC; k8s resourceVersion; env fail-closed).

### Review + fixes
A deep **6-lens adversarial security review** (distributed parity, every-producer-suppressed, observability isolation, descriptor + secret identity, migration/correctness, memo-completeness) with independent verification, plus the unit run, caught and fixed:
- **[blocker]** `run_started` leaked past the suppression chokepoint → would have made a quarantined run lineage-authoritative. Now stamped at both sites.
- **[blocker]** a **production-breaking** Vault KV-v2 version pin (`?version=` concatenated into the path → 404 for every versioned secret at container-create). Now pinned via the data map (`ReadWithDataWithContext`), verified against the real `*vault.Logical`.
- dispatch-metric over-suppression of normal runs (now sourced from `task.Quarantine` in hand); a `BaselineRunID` descriptor gap (the run id wasn't loaded).

A focused re-review confirmed all fixes **RESOLVED** with no fail-open introduced in the side-effect/event suppression.

### Verification
Full chain green: `just lint` + `just unit-test` + `just integration-test` (no normal-run regression). New unit tests: quarantine marker/migration, run_started suppression (real `Store.Start` surface), subscriber drop-before-metric (with positive control), descriptor envelope + KubernetesSpec completeness guard, vault version-on-the-wire.

### Scope notes
- **Quarantine activation** (setting `Quarantine=true`) is **B3** — this PR is the plumbing; the flag is internal-only, never request-settable.
- **Full quarantine integration scenarios** (incl. `/events` SSE quarantine end-to-end) are scoped to **B6**; B2 ships package-level coverage with real DB + auth.

Plan: `docs/exec-plans/active/data-plane-memory-ii.md` (B2).