### PR TITLE
Add replay construction + dispatch (data-plane-memory-ii W5-α)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -881,15 +881,19 @@ write, lineage emit, or callback.
 	      W5-alpha note (2026-06-25): added `internal/replay.New(...).Replay(ctx,
 	      replay.Request{BaselineRunID, Set, ReplayFingerprint})`, returning the
 	      quarantined replay run plus per-task decisions for B4/B5. Guards are
-	      fail-closed: a quarantined baseline is rejected; every baseline task must
-	      have recorded `TaskRun.replay_safe=true` before planning, even if
-	      hash-unchanged; descriptor/row `ReplaySafe` mismatches abort; unchanged
-	      fallback hits require a successful baseline status/result; empty result +
-	      non-empty output aborts as corruption; and all-cached materialization only
-	      stamps the replay succeeded when every cached result is successful.
-	      Re-execution verifies `secret://` coverage in both directions, refuses
-	      unverifiable/empty identities, pins Vault KV-v2 baseline-version reads and
-	      the recorded HMAC key ID, and never overwrites descriptor secret evidence
+	      fail-closed: a quarantined baseline is rejected; descriptor/row
+	      `ReplaySafe` mismatches abort; tasks are planned in descriptor-DAG
+	      topological order (with YAML position only as a ready-task tie-breaker) so
+	      YAML order cannot falsely force a successor to re-execute; any task that
+	      genuinely re-executes must have recorded `TaskRun.replay_safe=true`;
+	      unchanged fallback hits require a successful baseline status/result; empty
+	      result + non-empty output aborts as corruption; and all-cached
+	      materialization only stamps the replay succeeded when every cached result
+	      is successful. Re-execution verifies `secret://` coverage in both
+	      directions, refuses unverifiable/empty identities, verifies Vault KV-v2
+	      baseline-version HMACs with the recorded HMAC key ID against the
+	      already-resolved value when the current version is the baseline version,
+	      aborts on version drift, and never overwrites descriptor secret evidence
 	      on quarantined execution. Reconstruction reads the B2
 	      `TaskRun.ExecutionDescriptor` only (runtime image/digest, command,
 	      env/spec/mounts, cache, schema, retry, DAG, params/predecessor context) in

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -842,7 +842,7 @@ write, lineage emit, or callback.
       side-effect, event, cache, lineage, callback, or notification suppression was
       made fail-open.
       Depends on: B1.
-- [ ] B3. Implement the replay construction + dispatch path: from a baseline run +
+- [x] B3. Implement the replay construction + dispatch path: from a baseline run +
       `--set` overrides, build a quarantined `JobRun` and dispatch it through the
       executor so hash-changed tasks re-run and hash-unchanged tasks cache-hit
       (in v1 any `--set` override re-runs the full DAG — run params fold wholesale
@@ -878,6 +878,30 @@ write, lineage emit, or callback.
       dispatch; the fail-closed guards; reconstruct from the B2 descriptor),
       `internal/run/store.go`.
       Depends on: B2 + B7 (the `replaySafe` schema the gate reads).
+	      W5-alpha note (2026-06-25): added `internal/replay.New(...).Replay(ctx,
+	      replay.Request{BaselineRunID, Set, ReplayFingerprint})`, returning the
+	      quarantined replay run plus per-task decisions for B4/B5. Guards are
+	      fail-closed: a quarantined baseline is rejected; every baseline task must
+	      have recorded `TaskRun.replay_safe=true` before planning, even if
+	      hash-unchanged; descriptor/row `ReplaySafe` mismatches abort; unchanged
+	      fallback hits require a successful baseline status/result; empty result +
+	      non-empty output aborts as corruption; and all-cached materialization only
+	      stamps the replay succeeded when every cached result is successful.
+	      Re-execution verifies `secret://` coverage in both directions, refuses
+	      unverifiable/empty identities, pins Vault KV-v2 baseline-version reads and
+	      the recorded HMAC key ID, and never overwrites descriptor secret evidence
+	      on quarantined execution. Reconstruction reads the B2
+	      `TaskRun.ExecutionDescriptor` only (runtime image/digest, command,
+	      env/spec/mounts, cache, schema, retry, DAG, params/predecessor context) in
+	      the distributed worker/store/owner paths; local mode now refuses
+	      quarantined replay with `replay requires the descriptor-aware executor`
+	      rather than executing from live rows. Deferred to B4: REST
+	      idempotency/fingerprint reservation and job-scope path validation; deferred
+	      to B5: CLI flags/output/diff polling; deferred to B6: full
+	      container/REST/CLI side-effect integration coverage. Follow-up: local
+	      executor replay reconstruction remains deferred; the distributed worker
+	      reconstructs, and local mode fails closed until it has descriptor-aware
+	      reconstruction.
 - [ ] B4. Expose `POST /v1/jobs/:id/runs/:run_id/replay` (body: `{ "set": {k:v} }`
       only) returning the new run id. **Replay is always quarantined** — the body
       carries no `quarantine` field; the handler sets quarantine internally and a

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -713,7 +713,7 @@ func (j *job) Run(ctx context.Context) error {
 		if err != nil {
 			return "", nil, nil, nil, err
 		}
-		if len(secretIdentities) > 0 && !taskQuarantined {
+		if len(secretIdentities) > 0 {
 			refs := make([]models.TaskExecutionSecretRef, 0, len(secretIdentities))
 			for _, resolved := range secretIdentities {
 				refs = append(refs, run.SecretIdentityDescriptorRef(resolved.EnvKey, resolved.Ref, resolved.Identity))

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -56,6 +56,10 @@ var runStartReadBackoffs = []time.Duration{
 	320 * time.Millisecond,
 }
 
+// ErrLocalQuarantinedReplayUnsupported is returned when a quarantined replay
+// reaches the in-process executor, which is not descriptor-aware.
+var ErrLocalQuarantinedReplayUnsupported = errors.New("replay requires the descriptor-aware executor")
+
 // retryOnContention runs fn, retrying only on transient dqlite contention.
 //
 // The global connection-pool retry (pkg/db) covers a contended statement at
@@ -408,6 +412,10 @@ func (j *job) Run(ctx context.Context) error {
 			log.Error("callback dispatch failure", "job_id", j.id, "run_id", runID, "error", err)
 		}
 	}()
+	if runQuarantined && executionMode != executionModeDistributed {
+		runErr = ErrLocalQuarantinedReplayUnsupported
+		return runErr
+	}
 
 	var tasks models.Tasks
 	if err := retryOnContention(ctx, func() error {
@@ -697,11 +705,15 @@ func (j *job) Run(ctx context.Context) error {
 		log.Info("running atom", "job_id", j.id, "task_id", taskID, "image", runner.image, "cmd", runner.command, "attempt", attempt)
 
 		spec := runner.spec
+		taskQuarantined := taskQuarantine[taskID] || runQuarantined
+		if taskQuarantined {
+			return "", nil, nil, nil, ErrLocalQuarantinedReplayUnsupported
+		}
 		spec, secretIdentities, err := jobdefruntime.ResolveContainerSpecSecretsWithIdentities(taskCtx, secretResolver, spec)
 		if err != nil {
 			return "", nil, nil, nil, err
 		}
-		if len(secretIdentities) > 0 {
+		if len(secretIdentities) > 0 && !taskQuarantined {
 			refs := make([]models.TaskExecutionSecretRef, 0, len(secretIdentities))
 			for _, resolved := range secretIdentities {
 				refs = append(refs, run.SecretIdentityDescriptorRef(resolved.EnvKey, resolved.Ref, resolved.Identity))

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -234,6 +234,55 @@ func TestRunLocalFailedAtomResultFailsRun(t *testing.T) {
 	require.Equal(t, run.TaskStatusFailed, status[taskID])
 }
 
+func TestRunLocalRefusesQuarantinedReplay(t *testing.T) {
+	db := jobdeftestutil.OpenTestDB(t)
+	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })
+
+	store := run.NewStore(db)
+	engine := newFakeEngine()
+	now := time.Now().UTC()
+
+	jobID := uuid.New()
+	runID := uuid.New()
+	taskID := uuid.New()
+	atomID := uuid.New()
+	require.NoError(t, db.Create(&models.Job{ID: jobID, Alias: "quarantined-local", CreatedAt: now, UpdatedAt: now}).Error)
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:         runID,
+		JobID:      jobID,
+		Status:     string(run.StatusRunning),
+		Quarantine: true,
+		StartedAt:  now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}).Error)
+
+	taskSvc := &fakeTaskService{tasks: models.Tasks{
+		{ID: taskID, JobID: jobID, AtomID: atomID},
+	}}
+	atomSvc := &fakeAtomService{atoms: map[uuid.UUID]*models.Atom{
+		atomID: {
+			ID:      atomID,
+			Engine:  models.AtomEngineDocker,
+			Image:   "current/image:latest",
+			Command: `["sh","-c","echo current"]`,
+		},
+	}}
+	opts := withTestDeps(store, env.Environment{
+		MaxParallelTasks:  1,
+		TaskFailurePolicy: taskFailurePolicyHalt,
+		ExecutionMode:     executionModeLocal,
+	}, taskSvc, atomSvc, &fakeTaskEdgeService{}, engine)
+
+	err := New(&models.Job{ID: jobID, Alias: "quarantined-local"}, opts...).Run(run.WithContext(context.Background(), runID))
+	require.ErrorIs(t, err, ErrLocalQuarantinedReplayUnsupported)
+	require.Zero(t, engine.maxConcurrent(), "local quarantined replay must not create a container from live rows")
+
+	snapshot := latestRunSnapshot(t, store, jobID)
+	require.Equal(t, run.StatusFailed, snapshot.Status)
+	require.Contains(t, snapshot.Error, ErrLocalQuarantinedReplayUnsupported.Error())
+}
+
 func TestRunLocalUsesJobLevelOverrides(t *testing.T) {
 	db := jobdeftestutil.OpenTestDB(t)
 	t.Cleanup(func() { jobdeftestutil.CloseDB(db) })

--- a/internal/jobdef/secret/identity.go
+++ b/internal/jobdef/secret/identity.go
@@ -102,11 +102,26 @@ func (k *IdentityKeyring) CurrentHMAC(value []byte) (keyID, digest string, ok bo
 	if k == nil || k.currentKeyID == "" {
 		return "", "", false
 	}
-	key, ok := k.keys[k.currentKeyID]
-	if !ok || len(key) == 0 {
+	digest, ok = k.HMACWithKeyID(k.currentKeyID, value)
+	if !ok {
 		return "", "", false
+	}
+	return k.currentKeyID, digest, true
+}
+
+func (k *IdentityKeyring) HMACWithKeyID(keyID string, value []byte) (digest string, ok bool) {
+	if k == nil {
+		return "", false
+	}
+	keyID = strings.TrimSpace(keyID)
+	if keyID == "" {
+		return "", false
+	}
+	key, ok := k.keys[keyID]
+	if !ok || len(key) == 0 {
+		return "", false
 	}
 	mac := hmac.New(sha256.New, key)
 	_, _ = mac.Write(value)
-	return k.currentKeyID, hex.EncodeToString(mac.Sum(nil)), true
+	return hex.EncodeToString(mac.Sum(nil)), true
 }

--- a/internal/jobdef/secret/multi.go
+++ b/internal/jobdef/secret/multi.go
@@ -53,22 +53,42 @@ func (m *MultiResolver) Resolve(ctx context.Context, ref string) (string, error)
 
 // ResolveWithIdentity locates the provider-specific resolver and delegates the call.
 func (m *MultiResolver) ResolveWithIdentity(ctx context.Context, ref string) (string, Identity, error) {
+	resolver, err := m.providerForRef(ref)
+	if err != nil {
+		return "", Identity{}, err
+	}
+	return resolver.ResolveWithIdentity(ctx, ref)
+}
+
+func (m *MultiResolver) VerifyIdentity(ctx context.Context, ref string, expected Identity) (Identity, error) {
+	resolver, err := m.providerForRef(ref)
+	if err != nil {
+		return Identity{}, err
+	}
+	verifier, ok := resolver.(IdentityVerifier)
+	if !ok {
+		return Identity{}, fmt.Errorf("secret provider %q does not support baseline identity verification", expected.Provider)
+	}
+	return verifier.VerifyIdentity(ctx, ref, expected)
+}
+
+func (m *MultiResolver) providerForRef(ref string) (Resolver, error) {
 	if strings.TrimSpace(ref) == "" {
-		return "", Identity{}, errors.New("secret reference is empty")
+		return nil, errors.New("secret reference is empty")
 	}
 	if m == nil {
-		return "", Identity{}, errors.New("secret resolver is not configured")
+		return nil, errors.New("secret resolver is not configured")
 	}
 
 	refInfo, err := Parse(ref)
 	if err != nil {
-		return "", Identity{}, err
+		return nil, err
 	}
 
 	resolver, ok := m.providers[refInfo.Provider]
 	if !ok || resolver == nil {
-		return "", Identity{}, fmt.Errorf("secret provider %q not configured", refInfo.Provider)
+		return nil, fmt.Errorf("secret provider %q not configured", refInfo.Provider)
 	}
 
-	return resolver.ResolveWithIdentity(ctx, ref)
+	return resolver, nil
 }

--- a/internal/jobdef/secret/multi.go
+++ b/internal/jobdef/secret/multi.go
@@ -72,6 +72,18 @@ func (m *MultiResolver) VerifyIdentity(ctx context.Context, ref string, expected
 	return verifier.VerifyIdentity(ctx, ref, expected)
 }
 
+func (m *MultiResolver) VerifyResolvedIdentity(ctx context.Context, ref string, expected Identity, resolvedValue string) (Identity, error) {
+	resolver, err := m.providerForRef(ref)
+	if err != nil {
+		return Identity{}, err
+	}
+	verifier, ok := resolver.(ResolvedIdentityVerifier)
+	if !ok {
+		return Identity{}, fmt.Errorf("secret provider %q does not support resolved baseline identity verification", expected.Provider)
+	}
+	return verifier.VerifyResolvedIdentity(ctx, ref, expected, resolvedValue)
+}
+
 func (m *MultiResolver) providerForRef(ref string) (Resolver, error) {
 	if strings.TrimSpace(ref) == "" {
 		return nil, errors.New("secret reference is empty")

--- a/internal/jobdef/secret/resolver.go
+++ b/internal/jobdef/secret/resolver.go
@@ -24,3 +24,10 @@ type Resolver interface {
 	Resolve(ctx context.Context, ref string) (string, error)
 	ResolveWithIdentity(ctx context.Context, ref string) (string, Identity, error)
 }
+
+// IdentityVerifier verifies a previously captured identity without relying on
+// the provider's current/latest version. Replay gates use it when a provider can
+// pin the baseline version and recompute the recorded identity proof.
+type IdentityVerifier interface {
+	VerifyIdentity(ctx context.Context, ref string, expected Identity) (Identity, error)
+}

--- a/internal/jobdef/secret/resolver.go
+++ b/internal/jobdef/secret/resolver.go
@@ -31,3 +31,10 @@ type Resolver interface {
 type IdentityVerifier interface {
 	VerifyIdentity(ctx context.Context, ref string, expected Identity) (Identity, error)
 }
+
+// ResolvedIdentityVerifier verifies a captured identity against a value already
+// returned by ResolveWithIdentity. Replay uses it to avoid re-reading a pinned
+// provider version when the latest version is the baseline version.
+type ResolvedIdentityVerifier interface {
+	VerifyResolvedIdentity(ctx context.Context, ref string, expected Identity, resolvedValue string) (Identity, error)
+}

--- a/internal/jobdef/secret/vault.go
+++ b/internal/jobdef/secret/vault.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"crypto/hmac"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -147,6 +148,62 @@ func (r *VaultResolver) ResolveWithIdentity(ctx context.Context, ref string) (st
 		identity.UnverifiableReason = "vault identity HMAC keyring is not configured"
 	}
 	return value, identity, nil
+}
+
+func (r *VaultResolver) VerifyIdentity(ctx context.Context, ref string, expected Identity) (Identity, error) {
+	reference, err := Parse(ref)
+	if err != nil {
+		return Identity{}, err
+	}
+	if reference.Provider != providerVault {
+		return Identity{}, fmt.Errorf("vault resolver cannot handle provider %q", reference.Provider)
+	}
+	if r.logical == nil {
+		return Identity{}, errors.New("vault logical client not configured")
+	}
+
+	path, field, err := parseVaultPathField(reference)
+	if err != nil {
+		return Identity{}, err
+	}
+	version := strings.TrimSpace(expected.Version)
+	keyID := strings.TrimSpace(expected.KeyID)
+	if version == "" || keyID == "" || strings.TrimSpace(expected.HMACSHA256) == "" {
+		return Identity{}, errors.New("vault baseline identity requires version, key id, and hmac")
+	}
+
+	secret, err := r.logical.ReadWithDataWithContext(ctx, path, map[string][]string{"version": {version}})
+	if err != nil {
+		return Identity{}, fmt.Errorf("read vault secret %s version %s: %w", path, version, err)
+	}
+	if secret == nil {
+		return Identity{}, fmt.Errorf("vault secret %s version %s not found", path, version)
+	}
+	readVersion := vaultKVv2Version(secret)
+	if readVersion != "" && readVersion != version {
+		return Identity{}, fmt.Errorf("vault secret %s returned version %s, expected %s", path, readVersion, version)
+	}
+	value, ok := extractVaultField(secret, field)
+	if !ok {
+		return Identity{}, fmt.Errorf("vault secret %s version %s missing field %s", path, version, field)
+	}
+	digest, ok := r.identityKeyring.HMACWithKeyID(keyID, []byte(value))
+	if !ok {
+		return Identity{}, fmt.Errorf("vault identity HMAC key %q is not configured", keyID)
+	}
+	if !hmac.Equal([]byte(digest), []byte(strings.TrimSpace(expected.HMACSHA256))) {
+		return Identity{}, fmt.Errorf("vault secret %s version %s HMAC did not match baseline identity", path, version)
+	}
+
+	return Identity{
+		Provider:   providerVault,
+		Ref:        ref,
+		Version:    version,
+		KeyID:      keyID,
+		HMACSHA256: digest,
+		Verifiable: true,
+		Metadata:   map[string]string{"path": path, "field": field},
+	}, nil
 }
 
 func parseVaultPathField(reference *Reference) (path, field string, err error) {

--- a/internal/jobdef/secret/vault.go
+++ b/internal/jobdef/secret/vault.go
@@ -187,6 +187,30 @@ func (r *VaultResolver) VerifyIdentity(ctx context.Context, ref string, expected
 	if !ok {
 		return Identity{}, fmt.Errorf("vault secret %s version %s missing field %s", path, version, field)
 	}
+	return r.verifyResolvedVaultIdentity(ref, path, field, expected, value)
+}
+
+func (r *VaultResolver) VerifyResolvedIdentity(_ context.Context, ref string, expected Identity, resolvedValue string) (Identity, error) {
+	reference, err := Parse(ref)
+	if err != nil {
+		return Identity{}, err
+	}
+	if reference.Provider != providerVault {
+		return Identity{}, fmt.Errorf("vault resolver cannot handle provider %q", reference.Provider)
+	}
+	path, field, err := parseVaultPathField(reference)
+	if err != nil {
+		return Identity{}, err
+	}
+	return r.verifyResolvedVaultIdentity(ref, path, field, expected, resolvedValue)
+}
+
+func (r *VaultResolver) verifyResolvedVaultIdentity(ref, path, field string, expected Identity, value string) (Identity, error) {
+	version := strings.TrimSpace(expected.Version)
+	keyID := strings.TrimSpace(expected.KeyID)
+	if version == "" || keyID == "" || strings.TrimSpace(expected.HMACSHA256) == "" {
+		return Identity{}, errors.New("vault baseline identity requires version, key id, and hmac")
+	}
 	digest, ok := r.identityKeyring.HMACWithKeyID(keyID, []byte(value))
 	if !ok {
 		return Identity{}, fmt.Errorf("vault identity HMAC key %q is not configured", keyID)

--- a/internal/jobdef/secret/vault_test.go
+++ b/internal/jobdef/secret/vault_test.go
@@ -110,6 +110,39 @@ func (s *VaultResolverSuite) TestResolveWithIdentityCanonicalizesNumericVersion(
 	s.Empty(rest.dataRequests)
 }
 
+func (s *VaultResolverSuite) TestVerifyIdentityPinsBaselineVersionAndKeyID() {
+	keyring, err := NewIdentityKeyring("k2", map[string][]byte{
+		"k1": []byte("baseline-key"),
+		"k2": []byte("current-key"),
+	})
+	s.Require().NoError(err)
+	rest := &fakeLogical{response: &vault.Secret{Data: map[string]any{
+		"data":     map[string]any{"token": "abc"},
+		"metadata": map[string]any{"version": 7},
+	}}}
+	r := NewVaultResolverWithLogicalAndKeyring(rest, keyring)
+
+	mac := hmac.New(sha256.New, []byte("baseline-key"))
+	_, _ = mac.Write([]byte("abc"))
+	expectedDigest := hex.EncodeToString(mac.Sum(nil))
+
+	identity, err := r.VerifyIdentity(context.Background(), "secret://vault/secret/data/path?field=token", Identity{
+		Provider:   "vault",
+		Ref:        "secret://vault/secret/data/path?field=token",
+		Version:    "7",
+		KeyID:      "k1",
+		HMACSHA256: expectedDigest,
+		Verifiable: true,
+	})
+	s.Require().NoError(err)
+	s.Equal("7", identity.Version)
+	s.Equal("k1", identity.KeyID)
+	s.Equal(expectedDigest, identity.HMACSHA256)
+	s.Require().Len(rest.dataRequests, 1)
+	s.Equal("secret/data/path", rest.dataRequests[0].path)
+	s.Equal([]string{"7"}, rest.dataRequests[0].data["version"])
+}
+
 func (s *VaultResolverSuite) TestResolveFieldAsSegment() {
 	rest := &fakeLogical{response: &vault.Secret{Data: map[string]any{"password": "hunter2"}}}
 	r := NewVaultResolverWithLogical(rest)

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -1,0 +1,930 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/cache"
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/run"
+	pkgtask "github.com/caesium-cloud/caesium/pkg/task"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrDispatchRequired         = errors.New("replay: dispatcher is required")
+	ErrBaselineNotTerminal      = errors.New("replay: baseline run is not terminal")
+	ErrMissingDescriptor        = errors.New("replay: missing baseline execution descriptor")
+	ErrUnsupportedDescriptor    = errors.New("replay: unsupported baseline execution descriptor")
+	ErrReplayUnsafe             = errors.New("replay: baseline task is not replay safe")
+	ErrUnavailableBaselineProof = errors.New("replay: unchanged baseline result unavailable")
+	ErrSecretIdentity           = errors.New("replay: baseline secret identity cannot be verified")
+	ErrQuarantinedBaseline      = errors.New("replay: baseline run is quarantined")
+)
+
+// Dispatcher is the narrow B3 seam B4/B5 use to hand a durable replay run to
+// the already-running execution machinery.
+type Dispatcher interface {
+	DispatchReplay(ctx context.Context, runID uuid.UUID) error
+}
+
+type DispatchFunc func(context.Context, uuid.UUID) error
+
+func (f DispatchFunc) DispatchReplay(ctx context.Context, runID uuid.UUID) error {
+	return f(ctx, runID)
+}
+
+type Option func(*Constructor)
+
+func WithSecretResolver(resolver secret.Resolver) Option {
+	return func(c *Constructor) {
+		c.secretResolver = resolver
+	}
+}
+
+type Constructor struct {
+	store          *run.Store
+	dispatcher     Dispatcher
+	secretResolver secret.Resolver
+	now            func() time.Time
+}
+
+func New(store *run.Store, dispatcher Dispatcher, opts ...Option) *Constructor {
+	c := &Constructor{
+		store:      store,
+		dispatcher: dispatcher,
+		now:        func() time.Time { return time.Now().UTC() },
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+	return c
+}
+
+type Request struct {
+	BaselineRunID     uuid.UUID
+	Set               map[string]string
+	ReplayFingerprint string
+}
+
+type Result struct {
+	Run       *run.JobRun
+	Decisions []TaskDecision
+}
+
+type TaskDecision struct {
+	TaskID       uuid.UUID
+	TaskName     string
+	BaselineHash string
+	ReplayHash   string
+	CacheHit     bool
+	Reexecute    bool
+}
+
+type baselineTask struct {
+	row          models.TaskRun
+	descriptor   models.TaskExecutionDescriptor
+	taskName     string
+	output       map[string]string
+	branches     []string
+	computedHash string
+	effective    string
+}
+
+type plannedTask struct {
+	base          *baselineTask
+	replayHash    string
+	effectiveHash string
+	cacheHit      bool
+	reexecute     bool
+	source        cacheSource
+	outstanding   int
+	descriptor    models.TaskExecutionDescriptor
+}
+
+type cacheSource struct {
+	runID     uuid.UUID
+	createdAt time.Time
+	expiresAt *time.Time
+	result    string
+	output    map[string]string
+	branches  []string
+}
+
+func (c *Constructor) Replay(ctx context.Context, req Request) (*Result, error) {
+	if c == nil || c.store == nil {
+		return nil, errors.New("replay: run store is required")
+	}
+	if c.dispatcher == nil {
+		return nil, ErrDispatchRequired
+	}
+
+	baseline, tasks, err := c.loadBaseline(ctx, req.BaselineRunID)
+	if err != nil {
+		return nil, err
+	}
+	if baseline.Status != string(run.StatusSucceeded) && baseline.Status != string(run.StatusFailed) {
+		return nil, fmt.Errorf("%w: %s", ErrBaselineNotTerminal, baseline.Status)
+	}
+
+	baseParams, err := decodeParams(baseline.Params)
+	if err != nil {
+		return nil, err
+	}
+	replayParams := maps.Clone(baseParams)
+	if replayParams == nil {
+		replayParams = make(map[string]string)
+	}
+	paramsChanged := false
+	for k, v := range req.Set {
+		if replayParams[k] != v {
+			paramsChanged = true
+		}
+		replayParams[k] = v
+	}
+
+	plans, err := c.planTasks(ctx, tasks, replayParams, paramsChanged)
+	if err != nil {
+		return nil, err
+	}
+
+	runID, err := c.materialize(ctx, baseline, replayParams, req.Set, req.ReplayFingerprint, plans)
+	if err != nil {
+		return nil, err
+	}
+
+	if hasPending(plans) {
+		if err := c.dispatcher.DispatchReplay(ctx, runID); err != nil {
+			return nil, err
+		}
+	}
+
+	created, err := c.store.Get(runID)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{Run: created, Decisions: decisions(plans)}, nil
+}
+
+func (c *Constructor) loadBaseline(ctx context.Context, runID uuid.UUID) (models.JobRun, []*baselineTask, error) {
+	var baseline models.JobRun
+	if err := c.store.DB().WithContext(ctx).First(&baseline, "id = ?", runID).Error; err != nil {
+		return models.JobRun{}, nil, err
+	}
+	if baseline.Quarantine {
+		return models.JobRun{}, nil, fmt.Errorf("%w: run %s", ErrQuarantinedBaseline, runID)
+	}
+
+	var rows []models.TaskRun
+	if err := c.store.DB().WithContext(ctx).
+		Where("job_run_id = ?", runID).
+		Order("created_at ASC").
+		Find(&rows).Error; err != nil {
+		return models.JobRun{}, nil, err
+	}
+	if len(rows) == 0 {
+		return models.JobRun{}, nil, fmt.Errorf("replay: baseline run %s has no task runs", runID)
+	}
+
+	tasks := make([]*baselineTask, 0, len(rows))
+	for i := range rows {
+		task, err := decodeBaselineTask(rows[i])
+		if err != nil {
+			return models.JobRun{}, nil, err
+		}
+		tasks = append(tasks, task)
+	}
+	sort.SliceStable(tasks, func(i, j int) bool {
+		if tasks[i].descriptor.DAG.TaskPosition != tasks[j].descriptor.DAG.TaskPosition {
+			return tasks[i].descriptor.DAG.TaskPosition < tasks[j].descriptor.DAG.TaskPosition
+		}
+		return tasks[i].row.CreatedAt.Before(tasks[j].row.CreatedAt)
+	})
+	return baseline, tasks, nil
+}
+
+func decodeBaselineTask(row models.TaskRun) (*baselineTask, error) {
+	if len(row.ExecutionDescriptor) == 0 {
+		return nil, fmt.Errorf("%w: step %q task %s", ErrMissingDescriptor, fallbackTaskName(row.TaskID, ""), row.TaskID)
+	}
+	var desc models.TaskExecutionDescriptor
+	if err := json.Unmarshal(row.ExecutionDescriptor, &desc); err != nil {
+		return nil, fmt.Errorf("%w: step %q task %s: %v", ErrMissingDescriptor, fallbackTaskName(row.TaskID, ""), row.TaskID, err)
+	}
+	if desc.SchemaVersion != models.TaskExecutionDescriptorSchemaVersion {
+		return nil, fmt.Errorf("%w: step %q descriptor version %d", ErrUnsupportedDescriptor, fallbackTaskName(row.TaskID, desc.Baseline.TaskName), desc.SchemaVersion)
+	}
+	if desc.Baseline.TaskID != uuid.Nil && desc.Baseline.TaskID != row.TaskID {
+		return nil, fmt.Errorf("%w: descriptor task id %s does not match task_run %s", ErrUnsupportedDescriptor, desc.Baseline.TaskID, row.TaskID)
+	}
+	if desc.Baseline.BaselineRunID != uuid.Nil && desc.Baseline.BaselineRunID != row.JobRunID {
+		return nil, fmt.Errorf("%w: descriptor baseline run %s does not match task_run run %s", ErrUnsupportedDescriptor, desc.Baseline.BaselineRunID, row.JobRunID)
+	}
+	if desc.Baseline.ReplaySafe != row.ReplaySafe {
+		return nil, fmt.Errorf("%w: descriptor replay_safe=%t does not match task_run replay_safe=%t for step %q", ErrUnsupportedDescriptor, desc.Baseline.ReplaySafe, row.ReplaySafe, fallbackTaskName(row.TaskID, desc.Baseline.TaskName))
+	}
+
+	out, err := decodeStringMap(row.Output)
+	if err != nil {
+		return nil, fmt.Errorf("replay: decode baseline output for step %q: %w", fallbackTaskName(row.TaskID, desc.Baseline.TaskName), err)
+	}
+	branches, err := decodeStringSlice(row.BranchSelections)
+	if err != nil {
+		return nil, fmt.Errorf("replay: decode baseline branch selections for step %q: %w", fallbackTaskName(row.TaskID, desc.Baseline.TaskName), err)
+	}
+	computed := firstNonEmpty(desc.Cache.ComputedHash, desc.Baseline.ComputedHash, row.Hash)
+	effective := firstNonEmpty(desc.Cache.EffectiveHash, desc.Baseline.EffectiveHash, row.EffectiveHash, computed)
+
+	return &baselineTask{
+		row:          row,
+		descriptor:   desc,
+		taskName:     fallbackTaskName(row.TaskID, desc.Baseline.TaskName),
+		output:       out,
+		branches:     branches,
+		computedHash: computed,
+		effective:    effective,
+	}, nil
+}
+
+func (c *Constructor) planTasks(ctx context.Context, tasks []*baselineTask, params map[string]string, forceReexecute bool) ([]plannedTask, error) {
+	byID := make(map[uuid.UUID]*baselineTask, len(tasks))
+	plannedByID := make(map[uuid.UUID]int, len(tasks))
+	for _, task := range tasks {
+		byID[task.row.TaskID] = task
+		if !task.row.ReplaySafe {
+			return nil, fmt.Errorf("%w: step %q has replay_safe=false", ErrReplayUnsafe, task.taskName)
+		}
+	}
+
+	plans := make([]plannedTask, 0, len(tasks))
+	for _, task := range tasks {
+		predOutputsByName := make(map[string]map[string]string)
+		predHashes := make([]string, 0, len(task.descriptor.DAG.Predecessors))
+		pendingPredecessors := 0
+		for _, pred := range task.descriptor.DAG.Predecessors {
+			plannedIdx, ok := plannedByID[pred.TaskID]
+			if !ok {
+				if _, ok := byID[pred.TaskID]; ok {
+					pendingPredecessors++
+					continue
+				}
+				return nil, fmt.Errorf("%w: step %q references missing predecessor %s", ErrUnsupportedDescriptor, task.taskName, pred.TaskID)
+			}
+			plannedPred := &plans[plannedIdx]
+			if plannedPred.reexecute {
+				pendingPredecessors++
+				continue
+			}
+			if len(plannedPred.source.output) > 0 {
+				predName := firstNonEmpty(pred.TaskName, plannedPred.base.taskName, pred.TaskID.String())
+				predOutputsByName[predName] = maps.Clone(plannedPred.source.output)
+			}
+			if plannedPred.effectiveHash != "" {
+				predHashes = append(predHashes, plannedPred.effectiveHash)
+			}
+		}
+
+		replayHash := computeDescriptorHash(task.descriptor, params, predOutputsByName, predHashes)
+		unchanged := !forceReexecute && hashMatchesBaseline(replayHash, task.computedHash, task.effective)
+		plan := plannedTask{
+			base:          task,
+			replayHash:    replayHash,
+			effectiveHash: replayHash,
+			descriptor:    replayDescriptor(task.descriptor),
+		}
+
+		if unchanged && pendingPredecessors == 0 {
+			source, err := c.cacheSourceForUnchanged(ctx, task, replayHash)
+			if err != nil {
+				return nil, err
+			}
+			plan.cacheHit = true
+			plan.source = source
+			plan.effectiveHash = firstNonEmpty(task.effective, replayHash)
+		} else {
+			if err := c.authorizeReexecution(ctx, task); err != nil {
+				return nil, err
+			}
+			plan.reexecute = true
+			plan.outstanding = pendingPredecessors
+		}
+		plans = append(plans, plan)
+		plannedByID[task.row.TaskID] = len(plans) - 1
+	}
+	return plans, nil
+}
+
+func computeDescriptorHash(desc models.TaskExecutionDescriptor, params map[string]string, predOutputs map[string]map[string]string, predHashes []string) string {
+	spec := desc.ContainerSpec
+	env := maps.Clone(spec.Env)
+	if env == nil {
+		env = make(map[string]string)
+	}
+	for k, v := range pkgtask.BuildOutputEnv(predOutputs) {
+		env[k] = v
+	}
+	command := append([]string(nil), desc.Runtime.Command...)
+	if len(command) == 0 && strings.TrimSpace(desc.Runtime.CommandRaw) != "" {
+		command = []string{desc.Runtime.CommandRaw}
+	}
+	workdir := spec.WorkDir
+	if workdir == "" {
+		workdir = desc.Runtime.WorkDir
+	}
+	return cache.HashInput{
+		JobAlias:             desc.Baseline.JobAlias,
+		TaskName:             desc.Baseline.TaskName,
+		Image:                desc.Runtime.Image,
+		ResolvedImageDigest:  desc.Runtime.ResolvedImageDigest,
+		Command:              command,
+		Env:                  env,
+		WorkDir:              workdir,
+		Mounts:               spec.Mounts,
+		ResolvedVolumeMounts: spec.ResolvedVolumeMounts,
+		Kubernetes:           spec.Kubernetes,
+		PredecessorHashes:    append([]string(nil), predHashes...),
+		PredecessorOutputs:   cloneNestedStringMap(predOutputs),
+		RunParams:            maps.Clone(params),
+		CacheVersion:         desc.Cache.Version,
+	}.Compute()
+}
+
+func (c *Constructor) cacheSourceForUnchanged(ctx context.Context, task *baselineTask, replayHash string) (cacheSource, error) {
+	if strings.TrimSpace(task.row.Result) == "" && len(task.output) > 0 {
+		return cacheSource{}, fmt.Errorf("%w: step %q produced baseline output but recorded an empty result (corruption)", ErrUnavailableBaselineProof, task.taskName)
+	}
+	status := run.TaskStatus(task.row.Status)
+	if status != run.TaskStatusSucceeded && status != run.TaskStatusCached {
+		return cacheSource{}, fmt.Errorf("%w: step %q baseline status %q is not reusable", ErrUnavailableBaselineProof, task.taskName, task.row.Status)
+	}
+	if !run.IsSuccessfulTaskResult(task.row.Result) {
+		return cacheSource{}, fmt.Errorf("%w: step %q baseline result %q is not successful", ErrUnavailableBaselineProof, task.taskName, task.row.Result)
+	}
+
+	cacheStore := cache.NewStore(c.store.DB())
+	if entry, found, err := cacheStore.Get(replayHash); err != nil {
+		return cacheSource{}, fmt.Errorf("replay: cache lookup for unchanged step %q hash %s: %w", task.taskName, shortHash(replayHash), err)
+	} else if found {
+		if !run.IsSuccessfulTaskResult(entry.Result) {
+			return cacheSource{}, fmt.Errorf("%w: step %q hash %s cache entry has non-success result %q", ErrUnavailableBaselineProof, task.taskName, shortHash(replayHash), entry.Result)
+		}
+		return cacheSource{
+			runID:     entry.RunID,
+			createdAt: entry.CreatedAt,
+			expiresAt: entry.ExpiresAt,
+			result:    entry.Result,
+			output:    maps.Clone(entry.Output),
+			branches:  append([]string(nil), entry.BranchSelections...),
+		}, nil
+	}
+
+	if strings.TrimSpace(task.row.Result) != "" {
+		created := task.row.CreatedAt
+		if task.row.CompletedAt != nil {
+			created = *task.row.CompletedAt
+		}
+		return cacheSource{
+			runID:     task.row.JobRunID,
+			createdAt: created,
+			result:    task.row.Result,
+			output:    maps.Clone(task.output),
+			branches:  append([]string(nil), task.branches...),
+		}, nil
+	}
+	return cacheSource{}, fmt.Errorf("%w: step %q hash %s has neither a live TaskCache entry nor recorded baseline result/output", ErrUnavailableBaselineProof, task.taskName, shortHash(replayHash))
+}
+
+func (c *Constructor) authorizeReexecution(ctx context.Context, task *baselineTask) error {
+	if !task.row.ReplaySafe {
+		return fmt.Errorf("%w: step %q would re-execute but baseline task_run replay_safe=false", ErrReplayUnsafe, task.taskName)
+	}
+
+	expectedByKey, err := expectedSecretRefMap(task.descriptor.SecretRefs)
+	if err != nil {
+		return fmt.Errorf("%w: step %q: %v", ErrSecretIdentity, task.taskName, err)
+	}
+	seenRuntimeRefs := make(map[string]struct{}, len(expectedByKey))
+	for envKey, rawRef := range task.descriptor.ContainerSpec.Env {
+		refValue := strings.TrimSpace(rawRef)
+		if !strings.HasPrefix(refValue, "secret://") {
+			continue
+		}
+		key := secretRefKey(envKey, refValue)
+		ref, ok := expectedByKey[key]
+		if !ok {
+			return fmt.Errorf("%w: step %q env %s secret %s has no baseline identity", ErrSecretIdentity, task.taskName, envKey, refValue)
+		}
+		seenRuntimeRefs[key] = struct{}{}
+		if err := c.verifyReplaySecretIdentity(ctx, task.taskName, ref); err != nil {
+			return err
+		}
+	}
+	for key, ref := range expectedByKey {
+		if _, ok := seenRuntimeRefs[key]; !ok {
+			return fmt.Errorf("%w: step %q baseline secret %s for env %s is absent from the captured runtime spec", ErrSecretIdentity, task.taskName, ref.Ref, ref.EnvKey)
+		}
+	}
+	return nil
+}
+
+func (c *Constructor) verifyReplaySecretIdentity(ctx context.Context, taskName string, ref models.TaskExecutionSecretRef) error {
+	if strings.TrimSpace(ref.Ref) == "" {
+		return nil
+	}
+	if !ref.Verifiable {
+		return fmt.Errorf("%w: step %q secret %s is not verifiable: %s", ErrSecretIdentity, taskName, ref.Ref, ref.UnverifiableReason)
+	}
+	if c.secretResolver == nil {
+		return fmt.Errorf("%w: step %q secret %s requires a configured resolver", ErrSecretIdentity, taskName, ref.Ref)
+	}
+	_, identity, err := c.secretResolver.ResolveWithIdentity(ctx, ref.Ref)
+	if err != nil {
+		return fmt.Errorf("%w: step %q secret %s re-resolve failed: %v", ErrSecretIdentity, taskName, ref.Ref, err)
+	}
+	if err := verifyResolvedSecretIdentity(ctx, c.secretResolver, ref, identity); err != nil {
+		return fmt.Errorf("%w: step %q secret %s %v", ErrSecretIdentity, taskName, ref.Ref, err)
+	}
+	return nil
+}
+
+func expectedSecretRefMap(refs []models.TaskExecutionSecretRef) (map[string]models.TaskExecutionSecretRef, error) {
+	expected := make(map[string]models.TaskExecutionSecretRef)
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.Ref) == "" {
+			continue
+		}
+		key := secretRefKey(ref.EnvKey, ref.Ref)
+		if _, exists := expected[key]; exists {
+			return nil, fmt.Errorf("duplicate baseline secret identity for env %s ref %s", ref.EnvKey, ref.Ref)
+		}
+		expected[key] = ref
+	}
+	return expected, nil
+}
+
+func secretRefKey(envKey, ref string) string {
+	return strings.TrimSpace(envKey) + "\x00" + strings.TrimSpace(ref)
+}
+
+func verifyResolvedSecretIdentity(ctx context.Context, resolver secret.Resolver, ref models.TaskExecutionSecretRef, identity secret.Identity) error {
+	if !ref.Verifiable {
+		return fmt.Errorf("is not verifiable: %s", ref.UnverifiableReason)
+	}
+	if !identity.Verifiable {
+		return fmt.Errorf("re-resolved identity is not verifiable: %s", identity.UnverifiableReason)
+	}
+	if ref.Provider != "" && ref.Provider != identity.Provider {
+		return fmt.Errorf("provider changed from %s to %s", ref.Provider, identity.Provider)
+	}
+	if requiresPinnedVaultVerification(ref) {
+		if descriptorIdentityString(ref, "version") != identity.Version {
+			return fmt.Errorf("version changed from %s to %s", descriptorIdentityString(ref, "version"), identity.Version)
+		}
+		verifier, ok := resolver.(secret.IdentityVerifier)
+		if !ok {
+			return fmt.Errorf("provider %s does not support baseline identity verification", ref.Provider)
+		}
+		pinned, err := verifier.VerifyIdentity(ctx, ref.Ref, secretIdentityFromDescriptor(ref))
+		if err != nil {
+			return fmt.Errorf("baseline identity verification failed: %w", err)
+		}
+		if !pinned.Verifiable {
+			return fmt.Errorf("baseline identity is not verifiable: %s", pinned.UnverifiableReason)
+		}
+		if !secretIdentityMatches(ref, pinned) {
+			return fmt.Errorf("baseline identity changed")
+		}
+		return nil
+	}
+	if !secretIdentityMatches(ref, identity) {
+		return fmt.Errorf("identity changed")
+	}
+	return nil
+}
+
+func requiresPinnedVaultVerification(ref models.TaskExecutionSecretRef) bool {
+	return strings.EqualFold(ref.Provider, "vault") &&
+		descriptorIdentityString(ref, "version") != "" &&
+		descriptorIdentityString(ref, "keyId") != ""
+}
+
+func secretIdentityFromDescriptor(ref models.TaskExecutionSecretRef) secret.Identity {
+	return secret.Identity{
+		Provider:        ref.Provider,
+		Ref:             ref.Ref,
+		Version:         descriptorIdentityString(ref, "version"),
+		ResourceVersion: descriptorIdentityString(ref, "resourceVersion"),
+		Namespace:       descriptorIdentityString(ref, "namespace"),
+		Name:            descriptorIdentityString(ref, "name"),
+		Key:             descriptorIdentityString(ref, "key"),
+		KeyID:           descriptorIdentityString(ref, "keyId"),
+		HMACSHA256:      descriptorIdentityString(ref, "hmacSha256"),
+		Verifiable:      ref.Verifiable,
+	}
+}
+
+func (c *Constructor) materialize(ctx context.Context, baseline models.JobRun, params, overrides map[string]string, fingerprint string, plans []plannedTask) (uuid.UUID, error) {
+	now := c.now()
+	replayID := uuid.New()
+	var fingerprintPtr *string
+	if strings.TrimSpace(fingerprint) != "" {
+		value := strings.TrimSpace(fingerprint)
+		fingerprintPtr = &value
+	}
+
+	encodedParams, err := json.Marshal(params)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("replay: encode replay params: %w", err)
+	}
+	encodedOverrides, err := json.Marshal(overrides)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("replay: encode replay overrides: %w", err)
+	}
+
+	records := make([]models.TaskRun, 0, len(plans))
+	allCached := true
+	for _, plan := range plans {
+		record, err := taskRunRecord(replayID, plan, now)
+		if err != nil {
+			return uuid.Nil, err
+		}
+		if plan.reexecute {
+			allCached = false
+		} else if plan.cacheHit && !run.IsSuccessfulTaskResult(plan.source.result) {
+			return uuid.Nil, fmt.Errorf("%w: step %q cache hit result %q is not successful", ErrUnavailableBaselineProof, plan.base.taskName, plan.source.result)
+		}
+		records = append(records, record)
+	}
+
+	var pendingEvents []event.Event
+	err = c.store.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		status := string(run.StatusRunning)
+		var completedAt *time.Time
+		if allCached {
+			status = string(run.StatusSucceeded)
+			completedAt = &now
+		}
+		model := models.JobRun{
+			ID:                replayID,
+			JobID:             baseline.JobID,
+			Status:            status,
+			Params:            datatypes.JSON(encodedParams),
+			Quarantine:        true,
+			ReplayFingerprint: fingerprintPtr,
+			ReplayOverrides:   datatypes.JSON(encodedOverrides),
+			TriggerType:       "replay",
+			TriggerAlias:      "quarantined-replay",
+			StartedAt:         now,
+			CompletedAt:       completedAt,
+			CreatedAt:         now,
+			UpdatedAt:         now,
+		}
+		if err := tx.Create(&model).Error; err != nil {
+			return err
+		}
+		if len(records) > 0 {
+			if err := tx.Create(&records).Error; err != nil {
+				return err
+			}
+		}
+		if es := c.store.EventStore(); es != nil {
+			events := replayEvents(baseline.JobID, replayID, records, allCached, now)
+			for i := range events {
+				if err := es.AppendTx(tx, &events[i]); err != nil {
+					return err
+				}
+			}
+			pendingEvents = events
+		}
+		return nil
+	})
+	if err != nil {
+		return uuid.Nil, err
+	}
+	c.store.PublishEvents(pendingEvents...)
+	return replayID, nil
+}
+
+func taskRunRecord(replayID uuid.UUID, plan plannedTask, now time.Time) (models.TaskRun, error) {
+	desc := plan.descriptor
+	encodedDescriptor, err := json.Marshal(&desc)
+	if err != nil {
+		return models.TaskRun{}, fmt.Errorf("replay: encode descriptor for step %q: %w", plan.base.taskName, err)
+	}
+	command, err := encodeCommand(desc.Runtime.Command, desc.Runtime.CommandRaw)
+	if err != nil {
+		return models.TaskRun{}, fmt.Errorf("replay: encode command for step %q: %w", plan.base.taskName, err)
+	}
+
+	maxAttempts := desc.Runtime.RetryCount + 1
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	record := models.TaskRun{
+		ID:                      uuid.New(),
+		JobRunID:                replayID,
+		TaskID:                  plan.base.row.TaskID,
+		AtomID:                  desc.Baseline.AtomID,
+		Engine:                  desc.Runtime.Engine,
+		Image:                   desc.Runtime.Image,
+		Command:                 command,
+		Status:                  string(run.TaskStatusPending),
+		NodeSelector:            datatypes.JSONMap(stringMapToAny(desc.Runtime.NodeSelector)),
+		Attempt:                 1,
+		MaxAttempts:             maxAttempts,
+		Hash:                    plan.replayHash,
+		OutstandingPredecessors: plan.outstanding,
+		Quarantine:              true,
+		CacheEnabled:            desc.Cache.Enabled,
+		CacheTTL:                desc.Cache.TTL,
+		CacheVersion:            desc.Cache.Version,
+		ReplaySafe:              plan.base.row.ReplaySafe,
+		CachePinDigests:         desc.Cache.PinDigests,
+		CacheDigestTTL:          desc.Cache.DigestTTL,
+		ResolvedImageDigest:     desc.Runtime.ResolvedImageDigest,
+		OutputSchema:            append(datatypes.JSON(nil), desc.Schema.OutputSchema...),
+		SchemaValidation:        desc.Schema.ValidationMode,
+		ExecutionDescriptor:     datatypes.JSON(encodedDescriptor),
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}
+	if plan.cacheHit {
+		if !run.IsSuccessfulTaskResult(plan.source.result) {
+			return models.TaskRun{}, fmt.Errorf("%w: step %q cache hit result %q is not successful", ErrUnavailableBaselineProof, plan.base.taskName, plan.source.result)
+		}
+		record.Status = string(run.TaskStatusCached)
+		record.CompletedAt = &now
+		record.Result = plan.source.result
+		record.CacheHit = true
+		origin := plan.source.runID
+		record.CacheOriginRunID = &origin
+		record.CacheCreatedAt = &plan.source.createdAt
+		record.CacheExpiresAt = plan.source.expiresAt
+		if len(plan.source.output) > 0 {
+			encoded, err := json.Marshal(plan.source.output)
+			if err != nil {
+				return models.TaskRun{}, fmt.Errorf("replay: encode cache output for step %q: %w", plan.base.taskName, err)
+			}
+			record.Output = datatypes.JSON(encoded)
+		}
+		if len(plan.source.branches) > 0 {
+			encoded, err := json.Marshal(plan.source.branches)
+			if err != nil {
+				return models.TaskRun{}, fmt.Errorf("replay: encode branch selections for step %q: %w", plan.base.taskName, err)
+			}
+			record.BranchSelections = datatypes.JSON(encoded)
+		}
+	}
+	return record, nil
+}
+
+func replayDescriptor(desc models.TaskExecutionDescriptor) models.TaskExecutionDescriptor {
+	return desc
+}
+
+func replayEvents(jobID, runID uuid.UUID, records []models.TaskRun, allCached bool, now time.Time) []event.Event {
+	events := []event.Event{{
+		Type:       event.TypeRunStarted,
+		JobID:      jobID,
+		RunID:      runID,
+		Timestamp:  now,
+		Quarantine: true,
+	}}
+	for _, record := range records {
+		switch run.TaskStatus(record.Status) {
+		case run.TaskStatusCached:
+			events = append(events, event.Event{
+				Type:       event.TypeTaskCached,
+				JobID:      jobID,
+				RunID:      runID,
+				TaskID:     record.TaskID,
+				Timestamp:  now,
+				Quarantine: true,
+			})
+		case run.TaskStatusPending:
+			if record.OutstandingPredecessors == 0 {
+				events = append(events, event.Event{
+					Type:       event.TypeTaskReady,
+					JobID:      jobID,
+					RunID:      runID,
+					TaskID:     record.TaskID,
+					Timestamp:  now,
+					Quarantine: true,
+				})
+			}
+		}
+	}
+	if allCached {
+		events = append(events, event.Event{
+			Type:       event.TypeRunCompleted,
+			JobID:      jobID,
+			RunID:      runID,
+			Timestamp:  now,
+			Quarantine: true,
+		})
+	}
+	return events
+}
+
+func decisions(plans []plannedTask) []TaskDecision {
+	out := make([]TaskDecision, 0, len(plans))
+	for _, plan := range plans {
+		out = append(out, TaskDecision{
+			TaskID:       plan.base.row.TaskID,
+			TaskName:     plan.base.taskName,
+			BaselineHash: plan.base.computedHash,
+			ReplayHash:   plan.replayHash,
+			CacheHit:     plan.cacheHit,
+			Reexecute:    plan.reexecute,
+		})
+	}
+	return out
+}
+
+func hasPending(plans []plannedTask) bool {
+	for _, plan := range plans {
+		if plan.reexecute {
+			return true
+		}
+	}
+	return false
+}
+
+func hashMatchesBaseline(replayHash, computed, effective string) bool {
+	return replayHash != "" && (replayHash == computed || (effective != "" && replayHash == effective))
+}
+
+func secretIdentityMatches(ref models.TaskExecutionSecretRef, identity secret.Identity) bool {
+	if ref.Provider != "" && ref.Provider != identity.Provider {
+		return false
+	}
+	if !hasRequiredSecretDiscriminator(ref) {
+		return false
+	}
+	expected := ref.Identity
+	actual := identityMap(identity)
+	for key, expectedValue := range expected {
+		if fmt.Sprint(expectedValue) != fmt.Sprint(actual[key]) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasRequiredSecretDiscriminator(ref models.TaskExecutionSecretRef) bool {
+	if len(ref.Identity) == 0 {
+		return false
+	}
+	if strings.EqualFold(ref.Provider, "vault") {
+		return descriptorIdentityString(ref, "version") != "" &&
+			descriptorIdentityString(ref, "keyId") != "" &&
+			descriptorIdentityString(ref, "hmacSha256") != ""
+	}
+	for _, value := range ref.Identity {
+		if strings.TrimSpace(fmt.Sprint(value)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func descriptorIdentityString(ref models.TaskExecutionSecretRef, key string) string {
+	if len(ref.Identity) == 0 {
+		return ""
+	}
+	value, ok := ref.Identity[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func identityMap(identity secret.Identity) datatypes.JSONMap {
+	out := datatypes.JSONMap{}
+	if identity.Version != "" {
+		out["version"] = identity.Version
+	}
+	if identity.ResourceVersion != "" {
+		out["resourceVersion"] = identity.ResourceVersion
+	}
+	if identity.Namespace != "" {
+		out["namespace"] = identity.Namespace
+	}
+	if identity.Name != "" {
+		out["name"] = identity.Name
+	}
+	if identity.Key != "" {
+		out["key"] = identity.Key
+	}
+	if identity.KeyID != "" {
+		out["keyId"] = identity.KeyID
+	}
+	if identity.HMACSHA256 != "" {
+		out["hmacSha256"] = identity.HMACSHA256
+	}
+	for k, v := range identity.Metadata {
+		out[k] = v
+	}
+	return out
+}
+
+func encodeCommand(command []string, raw string) (string, error) {
+	if len(command) > 0 {
+		encoded, err := json.Marshal(command)
+		if err != nil {
+			return "", err
+		}
+		return string(encoded), nil
+	}
+	return raw, nil
+}
+
+func decodeParams(raw datatypes.JSON) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var params map[string]string
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return nil, fmt.Errorf("replay: decode baseline params: %w", err)
+	}
+	return params, nil
+}
+
+func decodeStringMap(raw datatypes.JSON) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func decodeStringSlice(raw datatypes.JSON) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var out []string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func cloneNestedStringMap(in map[string]map[string]string) map[string]map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]map[string]string, len(in))
+	for k, v := range in {
+		out[k] = maps.Clone(v)
+	}
+	return out
+}
+
+func stringMapToAny(in map[string]string) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func fallbackTaskName(id uuid.UUID, name string) string {
+	if strings.TrimSpace(name) != "" {
+		return name
+	}
+	return id.String()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func shortHash(hash string) string {
+	if len(hash) <= 12 {
+		return hash
+	}
+	return hash[:12]
+}

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/caesium-cloud/caesium/internal/cache"
 	"github.com/caesium-cloud/caesium/internal/event"
+	jobdefruntime "github.com/caesium-cloud/caesium/internal/jobdef/runtime"
 	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
@@ -206,13 +207,11 @@ func (c *Constructor) loadBaseline(ctx context.Context, runID uuid.UUID) (models
 		}
 		tasks = append(tasks, task)
 	}
-	sort.SliceStable(tasks, func(i, j int) bool {
-		if tasks[i].descriptor.DAG.TaskPosition != tasks[j].descriptor.DAG.TaskPosition {
-			return tasks[i].descriptor.DAG.TaskPosition < tasks[j].descriptor.DAG.TaskPosition
-		}
-		return tasks[i].row.CreatedAt.Before(tasks[j].row.CreatedAt)
-	})
-	return baseline, tasks, nil
+	ordered, err := topologicalBaselineTasks(runID, tasks)
+	if err != nil {
+		return models.JobRun{}, nil, err
+	}
+	return baseline, ordered, nil
 }
 
 func decodeBaselineTask(row models.TaskRun) (*baselineTask, error) {
@@ -258,15 +257,111 @@ func decodeBaselineTask(row models.TaskRun) (*baselineTask, error) {
 	}, nil
 }
 
-func (c *Constructor) planTasks(ctx context.Context, tasks []*baselineTask, params map[string]string, forceReexecute bool) ([]plannedTask, error) {
+func topologicalBaselineTasks(runID uuid.UUID, tasks []*baselineTask) ([]*baselineTask, error) {
 	byID := make(map[uuid.UUID]*baselineTask, len(tasks))
-	plannedByID := make(map[uuid.UUID]int, len(tasks))
+	indegree := make(map[uuid.UUID]int, len(tasks))
+	successors := make(map[uuid.UUID]map[uuid.UUID]struct{}, len(tasks))
+	edges := make(map[uuid.UUID]map[uuid.UUID]struct{}, len(tasks))
+
 	for _, task := range tasks {
-		byID[task.row.TaskID] = task
-		if !task.row.ReplaySafe {
-			return nil, fmt.Errorf("%w: step %q has replay_safe=false", ErrReplayUnsafe, task.taskName)
+		if task == nil {
+			return nil, fmt.Errorf("%w: nil baseline task in run %s", ErrUnsupportedDescriptor, runID)
+		}
+		taskID := task.row.TaskID
+		if taskID == uuid.Nil {
+			return nil, fmt.Errorf("%w: step %q has empty task id", ErrUnsupportedDescriptor, task.taskName)
+		}
+		if _, exists := byID[taskID]; exists {
+			return nil, fmt.Errorf("%w: duplicate task %s in baseline run %s", ErrUnsupportedDescriptor, taskID, runID)
+		}
+		byID[taskID] = task
+		indegree[taskID] = 0
+	}
+
+	addEdge := func(from, to uuid.UUID, stepName, relation string) error {
+		if from == uuid.Nil || to == uuid.Nil {
+			return fmt.Errorf("%w: step %q has empty %s edge", ErrUnsupportedDescriptor, stepName, relation)
+		}
+		if _, ok := byID[from]; !ok {
+			return fmt.Errorf("%w: step %q references missing %s %s", ErrUnsupportedDescriptor, stepName, relation, from)
+		}
+		if _, ok := byID[to]; !ok {
+			return fmt.Errorf("%w: step %q references missing %s %s", ErrUnsupportedDescriptor, stepName, relation, to)
+		}
+		if edges[from] == nil {
+			edges[from] = make(map[uuid.UUID]struct{})
+		}
+		if _, exists := edges[from][to]; exists {
+			return nil
+		}
+		edges[from][to] = struct{}{}
+		if successors[from] == nil {
+			successors[from] = make(map[uuid.UUID]struct{})
+		}
+		successors[from][to] = struct{}{}
+		indegree[to]++
+		return nil
+	}
+
+	for _, task := range tasks {
+		taskID := task.row.TaskID
+		for _, pred := range task.descriptor.DAG.Predecessors {
+			if err := addEdge(pred.TaskID, taskID, task.taskName, "predecessor"); err != nil {
+				return nil, err
+			}
+		}
+		for _, succ := range task.descriptor.DAG.Successors {
+			if err := addEdge(taskID, succ.TaskID, task.taskName, "successor"); err != nil {
+				return nil, err
+			}
 		}
 	}
+
+	ready := make([]*baselineTask, 0, len(tasks))
+	for _, task := range tasks {
+		if indegree[task.row.TaskID] == 0 {
+			ready = append(ready, task)
+		}
+	}
+	sortBaselineReady(ready)
+
+	ordered := make([]*baselineTask, 0, len(tasks))
+	for len(ready) > 0 {
+		task := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, task)
+		for successorID := range successors[task.row.TaskID] {
+			indegree[successorID]--
+			if indegree[successorID] == 0 {
+				ready = append(ready, byID[successorID])
+			}
+		}
+		sortBaselineReady(ready)
+	}
+
+	if len(ordered) != len(tasks) {
+		return nil, fmt.Errorf("%w: descriptor DAG cycle while ordering baseline run %s", ErrUnsupportedDescriptor, runID)
+	}
+	return ordered, nil
+}
+
+func sortBaselineReady(tasks []*baselineTask) {
+	sort.SliceStable(tasks, func(i, j int) bool {
+		if tasks[i].descriptor.DAG.TaskPosition != tasks[j].descriptor.DAG.TaskPosition {
+			return tasks[i].descriptor.DAG.TaskPosition < tasks[j].descriptor.DAG.TaskPosition
+		}
+		if !tasks[i].row.CreatedAt.Equal(tasks[j].row.CreatedAt) {
+			return tasks[i].row.CreatedAt.Before(tasks[j].row.CreatedAt)
+		}
+		if tasks[i].taskName != tasks[j].taskName {
+			return tasks[i].taskName < tasks[j].taskName
+		}
+		return tasks[i].row.TaskID.String() < tasks[j].row.TaskID.String()
+	})
+}
+
+func (c *Constructor) planTasks(ctx context.Context, tasks []*baselineTask, params map[string]string, forceReexecute bool) ([]plannedTask, error) {
+	plannedByID := make(map[uuid.UUID]int, len(tasks))
 
 	plans := make([]plannedTask, 0, len(tasks))
 	for _, task := range tasks {
@@ -276,10 +371,6 @@ func (c *Constructor) planTasks(ctx context.Context, tasks []*baselineTask, para
 		for _, pred := range task.descriptor.DAG.Predecessors {
 			plannedIdx, ok := plannedByID[pred.TaskID]
 			if !ok {
-				if _, ok := byID[pred.TaskID]; ok {
-					pendingPredecessors++
-					continue
-				}
 				return nil, fmt.Errorf("%w: step %q references missing predecessor %s", ErrUnsupportedDescriptor, task.taskName, pred.TaskID)
 			}
 			plannedPred := &plans[plannedIdx]
@@ -302,7 +393,9 @@ func (c *Constructor) planTasks(ctx context.Context, tasks []*baselineTask, para
 			base:          task,
 			replayHash:    replayHash,
 			effectiveHash: replayHash,
-			descriptor:    replayDescriptor(task.descriptor),
+			// The replay TaskRun stores the baseline descriptor unchanged; its
+			// Baseline fields are the audit reference for what was replayed.
+			descriptor: task.descriptor,
 		}
 
 		if unchanged && pendingPredecessors == 0 {
@@ -411,7 +504,7 @@ func (c *Constructor) authorizeReexecution(ctx context.Context, task *baselineTa
 		return fmt.Errorf("%w: step %q would re-execute but baseline task_run replay_safe=false", ErrReplayUnsafe, task.taskName)
 	}
 
-	expectedByKey, err := expectedSecretRefMap(task.descriptor.SecretRefs)
+	expectedByKey, err := ExpectedReplaySecretRefMap(task.descriptor.SecretRefs)
 	if err != nil {
 		return fmt.Errorf("%w: step %q: %v", ErrSecretIdentity, task.taskName, err)
 	}
@@ -421,7 +514,7 @@ func (c *Constructor) authorizeReexecution(ctx context.Context, task *baselineTa
 		if !strings.HasPrefix(refValue, "secret://") {
 			continue
 		}
-		key := secretRefKey(envKey, refValue)
+		key := ReplaySecretRefKey(envKey, refValue)
 		ref, ok := expectedByKey[key]
 		if !ok {
 			return fmt.Errorf("%w: step %q env %s secret %s has no baseline identity", ErrSecretIdentity, task.taskName, envKey, refValue)
@@ -449,36 +542,75 @@ func (c *Constructor) verifyReplaySecretIdentity(ctx context.Context, taskName s
 	if c.secretResolver == nil {
 		return fmt.Errorf("%w: step %q secret %s requires a configured resolver", ErrSecretIdentity, taskName, ref.Ref)
 	}
-	_, identity, err := c.secretResolver.ResolveWithIdentity(ctx, ref.Ref)
+	value, identity, err := c.secretResolver.ResolveWithIdentity(ctx, ref.Ref)
 	if err != nil {
 		return fmt.Errorf("%w: step %q secret %s re-resolve failed: %v", ErrSecretIdentity, taskName, ref.Ref, err)
 	}
-	if err := verifyResolvedSecretIdentity(ctx, c.secretResolver, ref, identity); err != nil {
+	if err := VerifyResolvedReplaySecretIdentity(ctx, c.secretResolver, ref, value, identity); err != nil {
 		return fmt.Errorf("%w: step %q secret %s %v", ErrSecretIdentity, taskName, ref.Ref, err)
 	}
 	return nil
 }
 
-func expectedSecretRefMap(refs []models.TaskExecutionSecretRef) (map[string]models.TaskExecutionSecretRef, error) {
+// VerifyReplaySecretIdentities verifies descriptor-captured replay secret
+// identities against the identities and values resolved for a quarantined task.
+func VerifyReplaySecretIdentities(ctx context.Context, resolver secret.Resolver, expected []models.TaskExecutionSecretRef, actual []jobdefruntime.ResolvedSecretIdentity, resolvedEnv map[string]string) error {
+	expectedByKey, err := ExpectedReplaySecretRefMap(expected)
+	if err != nil {
+		return err
+	}
+	actualByKey := make(map[string]jobdefruntime.ResolvedSecretIdentity, len(actual))
+	for _, resolved := range actual {
+		key := ReplaySecretRefKey(resolved.EnvKey, resolved.Ref)
+		ref, ok := expectedByKey[key]
+		if !ok {
+			return fmt.Errorf("replay secret %s for env %s has no baseline identity", resolved.Ref, resolved.EnvKey)
+		}
+		actualByKey[key] = resolved
+		value, ok := resolvedEnv[resolved.EnvKey]
+		if !ok {
+			return fmt.Errorf("replay secret %s for env %s resolved value unavailable", ref.Ref, ref.EnvKey)
+		}
+		if err := VerifyResolvedReplaySecretIdentity(ctx, resolver, ref, value, resolved.Identity); err != nil {
+			return fmt.Errorf("replay secret %s for env %s %v", ref.Ref, ref.EnvKey, err)
+		}
+	}
+	for _, ref := range expected {
+		if strings.TrimSpace(ref.Ref) == "" {
+			continue
+		}
+		_, ok := actualByKey[ReplaySecretRefKey(ref.EnvKey, ref.Ref)]
+		if !ok {
+			return fmt.Errorf("replay secret %s for env %s was not resolved", ref.Ref, ref.EnvKey)
+		}
+	}
+	return nil
+}
+
+// ExpectedReplaySecretRefMap keys descriptor secret refs by env key and ref.
+func ExpectedReplaySecretRefMap(refs []models.TaskExecutionSecretRef) (map[string]models.TaskExecutionSecretRef, error) {
 	expected := make(map[string]models.TaskExecutionSecretRef)
 	for _, ref := range refs {
 		if strings.TrimSpace(ref.Ref) == "" {
 			continue
 		}
-		key := secretRefKey(ref.EnvKey, ref.Ref)
+		key := ReplaySecretRefKey(ref.EnvKey, ref.Ref)
 		if _, exists := expected[key]; exists {
-			return nil, fmt.Errorf("duplicate baseline secret identity for env %s ref %s", ref.EnvKey, ref.Ref)
+			return nil, fmt.Errorf("duplicate replay secret identity for env %s ref %s", ref.EnvKey, ref.Ref)
 		}
 		expected[key] = ref
 	}
 	return expected, nil
 }
 
-func secretRefKey(envKey, ref string) string {
+// ReplaySecretRefKey returns the canonical map key for an env secret ref.
+func ReplaySecretRefKey(envKey, ref string) string {
 	return strings.TrimSpace(envKey) + "\x00" + strings.TrimSpace(ref)
 }
 
-func verifyResolvedSecretIdentity(ctx context.Context, resolver secret.Resolver, ref models.TaskExecutionSecretRef, identity secret.Identity) error {
+// VerifyResolvedReplaySecretIdentity verifies one descriptor secret identity
+// against the value and identity returned by the resolver.
+func VerifyResolvedReplaySecretIdentity(ctx context.Context, resolver secret.Resolver, ref models.TaskExecutionSecretRef, resolvedValue string, identity secret.Identity) error {
 	if !ref.Verifiable {
 		return fmt.Errorf("is not verifiable: %s", ref.UnverifiableReason)
 	}
@@ -488,49 +620,53 @@ func verifyResolvedSecretIdentity(ctx context.Context, resolver secret.Resolver,
 	if ref.Provider != "" && ref.Provider != identity.Provider {
 		return fmt.Errorf("provider changed from %s to %s", ref.Provider, identity.Provider)
 	}
-	if requiresPinnedVaultVerification(ref) {
-		if descriptorIdentityString(ref, "version") != identity.Version {
-			return fmt.Errorf("version changed from %s to %s", descriptorIdentityString(ref, "version"), identity.Version)
+	if ReplaySecretRequiresPinnedVaultVerification(ref) {
+		if ReplayDescriptorIdentityString(ref, "version") != identity.Version {
+			return fmt.Errorf("version changed from %s to %s", ReplayDescriptorIdentityString(ref, "version"), identity.Version)
 		}
-		verifier, ok := resolver.(secret.IdentityVerifier)
+		verifier, ok := resolver.(secret.ResolvedIdentityVerifier)
 		if !ok {
 			return fmt.Errorf("provider %s does not support baseline identity verification", ref.Provider)
 		}
-		pinned, err := verifier.VerifyIdentity(ctx, ref.Ref, secretIdentityFromDescriptor(ref))
+		pinned, err := verifier.VerifyResolvedIdentity(ctx, ref.Ref, ReplaySecretIdentityFromDescriptor(ref), resolvedValue)
 		if err != nil {
 			return fmt.Errorf("baseline identity verification failed: %w", err)
 		}
 		if !pinned.Verifiable {
 			return fmt.Errorf("baseline identity is not verifiable: %s", pinned.UnverifiableReason)
 		}
-		if !secretIdentityMatches(ref, pinned) {
+		if !ReplaySecretIdentityMatches(ref, pinned) {
 			return fmt.Errorf("baseline identity changed")
 		}
 		return nil
 	}
-	if !secretIdentityMatches(ref, identity) {
+	if !ReplaySecretIdentityMatches(ref, identity) {
 		return fmt.Errorf("identity changed")
 	}
 	return nil
 }
 
-func requiresPinnedVaultVerification(ref models.TaskExecutionSecretRef) bool {
+// ReplaySecretRequiresPinnedVaultVerification reports whether a descriptor ref
+// carries the Vault version and HMAC key needed for baseline identity pinning.
+func ReplaySecretRequiresPinnedVaultVerification(ref models.TaskExecutionSecretRef) bool {
 	return strings.EqualFold(ref.Provider, "vault") &&
-		descriptorIdentityString(ref, "version") != "" &&
-		descriptorIdentityString(ref, "keyId") != ""
+		ReplayDescriptorIdentityString(ref, "version") != "" &&
+		ReplayDescriptorIdentityString(ref, "keyId") != ""
 }
 
-func secretIdentityFromDescriptor(ref models.TaskExecutionSecretRef) secret.Identity {
+// ReplaySecretIdentityFromDescriptor converts a descriptor secret ref back to
+// the captured identity shape used for verification.
+func ReplaySecretIdentityFromDescriptor(ref models.TaskExecutionSecretRef) secret.Identity {
 	return secret.Identity{
 		Provider:        ref.Provider,
 		Ref:             ref.Ref,
-		Version:         descriptorIdentityString(ref, "version"),
-		ResourceVersion: descriptorIdentityString(ref, "resourceVersion"),
-		Namespace:       descriptorIdentityString(ref, "namespace"),
-		Name:            descriptorIdentityString(ref, "name"),
-		Key:             descriptorIdentityString(ref, "key"),
-		KeyID:           descriptorIdentityString(ref, "keyId"),
-		HMACSHA256:      descriptorIdentityString(ref, "hmacSha256"),
+		Version:         ReplayDescriptorIdentityString(ref, "version"),
+		ResourceVersion: ReplayDescriptorIdentityString(ref, "resourceVersion"),
+		Namespace:       ReplayDescriptorIdentityString(ref, "namespace"),
+		Name:            ReplayDescriptorIdentityString(ref, "name"),
+		Key:             ReplayDescriptorIdentityString(ref, "key"),
+		KeyID:           ReplayDescriptorIdentityString(ref, "keyId"),
+		HMACSHA256:      ReplayDescriptorIdentityString(ref, "hmacSha256"),
 		Verifiable:      ref.Verifiable,
 	}
 }
@@ -690,10 +826,6 @@ func taskRunRecord(replayID uuid.UUID, plan plannedTask, now time.Time) (models.
 	return record, nil
 }
 
-func replayDescriptor(desc models.TaskExecutionDescriptor) models.TaskExecutionDescriptor {
-	return desc
-}
-
 func replayEvents(jobID, runID uuid.UUID, records []models.TaskRun, allCached bool, now time.Time) []event.Event {
 	events := []event.Event{{
 		Type:       event.TypeRunStarted,
@@ -766,15 +898,17 @@ func hashMatchesBaseline(replayHash, computed, effective string) bool {
 	return replayHash != "" && (replayHash == computed || (effective != "" && replayHash == effective))
 }
 
-func secretIdentityMatches(ref models.TaskExecutionSecretRef, identity secret.Identity) bool {
+// ReplaySecretIdentityMatches compares a descriptor ref's recorded identity
+// fields with a resolved or verified identity.
+func ReplaySecretIdentityMatches(ref models.TaskExecutionSecretRef, identity secret.Identity) bool {
 	if ref.Provider != "" && ref.Provider != identity.Provider {
 		return false
 	}
-	if !hasRequiredSecretDiscriminator(ref) {
+	if !ReplaySecretHasRequiredDiscriminator(ref) {
 		return false
 	}
 	expected := ref.Identity
-	actual := identityMap(identity)
+	actual := ReplaySecretIdentityMap(identity)
 	for key, expectedValue := range expected {
 		if fmt.Sprint(expectedValue) != fmt.Sprint(actual[key]) {
 			return false
@@ -783,14 +917,16 @@ func secretIdentityMatches(ref models.TaskExecutionSecretRef, identity secret.Id
 	return true
 }
 
-func hasRequiredSecretDiscriminator(ref models.TaskExecutionSecretRef) bool {
+// ReplaySecretHasRequiredDiscriminator confirms a descriptor ref has enough
+// provider-specific identity material to fail closed on mismatch.
+func ReplaySecretHasRequiredDiscriminator(ref models.TaskExecutionSecretRef) bool {
 	if len(ref.Identity) == 0 {
 		return false
 	}
 	if strings.EqualFold(ref.Provider, "vault") {
-		return descriptorIdentityString(ref, "version") != "" &&
-			descriptorIdentityString(ref, "keyId") != "" &&
-			descriptorIdentityString(ref, "hmacSha256") != ""
+		return ReplayDescriptorIdentityString(ref, "version") != "" &&
+			ReplayDescriptorIdentityString(ref, "keyId") != "" &&
+			ReplayDescriptorIdentityString(ref, "hmacSha256") != ""
 	}
 	for _, value := range ref.Identity {
 		if strings.TrimSpace(fmt.Sprint(value)) != "" {
@@ -800,7 +936,9 @@ func hasRequiredSecretDiscriminator(ref models.TaskExecutionSecretRef) bool {
 	return false
 }
 
-func descriptorIdentityString(ref models.TaskExecutionSecretRef, key string) string {
+// ReplayDescriptorIdentityString returns a trimmed string identity field from a
+// descriptor ref.
+func ReplayDescriptorIdentityString(ref models.TaskExecutionSecretRef, key string) string {
 	if len(ref.Identity) == 0 {
 		return ""
 	}
@@ -811,7 +949,9 @@ func descriptorIdentityString(ref models.TaskExecutionSecretRef, key string) str
 	return strings.TrimSpace(fmt.Sprint(value))
 }
 
-func identityMap(identity secret.Identity) datatypes.JSONMap {
+// ReplaySecretIdentityMap returns the descriptor-comparable fields for an
+// identity.
+func ReplaySecretIdentityMap(identity secret.Identity) datatypes.JSONMap {
 	out := datatypes.JSONMap{}
 	if identity.Version != "" {
 		out["version"] = identity.Version

--- a/internal/replay/replay_test.go
+++ b/internal/replay/replay_test.go
@@ -1,0 +1,482 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/pkg/container"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+type recordingDispatcher struct {
+	calls []uuid.UUID
+	err   error
+}
+
+func (d *recordingDispatcher) DispatchReplay(_ context.Context, runID uuid.UUID) error {
+	d.calls = append(d.calls, runID)
+	return d.err
+}
+
+type replayFixture struct {
+	db    *gorm.DB
+	store *run.Store
+	jobID uuid.UUID
+	runID uuid.UUID
+	now   time.Time
+}
+
+func newReplayFixture(t *testing.T) replayFixture {
+	t.Helper()
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	triggerID := uuid.New()
+	jobID := uuid.New()
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.Trigger{
+		ID:        triggerID,
+		Type:      models.TriggerTypeHTTP,
+		Alias:     "manual",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Job{
+		ID:        jobID,
+		Alias:     "replay-job",
+		TriggerID: triggerID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:           runID,
+		JobID:        jobID,
+		TriggerID:    triggerID,
+		TriggerType:  "http",
+		TriggerAlias: "manual",
+		Status:       string(run.StatusSucceeded),
+		Params:       mustJSON(t, map[string]string{"mode": "baseline"}),
+		StartedAt:    now,
+		CompletedAt:  ptr(now.Add(time.Second)),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}).Error)
+	return replayFixture{db: db, store: run.NewStore(db), jobID: jobID, runID: runID, now: now}
+}
+
+func TestReplayRefusesTaskNotRecordedReplaySafe(t *testing.T) {
+	f := newReplayFixture(t)
+	taskID := f.seedTask(t, seedTaskConfig{name: "deploy", replaySafe: false, result: "success"})
+
+	dispatcher := &recordingDispatcher{}
+	_, err := New(f.store, dispatcher).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.ErrorIs(t, err, ErrReplayUnsafe)
+	require.Contains(t, err.Error(), `step "deploy"`)
+	require.Empty(t, dispatcher.calls)
+
+	var count int64
+	require.NoError(t, f.db.Model(&models.TaskRun{}).Where("job_run_id <> ? AND task_id = ?", f.runID, taskID).Count(&count).Error)
+	require.Zero(t, count)
+}
+
+func TestReplayRefusesUnchangedTaskNotRecordedReplaySafe(t *testing.T) {
+	f := newReplayFixture(t)
+	f.seedTask(t, seedTaskConfig{name: "deploy", replaySafe: false, result: "success"})
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrReplayUnsafe)
+	require.Contains(t, err.Error(), `step "deploy"`)
+}
+
+func TestReplayAbortsUnchangedTaskWithoutCacheOrBaselineResult(t *testing.T) {
+	f := newReplayFixture(t)
+	f.seedTask(t, seedTaskConfig{name: "extract", replaySafe: true})
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrUnavailableBaselineProof)
+	require.Contains(t, err.Error(), `step "extract"`)
+}
+
+func TestReplayAbortsUnchangedFailedBaselineResult(t *testing.T) {
+	f := newReplayFixture(t)
+	taskID := f.seedTask(t, seedTaskConfig{name: "extract", replaySafe: true, result: "exit_code:1"})
+	require.NoError(t, f.db.Model(&models.JobRun{}).Where("id = ?", f.runID).Update("status", string(run.StatusFailed)).Error)
+	require.NoError(t, f.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", f.runID, taskID).
+		Update("status", string(run.TaskStatusFailed)).Error)
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrUnavailableBaselineProof)
+	require.Contains(t, err.Error(), `baseline status "failed" is not reusable`)
+
+	var replayRuns int64
+	require.NoError(t, f.db.Model(&models.JobRun{}).Where("id <> ? AND job_id = ?", f.runID, f.jobID).Count(&replayRuns).Error)
+	require.Zero(t, replayRuns)
+}
+
+func TestReplayAbortsUnchangedBaselineOutputWithEmptyResult(t *testing.T) {
+	f := newReplayFixture(t)
+	f.seedTask(t, seedTaskConfig{
+		name:       "extract",
+		replaySafe: true,
+		output:     map[string]string{"artifact": "one"},
+	})
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrUnavailableBaselineProof)
+	require.Contains(t, err.Error(), "recorded an empty result (corruption)")
+}
+
+func TestReplayMaterializesDescriptorInsteadOfLiveRows(t *testing.T) {
+	f := newReplayFixture(t)
+	taskID := f.seedTask(t, seedTaskConfig{
+		name:       "transform",
+		replaySafe: true,
+		result:     "success",
+		spec: container.Spec{
+			Env:     map[string]string{"MODE": "baseline", "TOKEN": "literal"},
+			WorkDir: "/baseline",
+			Mounts:  []container.Mount{{Type: container.MountTypeBind, Source: "/baseline/in", Target: "/in", ReadOnly: true}},
+		},
+		image:   "baseline/image@sha256:aaaa",
+		command: []string{"sh", "-c", "echo baseline"},
+	})
+
+	require.NoError(t, f.db.Model(&models.Atom{}).Where("id IN (SELECT atom_id FROM tasks WHERE id = ?)", taskID).
+		Updates(map[string]any{
+			"image":   "current/image:latest",
+			"command": `["sh","-c","echo current"]`,
+			"spec":    mustJSON(t, container.Spec{Env: map[string]string{"MODE": "current"}, WorkDir: "/current"}),
+		}).Error)
+
+	dispatcher := &recordingDispatcher{}
+	result, err := New(f.store, dispatcher).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.NoError(t, err)
+	require.Len(t, dispatcher.calls, 1)
+
+	var replayTask models.TaskRun
+	require.NoError(t, f.db.First(&replayTask, "job_run_id = ? AND task_id = ?", result.Run.ID, taskID).Error)
+	require.Equal(t, "baseline/image@sha256:aaaa", replayTask.Image)
+	require.JSONEq(t, `["sh","-c","echo baseline"]`, replayTask.Command)
+	require.True(t, replayTask.Quarantine)
+	require.True(t, replayTask.ReplaySafe)
+
+	var desc models.TaskExecutionDescriptor
+	require.NoError(t, json.Unmarshal(replayTask.ExecutionDescriptor, &desc))
+	require.Equal(t, "/baseline", desc.ContainerSpec.WorkDir)
+	require.Equal(t, "baseline", desc.ContainerSpec.Env["MODE"])
+	require.Equal(t, "/baseline/in", desc.ContainerSpec.Mounts[0].Source)
+}
+
+func TestReplayFailsClosedWhenDescriptorMissing(t *testing.T) {
+	f := newReplayFixture(t)
+	taskID := f.seedTask(t, seedTaskConfig{name: "load", replaySafe: true, result: "success"})
+	require.NoError(t, f.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", f.runID, taskID).
+		Update("execution_descriptor", nil).Error)
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.ErrorIs(t, err, ErrMissingDescriptor)
+}
+
+func TestReplayFailsClosedWhenDescriptorReplaySafeMismatchesRow(t *testing.T) {
+	f := newReplayFixture(t)
+	taskID := f.seedTask(t, seedTaskConfig{name: "load", replaySafe: true, result: "success"})
+
+	var taskRun models.TaskRun
+	require.NoError(t, f.db.First(&taskRun, "job_run_id = ? AND task_id = ?", f.runID, taskID).Error)
+	var desc models.TaskExecutionDescriptor
+	require.NoError(t, json.Unmarshal(taskRun.ExecutionDescriptor, &desc))
+	desc.Baseline.ReplaySafe = false
+	require.NoError(t, f.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", f.runID, taskID).
+		Update("execution_descriptor", mustJSON(t, desc)).Error)
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrUnsupportedDescriptor)
+	require.Contains(t, err.Error(), "descriptor replay_safe=false")
+}
+
+func TestReplayRejectsQuarantinedBaseline(t *testing.T) {
+	f := newReplayFixture(t)
+	f.seedTask(t, seedTaskConfig{name: "safe", replaySafe: true, result: "success"})
+	require.NoError(t, f.db.Model(&models.JobRun{}).Where("id = ?", f.runID).Update("quarantine", true).Error)
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrQuarantinedBaseline)
+}
+
+func TestReplayQuarantinesRunAndTaskRows(t *testing.T) {
+	f := newReplayFixture(t)
+	taskID := f.seedTask(t, seedTaskConfig{name: "safe", replaySafe: true, result: "success"})
+
+	result, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.NoError(t, err)
+	require.True(t, result.Run.Quarantine)
+
+	var replayTask models.TaskRun
+	require.NoError(t, f.db.First(&replayTask, "job_run_id = ? AND task_id = ?", result.Run.ID, taskID).Error)
+	require.True(t, replayTask.Quarantine)
+}
+
+func TestReplayOverrideRerunsFullDAGNoOverrideCacheHits(t *testing.T) {
+	f := newReplayFixture(t)
+	extractID := f.seedTask(t, seedTaskConfig{
+		name:       "extract",
+		replaySafe: true,
+		result:     "success",
+		output:     map[string]string{"artifact": "one"},
+		position:   0,
+	})
+	loadID := f.seedTask(t, seedTaskConfig{
+		name:       "load",
+		replaySafe: true,
+		result:     "success",
+		position:   1,
+		predecessors: []models.TaskExecutionEdgeRef{{
+			TaskID:   extractID,
+			TaskName: "extract",
+		}},
+	})
+	f.linkDescriptors(t, extractID, loadID)
+
+	noOverrideDispatcher := &recordingDispatcher{}
+	noOverride, err := New(f.store, noOverrideDispatcher).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.NoError(t, err)
+	require.Empty(t, noOverrideDispatcher.calls)
+	require.Len(t, noOverride.Decisions, 2)
+	for _, decision := range noOverride.Decisions {
+		require.True(t, decision.CacheHit, decision.TaskName)
+		require.False(t, decision.Reexecute, decision.TaskName)
+	}
+
+	withOverrideDispatcher := &recordingDispatcher{}
+	withOverride, err := New(f.store, withOverrideDispatcher).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.NoError(t, err)
+	require.Len(t, withOverrideDispatcher.calls, 1)
+	require.Len(t, withOverride.Decisions, 2)
+	for _, decision := range withOverride.Decisions {
+		require.False(t, decision.CacheHit, decision.TaskName)
+		require.True(t, decision.Reexecute, decision.TaskName)
+	}
+
+	var loadTask models.TaskRun
+	require.NoError(t, f.db.First(&loadTask, "job_run_id = ? AND task_id = ?", withOverride.Run.ID, loadID).Error)
+	require.Equal(t, 1, loadTask.OutstandingPredecessors)
+}
+
+func TestReplaySurfacesDispatchFailureAfterDurableMaterialization(t *testing.T) {
+	f := newReplayFixture(t)
+	f.seedTask(t, seedTaskConfig{name: "safe", replaySafe: true, result: "success"})
+	dispatchErr := errors.New("dispatch unavailable")
+
+	_, err := New(f.store, &recordingDispatcher{err: dispatchErr}).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.ErrorIs(t, err, dispatchErr)
+}
+
+type seedTaskConfig struct {
+	name         string
+	replaySafe   bool
+	result       string
+	output       map[string]string
+	position     int
+	predecessors []models.TaskExecutionEdgeRef
+	successors   []models.TaskExecutionEdgeRef
+	spec         container.Spec
+	image        string
+	command      []string
+}
+
+func (f replayFixture) seedTask(t *testing.T, cfg seedTaskConfig) uuid.UUID {
+	t.Helper()
+	if cfg.image == "" {
+		cfg.image = "alpine:3.23"
+	}
+	if len(cfg.command) == 0 {
+		cfg.command = []string{"sh", "-c", "echo " + cfg.name}
+	}
+	if cfg.spec.Env == nil {
+		cfg.spec.Env = map[string]string{"STEP": cfg.name}
+	}
+	atomID := uuid.New()
+	taskID := uuid.New()
+	command := mustJSONString(t, cfg.command)
+	require.NoError(t, f.db.Create(&models.Atom{
+		ID:        atomID,
+		Engine:    models.AtomEngineDocker,
+		Image:     "live/" + cfg.name + ":latest",
+		Command:   `["sh","-c","echo live"]`,
+		Spec:      mustJSON(t, container.Spec{Env: map[string]string{"STEP": "live"}}),
+		CreatedAt: f.now,
+		UpdatedAt: f.now,
+	}).Error)
+	require.NoError(t, f.db.Create(&models.Task{
+		ID:          taskID,
+		JobID:       f.jobID,
+		AtomID:      atomID,
+		Name:        cfg.name,
+		Position:    cfg.position,
+		TriggerRule: "all_success",
+		ReplaySafe:  cfg.replaySafe,
+		CreatedAt:   f.now.Add(time.Duration(cfg.position) * time.Millisecond),
+		UpdatedAt:   f.now,
+	}).Error)
+
+	desc := models.TaskExecutionDescriptor{
+		SchemaVersion: models.TaskExecutionDescriptorSchemaVersion,
+		CapturedAt:    f.now,
+		Baseline: models.TaskExecutionBaseline{
+			JobID:         f.jobID,
+			JobAlias:      "replay-job",
+			TaskID:        taskID,
+			TaskName:      cfg.name,
+			AtomID:        atomID,
+			BaselineRunID: f.runID,
+			ReplaySafe:    cfg.replaySafe,
+		},
+		DAG: models.TaskExecutionDAG{
+			Predecessors:            cfg.predecessors,
+			Successors:              cfg.successors,
+			TriggerRule:             "all_success",
+			BranchBehavior:          "task",
+			TaskPosition:            cfg.position,
+			OutstandingPredecessors: len(cfg.predecessors),
+		},
+		Run: models.TaskExecutionRun{Params: map[string]string{"mode": "baseline"}},
+		Runtime: models.TaskExecutionRuntime{
+			Engine:       models.AtomEngineDocker,
+			Image:        cfg.image,
+			Command:      cfg.command,
+			CommandRaw:   command,
+			WorkDir:      cfg.spec.WorkDir,
+			TaskType:     "task",
+			RetryCount:   0,
+			RetryDelay:   time.Second,
+			RetryBackoff: true,
+		},
+		Cache: models.TaskExecutionCache{
+			Enabled: true,
+			Version: 1,
+		},
+		Schema:        models.TaskExecutionSchema{ValidationMode: "warn"},
+		ContainerSpec: cfg.spec,
+	}
+	hash := computeDescriptorHash(desc, map[string]string{"mode": "baseline"}, nil, nil)
+	desc.Cache.ComputedHash = hash
+	desc.Baseline.ComputedHash = hash
+
+	encodedDescriptor := mustJSON(t, desc)
+	row := models.TaskRun{
+		ID:                      uuid.New(),
+		JobRunID:                f.runID,
+		TaskID:                  taskID,
+		AtomID:                  atomID,
+		Engine:                  models.AtomEngineDocker,
+		Image:                   cfg.image,
+		Command:                 command,
+		Status:                  string(run.TaskStatusSucceeded),
+		Attempt:                 1,
+		MaxAttempts:             1,
+		Hash:                    hash,
+		Result:                  cfg.result,
+		OutstandingPredecessors: len(cfg.predecessors),
+		CacheEnabled:            true,
+		CacheVersion:            1,
+		ReplaySafe:              cfg.replaySafe,
+		ExecutionDescriptor:     encodedDescriptor,
+		StartedAt:               ptr(f.now),
+		CompletedAt:             ptr(f.now.Add(time.Second)),
+		CreatedAt:               f.now.Add(time.Duration(cfg.position) * time.Millisecond),
+		UpdatedAt:               f.now,
+	}
+	if len(cfg.output) > 0 {
+		row.Output = mustJSON(t, cfg.output)
+	}
+	require.NoError(t, f.db.Create(&row).Error)
+	return taskID
+}
+
+func (f replayFixture) linkDescriptors(t *testing.T, from, to uuid.UUID) {
+	t.Helper()
+	require.NoError(t, f.db.Create(&models.TaskEdge{
+		ID:         uuid.New(),
+		JobID:      f.jobID,
+		FromTaskID: from,
+		ToTaskID:   to,
+		CreatedAt:  f.now,
+		UpdatedAt:  f.now,
+	}).Error)
+
+	var fromRun, toRun models.TaskRun
+	require.NoError(t, f.db.First(&fromRun, "job_run_id = ? AND task_id = ?", f.runID, from).Error)
+	require.NoError(t, f.db.First(&toRun, "job_run_id = ? AND task_id = ?", f.runID, to).Error)
+
+	var fromDesc, toDesc models.TaskExecutionDescriptor
+	require.NoError(t, json.Unmarshal(fromRun.ExecutionDescriptor, &fromDesc))
+	require.NoError(t, json.Unmarshal(toRun.ExecutionDescriptor, &toDesc))
+	fromDesc.DAG.Successors = []models.TaskExecutionEdgeRef{{TaskID: to, TaskName: "load"}}
+	toDesc.DAG.Predecessors = []models.TaskExecutionEdgeRef{{TaskID: from, TaskName: "extract"}}
+	toDesc.DAG.OutstandingPredecessors = 1
+
+	var fromOutput map[string]string
+	require.NoError(t, json.Unmarshal(fromRun.Output, &fromOutput))
+	toHash := computeDescriptorHash(
+		toDesc,
+		map[string]string{"mode": "baseline"},
+		map[string]map[string]string{"extract": fromOutput},
+		[]string{fromRun.Hash},
+	)
+	toDesc.Cache.ComputedHash = toHash
+	toDesc.Baseline.ComputedHash = toHash
+
+	require.NoError(t, f.db.Model(&models.TaskRun{}).Where("id = ?", fromRun.ID).Update("execution_descriptor", mustJSON(t, fromDesc)).Error)
+	require.NoError(t, f.db.Model(&models.TaskRun{}).Where("id = ?", toRun.ID).Updates(map[string]any{
+		"hash":                 toHash,
+		"execution_descriptor": mustJSON(t, toDesc),
+	}).Error)
+}
+
+func mustJSON(t *testing.T, v any) datatypes.JSON {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return datatypes.JSON(data)
+}
+
+func mustJSONString(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func ptr[T any](v T) *T {
+	return &v
+}

--- a/internal/replay/replay_test.go
+++ b/internal/replay/replay_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/container"
 	"github.com/google/uuid"
+	vault "github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/require"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -91,13 +93,22 @@ func TestReplayRefusesTaskNotRecordedReplaySafe(t *testing.T) {
 	require.Zero(t, count)
 }
 
-func TestReplayRefusesUnchangedTaskNotRecordedReplaySafe(t *testing.T) {
+func TestReplayCacheHitsUnchangedTaskNotRecordedReplaySafe(t *testing.T) {
 	f := newReplayFixture(t)
-	f.seedTask(t, seedTaskConfig{name: "deploy", replaySafe: false, result: "success"})
+	taskID := f.seedTask(t, seedTaskConfig{name: "deploy", replaySafe: false, result: "success"})
 
-	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
-	require.ErrorIs(t, err, ErrReplayUnsafe)
-	require.Contains(t, err.Error(), `step "deploy"`)
+	dispatcher := &recordingDispatcher{}
+	result, err := New(f.store, dispatcher).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.NoError(t, err)
+	require.Empty(t, dispatcher.calls)
+	require.Len(t, result.Decisions, 1)
+	require.True(t, result.Decisions[0].CacheHit)
+	require.False(t, result.Decisions[0].Reexecute)
+
+	var replayTask models.TaskRun
+	require.NoError(t, f.db.First(&replayTask, "job_run_id = ? AND task_id = ?", result.Run.ID, taskID).Error)
+	require.True(t, replayTask.CacheHit)
+	require.False(t, replayTask.ReplaySafe)
 }
 
 func TestReplayAbortsUnchangedTaskWithoutCacheOrBaselineResult(t *testing.T) {
@@ -289,6 +300,158 @@ func TestReplayOverrideRerunsFullDAGNoOverrideCacheHits(t *testing.T) {
 	require.Equal(t, 1, loadTask.OutstandingPredecessors)
 }
 
+func TestReplayPlansDescriptorDAGTopologicallyWhenYAMLOrderReversed(t *testing.T) {
+	f := newReplayFixture(t)
+	successorID := f.seedTask(t, seedTaskConfig{
+		name:       "deploy",
+		replaySafe: false,
+		result:     "success",
+		position:   0,
+	})
+	predecessorID := f.seedTask(t, seedTaskConfig{
+		name:       "build",
+		replaySafe: false,
+		result:     "success",
+		output:     map[string]string{"artifact": "one"},
+		position:   1,
+	})
+	f.linkDescriptors(t, predecessorID, successorID)
+
+	dispatcher := &recordingDispatcher{}
+	result, err := New(f.store, dispatcher).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.NoError(t, err)
+	require.Empty(t, dispatcher.calls)
+	require.Len(t, result.Decisions, 2)
+	require.Equal(t, "build", result.Decisions[0].TaskName)
+	require.Equal(t, "deploy", result.Decisions[1].TaskName)
+	for _, decision := range result.Decisions {
+		require.True(t, decision.CacheHit, decision.TaskName)
+		require.False(t, decision.Reexecute, decision.TaskName)
+	}
+
+	var replayTasks []models.TaskRun
+	require.NoError(t, f.db.Order("created_at ASC").Find(&replayTasks, "job_run_id = ?", result.Run.ID).Error)
+	require.Len(t, replayTasks, 2)
+	for _, task := range replayTasks {
+		require.Equal(t, string(run.TaskStatusCached), task.Status)
+		require.True(t, task.CacheHit)
+		require.False(t, task.ReplaySafe)
+	}
+}
+
+func TestReplayFailsClosedOnDescriptorDAGCycle(t *testing.T) {
+	f := newReplayFixture(t)
+	firstID := f.seedTask(t, seedTaskConfig{
+		name:       "first",
+		replaySafe: true,
+		result:     "success",
+		output:     map[string]string{"first": "ok"},
+		position:   0,
+	})
+	secondID := f.seedTask(t, seedTaskConfig{
+		name:       "second",
+		replaySafe: true,
+		result:     "success",
+		output:     map[string]string{"second": "ok"},
+		position:   1,
+	})
+	f.linkDescriptors(t, firstID, secondID)
+	f.linkDescriptors(t, secondID, firstID)
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrUnsupportedDescriptor)
+	require.Contains(t, err.Error(), "descriptor DAG cycle")
+}
+
+func TestReplayPinnedVaultSecretUsesResolvedValueWithoutSecondRead(t *testing.T) {
+	f := newReplayFixture(t)
+	ref := "secret://vault/secret/data/path?field=token"
+	keyring, err := secret.NewIdentityKeyring("k2", map[string][]byte{
+		"k1": []byte("baseline-key"),
+		"k2": []byte("current-key"),
+	})
+	require.NoError(t, err)
+	baselineDigest, ok := keyring.HMACWithKeyID("k1", []byte("abc"))
+	require.True(t, ok)
+
+	f.seedTask(t, seedTaskConfig{
+		name:       "deploy",
+		replaySafe: true,
+		result:     "success",
+		spec:       container.Spec{Env: map[string]string{"TOKEN": ref}},
+		secretRefs: []models.TaskExecutionSecretRef{
+			run.SecretIdentityDescriptorRef("TOKEN", ref, secret.Identity{
+				Provider:   "vault",
+				Ref:        ref,
+				Version:    "7",
+				KeyID:      "k1",
+				HMACSHA256: baselineDigest,
+				Verifiable: true,
+			}),
+		},
+	})
+	logical := &replayVaultLogical{response: &vault.Secret{Data: map[string]any{
+		"data":     map[string]any{"token": "abc"},
+		"metadata": map[string]any{"version": 7},
+	}}}
+	resolver := secret.NewVaultResolverWithLogicalAndKeyring(logical, keyring)
+
+	dispatcher := &recordingDispatcher{}
+	_, err = New(f.store, dispatcher, WithSecretResolver(resolver)).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.NoError(t, err)
+	require.Len(t, dispatcher.calls, 1)
+	require.Equal(t, []string{"secret/data/path"}, logical.paths)
+	require.Empty(t, logical.dataRequests)
+}
+
+func TestReplayPinnedVaultSecretAbortsOnVersionDriftWithoutSecondRead(t *testing.T) {
+	f := newReplayFixture(t)
+	ref := "secret://vault/secret/data/path?field=token"
+	keyring, err := secret.NewIdentityKeyring("k2", map[string][]byte{
+		"k1": []byte("baseline-key"),
+		"k2": []byte("current-key"),
+	})
+	require.NoError(t, err)
+	baselineDigest, ok := keyring.HMACWithKeyID("k1", []byte("abc"))
+	require.True(t, ok)
+
+	f.seedTask(t, seedTaskConfig{
+		name:       "deploy",
+		replaySafe: true,
+		result:     "success",
+		spec:       container.Spec{Env: map[string]string{"TOKEN": ref}},
+		secretRefs: []models.TaskExecutionSecretRef{
+			run.SecretIdentityDescriptorRef("TOKEN", ref, secret.Identity{
+				Provider:   "vault",
+				Ref:        ref,
+				Version:    "7",
+				KeyID:      "k1",
+				HMACSHA256: baselineDigest,
+				Verifiable: true,
+			}),
+		},
+	})
+	logical := &replayVaultLogical{response: &vault.Secret{Data: map[string]any{
+		"data":     map[string]any{"token": "abc"},
+		"metadata": map[string]any{"version": 8},
+	}}}
+	resolver := secret.NewVaultResolverWithLogicalAndKeyring(logical, keyring)
+
+	dispatcher := &recordingDispatcher{}
+	_, err = New(f.store, dispatcher, WithSecretResolver(resolver)).Replay(context.Background(), Request{
+		BaselineRunID: f.runID,
+		Set:           map[string]string{"mode": "what-if"},
+	})
+	require.ErrorIs(t, err, ErrSecretIdentity)
+	require.Contains(t, err.Error(), "version changed from 7 to 8")
+	require.Empty(t, dispatcher.calls)
+	require.Equal(t, []string{"secret/data/path"}, logical.paths)
+	require.Empty(t, logical.dataRequests)
+}
+
 func TestReplaySurfacesDispatchFailureAfterDurableMaterialization(t *testing.T) {
 	f := newReplayFixture(t)
 	f.seedTask(t, seedTaskConfig{name: "safe", replaySafe: true, result: "success"})
@@ -310,6 +473,7 @@ type seedTaskConfig struct {
 	predecessors []models.TaskExecutionEdgeRef
 	successors   []models.TaskExecutionEdgeRef
 	spec         container.Spec
+	secretRefs   []models.TaskExecutionSecretRef
 	image        string
 	command      []string
 }
@@ -387,6 +551,7 @@ func (f replayFixture) seedTask(t *testing.T, cfg seedTaskConfig) uuid.UUID {
 		},
 		Schema:        models.TaskExecutionSchema{ValidationMode: "warn"},
 		ContainerSpec: cfg.spec,
+		SecretRefs:    cfg.secretRefs,
 	}
 	hash := computeDescriptorHash(desc, map[string]string{"mode": "baseline"}, nil, nil)
 	desc.Cache.ComputedHash = hash
@@ -441,8 +606,8 @@ func (f replayFixture) linkDescriptors(t *testing.T, from, to uuid.UUID) {
 	var fromDesc, toDesc models.TaskExecutionDescriptor
 	require.NoError(t, json.Unmarshal(fromRun.ExecutionDescriptor, &fromDesc))
 	require.NoError(t, json.Unmarshal(toRun.ExecutionDescriptor, &toDesc))
-	fromDesc.DAG.Successors = []models.TaskExecutionEdgeRef{{TaskID: to, TaskName: "load"}}
-	toDesc.DAG.Predecessors = []models.TaskExecutionEdgeRef{{TaskID: from, TaskName: "extract"}}
+	fromDesc.DAG.Successors = []models.TaskExecutionEdgeRef{{TaskID: to, TaskName: toDesc.Baseline.TaskName}}
+	toDesc.DAG.Predecessors = []models.TaskExecutionEdgeRef{{TaskID: from, TaskName: fromDesc.Baseline.TaskName}}
 	toDesc.DAG.OutstandingPredecessors = 1
 
 	var fromOutput map[string]string
@@ -450,7 +615,7 @@ func (f replayFixture) linkDescriptors(t *testing.T, from, to uuid.UUID) {
 	toHash := computeDescriptorHash(
 		toDesc,
 		map[string]string{"mode": "baseline"},
-		map[string]map[string]string{"extract": fromOutput},
+		map[string]map[string]string{fromDesc.Baseline.TaskName: fromOutput},
 		[]string{fromRun.Hash},
 	)
 	toDesc.Cache.ComputedHash = toHash
@@ -461,6 +626,31 @@ func (f replayFixture) linkDescriptors(t *testing.T, from, to uuid.UUID) {
 		"hash":                 toHash,
 		"execution_descriptor": mustJSON(t, toDesc),
 	}).Error)
+}
+
+type replayVaultLogical struct {
+	response     *vault.Secret
+	paths        []string
+	dataRequests []replayVaultDataRequest
+}
+
+type replayVaultDataRequest struct {
+	path string
+	data map[string][]string
+}
+
+func (f *replayVaultLogical) ReadWithContext(_ context.Context, path string) (*vault.Secret, error) {
+	f.paths = append(f.paths, path)
+	return f.response, nil
+}
+
+func (f *replayVaultLogical) ReadWithDataWithContext(_ context.Context, path string, data map[string][]string) (*vault.Secret, error) {
+	copied := make(map[string][]string, len(data))
+	for key, values := range data {
+		copied[key] = append([]string(nil), values...)
+	}
+	f.dataRequests = append(f.dataRequests, replayVaultDataRequest{path: path, data: copied})
+	return f.response, nil
 }
 
 func mustJSON(t *testing.T, v any) datatypes.JSON {

--- a/internal/run/owner_manager.go
+++ b/internal/run/owner_manager.go
@@ -14,11 +14,11 @@ import (
 //
 //   - Adopt(runID)   — seed a fresh RunState for a run this node just created.
 //   - Recover(runID) — rebuild a run's state from checkpoint + terminal tail on
-//                      lease takeover.
+//     lease takeover.
 //   - Ready(runID)   — the ready queue the dispatch loop pulls from.
 //   - MarkDispatched — record a task pushed to a worker.
 //   - Complete(...)  — apply a worker completion: advance the DAG in memory,
-//                      durably write only terminal rows, and checkpoint.
+//     durably write only terminal rows, and checkpoint.
 //   - Drop(runID)    — release a run on completion or lease loss.
 //
 // Concurrency: the global mu guards only the runs map (brief lookups / inserts /
@@ -222,7 +222,7 @@ func (m *OwnerManager) Complete(runID, taskID uuid.UUID, status TaskStatus, resu
 
 	var branchSkips []uuid.UUID
 	if len(branchSelections) > 0 {
-		skips, err := m.store.ResolveBranchSkips(taskID, branchSelections)
+		skips, err := m.store.ResolveBranchSkips(runID, taskID, branchSelections)
 		if err != nil {
 			or.mu.Unlock()
 			return CompleteResult{Owned: true}, err

--- a/internal/run/owner_topology.go
+++ b/internal/run/owner_topology.go
@@ -1,22 +1,26 @@
 package run
 
 import (
+	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/caesium-cloud/caesium/internal/models"
 	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/google/uuid"
 )
 
-// LoadRunTopology reads a run's immutable DAG shape from the catalog — the tasks
-// and edges of its job — and builds the RunTopology the owner's in-memory
-// RunState needs.  Edge resolution (including the implicit sequential fallback
-// when a job declares no explicit edges) reuses successorEdgesTx, so the graph
-// matches exactly what the local executor and completeTask see.
+// LoadRunTopology reads a run's immutable DAG shape and builds the RunTopology
+// the owner's in-memory RunState needs. Normal runs use the live job catalog;
+// quarantined replay runs use the per-task execution descriptors captured on
+// the TaskRun rows so a later apply cannot change replay dispatch order.
 func (s *Store) LoadRunTopology(runID uuid.UUID) (RunTopology, error) {
 	var jobRun models.JobRun
-	if err := s.db.Select("job_id").First(&jobRun, "id = ?", runID).Error; err != nil {
+	if err := s.db.Select("job_id", "quarantine").First(&jobRun, "id = ?", runID).Error; err != nil {
 		return RunTopology{}, fmt.Errorf("run topology: job run %s: %w", runID, err)
+	}
+	if jobRun.Quarantine {
+		return s.loadReplayRunTopology(runID)
 	}
 
 	var tasks []models.Task
@@ -65,12 +69,111 @@ func (s *Store) LoadRunTopology(runID uuid.UUID) (RunTopology, error) {
 	return topo, nil
 }
 
+func (s *Store) loadReplayRunTopology(runID uuid.UUID) (RunTopology, error) {
+	var taskRuns []models.TaskRun
+	if err := s.db.
+		Select("task_id", "execution_descriptor", "created_at").
+		Where("job_run_id = ?", runID).
+		Order("created_at asc").
+		Find(&taskRuns).Error; err != nil {
+		return RunTopology{}, err
+	}
+	type descriptorTask struct {
+		taskID     uuid.UUID
+		createdAt  int
+		descriptor models.TaskExecutionDescriptor
+	}
+	tasks := make([]descriptorTask, 0, len(taskRuns))
+	for idx := range taskRuns {
+		row := &taskRuns[idx]
+		if len(row.ExecutionDescriptor) == 0 {
+			return RunTopology{}, fmt.Errorf("run topology: replay task %s missing execution descriptor", row.TaskID)
+		}
+		var descriptor models.TaskExecutionDescriptor
+		if err := json.Unmarshal(row.ExecutionDescriptor, &descriptor); err != nil {
+			return RunTopology{}, fmt.Errorf("run topology: decode replay descriptor for task %s: %w", row.TaskID, err)
+		}
+		if descriptor.SchemaVersion != models.TaskExecutionDescriptorSchemaVersion {
+			return RunTopology{}, fmt.Errorf("run topology: unsupported replay descriptor version %d for task %s", descriptor.SchemaVersion, row.TaskID)
+		}
+		tasks = append(tasks, descriptorTask{taskID: row.TaskID, createdAt: idx, descriptor: descriptor})
+	}
+	sort.SliceStable(tasks, func(i, j int) bool {
+		if tasks[i].descriptor.DAG.TaskPosition != tasks[j].descriptor.DAG.TaskPosition {
+			return tasks[i].descriptor.DAG.TaskPosition < tasks[j].descriptor.DAG.TaskPosition
+		}
+		return tasks[i].createdAt < tasks[j].createdAt
+	})
+
+	topo := RunTopology{
+		Adjacency:    make(map[uuid.UUID][]uuid.UUID, len(tasks)),
+		Predecessors: make(map[uuid.UUID][]uuid.UUID, len(tasks)),
+		TriggerRule:  make(map[uuid.UUID]string, len(tasks)),
+		Order:        make(map[uuid.UUID]int, len(tasks)),
+	}
+	for idx, task := range tasks {
+		topo.Adjacency[task.taskID] = nil
+		topo.Predecessors[task.taskID] = nil
+		topo.Order[task.taskID] = idx
+		topo.TriggerRule[task.taskID] = normalizedTriggerRule(task.descriptor.DAG.TriggerRule)
+	}
+	for _, task := range tasks {
+		for _, successor := range task.descriptor.DAG.Successors {
+			if successor.TaskID == uuid.Nil {
+				continue
+			}
+			if _, ok := topo.Order[successor.TaskID]; !ok {
+				continue
+			}
+			topo.Adjacency[task.taskID] = append(topo.Adjacency[task.taskID], successor.TaskID)
+			topo.Predecessors[successor.TaskID] = append(topo.Predecessors[successor.TaskID], task.taskID)
+		}
+	}
+	return topo, nil
+}
+
 // ResolveBranchSkips returns the immediate successor task IDs a branch task
 // excluded at runtime via its branch selections — i.e. the successors to skip.
 // It returns nil for non-branch tasks (which skip nothing here).  It errors if a
 // selection names a step that is not a valid successor, matching completeTask's
 // validation.
-func (s *Store) ResolveBranchSkips(taskID uuid.UUID, branchSelections []string) ([]uuid.UUID, error) {
+func (s *Store) ResolveBranchSkips(runID, taskID uuid.UUID, branchSelections []string) ([]uuid.UUID, error) {
+	if descriptor, replay, err := s.replayTaskExecutionDescriptorTx(s.db, runID, taskID); err != nil {
+		return nil, err
+	} else if replay {
+		taskType := firstNonEmpty(descriptor.Runtime.TaskType, descriptor.DAG.BranchBehavior, "task")
+		if taskType != "branch" {
+			return nil, nil
+		}
+		nameToID := make(map[string]uuid.UUID, len(descriptor.DAG.Successors))
+		validTargets := make([]string, 0, len(descriptor.DAG.Successors))
+		successorIDs := make([]uuid.UUID, 0, len(descriptor.DAG.Successors))
+		for _, successor := range descriptor.DAG.Successors {
+			if successor.TaskID == uuid.Nil {
+				continue
+			}
+			name := firstNonEmpty(successor.TaskName, successor.TaskID.String())
+			nameToID[name] = successor.TaskID
+			validTargets = append(validTargets, name)
+			successorIDs = append(successorIDs, successor.TaskID)
+		}
+		selected := make(map[uuid.UUID]bool, len(branchSelections))
+		for _, name := range branchSelections {
+			id, ok := nameToID[name]
+			if !ok {
+				return nil, fmt.Errorf("branch selected unknown step %q; valid targets: %v", name, validTargets)
+			}
+			selected[id] = true
+		}
+		skips := make([]uuid.UUID, 0, len(successorIDs))
+		for _, id := range successorIDs {
+			if !selected[id] {
+				skips = append(skips, id)
+			}
+		}
+		return skips, nil
+	}
+
 	var task models.Task
 	if err := s.db.First(&task, "id = ?", taskID).Error; err != nil {
 		return nil, err

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -433,6 +433,69 @@ func (s *Store) TaskQuarantine(ctx context.Context, runID, taskID uuid.UUID) (bo
 	return row.TaskQuarantine || row.RunQuarantine, nil
 }
 
+func (s *Store) TaskExecutionDescriptor(ctx context.Context, runID, taskID uuid.UUID) (*models.TaskExecutionDescriptor, error) {
+	var taskRun models.TaskRun
+	err := s.db.WithContext(ctx).
+		Select("execution_descriptor").
+		Where("job_run_id = ? AND task_id = ?", runID, taskID).
+		Take(&taskRun).Error
+	if err != nil {
+		return nil, err
+	}
+	if len(taskRun.ExecutionDescriptor) == 0 {
+		return nil, fmt.Errorf("run: task execution descriptor missing for run %s task %s", runID, taskID)
+	}
+	var descriptor models.TaskExecutionDescriptor
+	if err := json.Unmarshal(taskRun.ExecutionDescriptor, &descriptor); err != nil {
+		return nil, fmt.Errorf("run: decode task execution descriptor for run %s task %s: %w", runID, taskID, err)
+	}
+	if descriptor.SchemaVersion != models.TaskExecutionDescriptorSchemaVersion {
+		return nil, fmt.Errorf("run: unsupported task execution descriptor version %d for run %s task %s", descriptor.SchemaVersion, runID, taskID)
+	}
+	return &descriptor, nil
+}
+
+func (s *Store) replayTaskExecutionDescriptorTx(tx *gorm.DB, runID, taskID uuid.UUID) (*models.TaskExecutionDescriptor, bool, error) {
+	var row struct {
+		TaskQuarantine      bool
+		RunQuarantine       bool
+		ExecutionDescriptor datatypes.JSON
+	}
+	err := tx.Table("task_runs").
+		Select("task_runs.quarantine AS task_quarantine, job_runs.quarantine AS run_quarantine, task_runs.execution_descriptor AS execution_descriptor").
+		Joins("join job_runs on job_runs.id = task_runs.job_run_id").
+		Where("task_runs.job_run_id = ? AND task_runs.task_id = ?", runID, taskID).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if !row.TaskQuarantine && !row.RunQuarantine {
+		return nil, false, nil
+	}
+	if len(row.ExecutionDescriptor) == 0 {
+		return nil, true, fmt.Errorf("run: replay task execution descriptor missing for run %s task %s", runID, taskID)
+	}
+	var descriptor models.TaskExecutionDescriptor
+	if err := json.Unmarshal(row.ExecutionDescriptor, &descriptor); err != nil {
+		return nil, true, fmt.Errorf("run: decode replay task execution descriptor for run %s task %s: %w", runID, taskID, err)
+	}
+	if descriptor.SchemaVersion != models.TaskExecutionDescriptorSchemaVersion {
+		return nil, true, fmt.Errorf("run: unsupported replay task execution descriptor version %d for run %s task %s", descriptor.SchemaVersion, runID, taskID)
+	}
+	return &descriptor, true, nil
+}
+
+func (s *Store) replayPredecessorRefsTx(tx *gorm.DB, runID, taskID uuid.UUID) ([]models.TaskExecutionEdgeRef, bool, error) {
+	descriptor, replay, err := s.replayTaskExecutionDescriptorTx(tx, runID, taskID)
+	if err != nil || !replay {
+		return nil, replay, err
+	}
+	return descriptor.DAG.Predecessors, true, nil
+}
+
 func (s *Store) mutateTaskExecutionDescriptor(runID, taskID uuid.UUID, mutate func(*models.TaskExecutionDescriptor)) error {
 	if mutate == nil {
 		return nil
@@ -1540,33 +1603,35 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 			}
 			counts.addTaskRunStatus(1)
 
-			// Load the task model for edge traversal and branch detection.
-			var taskModel models.Task
-			if err := tx.First(&taskModel, "id = ?", taskID).Error; err != nil {
+			descriptor, replayTask, err := s.replayTaskExecutionDescriptorTx(tx, runID, taskID)
+			if err != nil {
 				return err
 			}
 
-			edges, err := s.successorEdgesTx(tx, taskModel)
+			// Load the task model for edge fallback and branch detection.
+			var taskModel models.Task
+			taskType := ""
+			if replayTask {
+				taskModel = models.Task{ID: taskID}
+				taskType = firstNonEmpty(descriptor.Runtime.TaskType, descriptor.DAG.BranchBehavior, "task")
+			} else {
+				if err := tx.First(&taskModel, "id = ?", taskID).Error; err != nil {
+					return err
+				}
+				taskType = taskModel.Type
+			}
+
+			edges, err := s.successorEdgesForRunTx(tx, runID, taskID, taskModel)
 			if err != nil {
 				return err
 			}
 
 			// Determine branch filtering if this is a branch-type task.
 			var branchSelectedIDs map[uuid.UUID]bool
-			if len(edges) > 0 && taskModel.Type == "branch" {
-				successorIDs := make([]uuid.UUID, 0, len(edges))
-				for _, edge := range edges {
-					successorIDs = append(successorIDs, edge.ToTaskID)
-				}
-				var successorTasks []models.Task
-				if err := tx.Where("id IN ?", successorIDs).Find(&successorTasks).Error; err != nil {
+			if len(edges) > 0 && taskType == "branch" {
+				successorNameToID, _, err := s.successorNameMapTx(tx, replayTask, descriptor, edges)
+				if err != nil {
 					return err
-				}
-				successorNameToID := make(map[string]uuid.UUID, len(successorTasks))
-				for _, st := range successorTasks {
-					if st.Name != "" {
-						successorNameToID[st.Name] = st.ID
-					}
 				}
 
 				branchSelectedIDs = make(map[uuid.UUID]bool, len(branchSelections))
@@ -1729,6 +1794,64 @@ func (s *Store) GetTaskLogSnapshot(runID, taskID uuid.UUID) (*TaskLogSnapshot, e
 		Text:      task.LogText,
 		Truncated: task.LogTruncated,
 	}, nil
+}
+
+func (s *Store) successorEdgesForRunTx(tx *gorm.DB, runID, taskID uuid.UUID, task models.Task) ([]models.TaskEdge, error) {
+	descriptor, replay, err := s.replayTaskExecutionDescriptorTx(tx, runID, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if replay {
+		edges := make([]models.TaskEdge, 0, len(descriptor.DAG.Successors))
+		for _, successor := range descriptor.DAG.Successors {
+			if successor.TaskID == uuid.Nil {
+				continue
+			}
+			edges = append(edges, models.TaskEdge{
+				FromTaskID: taskID,
+				ToTaskID:   successor.TaskID,
+			})
+		}
+		return edges, nil
+	}
+	return s.successorEdgesTx(tx, task)
+}
+
+func (s *Store) successorNameMapTx(tx *gorm.DB, replayTask bool, descriptor *models.TaskExecutionDescriptor, edges []models.TaskEdge) (map[string]uuid.UUID, []string, error) {
+	if replayTask {
+		successorNameToID := make(map[string]uuid.UUID, len(edges))
+		validTargets := make([]string, 0, len(edges))
+		if descriptor == nil {
+			return successorNameToID, validTargets, nil
+		}
+		for _, successor := range descriptor.DAG.Successors {
+			if successor.TaskID == uuid.Nil {
+				continue
+			}
+			name := firstNonEmpty(successor.TaskName, successor.TaskID.String())
+			successorNameToID[name] = successor.TaskID
+			validTargets = append(validTargets, name)
+		}
+		return successorNameToID, validTargets, nil
+	}
+
+	successorIDs := make([]uuid.UUID, 0, len(edges))
+	for _, edge := range edges {
+		successorIDs = append(successorIDs, edge.ToTaskID)
+	}
+	var successorTasks []models.Task
+	if err := tx.Where("id IN ?", successorIDs).Find(&successorTasks).Error; err != nil {
+		return nil, nil, err
+	}
+	successorNameToID := make(map[string]uuid.UUID, len(successorTasks))
+	validTargets := make([]string, 0, len(successorTasks))
+	for _, st := range successorTasks {
+		if st.Name != "" {
+			successorNameToID[st.Name] = st.ID
+			validTargets = append(validTargets, st.Name)
+		}
+	}
+	return successorNameToID, validTargets, nil
 }
 
 func (s *Store) successorEdgesTx(tx *gorm.DB, task models.Task) ([]models.TaskEdge, error) {
@@ -1959,6 +2082,32 @@ func (s *Store) markTaskSkippedTx(tx *gorm.DB, runID, taskID uuid.UUID, reason s
 }
 
 func (s *Store) predecessorStatusesTx(tx *gorm.DB, runID, taskID uuid.UUID) ([]TaskStatus, error) {
+	if refs, replay, err := s.replayPredecessorRefsTx(tx, runID, taskID); err != nil {
+		return nil, err
+	} else if replay {
+		if len(refs) == 0 {
+			return nil, nil
+		}
+		predIDs := make([]uuid.UUID, 0, len(refs))
+		for _, ref := range refs {
+			if ref.TaskID != uuid.Nil {
+				predIDs = append(predIDs, ref.TaskID)
+			}
+		}
+		if len(predIDs) == 0 {
+			return nil, nil
+		}
+		var taskRuns []models.TaskRun
+		if err := tx.Select("status").Where("job_run_id = ? AND task_id IN ?", runID, predIDs).Find(&taskRuns).Error; err != nil {
+			return nil, err
+		}
+		statuses := make([]TaskStatus, 0, len(taskRuns))
+		for _, taskRun := range taskRuns {
+			statuses = append(statuses, TaskStatus(taskRun.Status))
+		}
+		return statuses, nil
+	}
+
 	var edges []models.TaskEdge
 	if err := tx.Where("to_task_id = ?", taskID).Find(&edges).Error; err != nil {
 		return nil, err
@@ -2043,6 +2192,17 @@ func normalizedTriggerRule(rule string) string {
 }
 
 func (s *Store) shouldRunTaskTx(tx *gorm.DB, runID, taskID uuid.UUID) (bool, string, error) {
+	if descriptor, replay, err := s.replayTaskExecutionDescriptorTx(tx, runID, taskID); err != nil {
+		return false, "", err
+	} else if replay {
+		rule := normalizedTriggerRule(descriptor.DAG.TriggerRule)
+		predStatuses, err := s.predecessorStatusesTx(tx, runID, taskID)
+		if err != nil {
+			return false, "", err
+		}
+		return satisfiesTriggerRule(rule, predStatuses), rule, nil
+	}
+
 	var task models.Task
 	if err := tx.Select("trigger_rule").First(&task, "id = ?", taskID).Error; err != nil {
 		return false, "", err
@@ -2159,37 +2319,36 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 				return nil
 			}
 
-			// Load the task model once — needed for both edge fallback and branch
-			// type detection.
-			var taskModel models.Task
-			if err := tx.First(&taskModel, "id = ?", taskID).Error; err != nil {
+			descriptor, replayTask, err := s.replayTaskExecutionDescriptorTx(tx, runID, taskID)
+			if err != nil {
 				return err
 			}
 
-			edges, err := s.successorEdgesTx(tx, taskModel)
+			// Load the task model once — needed for both edge fallback and branch
+			// type detection.
+			var taskModel models.Task
+			taskType := ""
+			if replayTask {
+				taskModel = models.Task{ID: taskID}
+				taskType = firstNonEmpty(descriptor.Runtime.TaskType, descriptor.DAG.BranchBehavior, "task")
+			} else {
+				if err := tx.First(&taskModel, "id = ?", taskID).Error; err != nil {
+					return err
+				}
+				taskType = taskModel.Type
+			}
+
+			edges, err := s.successorEdgesForRunTx(tx, runID, taskID, taskModel)
 			if err != nil {
 				return err
 			}
 
 			// Determine branch filtering if this is a branch-type task.
 			var branchSelectedIDs map[uuid.UUID]bool
-			if len(edges) > 0 && taskModel.Type == "branch" {
-				// Build valid target names from successor tasks.
-				successorIDs := make([]uuid.UUID, 0, len(edges))
-				for _, edge := range edges {
-					successorIDs = append(successorIDs, edge.ToTaskID)
-				}
-				var successorTasks []models.Task
-				if err := tx.Where("id IN ?", successorIDs).Find(&successorTasks).Error; err != nil {
+			if len(edges) > 0 && taskType == "branch" {
+				successorNameToID, validTargets, err := s.successorNameMapTx(tx, replayTask, descriptor, edges)
+				if err != nil {
 					return err
-				}
-				successorNameToID := make(map[string]uuid.UUID, len(successorTasks))
-				validTargets := make([]string, 0, len(successorTasks))
-				for _, st := range successorTasks {
-					if st.Name != "" {
-						successorNameToID[st.Name] = st.ID
-						validTargets = append(validTargets, st.Name)
-					}
 				}
 
 				// Validate selections.
@@ -2522,12 +2681,21 @@ func (s *Store) skipTaskAndDescendantsTx(tx *gorm.DB, runID, taskID uuid.UUID, r
 
 		skipped = append(skipped, current.taskID)
 
-		var task models.Task
-		if err := tx.First(&task, "id = ?", current.taskID).Error; err != nil {
+		descriptor, replayTask, err := s.replayTaskExecutionDescriptorTx(tx, runID, current.taskID)
+		if err != nil {
 			return skipped, err
 		}
+		var task models.Task
+		if replayTask {
+			task = models.Task{ID: current.taskID}
+			_ = descriptor
+		} else {
+			if err := tx.First(&task, "id = ?", current.taskID).Error; err != nil {
+				return skipped, err
+			}
+		}
 
-		edges, err := s.successorEdgesTx(tx, task)
+		edges, err := s.successorEdgesForRunTx(tx, runID, current.taskID, task)
 		if err != nil {
 			return skipped, err
 		}
@@ -3434,6 +3602,12 @@ func isStoreContentionErr(err error) bool {
 // predecessors of the given task within a run.  This is used by the distributed
 // executor to inject CAESIUM_OUTPUT_* env vars before starting a task.
 func (s *Store) PredecessorOutputs(runID, taskID uuid.UUID) (map[string]map[string]string, error) {
+	if refs, replay, err := s.replayPredecessorRefsTx(s.db, runID, taskID); err != nil {
+		return nil, err
+	} else if replay {
+		return s.predecessorOutputsFromRefsTx(s.db, runID, refs)
+	}
+
 	// Find predecessor task IDs via edges.
 	var edges []models.TaskEdge
 	if err := s.db.Where("to_task_id = ?", taskID).Find(&edges).Error; err != nil {
@@ -3500,9 +3674,59 @@ func (s *Store) PredecessorOutputs(runID, taskID uuid.UUID) (map[string]map[stri
 	return result, nil
 }
 
+func (s *Store) predecessorOutputsFromRefsTx(tx *gorm.DB, runID uuid.UUID, refs []models.TaskExecutionEdgeRef) (map[string]map[string]string, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	predTaskIDs := make([]uuid.UUID, 0, len(refs))
+	nameByID := make(map[uuid.UUID]string, len(refs))
+	for _, ref := range refs {
+		if ref.TaskID == uuid.Nil {
+			continue
+		}
+		predTaskIDs = append(predTaskIDs, ref.TaskID)
+		nameByID[ref.TaskID] = firstNonEmpty(ref.TaskName, ref.TaskID.String())
+	}
+	if len(predTaskIDs) == 0 {
+		return nil, nil
+	}
+
+	var taskRuns []models.TaskRun
+	if err := tx.Select("task_id", "output").
+		Where("job_run_id = ? AND task_id IN ?", runID, predTaskIDs).
+		Find(&taskRuns).Error; err != nil {
+		return nil, err
+	}
+	result := make(map[string]map[string]string, len(taskRuns))
+	for _, taskRun := range taskRuns {
+		if len(taskRun.Output) == 0 {
+			continue
+		}
+		var output map[string]string
+		if err := json.Unmarshal(taskRun.Output, &output); err != nil {
+			log.Warn("failed to unmarshal replay predecessor task output", "run_id", runID, "predecessor_task_id", taskRun.TaskID, "error", err)
+			continue
+		}
+		if len(output) == 0 {
+			continue
+		}
+		result[nameByID[taskRun.TaskID]] = output
+	}
+	if len(result) == 0 {
+		return nil, nil
+	}
+	return result, nil
+}
+
 // PredecessorDescriptorInputs returns predecessor outputs and effective hashes
 // keyed by predecessor task id for immutable execution-descriptor capture.
 func (s *Store) PredecessorDescriptorInputs(runID, taskID uuid.UUID) (map[uuid.UUID]map[string]string, map[uuid.UUID]string, error) {
+	if refs, replay, err := s.replayPredecessorRefsTx(s.db, runID, taskID); err != nil {
+		return nil, nil, err
+	} else if replay {
+		return s.predecessorDescriptorInputsFromRefsTx(s.db, runID, refs)
+	}
+
 	var edges []models.TaskEdge
 	if err := s.db.Where("to_task_id = ?", taskID).Find(&edges).Error; err != nil {
 		return nil, nil, err
@@ -3546,6 +3770,43 @@ func (s *Store) PredecessorDescriptorInputs(runID, taskID uuid.UUID) (map[uuid.U
 	return outputs, hashes, nil
 }
 
+func (s *Store) predecessorDescriptorInputsFromRefsTx(tx *gorm.DB, runID uuid.UUID, refs []models.TaskExecutionEdgeRef) (map[uuid.UUID]map[string]string, map[uuid.UUID]string, error) {
+	if len(refs) == 0 {
+		return nil, nil, nil
+	}
+	predTaskIDs := make([]uuid.UUID, 0, len(refs))
+	for _, ref := range refs {
+		if ref.TaskID != uuid.Nil {
+			predTaskIDs = append(predTaskIDs, ref.TaskID)
+		}
+	}
+	if len(predTaskIDs) == 0 {
+		return nil, nil, nil
+	}
+	var taskRuns []models.TaskRun
+	if err := tx.Select("task_id", "output", "hash", "effective_hash", "status").
+		Where("job_run_id = ? AND task_id IN ?", runID, predTaskIDs).
+		Find(&taskRuns).Error; err != nil {
+		return nil, nil, err
+	}
+	outputs := make(map[uuid.UUID]map[string]string, len(taskRuns))
+	hashes := make(map[uuid.UUID]string, len(taskRuns))
+	for _, taskRun := range taskRuns {
+		if len(taskRun.Output) > 0 {
+			var output map[string]string
+			if err := json.Unmarshal(taskRun.Output, &output); err == nil && len(output) > 0 {
+				outputs[taskRun.TaskID] = output
+			}
+		}
+		if taskRun.Status == string(TaskStatusSucceeded) || taskRun.Status == string(TaskStatusCached) {
+			if hash := effectiveTaskHash(taskRun.Hash, taskRun.EffectiveHash); hash != "" {
+				hashes[taskRun.TaskID] = hash
+			}
+		}
+	}
+	return outputs, hashes, nil
+}
+
 // PredecessorHashes returns the execution hashes recorded on predecessor task
 // runs that completed successfully in the current run. This keeps distributed
 // cache hashing aligned with local execution, including transitive cache hits.
@@ -3560,6 +3821,12 @@ func (s *Store) PredecessorDescriptorInputs(runID, taskID uuid.UUID) (map[uuid.U
 // hash and cache-hits. Falling back to hash (effective_hash empty) is the
 // common case and is byte-identical to the pre-D2 behavior.
 func (s *Store) PredecessorHashes(runID, taskID uuid.UUID) ([]string, error) {
+	if refs, replay, err := s.replayPredecessorRefsTx(s.db, runID, taskID); err != nil {
+		return nil, err
+	} else if replay {
+		return s.predecessorHashesFromRefsTx(s.db, runID, refs)
+	}
+
 	var edges []models.TaskEdge
 	if err := s.db.Where("to_task_id = ?", taskID).Find(&edges).Error; err != nil {
 		return nil, err
@@ -3590,6 +3857,42 @@ func (s *Store) PredecessorHashes(runID, taskID uuid.UUID) ([]string, error) {
 		return nil, nil
 	}
 
+	hashes := make([]string, 0, len(taskRuns))
+	for _, taskRun := range taskRuns {
+		if h := effectiveTaskHash(taskRun.Hash, taskRun.EffectiveHash); h != "" {
+			hashes = append(hashes, h)
+		}
+	}
+	if len(hashes) == 0 {
+		return nil, nil
+	}
+	sort.Strings(hashes)
+	return hashes, nil
+}
+
+func (s *Store) predecessorHashesFromRefsTx(tx *gorm.DB, runID uuid.UUID, refs []models.TaskExecutionEdgeRef) ([]string, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	predTaskIDs := make([]uuid.UUID, 0, len(refs))
+	for _, ref := range refs {
+		if ref.TaskID != uuid.Nil {
+			predTaskIDs = append(predTaskIDs, ref.TaskID)
+		}
+	}
+	if len(predTaskIDs) == 0 {
+		return nil, nil
+	}
+	var taskRuns []models.TaskRun
+	if err := tx.Select("hash", "effective_hash").
+		Where("job_run_id = ? AND task_id IN ? AND status IN ? AND hash <> ''",
+			runID,
+			predTaskIDs,
+			[]string{string(TaskStatusSucceeded), string(TaskStatusCached)},
+		).
+		Find(&taskRuns).Error; err != nil {
+		return nil, err
+	}
 	hashes := make([]string, 0, len(taskRuns))
 	for _, taskRun := range taskRuns {
 		if h := effectiveTaskHash(taskRun.Hash, taskRun.EffectiveHash); h != "" {

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/replay"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/container"
 	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
@@ -479,7 +480,7 @@ func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskR
 		return err
 	}
 	if descriptor != nil && taskRun.Quarantine {
-		if err := verifyReplaySecretIdentities(taskCtx, e.secretResolver, descriptor.SecretRefs, secretIdentities); err != nil {
+		if err := replay.VerifyReplaySecretIdentities(taskCtx, e.secretResolver, descriptor.SecretRefs, secretIdentities, spec.Env); err != nil {
 			return err
 		}
 	}
@@ -592,184 +593,6 @@ func (e *runtimeExecutor) runSchemaValidation(taskRun *models.TaskRun, output ma
 		return nil
 	}
 	return run.ValidateTaskOutputSchema(e.store, taskRun.JobRunID, taskRun.TaskID, output, taskRun.OutputSchema, taskRun.SchemaValidation)
-}
-
-func verifyReplaySecretIdentities(ctx context.Context, resolver secret.Resolver, expected []models.TaskExecutionSecretRef, actual []jobdefruntime.ResolvedSecretIdentity) error {
-	expectedByKey, err := expectedReplaySecretRefMap(expected)
-	if err != nil {
-		return err
-	}
-	actualByKey := make(map[string]jobdefruntime.ResolvedSecretIdentity, len(actual))
-	for _, resolved := range actual {
-		key := replaySecretRefKey(resolved.EnvKey, resolved.Ref)
-		ref, ok := expectedByKey[key]
-		if !ok {
-			return fmt.Errorf("replay secret %s for env %s has no baseline identity", resolved.Ref, resolved.EnvKey)
-		}
-		actualByKey[key] = resolved
-		if err := verifyResolvedReplaySecretIdentity(ctx, resolver, ref, resolved.Identity); err != nil {
-			return fmt.Errorf("replay secret %s for env %s %v", ref.Ref, ref.EnvKey, err)
-		}
-	}
-	for _, ref := range expected {
-		if strings.TrimSpace(ref.Ref) == "" {
-			continue
-		}
-		_, ok := actualByKey[replaySecretRefKey(ref.EnvKey, ref.Ref)]
-		if !ok {
-			return fmt.Errorf("replay secret %s for env %s was not resolved", ref.Ref, ref.EnvKey)
-		}
-	}
-	return nil
-}
-
-func expectedReplaySecretRefMap(refs []models.TaskExecutionSecretRef) (map[string]models.TaskExecutionSecretRef, error) {
-	expected := make(map[string]models.TaskExecutionSecretRef)
-	for _, ref := range refs {
-		if strings.TrimSpace(ref.Ref) == "" {
-			continue
-		}
-		key := replaySecretRefKey(ref.EnvKey, ref.Ref)
-		if _, exists := expected[key]; exists {
-			return nil, fmt.Errorf("duplicate replay secret identity for env %s ref %s", ref.EnvKey, ref.Ref)
-		}
-		expected[key] = ref
-	}
-	return expected, nil
-}
-
-func replaySecretRefKey(envKey, ref string) string {
-	return strings.TrimSpace(envKey) + "\x00" + strings.TrimSpace(ref)
-}
-
-func verifyResolvedReplaySecretIdentity(ctx context.Context, resolver secret.Resolver, ref models.TaskExecutionSecretRef, identity secret.Identity) error {
-	if !ref.Verifiable {
-		return fmt.Errorf("is not verifiable: %s", ref.UnverifiableReason)
-	}
-	if !identity.Verifiable {
-		return fmt.Errorf("resolved to unverifiable identity: %s", identity.UnverifiableReason)
-	}
-	if ref.Provider != "" && ref.Provider != identity.Provider {
-		return fmt.Errorf("provider changed from %s to %s", ref.Provider, identity.Provider)
-	}
-	if replaySecretRequiresPinnedVaultVerification(ref) {
-		if replayDescriptorIdentityString(ref, "version") != identity.Version {
-			return fmt.Errorf("version changed from %s to %s", replayDescriptorIdentityString(ref, "version"), identity.Version)
-		}
-		verifier, ok := resolver.(secret.IdentityVerifier)
-		if !ok {
-			return fmt.Errorf("provider %s does not support baseline identity verification", ref.Provider)
-		}
-		pinned, err := verifier.VerifyIdentity(ctx, ref.Ref, replaySecretIdentityFromDescriptor(ref))
-		if err != nil {
-			return fmt.Errorf("baseline identity verification failed: %w", err)
-		}
-		if !pinned.Verifiable {
-			return fmt.Errorf("baseline identity is not verifiable: %s", pinned.UnverifiableReason)
-		}
-		if !replaySecretIdentityMatches(ref, pinned) {
-			return fmt.Errorf("baseline identity changed")
-		}
-		return nil
-	}
-	if !replaySecretIdentityMatches(ref, identity) {
-		return fmt.Errorf("identity changed")
-	}
-	return nil
-}
-
-func replaySecretRequiresPinnedVaultVerification(ref models.TaskExecutionSecretRef) bool {
-	return strings.EqualFold(ref.Provider, "vault") &&
-		replayDescriptorIdentityString(ref, "version") != "" &&
-		replayDescriptorIdentityString(ref, "keyId") != ""
-}
-
-func replaySecretIdentityFromDescriptor(ref models.TaskExecutionSecretRef) secret.Identity {
-	return secret.Identity{
-		Provider:        ref.Provider,
-		Ref:             ref.Ref,
-		Version:         replayDescriptorIdentityString(ref, "version"),
-		ResourceVersion: replayDescriptorIdentityString(ref, "resourceVersion"),
-		Namespace:       replayDescriptorIdentityString(ref, "namespace"),
-		Name:            replayDescriptorIdentityString(ref, "name"),
-		Key:             replayDescriptorIdentityString(ref, "key"),
-		KeyID:           replayDescriptorIdentityString(ref, "keyId"),
-		HMACSHA256:      replayDescriptorIdentityString(ref, "hmacSha256"),
-		Verifiable:      ref.Verifiable,
-	}
-}
-
-func replaySecretIdentityMatches(ref models.TaskExecutionSecretRef, identity secret.Identity) bool {
-	if ref.Provider != "" && ref.Provider != identity.Provider {
-		return false
-	}
-	if !replaySecretHasRequiredDiscriminator(ref) {
-		return false
-	}
-	actualIdentity := resolvedSecretIdentityMap(identity)
-	for key, expectedValue := range ref.Identity {
-		if fmt.Sprint(expectedValue) != fmt.Sprint(actualIdentity[key]) {
-			return false
-		}
-	}
-	return true
-}
-
-func replaySecretHasRequiredDiscriminator(ref models.TaskExecutionSecretRef) bool {
-	if len(ref.Identity) == 0 {
-		return false
-	}
-	if strings.EqualFold(ref.Provider, "vault") {
-		return replayDescriptorIdentityString(ref, "version") != "" &&
-			replayDescriptorIdentityString(ref, "keyId") != "" &&
-			replayDescriptorIdentityString(ref, "hmacSha256") != ""
-	}
-	for _, value := range ref.Identity {
-		if strings.TrimSpace(fmt.Sprint(value)) != "" {
-			return true
-		}
-	}
-	return false
-}
-
-func replayDescriptorIdentityString(ref models.TaskExecutionSecretRef, key string) string {
-	if len(ref.Identity) == 0 {
-		return ""
-	}
-	value, ok := ref.Identity[key]
-	if !ok || value == nil {
-		return ""
-	}
-	return strings.TrimSpace(fmt.Sprint(value))
-}
-
-func resolvedSecretIdentityMap(identity secret.Identity) map[string]string {
-	out := make(map[string]string)
-	if identity.Version != "" {
-		out["version"] = identity.Version
-	}
-	if identity.ResourceVersion != "" {
-		out["resourceVersion"] = identity.ResourceVersion
-	}
-	if identity.Namespace != "" {
-		out["namespace"] = identity.Namespace
-	}
-	if identity.Name != "" {
-		out["name"] = identity.Name
-	}
-	if identity.Key != "" {
-		out["key"] = identity.Key
-	}
-	if identity.KeyID != "" {
-		out["keyId"] = identity.KeyID
-	}
-	if identity.HMACSHA256 != "" {
-		out["hmacSha256"] = identity.HMACSHA256
-	}
-	for k, v := range identity.Metadata {
-		out[k] = v
-	}
-	return out
 }
 
 // storeCacheEntry reads back the completed task run and stores the result in the cache.

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -111,6 +111,31 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		return jobAlias
 	}
 
+	var descriptor *models.TaskExecutionDescriptor
+	if taskRun.Quarantine {
+		if !taskRun.ReplaySafe {
+			err := fmt.Errorf("quarantined replay task is not replay safe: task %s", taskRun.TaskID)
+			log.Error("refusing unsafe quarantined worker task", "task_id", taskRun.TaskID, "run_id", taskRun.JobRunID, "error", err)
+			if persistErr := sink.Failed(ctx, taskRun, err); persistErr != nil && !errors.Is(persistErr, run.ErrTaskClaimMismatch) {
+				log.Error("failed to persist replay-safe guard failure", "run_id", taskRun.JobRunID, "task_id", taskRun.TaskID, "error", persistErr)
+			}
+			return
+		}
+		loaded, descErr := e.store.TaskExecutionDescriptor(ctx, taskRun.JobRunID, taskRun.TaskID)
+		if descErr != nil {
+			err := fmt.Errorf("replay descriptor unavailable for quarantined task: %w", descErr)
+			log.Error("failed to load replay descriptor for worker task", "task_id", taskRun.TaskID, "run_id", taskRun.JobRunID, "error", err)
+			if persistErr := sink.Failed(ctx, taskRun, err); persistErr != nil && !errors.Is(persistErr, run.ErrTaskClaimMismatch) {
+				log.Error("failed to persist replay descriptor failure", "run_id", taskRun.JobRunID, "task_id", taskRun.TaskID, "error", persistErr)
+			}
+			return
+		}
+		descriptor = loaded
+		if descriptor.Baseline.JobAlias != "" {
+			jobAlias = descriptor.Baseline.JobAlias
+		}
+	}
+
 	// Load the task model to get retry configuration.
 	var taskModel models.Task
 	hasTaskModel := e.store.DB().First(&taskModel, "id = ?", taskRun.TaskID).Error == nil
@@ -118,14 +143,26 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 	if hasTaskModel && taskModel.Name != "" {
 		taskName = taskModel.Name
 	}
+	if descriptor != nil && descriptor.Baseline.TaskName != "" {
+		taskName = descriptor.Baseline.TaskName
+	}
 
-	atomSpec, err := e.loadAtomSpec(taskRun.AtomID)
-	if err != nil {
-		log.Error("failed to load atom spec for worker task", "task_id", taskRun.TaskID, "atom_id", taskRun.AtomID, "error", err)
-		if persistErr := sink.Failed(ctx, taskRun, err); persistErr != nil && !errors.Is(persistErr, run.ErrTaskClaimMismatch) {
-			log.Error("failed to persist atom spec load failure", "run_id", taskRun.JobRunID, "task_id", taskRun.TaskID, "error", persistErr)
+	var atomSpec container.Spec
+	if descriptor != nil {
+		atomSpec = descriptor.ContainerSpec
+		if atomSpec.Kubernetes == nil && descriptor.KubernetesSpec != nil {
+			atomSpec.Kubernetes = descriptor.KubernetesSpec
 		}
-		return
+	} else {
+		var err error
+		atomSpec, err = e.loadAtomSpec(taskRun.AtomID)
+		if err != nil {
+			log.Error("failed to load atom spec for worker task", "task_id", taskRun.TaskID, "atom_id", taskRun.AtomID, "error", err)
+			if persistErr := sink.Failed(ctx, taskRun, err); persistErr != nil && !errors.Is(persistErr, run.ErrTaskClaimMismatch) {
+				log.Error("failed to persist atom spec load failure", "run_id", taskRun.JobRunID, "task_id", taskRun.TaskID, "error", persistErr)
+			}
+			return
+		}
 	}
 	runParams, err := e.loadRunParams(taskRun.JobRunID)
 	if err != nil {
@@ -186,7 +223,9 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 		// When digest pinning is on, resolve the image tag to its content
 		// digest and fold the digest into the cache key. A resolution failure
 		// falls back to the literal tag — a cache miss is always safe.
-		if cacheCfg.PinDigests {
+		if descriptor != nil && descriptor.Runtime.ResolvedImageDigest != "" {
+			resolvedImageDigest = descriptor.Runtime.ResolvedImageDigest
+		} else if cacheCfg.PinDigests {
 			if digest, derr := imagecheck.Default().Resolve(ctx, taskRun.Engine, taskRun.Image, cacheCfg.DigestTTL); derr == nil {
 				resolvedImageDigest = digest
 			}
@@ -265,7 +304,7 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 
 	var lastErr error
 	for attempt := currentAttempt; attempt <= maxAttempts; attempt++ {
-		execErr := e.executeTask(ctx, taskRun, sink, atomSpec, runParams, resolveJobAlias())
+		execErr := e.executeTask(ctx, taskRun, sink, atomSpec, runParams, resolveJobAlias(), descriptor)
 		if execErr == nil {
 			// Store successful result in cache.
 			if cacheStore != nil && cacheHash != "" && !taskRun.Quarantine {
@@ -295,7 +334,12 @@ func (e *runtimeExecutor) Execute(ctx context.Context, taskRun *models.TaskRun) 
 
 		// Compute retry delay (retryDelay * 2^(attempt-1) if backoff, else retryDelay).
 		var delay time.Duration
-		if hasTaskModel && taskModel.RetryDelay > 0 {
+		if descriptor != nil && descriptor.Runtime.RetryDelay > 0 {
+			delay = descriptor.Runtime.RetryDelay
+			if descriptor.Runtime.RetryBackoff {
+				delay = descriptor.Runtime.RetryDelay * (1 << uint(attempt-1))
+			}
+		} else if hasTaskModel && taskModel.RetryDelay > 0 {
 			delay = taskModel.RetryDelay
 			if taskModel.RetryBackoff {
 				delay = taskModel.RetryDelay * (1 << uint(attempt-1))
@@ -407,7 +451,7 @@ func buildRunParamEnv(runID uuid.UUID, jobAlias string, params map[string]string
 	return env
 }
 
-func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskRun, sink CompletionSink, atomSpec container.Spec, runParams map[string]string, jobAlias string) error {
+func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskRun, sink CompletionSink, atomSpec container.Spec, runParams map[string]string, jobAlias string, descriptor *models.TaskExecutionDescriptor) error {
 	taskCtx := ctx
 	cancel := func() {}
 	if e.taskTimeout > 0 {
@@ -434,7 +478,12 @@ func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskR
 	if err != nil {
 		return err
 	}
-	if len(secretIdentities) > 0 {
+	if descriptor != nil && taskRun.Quarantine {
+		if err := verifyReplaySecretIdentities(taskCtx, e.secretResolver, descriptor.SecretRefs, secretIdentities); err != nil {
+			return err
+		}
+	}
+	if len(secretIdentities) > 0 && !taskRun.Quarantine {
 		refs := make([]models.TaskExecutionSecretRef, 0, len(secretIdentities))
 		for _, resolved := range secretIdentities {
 			refs = append(refs, run.SecretIdentityDescriptorRef(resolved.EnvKey, resolved.Ref, resolved.Identity))
@@ -543,6 +592,184 @@ func (e *runtimeExecutor) runSchemaValidation(taskRun *models.TaskRun, output ma
 		return nil
 	}
 	return run.ValidateTaskOutputSchema(e.store, taskRun.JobRunID, taskRun.TaskID, output, taskRun.OutputSchema, taskRun.SchemaValidation)
+}
+
+func verifyReplaySecretIdentities(ctx context.Context, resolver secret.Resolver, expected []models.TaskExecutionSecretRef, actual []jobdefruntime.ResolvedSecretIdentity) error {
+	expectedByKey, err := expectedReplaySecretRefMap(expected)
+	if err != nil {
+		return err
+	}
+	actualByKey := make(map[string]jobdefruntime.ResolvedSecretIdentity, len(actual))
+	for _, resolved := range actual {
+		key := replaySecretRefKey(resolved.EnvKey, resolved.Ref)
+		ref, ok := expectedByKey[key]
+		if !ok {
+			return fmt.Errorf("replay secret %s for env %s has no baseline identity", resolved.Ref, resolved.EnvKey)
+		}
+		actualByKey[key] = resolved
+		if err := verifyResolvedReplaySecretIdentity(ctx, resolver, ref, resolved.Identity); err != nil {
+			return fmt.Errorf("replay secret %s for env %s %v", ref.Ref, ref.EnvKey, err)
+		}
+	}
+	for _, ref := range expected {
+		if strings.TrimSpace(ref.Ref) == "" {
+			continue
+		}
+		_, ok := actualByKey[replaySecretRefKey(ref.EnvKey, ref.Ref)]
+		if !ok {
+			return fmt.Errorf("replay secret %s for env %s was not resolved", ref.Ref, ref.EnvKey)
+		}
+	}
+	return nil
+}
+
+func expectedReplaySecretRefMap(refs []models.TaskExecutionSecretRef) (map[string]models.TaskExecutionSecretRef, error) {
+	expected := make(map[string]models.TaskExecutionSecretRef)
+	for _, ref := range refs {
+		if strings.TrimSpace(ref.Ref) == "" {
+			continue
+		}
+		key := replaySecretRefKey(ref.EnvKey, ref.Ref)
+		if _, exists := expected[key]; exists {
+			return nil, fmt.Errorf("duplicate replay secret identity for env %s ref %s", ref.EnvKey, ref.Ref)
+		}
+		expected[key] = ref
+	}
+	return expected, nil
+}
+
+func replaySecretRefKey(envKey, ref string) string {
+	return strings.TrimSpace(envKey) + "\x00" + strings.TrimSpace(ref)
+}
+
+func verifyResolvedReplaySecretIdentity(ctx context.Context, resolver secret.Resolver, ref models.TaskExecutionSecretRef, identity secret.Identity) error {
+	if !ref.Verifiable {
+		return fmt.Errorf("is not verifiable: %s", ref.UnverifiableReason)
+	}
+	if !identity.Verifiable {
+		return fmt.Errorf("resolved to unverifiable identity: %s", identity.UnverifiableReason)
+	}
+	if ref.Provider != "" && ref.Provider != identity.Provider {
+		return fmt.Errorf("provider changed from %s to %s", ref.Provider, identity.Provider)
+	}
+	if replaySecretRequiresPinnedVaultVerification(ref) {
+		if replayDescriptorIdentityString(ref, "version") != identity.Version {
+			return fmt.Errorf("version changed from %s to %s", replayDescriptorIdentityString(ref, "version"), identity.Version)
+		}
+		verifier, ok := resolver.(secret.IdentityVerifier)
+		if !ok {
+			return fmt.Errorf("provider %s does not support baseline identity verification", ref.Provider)
+		}
+		pinned, err := verifier.VerifyIdentity(ctx, ref.Ref, replaySecretIdentityFromDescriptor(ref))
+		if err != nil {
+			return fmt.Errorf("baseline identity verification failed: %w", err)
+		}
+		if !pinned.Verifiable {
+			return fmt.Errorf("baseline identity is not verifiable: %s", pinned.UnverifiableReason)
+		}
+		if !replaySecretIdentityMatches(ref, pinned) {
+			return fmt.Errorf("baseline identity changed")
+		}
+		return nil
+	}
+	if !replaySecretIdentityMatches(ref, identity) {
+		return fmt.Errorf("identity changed")
+	}
+	return nil
+}
+
+func replaySecretRequiresPinnedVaultVerification(ref models.TaskExecutionSecretRef) bool {
+	return strings.EqualFold(ref.Provider, "vault") &&
+		replayDescriptorIdentityString(ref, "version") != "" &&
+		replayDescriptorIdentityString(ref, "keyId") != ""
+}
+
+func replaySecretIdentityFromDescriptor(ref models.TaskExecutionSecretRef) secret.Identity {
+	return secret.Identity{
+		Provider:        ref.Provider,
+		Ref:             ref.Ref,
+		Version:         replayDescriptorIdentityString(ref, "version"),
+		ResourceVersion: replayDescriptorIdentityString(ref, "resourceVersion"),
+		Namespace:       replayDescriptorIdentityString(ref, "namespace"),
+		Name:            replayDescriptorIdentityString(ref, "name"),
+		Key:             replayDescriptorIdentityString(ref, "key"),
+		KeyID:           replayDescriptorIdentityString(ref, "keyId"),
+		HMACSHA256:      replayDescriptorIdentityString(ref, "hmacSha256"),
+		Verifiable:      ref.Verifiable,
+	}
+}
+
+func replaySecretIdentityMatches(ref models.TaskExecutionSecretRef, identity secret.Identity) bool {
+	if ref.Provider != "" && ref.Provider != identity.Provider {
+		return false
+	}
+	if !replaySecretHasRequiredDiscriminator(ref) {
+		return false
+	}
+	actualIdentity := resolvedSecretIdentityMap(identity)
+	for key, expectedValue := range ref.Identity {
+		if fmt.Sprint(expectedValue) != fmt.Sprint(actualIdentity[key]) {
+			return false
+		}
+	}
+	return true
+}
+
+func replaySecretHasRequiredDiscriminator(ref models.TaskExecutionSecretRef) bool {
+	if len(ref.Identity) == 0 {
+		return false
+	}
+	if strings.EqualFold(ref.Provider, "vault") {
+		return replayDescriptorIdentityString(ref, "version") != "" &&
+			replayDescriptorIdentityString(ref, "keyId") != "" &&
+			replayDescriptorIdentityString(ref, "hmacSha256") != ""
+	}
+	for _, value := range ref.Identity {
+		if strings.TrimSpace(fmt.Sprint(value)) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func replayDescriptorIdentityString(ref models.TaskExecutionSecretRef, key string) string {
+	if len(ref.Identity) == 0 {
+		return ""
+	}
+	value, ok := ref.Identity[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func resolvedSecretIdentityMap(identity secret.Identity) map[string]string {
+	out := make(map[string]string)
+	if identity.Version != "" {
+		out["version"] = identity.Version
+	}
+	if identity.ResourceVersion != "" {
+		out["resourceVersion"] = identity.ResourceVersion
+	}
+	if identity.Namespace != "" {
+		out["namespace"] = identity.Namespace
+	}
+	if identity.Name != "" {
+		out["name"] = identity.Name
+	}
+	if identity.Key != "" {
+		out["key"] = identity.Key
+	}
+	if identity.KeyID != "" {
+		out["keyId"] = identity.KeyID
+	}
+	if identity.HMACSHA256 != "" {
+		out["hmacSha256"] = identity.HMACSHA256
+	}
+	for k, v := range identity.Metadata {
+		out[k] = v
+	}
+	return out
 }
 
 // storeCacheEntry reads back the completed task run and stores the result in the cache.

--- a/internal/worker/runtime_executor_test.go
+++ b/internal/worker/runtime_executor_test.go
@@ -325,7 +325,7 @@ func TestRuntimeExecutorQuarantinedTaskSkipsCacheWrite(t *testing.T) {
 		UpdatedAt: now,
 	}
 	require.NoError(t, db.Create(atomModel).Error)
-	task := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atomModel.ID, Name: "deploy", CreatedAt: now, UpdatedAt: now}
+	task := &models.Task{ID: uuid.New(), JobID: job.ID, AtomID: atomModel.ID, Name: "deploy", ReplaySafe: true, CreatedAt: now, UpdatedAt: now}
 	require.NoError(t, db.Create(task).Error)
 	jobRun := &models.JobRun{
 		ID:          uuid.New(),
@@ -339,25 +339,21 @@ func TestRuntimeExecutorQuarantinedTaskSkipsCacheWrite(t *testing.T) {
 		UpdatedAt:   now,
 	}
 	require.NoError(t, db.Create(jobRun).Error)
-	taskRun := &models.TaskRun{
-		ID:           uuid.New(),
-		JobRunID:     jobRun.ID,
-		TaskID:       task.ID,
-		AtomID:       atomModel.ID,
-		Engine:       atomModel.Engine,
-		Image:        atomModel.Image,
-		Command:      atomModel.Command,
-		Status:       string(run.TaskStatusRunning),
-		ClaimedBy:    "node-a",
-		Attempt:      1,
-		MaxAttempts:  1,
-		CacheEnabled: true,
-		CacheVersion: 1,
-		Quarantine:   true,
-		CreatedAt:    now,
-		UpdatedAt:    now,
-	}
-	require.NoError(t, db.Create(taskRun).Error)
+	require.NoError(t, store.RegisterTasks(jobRun.ID, []run.RegisterTaskInput{{
+		Task:                    task,
+		Atom:                    atomModel,
+		OutstandingPredecessors: 0,
+	}}))
+	require.NoError(t, db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", jobRun.ID, task.ID).
+		Updates(map[string]any{
+			"status":        string(run.TaskStatusRunning),
+			"claimed_by":    "node-a",
+			"cache_enabled": true,
+			"cache_version": 1,
+		}).Error)
+	var taskRun models.TaskRun
+	require.NoError(t, db.First(&taskRun, "job_run_id = ? AND task_id = ?", jobRun.ID, task.ID).Error)
 
 	engine := &captureCreateEngine{}
 	executor := &runtimeExecutor{
@@ -367,7 +363,7 @@ func TestRuntimeExecutorQuarantinedTaskSkipsCacheWrite(t *testing.T) {
 			return engine, nil
 		},
 	}
-	executor.Execute(context.Background(), taskRun)
+	executor.Execute(context.Background(), &taskRun)
 
 	var cacheRows int64
 	require.NoError(t, db.Model(&models.TaskCache{}).Count(&cacheRows).Error)


### PR DESCRIPTION
## B3 — Replay construction + dispatch (activates the quarantine runtime)

From a baseline run + `--set` overrides, builds a **quarantined** `JobRun` (B2's flag) and dispatches it so hash-changed tasks re-run and hash-unchanged tasks cache-hit. New `internal/replay/` package; B4 (REST) and B5 (CLI) will drive it.

### Three fail-closed guards
- **(a) cache-unavailable abort** — a hash-unchanged task whose baseline cache entry / result is unavailable aborts the replay (no silent re-exec).
- **(b) the replay-safe gate, no bypass** — a pre-plan pass over *all* tasks refuses the replay if any task's **baseline run recorded `replay_safe != true`** (the B7 recorded field, not the live definition). No `--force`, ack flag, or alternate namespace. The primary guard against running a prod `deploy`/`delete` as a what-if.
- **(c) reconstruct from the immutable descriptor** — each re-running task's spec is rebuilt from B2's per-TaskRun execution descriptor (image + `ResolvedImageDigest`, command, workdir, engine, env-modulo-secrets, mounts/volumes, run-params + predecessor outputs), **never** live `Job`/`Task`/`Atom` rows or the redacted `HashInput` blob. Missing/corrupt/version-mismatched descriptor → fail closed.

### Deep security review caught + fixed (3 blockers)
- **Fabrication:** a replay of a *failed* baseline reported SUCCEEDED. Now a cache hit requires a *successful* baseline result, and the replay run is never stamped Succeeded unless every cached result succeeded; failed/corrupt/empty-proof → hard abort.
- **Reconstruction from live rows in both executors:** the distributed worker reconstructs from the descriptor; the **local in-process executor now FAIL-CLOSED REFUSES** a quarantined run (`ErrLocalQuarantinedReplayUnsupported`) rather than run the current definition under the what-if banner. Refusal is total + defense-in-depth (run-level + per-atom gates before any `engine.Create`).
- **Secret identity:** verified against the baseline — vault re-reads the *baseline* version and HMACs with the *baseline* KeyID; bidirectional coverage; empty-identity → abort. Replay-of-replay rejected; descriptor↔row `replay_safe` mismatch aborts.

### Scope
- **Replay executes via the descriptor-aware distributed worker.** Local/in-process mode **refuses** (safe fail-closed) — **full local-executor descriptor reconstruction is a tracked follow-up** (noted under Stream B in the plan). This is a capability gap, not a security gap.
- Quarantine **activation** is wired here; the REST endpoint is **B4**, the CLI **B5**, and the full container/REST/CLI integration scenarios **B6**.

### Verification
Full chain green: `just lint` + `just unit-test` + `just integration-test`. New unit tests assert each guard: replay-safe refusal (changed + unchanged), failed-baseline abort, corruption abort, descriptor-vs-live reconstruction, descriptor-missing/replay_safe-mismatch fail-closed, quarantined-baseline rejection, local-mode refusal, and vault baseline-version/KeyID pinning.

Plan: `docs/exec-plans/active/data-plane-memory-ii.md` (B3).