### PR TITLE
Add REST replay endpoint + idempotent reservation (data-plane-memory-ii W6-α)

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -17,6 +17,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/node"
 	notifctrl "github.com/caesium-cloud/caesium/api/rest/controller/notification"
 	receiptctrl "github.com/caesium-cloud/caesium/api/rest/controller/receipt"
+	replayctrl "github.com/caesium-cloud/caesium/api/rest/controller/replay"
 	rundiffctrl "github.com/caesium-cloud/caesium/api/rest/controller/rundiff"
 	"github.com/caesium-cloud/caesium/api/rest/controller/stats"
 	"github.com/caesium-cloud/caesium/api/rest/controller/system"
@@ -80,6 +81,7 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		// causal explainer (data-plane-memory A3): why a task ran/hit cache/re-ran
 		g.GET("/jobs/:id/runs/:run_id/why", whyctrl.Get)
 		g.POST("/jobs/:id/runs/:run_id/callbacks/retry", run.RetryCallbacks)
+		g.POST("/jobs/:id/runs/:run_id/replay", replayctrl.Post)
 		g.POST("/jobs/:id/runs/:run_id/retry", run.Retry)
 		g.POST("/jobs/:id/run", run.Post)
 		g.POST("/jobs", job.Post)

--- a/api/rest/controller/replay/replay.go
+++ b/api/rest/controller/replay/replay.go
@@ -33,7 +33,6 @@ type PostRequest struct {
 
 // PostResponse returns the materialized replay run id.
 type PostResponse struct {
-	ID         uuid.UUID `json:"id"`
 	RunID      uuid.UUID `json:"run_id"`
 	Status     string    `json:"status"`
 	Quarantine bool      `json:"quarantine"`
@@ -96,7 +95,6 @@ func Post(c *echo.Context) error {
 	}
 
 	return c.JSON(http.StatusAccepted, PostResponse{
-		ID:         result.Run.ID,
 		RunID:      result.Run.ID,
 		Status:     string(result.Run.Status),
 		Quarantine: result.Run.Quarantine,
@@ -138,10 +136,10 @@ func validatePostRequest(req PostRequest) error {
 		if strings.TrimSpace(key) == "" {
 			return errors.New("set keys must be non-empty")
 		}
-		if len([]byte(key)) > maxReplaySetKeyBytes {
+		if len(key) > maxReplaySetKeyBytes {
 			return fmt.Errorf("set key %q exceeds %d bytes", key, maxReplaySetKeyBytes)
 		}
-		if len([]byte(value)) > maxReplaySetValueBytes {
+		if len(value) > maxReplaySetValueBytes {
 			return fmt.Errorf("set value for %q exceeds %d bytes", key, maxReplaySetValueBytes)
 		}
 	}

--- a/api/rest/controller/replay/replay.go
+++ b/api/rest/controller/replay/replay.go
@@ -1,0 +1,178 @@
+// Package replay implements the quarantined replay REST endpoint.
+package replay
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
+	replaysvc "github.com/caesium-cloud/caesium/api/rest/service/replay"
+	runsvc "github.com/caesium-cloud/caesium/api/rest/service/run"
+	replaycore "github.com/caesium-cloud/caesium/internal/replay"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+const (
+	maxReplayRequestBodyBytes = 64 * 1024
+	maxReplaySetEntries       = 256
+	maxReplaySetKeyBytes      = 1024
+	maxReplaySetValueBytes    = 1024
+)
+
+// PostRequest is the only accepted body for POST /v1/jobs/:id/runs/:run_id/replay.
+type PostRequest struct {
+	Set map[string]string `json:"set,omitempty"`
+}
+
+// PostResponse returns the materialized replay run id.
+type PostResponse struct {
+	ID         uuid.UUID `json:"id"`
+	RunID      uuid.UUID `json:"run_id"`
+	Status     string    `json:"status"`
+	Quarantine bool      `json:"quarantine"`
+}
+
+// Post handles POST /v1/jobs/:id/runs/:run_id/replay.
+func Post(c *echo.Context) error {
+	ctx := c.Request().Context()
+
+	jobID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+	baselineRunID, err := uuid.Parse(c.Param("run_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	idempotencyKey := strings.TrimSpace(c.Request().Header.Get("Idempotency-Key"))
+	if idempotencyKey == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "Idempotency-Key header is required")
+	}
+
+	req, err := decodePostRequest(c)
+	if err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return echo.NewHTTPError(http.StatusRequestEntityTooLarge, "request body too large").Wrap(err)
+		}
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	if _, err = jsvc.Service(ctx).Get(jobID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	baseline, err := runsvc.New(ctx).Get(baselineRunID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	if baseline.JobID != jobID {
+		return echo.ErrNotFound
+	}
+
+	result, err := replaysvc.New(ctx).Replay(replaysvc.Request{
+		JobID:          jobID,
+		BaselineRunID:  baselineRunID,
+		Set:            req.Set,
+		IdempotencyKey: idempotencyKey,
+		Principal:      authmw.GetPrincipal(c),
+	})
+	if err != nil {
+		return replayError(err)
+	}
+
+	return c.JSON(http.StatusAccepted, PostResponse{
+		ID:         result.Run.ID,
+		RunID:      result.Run.ID,
+		Status:     string(result.Run.Status),
+		Quarantine: result.Run.Quarantine,
+	})
+}
+
+func decodePostRequest(c *echo.Context) (PostRequest, error) {
+	var req PostRequest
+	body := c.Request().Body
+	if body == nil {
+		return req, nil
+	}
+
+	body = http.MaxBytesReader(c.Response(), body, maxReplayRequestBodyBytes)
+	dec := json.NewDecoder(body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
+		if errors.Is(err, io.EOF) {
+			return req, nil
+		}
+		return req, err
+	}
+
+	var extra struct{}
+	if err := dec.Decode(&extra); err != nil {
+		if errors.Is(err, io.EOF) {
+			return req, validatePostRequest(req)
+		}
+		return req, err
+	}
+	return req, errors.New("request body must contain a single JSON object")
+}
+
+func validatePostRequest(req PostRequest) error {
+	if len(req.Set) > maxReplaySetEntries {
+		return fmt.Errorf("set may contain at most %d entries", maxReplaySetEntries)
+	}
+	for key, value := range req.Set {
+		if strings.TrimSpace(key) == "" {
+			return errors.New("set keys must be non-empty")
+		}
+		if len([]byte(key)) > maxReplaySetKeyBytes {
+			return fmt.Errorf("set key %q exceeds %d bytes", key, maxReplaySetKeyBytes)
+		}
+		if len([]byte(value)) > maxReplaySetValueBytes {
+			return fmt.Errorf("set value for %q exceeds %d bytes", key, maxReplaySetValueBytes)
+		}
+	}
+	return nil
+}
+
+func replayError(err error) error {
+	switch {
+	case errors.Is(err, replaysvc.ErrMissingIdempotencyKey):
+		return echo.NewHTTPError(http.StatusBadRequest, "Idempotency-Key header is required")
+	case errors.Is(err, replaysvc.ErrReplayRequiresDistributedMode):
+		return echo.NewHTTPError(http.StatusConflict, err.Error())
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return echo.ErrNotFound
+	case errors.Is(err, replaycore.ErrReplayUnsafe):
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	case errors.Is(err, replaycore.ErrUnavailableBaselineProof):
+		return echo.NewHTTPError(http.StatusConflict, err.Error())
+	case errors.Is(err, replaycore.ErrMissingDescriptor):
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	case errors.Is(err, replaycore.ErrUnsupportedDescriptor):
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	case errors.Is(err, replaycore.ErrQuarantinedBaseline):
+		return echo.NewHTTPError(http.StatusConflict, err.Error())
+	case errors.Is(err, replaycore.ErrBaselineNotTerminal):
+		return echo.NewHTTPError(http.StatusConflict, err.Error())
+	case errors.Is(err, replaycore.ErrSecretIdentity):
+		return echo.NewHTTPError(http.StatusUnprocessableEntity, err.Error())
+	case errors.Is(err, replaycore.ErrDispatchRequired):
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(fmt.Errorf("replay: %w", err))
+	}
+}

--- a/api/rest/controller/replay/replay_test.go
+++ b/api/rest/controller/replay/replay_test.go
@@ -1,0 +1,44 @@
+package replay
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodePostRequestRejectsOversizedBody(t *testing.T) {
+	c := replayDecodeContext(`{"set":{"k":"` + strings.Repeat("a", maxReplayRequestBodyBytes) + `"}}`)
+
+	_, err := decodePostRequest(c)
+	require.Error(t, err)
+	var maxBytesErr *http.MaxBytesError
+	require.True(t, errors.As(err, &maxBytesErr), "expected MaxBytesReader overflow, got %v", err)
+}
+
+func TestDecodePostRequestRejectsOverCapSet(t *testing.T) {
+	set := make(map[string]string, maxReplaySetEntries+1)
+	for i := 0; i < maxReplaySetEntries+1; i++ {
+		set[fmt.Sprintf("key-%03d", i)] = "value"
+	}
+	body, err := json.Marshal(PostRequest{Set: set})
+	require.NoError(t, err)
+
+	_, err = decodePostRequest(replayDecodeContext(string(body)))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "at most")
+}
+
+func replayDecodeContext(body string) *echo.Context {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/jobs/job/runs/run/replay", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec)
+}

--- a/api/rest/service/replay/replay.go
+++ b/api/rest/service/replay/replay.go
@@ -1,0 +1,377 @@
+// Package replay implements the REST replay service around the internal replay
+// constructor, including B4's scoped idempotency reservation.
+package replay
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	jobrunner "github.com/caesium-cloud/caesium/internal/job"
+	"github.com/caesium-cloud/caesium/internal/models"
+	replaycore "github.com/caesium-cloud/caesium/internal/replay"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/caesium-cloud/caesium/pkg/sqlerr"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrMissingIdempotencyKey         = errors.New("replay: idempotency key is required")
+	ErrReplayReservationCorrupt      = errors.New("replay: idempotency reservation is corrupt")
+	ErrReplayReservationIncomplete   = errors.New("replay: idempotency reservation has no materialized work")
+	ErrReplayRequiresDistributedMode = errors.New(
+		"replay requires distributed execution mode for re-executing tasks",
+	)
+)
+
+// Request is the service-level request for a quarantined replay.
+type Request struct {
+	JobID          uuid.UUID
+	BaselineRunID  uuid.UUID
+	Set            map[string]string
+	IdempotencyKey string
+	Principal      *iauth.Principal
+}
+
+// Result is the replay endpoint result.
+type Result struct {
+	Run         *runstorage.JobRun
+	Fingerprint string
+	Existing    bool
+}
+
+// Service owns REST replay idempotency and delegates materialization to B3.
+type Service struct {
+	ctx           context.Context
+	store         *runstorage.Store
+	dispatcher    replaycore.Dispatcher
+	executionMode func() string
+}
+
+// New returns a replay service backed by the default run store.
+func New(ctx context.Context) *Service {
+	store := runstorage.Default()
+	return &Service{
+		ctx:           ctx,
+		store:         store,
+		dispatcher:    NewAsyncDispatcher(store),
+		executionMode: func() string { return env.Variables().ExecutionMode },
+	}
+}
+
+// WithStore returns a copy of the service backed by store.
+func (s *Service) WithStore(store *runstorage.Store) *Service {
+	if store == nil {
+		return s
+	}
+	next := *s
+	next.store = store
+	if _, ok := s.dispatcher.(*AsyncDispatcher); ok {
+		next.dispatcher = NewAsyncDispatcher(store)
+	}
+	return &next
+}
+
+// WithDatabase returns a copy of the service backed by conn; used by tests.
+func (s *Service) WithDatabase(conn *gorm.DB) *Service {
+	if conn == nil {
+		return s
+	}
+	return s.WithStore(runstorage.NewStore(conn))
+}
+
+// WithDispatcher returns a copy of the service with a custom dispatcher.
+func (s *Service) WithDispatcher(dispatcher replaycore.Dispatcher) *Service {
+	if dispatcher == nil {
+		return s
+	}
+	next := *s
+	next.dispatcher = dispatcher
+	return &next
+}
+
+// WithExecutionMode returns a copy of the service using mode for replay
+// dispatch preflight. It is intended for tests and for explicit callers.
+func (s *Service) WithExecutionMode(mode string) *Service {
+	next := *s
+	next.executionMode = func() string { return mode }
+	return &next
+}
+
+// Replay creates or resumes an idempotent quarantined replay.
+func (s *Service) Replay(req Request) (*Result, error) {
+	if s == nil || s.store == nil {
+		return nil, errors.New("replay: run store is required")
+	}
+	if s.dispatcher == nil {
+		return nil, replaycore.ErrDispatchRequired
+	}
+
+	key := strings.TrimSpace(req.IdempotencyKey)
+	if key == "" {
+		return nil, ErrMissingIdempotencyKey
+	}
+
+	overrides := cloneSet(req.Set)
+	fingerprint, err := Fingerprint(req.JobID, req.BaselineRunID, req.Principal, overrides, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing, err := s.findByFingerprint(fingerprint); err == nil {
+		return s.returnExisting(req.JobID, existing.ID, fingerprint)
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	constructor := replaycore.New(s.store, s.dispatcher)
+	prepared, err := constructor.Prepare(s.ctx, replaycore.Request{
+		BaselineRunID:     req.BaselineRunID,
+		Set:               overrides,
+		ReplayFingerprint: fingerprint,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if prepared.RequiresDispatch() && !s.isDistributedExecutionMode() {
+		return nil, ErrReplayRequiresDistributedMode
+	}
+
+	result, err := constructor.Materialize(s.ctx, prepared)
+	if err == nil {
+		return &Result{Run: result.Run, Fingerprint: fingerprint}, nil
+	}
+	if !isUniqueReplayFingerprintError(err) {
+		return nil, err
+	}
+
+	existing, loadErr := s.findByFingerprint(fingerprint)
+	if loadErr != nil {
+		return nil, fmt.Errorf("replay: load existing idempotency reservation: %w", loadErr)
+	}
+	return s.returnExisting(req.JobID, existing.ID, fingerprint)
+}
+
+func (s *Service) returnExisting(jobID, runID uuid.UUID, fingerprint string) (*Result, error) {
+	if err := s.resumePending(runID, jobID); err != nil {
+		return nil, err
+	}
+	run, err := s.store.Get(runID)
+	if err != nil {
+		return nil, err
+	}
+	return &Result{Run: run, Fingerprint: fingerprint, Existing: true}, nil
+}
+
+func (s *Service) findByFingerprint(fingerprint string) (*models.JobRun, error) {
+	var existing models.JobRun
+	if err := s.store.DB().WithContext(s.ctx).
+		First(&existing, "replay_fingerprint = ?", fingerprint).Error; err != nil {
+		return nil, err
+	}
+	return &existing, nil
+}
+
+func (s *Service) resumePending(runID, expectedJobID uuid.UUID) error {
+	var reservation models.JobRun
+	if err := s.store.DB().WithContext(s.ctx).
+		Select("id", "job_id", "status", "quarantine", "replay_fingerprint").
+		First(&reservation, "id = ?", runID).Error; err != nil {
+		return err
+	}
+	if reservation.JobID != expectedJobID {
+		return fmt.Errorf("%w: fingerprint resolved to job %s, want %s", ErrReplayReservationCorrupt, reservation.JobID, expectedJobID)
+	}
+	if !reservation.Quarantine || reservation.ReplayFingerprint == nil || strings.TrimSpace(*reservation.ReplayFingerprint) == "" {
+		return fmt.Errorf("%w: run %s is not a quarantined replay reservation", ErrReplayReservationCorrupt, runID)
+	}
+	switch reservation.Status {
+	case string(runstorage.StatusRunning):
+	case string(runstorage.StatusSucceeded), string(runstorage.StatusFailed):
+		return nil
+	default:
+		return fmt.Errorf("%w: run %s has unexpected status %q", ErrReplayReservationCorrupt, runID, reservation.Status)
+	}
+
+	var taskCount int64
+	if err := s.store.DB().WithContext(s.ctx).
+		Model(&models.TaskRun{}).
+		Where("job_run_id = ?", runID).
+		Count(&taskCount).Error; err != nil {
+		return err
+	}
+	if taskCount == 0 {
+		return fmt.Errorf("%w: run %s", ErrReplayReservationIncomplete, runID)
+	}
+
+	var pendingCount int64
+	if err := s.store.DB().WithContext(s.ctx).
+		Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND status = ?", runID, string(runstorage.TaskStatusPending)).
+		Count(&pendingCount).Error; err != nil {
+		return err
+	}
+	if pendingCount == 0 {
+		return nil
+	}
+	if !s.isDistributedExecutionMode() {
+		return ErrReplayRequiresDistributedMode
+	}
+	return s.dispatcher.DispatchReplay(s.ctx, runID)
+}
+
+func (s *Service) isDistributedExecutionMode() bool {
+	mode := ""
+	if s != nil && s.executionMode != nil {
+		mode = s.executionMode()
+	} else {
+		mode = env.Variables().ExecutionMode
+	}
+	return strings.EqualFold(strings.TrimSpace(mode), "distributed")
+}
+
+type fingerprintPayload struct {
+	Version        int            `json:"version"`
+	JobID          string         `json:"job_id"`
+	BaselineRunID  string         `json:"baseline_run_id"`
+	Principal      string         `json:"principal"`
+	Overrides      []overridePair `json:"overrides"`
+	IdempotencyKey string         `json:"idempotency_key"`
+}
+
+type overridePair struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Fingerprint derives the durable, scoped replay idempotency key.
+func Fingerprint(jobID, baselineRunID uuid.UUID, principal *iauth.Principal, overrides map[string]string, idempotencyKey string) (string, error) {
+	key := strings.TrimSpace(idempotencyKey)
+	if key == "" {
+		return "", ErrMissingIdempotencyKey
+	}
+	payload := fingerprintPayload{
+		Version:        1,
+		JobID:          jobID.String(),
+		BaselineRunID:  baselineRunID.String(),
+		Principal:      principalIdentity(principal),
+		Overrides:      normalizeOverrides(overrides),
+		IdempotencyKey: key,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("replay: encode idempotency fingerprint input: %w", err)
+	}
+	sum := sha256.Sum256(encoded)
+	return "replay:v1:" + hex.EncodeToString(sum[:]), nil
+}
+
+func principalIdentity(principal *iauth.Principal) string {
+	if principal == nil {
+		return "anonymous"
+	}
+	if principal.KeyID != nil {
+		return string(principal.Kind) + ":" + principal.KeyID.String()
+	}
+	if principal.UserID != nil {
+		return string(principal.Kind) + ":" + principal.UserID.String()
+	}
+	if subject := strings.TrimSpace(principal.Subject); subject != "" {
+		return string(principal.Kind) + ":" + subject
+	}
+	return string(principal.Kind) + ":unknown"
+}
+
+func normalizeOverrides(overrides map[string]string) []overridePair {
+	if len(overrides) == 0 {
+		return []overridePair{}
+	}
+	keys := make([]string, 0, len(overrides))
+	for key := range overrides {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	normalized := make([]overridePair, 0, len(keys))
+	for _, key := range keys {
+		normalized = append(normalized, overridePair{Key: key, Value: overrides[key]})
+	}
+	return normalized
+}
+
+func cloneSet(set map[string]string) map[string]string {
+	if len(set) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(set))
+	for k, v := range set {
+		out[k] = v
+	}
+	return out
+}
+
+func isUniqueReplayFingerprintError(err error) bool {
+	return sqlerr.IsUniqueConstraint(err)
+}
+
+// AsyncDispatcher resumes a materialized replay run through the existing job
+// execution surface. Local mode fails closed inside job.Run for quarantined
+// replays; distributed mode lets workers reconstruct from task descriptors.
+type AsyncDispatcher struct {
+	store *runstorage.Store
+}
+
+// NewAsyncDispatcher creates the default REST replay dispatcher.
+func NewAsyncDispatcher(store *runstorage.Store) *AsyncDispatcher {
+	return &AsyncDispatcher{store: store}
+}
+
+// DispatchReplay starts or wakes execution for runID and returns once the launch
+// was durably accepted.
+func (d *AsyncDispatcher) DispatchReplay(ctx context.Context, runID uuid.UUID) error {
+	if d == nil || d.store == nil {
+		return errors.New("replay: run store is required")
+	}
+
+	var runModel models.JobRun
+	if err := d.store.DB().WithContext(ctx).Select("id", "job_id").First(&runModel, "id = ?", runID).Error; err != nil {
+		return err
+	}
+
+	var jobModel models.Job
+	if err := d.store.DB().WithContext(ctx).First(&jobModel, "id = ?", runModel.JobID).Error; err != nil {
+		return err
+	}
+
+	if ls := d.store.LeaseStore(); ls != nil {
+		vars := env.Variables()
+		if _, err := ls.AcquireLease(ctx, runID, vars.NodeAddress, vars.RunLeaseTTL); err != nil {
+			return err
+		}
+	}
+
+	go func() {
+		runCtx := runstorage.WithContext(context.Background(), runID)
+		err := jobrunner.New(
+			&jobModel,
+			jobrunner.WithTriggerID(nil),
+			jobrunner.WithRunStoreFactory(func() *runstorage.Store { return d.store }),
+		).Run(runCtx)
+		if err != nil {
+			log.Error("replay dispatch failure", "job_id", runModel.JobID, "run_id", runID, "error", err)
+		}
+	}()
+
+	return nil
+}
+
+var _ replaycore.Dispatcher = (*AsyncDispatcher)(nil)

--- a/api/rest/service/replay/replay.go
+++ b/api/rest/service/replay/replay.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"sort"
 	"strings"
 
@@ -121,7 +122,7 @@ func (s *Service) Replay(req Request) (*Result, error) {
 		return nil, ErrMissingIdempotencyKey
 	}
 
-	overrides := cloneSet(req.Set)
+	overrides := maps.Clone(req.Set)
 	fingerprint, err := Fingerprint(req.JobID, req.BaselineRunID, req.Principal, overrides, key)
 	if err != nil {
 		return nil, err
@@ -155,10 +156,13 @@ func (s *Service) Replay(req Request) (*Result, error) {
 	}
 
 	existing, loadErr := s.findByFingerprint(fingerprint)
-	if loadErr != nil {
-		return nil, fmt.Errorf("replay: load existing idempotency reservation: %w", loadErr)
+	if loadErr == nil {
+		return s.returnExisting(req.JobID, existing.ID, fingerprint)
 	}
-	return s.returnExisting(req.JobID, existing.ID, fingerprint)
+	if errors.Is(loadErr, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("replay: materialize idempotency reservation: %w", err)
+	}
+	return nil, fmt.Errorf("replay: load existing idempotency reservation: %w", loadErr)
 }
 
 func (s *Service) returnExisting(jobID, runID uuid.UUID, fingerprint string) (*Result, error) {
@@ -308,17 +312,6 @@ func normalizeOverrides(overrides map[string]string) []overridePair {
 	return normalized
 }
 
-func cloneSet(set map[string]string) map[string]string {
-	if len(set) == 0 {
-		return nil
-	}
-	out := make(map[string]string, len(set))
-	for k, v := range set {
-		out[k] = v
-	}
-	return out
-}
-
 func isUniqueReplayFingerprintError(err error) bool {
 	return sqlerr.IsUniqueConstraint(err)
 }
@@ -360,6 +353,11 @@ func (d *AsyncDispatcher) DispatchReplay(ctx context.Context, runID uuid.UUID) e
 	}
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Error("replay dispatch panic", "job_id", runModel.JobID, "run_id", runID, "recover", r)
+			}
+		}()
 		runCtx := runstorage.WithContext(context.Background(), runID)
 		err := jobrunner.New(
 			&jobModel,

--- a/api/rest/service/replay/replay_test.go
+++ b/api/rest/service/replay/replay_test.go
@@ -375,6 +375,48 @@ func TestUniqueReplayFingerprintClassifierUsesDriverError(t *testing.T) {
 	require.True(t, isUniqueReplayFingerprintError(err), "actual duplicate insert error was not classified: %v", err)
 }
 
+func TestReplayUniqueViolationWithoutFingerprintMatchReturnsInsertError(t *testing.T) {
+	f := newServiceReplayFixture(t)
+	f.seedTask(t, true, "success")
+
+	require.NoError(t, f.db.Create(&models.JobRun{
+		ID:           uuid.New(),
+		JobID:        f.jobID,
+		Status:       string(runstorage.StatusSucceeded),
+		Quarantine:   true,
+		TriggerType:  "replay",
+		TriggerAlias: "quarantined-replay",
+		StartedAt:    f.now,
+		CompletedAt:  servicePtr(f.now),
+		CreatedAt:    f.now,
+		UpdatedAt:    f.now,
+	}).Error)
+	require.NoError(t, f.db.Exec("CREATE UNIQUE INDEX idx_test_job_runs_trigger_alias ON job_runs(trigger_alias)").Error)
+
+	key := "non-fingerprint-unique"
+	fingerprint, err := Fingerprint(f.jobID, f.runID, f.principal, nil, key)
+	require.NoError(t, err)
+
+	_, err = (&Service{
+		ctx:        context.Background(),
+		store:      f.store,
+		dispatcher: &recordingDispatcher{},
+	}).WithExecutionMode("local").Replay(Request{
+		JobID:          f.jobID,
+		BaselineRunID:  f.runID,
+		IdempotencyKey: key,
+		Principal:      f.principal,
+	})
+	require.Error(t, err)
+	require.True(t, isUniqueReplayFingerprintError(err), "non-fingerprint unique violation must surface as the insert failure: %v", err)
+	require.False(t, errors.Is(err, gorm.ErrRecordNotFound), "non-fingerprint unique violation must not be reported as a missing reservation")
+	require.NotContains(t, err.Error(), "load existing idempotency reservation")
+
+	var replayRuns int64
+	require.NoError(t, f.db.Model(&models.JobRun{}).Where("replay_fingerprint = ?", fingerprint).Count(&replayRuns).Error)
+	require.Zero(t, replayRuns)
+}
+
 type serviceReplayFixture struct {
 	db        *gorm.DB
 	store     *runstorage.Store

--- a/api/rest/service/replay/replay_test.go
+++ b/api/rest/service/replay/replay_test.go
@@ -1,0 +1,577 @@
+package replay
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/cache"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/pkg/container"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+type recordingDispatcher struct {
+	calls []uuid.UUID
+	err   error
+}
+
+func (d *recordingDispatcher) DispatchReplay(_ context.Context, runID uuid.UUID) error {
+	d.calls = append(d.calls, runID)
+	return d.err
+}
+
+func TestFingerprintScopesAndSortsOverrides(t *testing.T) {
+	jobID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	baselineID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	otherJobID := uuid.MustParse("33333333-3333-3333-3333-333333333333")
+	keyID := uuid.MustParse("44444444-4444-4444-4444-444444444444")
+	otherKeyID := uuid.MustParse("55555555-5555-5555-5555-555555555555")
+	principal := &iauth.Principal{Kind: iauth.PrincipalAPIKey, KeyID: &keyID}
+
+	first, err := Fingerprint(jobID, baselineID, principal, map[string]string{
+		"z": "last",
+		"a": "first",
+	}, "same-key")
+	require.NoError(t, err)
+	second, err := Fingerprint(jobID, baselineID, principal, map[string]string{
+		"a": "first",
+		"z": "last",
+	}, "same-key")
+	require.NoError(t, err)
+	require.Equal(t, first, second, "override map iteration order must not affect the fingerprint")
+
+	otherPrincipal := &iauth.Principal{Kind: iauth.PrincipalAPIKey, KeyID: &otherKeyID}
+	differentInputs := []struct {
+		name          string
+		jobID         uuid.UUID
+		baselineRunID uuid.UUID
+		principal     *iauth.Principal
+		overrides     map[string]string
+		key           string
+	}{
+		{name: "job", jobID: otherJobID, baselineRunID: baselineID, principal: principal, overrides: map[string]string{"a": "first", "z": "last"}, key: "same-key"},
+		{name: "baseline", jobID: jobID, baselineRunID: uuid.New(), principal: principal, overrides: map[string]string{"a": "first", "z": "last"}, key: "same-key"},
+		{name: "principal", jobID: jobID, baselineRunID: baselineID, principal: otherPrincipal, overrides: map[string]string{"a": "first", "z": "last"}, key: "same-key"},
+		{name: "overrides", jobID: jobID, baselineRunID: baselineID, principal: principal, overrides: map[string]string{"a": "changed", "z": "last"}, key: "same-key"},
+		{name: "key", jobID: jobID, baselineRunID: baselineID, principal: principal, overrides: map[string]string{"a": "first", "z": "last"}, key: "different-key"},
+	}
+	for _, tt := range differentInputs {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Fingerprint(tt.jobID, tt.baselineRunID, tt.principal, tt.overrides, tt.key)
+			require.NoError(t, err)
+			require.NotEqual(t, first, got)
+		})
+	}
+}
+
+func TestReplayResumesPendingReservation(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := runstorage.NewStore(db)
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	jobID := uuid.New()
+	baselineRunID := uuid.New()
+	replayRunID := uuid.New()
+	taskID := uuid.New()
+	atomID := uuid.New()
+	triggerID := uuid.New()
+	keyID := uuid.New()
+	principal := &iauth.Principal{Kind: iauth.PrincipalAPIKey, KeyID: &keyID}
+	overrides := map[string]string{"mode": "what-if"}
+	fingerprint, err := Fingerprint(jobID, baselineRunID, principal, overrides, "retry-key")
+	require.NoError(t, err)
+
+	require.NoError(t, db.Create(&models.Trigger{
+		ID:        triggerID,
+		Type:      models.TriggerTypeHTTP,
+		Alias:     "manual",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Job{
+		ID:        jobID,
+		Alias:     "resume-replay",
+		TriggerID: triggerID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:           baselineRunID,
+		JobID:        jobID,
+		TriggerID:    triggerID,
+		TriggerType:  string(models.TriggerTypeHTTP),
+		TriggerAlias: "manual",
+		Status:       string(runstorage.StatusSucceeded),
+		StartedAt:    now,
+		CompletedAt:  &now,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}).Error)
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:                replayRunID,
+		JobID:             jobID,
+		Status:            string(runstorage.StatusRunning),
+		Quarantine:        true,
+		ReplayFingerprint: &fingerprint,
+		TriggerType:       "replay",
+		TriggerAlias:      "quarantined-replay",
+		StartedAt:         now,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}).Error)
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID:                      uuid.New(),
+		JobRunID:                replayRunID,
+		TaskID:                  taskID,
+		AtomID:                  atomID,
+		Engine:                  models.AtomEngineDocker,
+		Image:                   "alpine:3.23",
+		Command:                 `["sh","-c","echo replay"]`,
+		Status:                  string(runstorage.TaskStatusPending),
+		Attempt:                 1,
+		MaxAttempts:             1,
+		OutstandingPredecessors: 0,
+		Quarantine:              true,
+		ReplaySafe:              true,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}).Error)
+
+	dispatcher := &recordingDispatcher{}
+	result, err := (&Service{
+		ctx:        context.Background(),
+		store:      store,
+		dispatcher: dispatcher,
+		executionMode: func() string {
+			return "distributed"
+		},
+	}).Replay(Request{
+		JobID:          jobID,
+		BaselineRunID:  baselineRunID,
+		Set:            overrides,
+		IdempotencyKey: "retry-key",
+		Principal:      principal,
+	})
+	require.NoError(t, err)
+	require.True(t, result.Existing)
+	require.Equal(t, replayRunID, result.Run.ID)
+	require.Equal(t, []uuid.UUID{replayRunID}, dispatcher.calls)
+
+	var replayRuns int64
+	require.NoError(t, db.Model(&models.JobRun{}).Where("replay_fingerprint = ?", fingerprint).Count(&replayRuns).Error)
+	require.EqualValues(t, 1, replayRuns)
+}
+
+func TestReplayConcurrentIdenticalRequestsReturnSingleReservation(t *testing.T) {
+	f := newServiceReplayFixture(t)
+	f.seedTask(t, true, "success")
+	key := "parallel-retry-key"
+	svc := (&Service{
+		ctx:        context.Background(),
+		store:      f.store,
+		dispatcher: &recordingDispatcher{},
+	}).WithExecutionMode("local")
+
+	const workers = 8
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	results := make([]*Result, workers)
+	errs := make([]error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			results[idx], errs[idx] = svc.Replay(Request{
+				JobID:          f.jobID,
+				BaselineRunID:  f.runID,
+				IdempotencyKey: key,
+				Principal:      f.principal,
+			})
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	var replayID uuid.UUID
+	for i := 0; i < workers; i++ {
+		require.NoError(t, errs[i])
+		require.NotNil(t, results[i])
+		require.True(t, results[i].Run.Quarantine)
+		if replayID == uuid.Nil {
+			replayID = results[i].Run.ID
+			continue
+		}
+		require.Equal(t, replayID, results[i].Run.ID)
+	}
+
+	fingerprint, err := Fingerprint(f.jobID, f.runID, f.principal, nil, key)
+	require.NoError(t, err)
+	var replayRuns int64
+	require.NoError(t, f.db.Model(&models.JobRun{}).Where("replay_fingerprint = ?", fingerprint).Count(&replayRuns).Error)
+	require.EqualValues(t, 1, replayRuns)
+}
+
+func TestReplayRetryResumesAfterDispatchFailure(t *testing.T) {
+	f := newServiceReplayFixture(t)
+	f.seedTask(t, true, "success")
+	dispatchErr := errors.New("dispatch unavailable")
+	req := Request{
+		JobID:          f.jobID,
+		BaselineRunID:  f.runID,
+		Set:            map[string]string{"mode": "what-if"},
+		IdempotencyKey: "resume-after-dispatch-error",
+		Principal:      f.principal,
+	}
+
+	firstDispatcher := &recordingDispatcher{err: dispatchErr}
+	_, err := (&Service{
+		ctx:        context.Background(),
+		store:      f.store,
+		dispatcher: firstDispatcher,
+	}).WithExecutionMode("distributed").Replay(req)
+	require.ErrorIs(t, err, dispatchErr)
+	require.Len(t, firstDispatcher.calls, 1)
+
+	fingerprint, err := Fingerprint(f.jobID, f.runID, f.principal, req.Set, req.IdempotencyKey)
+	require.NoError(t, err)
+	var reserved models.JobRun
+	require.NoError(t, f.db.First(&reserved, "replay_fingerprint = ?", fingerprint).Error)
+	require.Equal(t, string(runstorage.StatusRunning), reserved.Status)
+
+	var pendingTasks int64
+	require.NoError(t, f.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND status = ?", reserved.ID, string(runstorage.TaskStatusPending)).
+		Count(&pendingTasks).Error)
+	require.EqualValues(t, 1, pendingTasks)
+
+	secondDispatcher := &completingDispatcher{store: f.store}
+	result, err := (&Service{
+		ctx:        context.Background(),
+		store:      f.store,
+		dispatcher: secondDispatcher,
+	}).WithExecutionMode("distributed").Replay(req)
+	require.NoError(t, err)
+	require.True(t, result.Existing)
+	require.Equal(t, reserved.ID, result.Run.ID)
+	require.Equal(t, runstorage.StatusSucceeded, result.Run.Status)
+	require.Equal(t, []uuid.UUID{reserved.ID}, secondDispatcher.calls)
+
+	var replayRuns int64
+	require.NoError(t, f.db.Model(&models.JobRun{}).Where("replay_fingerprint = ?", fingerprint).Count(&replayRuns).Error)
+	require.EqualValues(t, 1, replayRuns)
+}
+
+func TestReplayRefusesLocalModeWhenReplayWouldReexecute(t *testing.T) {
+	f := newServiceReplayFixture(t)
+	f.seedTask(t, true, "success")
+	overrides := map[string]string{"mode": "what-if"}
+	key := "local-reexecute"
+	dispatcher := &recordingDispatcher{}
+
+	_, err := (&Service{
+		ctx:        context.Background(),
+		store:      f.store,
+		dispatcher: dispatcher,
+	}).WithExecutionMode("local").Replay(Request{
+		JobID:          f.jobID,
+		BaselineRunID:  f.runID,
+		Set:            overrides,
+		IdempotencyKey: key,
+		Principal:      f.principal,
+	})
+	require.ErrorIs(t, err, ErrReplayRequiresDistributedMode)
+	require.Empty(t, dispatcher.calls)
+
+	fingerprint, err := Fingerprint(f.jobID, f.runID, f.principal, overrides, key)
+	require.NoError(t, err)
+	var replayRuns int64
+	require.NoError(t, f.db.Model(&models.JobRun{}).Where("replay_fingerprint = ?", fingerprint).Count(&replayRuns).Error)
+	require.Zero(t, replayRuns)
+}
+
+func TestReplayExistingUnexpectedNonTerminalStatusIsCorrupt(t *testing.T) {
+	f := newServiceReplayFixture(t)
+	key := "corrupt-nonterminal"
+	fingerprint, err := Fingerprint(f.jobID, f.runID, f.principal, nil, key)
+	require.NoError(t, err)
+	replayRunID := uuid.New()
+	require.NoError(t, f.db.Create(&models.JobRun{
+		ID:                replayRunID,
+		JobID:             f.jobID,
+		Status:            "pending",
+		Quarantine:        true,
+		ReplayFingerprint: &fingerprint,
+		TriggerType:       "replay",
+		TriggerAlias:      "quarantined-replay",
+		StartedAt:         f.now,
+		CreatedAt:         f.now,
+		UpdatedAt:         f.now,
+	}).Error)
+	require.NoError(t, f.db.Create(&models.TaskRun{
+		ID:          uuid.New(),
+		JobRunID:    replayRunID,
+		TaskID:      uuid.New(),
+		AtomID:      uuid.New(),
+		Engine:      models.AtomEngineDocker,
+		Image:       "alpine:3.23",
+		Command:     `["sh","-c","echo pending"]`,
+		Status:      string(runstorage.TaskStatusPending),
+		Attempt:     1,
+		MaxAttempts: 1,
+		Quarantine:  true,
+		ReplaySafe:  true,
+		CreatedAt:   f.now,
+		UpdatedAt:   f.now,
+	}).Error)
+
+	dispatcher := &recordingDispatcher{}
+	_, err = (&Service{
+		ctx:        context.Background(),
+		store:      f.store,
+		dispatcher: dispatcher,
+	}).WithExecutionMode("distributed").Replay(Request{
+		JobID:          f.jobID,
+		BaselineRunID:  f.runID,
+		IdempotencyKey: key,
+		Principal:      f.principal,
+	})
+	require.ErrorIs(t, err, ErrReplayReservationCorrupt)
+	require.Empty(t, dispatcher.calls)
+}
+
+func TestUniqueReplayFingerprintClassifierUsesDriverError(t *testing.T) {
+	f := newServiceReplayFixture(t)
+	fingerprint := "replay:v1:duplicate-driver-error"
+	first := models.JobRun{
+		ID:                uuid.New(),
+		JobID:             f.jobID,
+		Status:            string(runstorage.StatusRunning),
+		Quarantine:        true,
+		ReplayFingerprint: &fingerprint,
+		TriggerType:       "replay",
+		TriggerAlias:      "quarantined-replay",
+		StartedAt:         f.now,
+		CreatedAt:         f.now,
+		UpdatedAt:         f.now,
+	}
+	second := first
+	second.ID = uuid.New()
+
+	require.NoError(t, f.db.Create(&first).Error)
+	err := f.db.Create(&second).Error
+	require.Error(t, err)
+	require.True(t, isUniqueReplayFingerprintError(err), "actual duplicate insert error was not classified: %v", err)
+}
+
+type serviceReplayFixture struct {
+	db        *gorm.DB
+	store     *runstorage.Store
+	jobID     uuid.UUID
+	runID     uuid.UUID
+	now       time.Time
+	principal *iauth.Principal
+}
+
+func newServiceReplayFixture(t *testing.T) serviceReplayFixture {
+	t.Helper()
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := runstorage.NewStore(db)
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	triggerID := uuid.New()
+	jobID := uuid.New()
+	runID := uuid.New()
+	keyID := uuid.New()
+	require.NoError(t, db.Create(&models.Trigger{
+		ID:        triggerID,
+		Type:      models.TriggerTypeHTTP,
+		Alias:     "manual",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Job{
+		ID:        jobID,
+		Alias:     "service-replay-job",
+		TriggerID: triggerID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:           runID,
+		JobID:        jobID,
+		TriggerID:    triggerID,
+		TriggerType:  string(models.TriggerTypeHTTP),
+		TriggerAlias: "manual",
+		Status:       string(runstorage.StatusSucceeded),
+		Params:       serviceJSON(t, map[string]string{"mode": "baseline"}),
+		StartedAt:    now,
+		CompletedAt:  servicePtr(now.Add(time.Second)),
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}).Error)
+
+	return serviceReplayFixture{
+		db:        db,
+		store:     store,
+		jobID:     jobID,
+		runID:     runID,
+		now:       now,
+		principal: &iauth.Principal{Kind: iauth.PrincipalAPIKey, KeyID: &keyID},
+	}
+}
+
+func (f serviceReplayFixture) seedTask(t *testing.T, replaySafe bool, result string) uuid.UUID {
+	t.Helper()
+	atomID := uuid.New()
+	taskID := uuid.New()
+	command := []string{"sh", "-c", "echo deploy"}
+	commandJSON := serviceJSONString(t, command)
+	spec := container.Spec{Env: map[string]string{"STEP": "deploy"}}
+	require.NoError(t, f.db.Create(&models.Atom{
+		ID:        atomID,
+		Engine:    models.AtomEngineDocker,
+		Image:     "alpine:3.23",
+		Command:   commandJSON,
+		Spec:      serviceJSON(t, spec),
+		CreatedAt: f.now,
+		UpdatedAt: f.now,
+	}).Error)
+	require.NoError(t, f.db.Create(&models.Task{
+		ID:          taskID,
+		JobID:       f.jobID,
+		AtomID:      atomID,
+		Name:        "deploy",
+		Position:    0,
+		TriggerRule: "all_success",
+		ReplaySafe:  replaySafe,
+		CreatedAt:   f.now,
+		UpdatedAt:   f.now,
+	}).Error)
+
+	desc := models.TaskExecutionDescriptor{
+		SchemaVersion: models.TaskExecutionDescriptorSchemaVersion,
+		CapturedAt:    f.now,
+		Baseline: models.TaskExecutionBaseline{
+			JobID:         f.jobID,
+			JobAlias:      "service-replay-job",
+			TaskID:        taskID,
+			TaskName:      "deploy",
+			AtomID:        atomID,
+			BaselineRunID: f.runID,
+			ReplaySafe:    replaySafe,
+		},
+		DAG: models.TaskExecutionDAG{
+			TriggerRule:    "all_success",
+			BranchBehavior: "task",
+			TaskPosition:   0,
+		},
+		Run: models.TaskExecutionRun{Params: map[string]string{"mode": "baseline"}},
+		Runtime: models.TaskExecutionRuntime{
+			Engine:     models.AtomEngineDocker,
+			Image:      "alpine:3.23",
+			Command:    command,
+			CommandRaw: commandJSON,
+			TaskType:   "task",
+		},
+		Cache:         models.TaskExecutionCache{Enabled: true, Version: 1},
+		Schema:        models.TaskExecutionSchema{ValidationMode: "warn"},
+		ContainerSpec: spec,
+	}
+	hash := cache.HashInput{
+		JobAlias:     "service-replay-job",
+		TaskName:     "deploy",
+		Image:        "alpine:3.23",
+		Command:      command,
+		Env:          spec.Env,
+		RunParams:    map[string]string{"mode": "baseline"},
+		CacheVersion: 1,
+	}.Compute()
+	desc.Cache.ComputedHash = hash
+	desc.Baseline.ComputedHash = hash
+
+	require.NoError(t, f.db.Create(&models.TaskRun{
+		ID:                  uuid.New(),
+		JobRunID:            f.runID,
+		TaskID:              taskID,
+		AtomID:              atomID,
+		Engine:              models.AtomEngineDocker,
+		Image:               "alpine:3.23",
+		Command:             commandJSON,
+		Status:              string(runstorage.TaskStatusSucceeded),
+		Attempt:             1,
+		MaxAttempts:         1,
+		Hash:                hash,
+		Result:              result,
+		CacheEnabled:        true,
+		CacheVersion:        1,
+		ReplaySafe:          replaySafe,
+		ExecutionDescriptor: serviceJSON(t, desc),
+		StartedAt:           servicePtr(f.now),
+		CompletedAt:         servicePtr(f.now.Add(time.Second)),
+		CreatedAt:           f.now,
+		UpdatedAt:           f.now,
+	}).Error)
+	return taskID
+}
+
+type completingDispatcher struct {
+	store *runstorage.Store
+	calls []uuid.UUID
+	mu    sync.Mutex
+}
+
+func (d *completingDispatcher) DispatchReplay(ctx context.Context, runID uuid.UUID) error {
+	d.mu.Lock()
+	d.calls = append(d.calls, runID)
+	d.mu.Unlock()
+
+	now := time.Now().UTC()
+	if err := d.store.DB().WithContext(ctx).Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND status = ?", runID, string(runstorage.TaskStatusPending)).
+		Updates(map[string]any{
+			"status":       string(runstorage.TaskStatusSucceeded),
+			"result":       "success",
+			"completed_at": now,
+			"updated_at":   now,
+		}).Error; err != nil {
+		return err
+	}
+	return d.store.DB().WithContext(ctx).Model(&models.JobRun{}).
+		Where("id = ?", runID).
+		Updates(map[string]any{
+			"status":       string(runstorage.StatusSucceeded),
+			"completed_at": now,
+			"updated_at":   now,
+		}).Error
+}
+
+func serviceJSON(t *testing.T, v any) datatypes.JSON {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return datatypes.JSON(data)
+}
+
+func serviceJSONString(t *testing.T, v any) string {
+	t.Helper()
+	data, err := json.Marshal(v)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func servicePtr[T any](v T) *T {
+	return &v
+}

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -942,7 +942,7 @@ write, lineage emit, or callback.
 	      executor replay reconstruction remains deferred; the distributed worker
 	      reconstructs, and local mode fails closed until it has descriptor-aware
 	      reconstruction.
-- [ ] B4. Expose `POST /v1/jobs/:id/runs/:run_id/replay` (body: `{ "set": {k:v} }`
+- [x] B4. Expose `POST /v1/jobs/:id/runs/:run_id/replay` (body: `{ "set": {k:v} }`
       only) returning the new run id. **Replay is always quarantined** — the body
       carries no `quarantine` field; the handler sets quarantine internally and a
       request attempting to disable it is rejected (the invariant cannot be turned
@@ -995,6 +995,50 @@ write, lineage emit, or callback.
       Files: new `api/rest/controller/replay/`, new `api/rest/service/replay/`,
       route + import in `api/rest/bind/bind.go`, `internal/auth/rbac.go` (policy
       entry) + `internal/auth/rbac_test.go` (RoleRunner assertion).
+      W6-alpha note (2026-06-26): implemented `POST
+      /v1/jobs/:id/runs/:run_id/replay` with a strict `{set}`-only body and
+      required non-blank `Idempotency-Key`; the service derives a scoped
+      SHA-256 fingerprint over path job id, baseline run id, principal, sorted
+      overrides, and the key, then relies on B3's same-transaction
+      `JobRun.ReplayFingerprint` unique insert for the durable reservation. On
+      duplicate/previously-materialized fingerprints it reloads the existing
+      replay run and resumes any `running` reservation with pending task rows
+      through the dispatcher, while treating an empty materialization as corrupt
+      instead of returning a silent no-op. The controller mirrors A2's security
+      boundary by loading the baseline run and rejecting
+      `baselineRun.JobID != :id` with not-found before constructing or
+      dispatching replay. B3 typed refusals are mapped to expected 4xx statuses
+      (`ErrReplayUnsafe`/descriptor/secret issues to 422, unavailable
+      proof/quarantined/non-terminal baseline to 409, missing baseline to 404),
+      and the route is registered as `/jobs/:id/runs/:run_id/replay` with
+      endpointPolicy key `POST /v1/jobs/:id/runs/:id/replay` → `RoleRunner`.
+      W6-alpha follow-up note (2026-06-26): tightened the endpoint without
+      changing the hard invariants. The controller now caps replay request bodies
+      at 64 KiB, rejects oversized/over-cap `set` payloads, rejects empty or
+      overlong override keys/values, and still uses `DisallowUnknownFields` so
+      quarantine remains non-wire-settable. Baselines with no task runs now wrap
+      `ErrUnavailableBaselineProof` and map to a 4xx instead of falling through
+      as 500. Replay fingerprint unique-collision detection now uses the shared
+      sqlite/dqlite typed unique-constraint classifier instead of depending on
+      the `replay_fingerprint` column name in the error string. The REST service
+      prepares the replay plan before materialization and, in local execution
+      mode, refuses any replay that would re-execute pending tasks with a clean
+      409 while still allowing no-override all-cache-hit replays. Existing
+      running reservations with pending rows are resumed only in distributed
+      mode; unexpected non-terminal reservation statuses are treated as corrupt
+      rather than returned as dead runs. The replay e2e now verifies quarantined
+      replay runs via `GET /v1/jobs/:id/runs/:run_id` because the default run
+      list intentionally excludes quarantine, and uses distinct no-override
+      idempotency keys for successful local-mode replays. Deferred follow-ups:
+      J2 dispatcher single-flight remains low priority because downstream guards
+      cover duplicate dispatch; J4 service-boundary ownership defense-in-depth is
+      fix-when-touched; J5 cross-job coverage under the auth-enabled harness
+      stays with B6(9); J7 reservation-corrupt sentinel controller cases remain
+      optional.
+      B4 integration repair note (2026-06-26): the replay e2e now exercises the
+      full successful local-mode path by making the baseline manifest cacheable
+      (`metadata.cache.ttl: "1h"`), so the no-override replay proves every task
+      unchanged and materializes as all-cache-hit instead of re-executing.
       Depends on: B3.
 - [ ] B5. Add `caesium run replay <run-id> --job-id <id> --set k=v [--idempotency-key
       <k>] [--diff] [--json]`: fires a quarantined replay. **`--job-id` is required**

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -72,6 +72,7 @@ var endpointPolicy = map[string]models.Role{
 
 	// Runner
 	"POST /v1/jobs/:id/run":                      models.RoleRunner,
+	"POST /v1/jobs/:id/runs/:id/replay":          models.RoleRunner,
 	"POST /v1/jobs/:id/runs/:id/retry":           models.RoleRunner,
 	"POST /v1/jobs/:id/runs/:id/callbacks/retry": models.RoleRunner,
 	"POST /v1/jobs/:id/backfill":                 models.RoleRunner,

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -109,6 +109,7 @@ func TestRequiredRoleBackfilledProtectedEndpoints(t *testing.T) {
 		{"POST", "/v1/notifications/policies", models.RoleOperator},
 		{"PATCH", "/v1/notifications/policies/:id", models.RoleOperator},
 		{"DELETE", "/v1/notifications/policies/:id", models.RoleOperator},
+		{"POST", "/v1/jobs/:id/runs/:id/replay", models.RoleRunner},
 	}
 
 	for _, tt := range tests {

--- a/internal/auth/saml/replay_store.go
+++ b/internal/auth/saml/replay_store.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/models"
-	"github.com/mattn/go-sqlite3"
+	"github.com/caesium-cloud/caesium/pkg/sqlerr"
 	"gorm.io/gorm"
 )
 
@@ -102,19 +102,5 @@ func (s *ReplayStore) Reap(ctx context.Context) (int64, error) {
 }
 
 func isUniqueConstraintError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	var sqliteErr sqlite3.Error
-	if errors.As(err, &sqliteErr) {
-		return sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique ||
-			sqliteErr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey
-	}
-
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "unique constraint") ||
-		(strings.Contains(msg, "constraint failed") && strings.Contains(msg, "unique")) ||
-		strings.Contains(msg, "duplicate key") ||
-		strings.Contains(msg, "duplicate entry")
+	return sqlerr.IsUniqueConstraint(err)
 }

--- a/internal/replay/replay.go
+++ b/internal/replay/replay.go
@@ -85,6 +85,23 @@ type Result struct {
 	Decisions []TaskDecision
 }
 
+// PreparedReplay is a validated replay plan that has not yet been materialized.
+type PreparedReplay struct {
+	baseline    models.JobRun
+	params      map[string]string
+	overrides   map[string]string
+	fingerprint string
+	plans       []plannedTask
+}
+
+// RequiresDispatch reports whether this replay has tasks that must re-execute.
+func (p *PreparedReplay) RequiresDispatch() bool {
+	if p == nil {
+		return false
+	}
+	return hasPending(p.plans)
+}
+
 type TaskDecision struct {
 	TaskID       uuid.UUID
 	TaskName     string
@@ -132,6 +149,20 @@ func (c *Constructor) Replay(ctx context.Context, req Request) (*Result, error) 
 		return nil, ErrDispatchRequired
 	}
 
+	prepared, err := c.Prepare(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return c.Materialize(ctx, prepared)
+}
+
+// Prepare validates the baseline and computes replay task decisions without
+// inserting the replay run. Callers may inspect the plan before materialization.
+func (c *Constructor) Prepare(ctx context.Context, req Request) (*PreparedReplay, error) {
+	if c == nil || c.store == nil {
+		return nil, errors.New("replay: run store is required")
+	}
+
 	baseline, tasks, err := c.loadBaseline(ctx, req.BaselineRunID)
 	if err != nil {
 		return nil, err
@@ -161,12 +192,33 @@ func (c *Constructor) Replay(ctx context.Context, req Request) (*Result, error) 
 		return nil, err
 	}
 
-	runID, err := c.materialize(ctx, baseline, replayParams, req.Set, req.ReplayFingerprint, plans)
+	return &PreparedReplay{
+		baseline:    baseline,
+		params:      replayParams,
+		overrides:   maps.Clone(req.Set),
+		fingerprint: req.ReplayFingerprint,
+		plans:       plans,
+	}, nil
+}
+
+// Materialize commits a prepared replay run and dispatches pending replay work.
+func (c *Constructor) Materialize(ctx context.Context, prepared *PreparedReplay) (*Result, error) {
+	if c == nil || c.store == nil {
+		return nil, errors.New("replay: run store is required")
+	}
+	if c.dispatcher == nil {
+		return nil, ErrDispatchRequired
+	}
+	if prepared == nil {
+		return nil, errors.New("replay: prepared replay is required")
+	}
+
+	runID, err := c.materialize(ctx, prepared.baseline, prepared.params, prepared.overrides, prepared.fingerprint, prepared.plans)
 	if err != nil {
 		return nil, err
 	}
 
-	if hasPending(plans) {
+	if hasPending(prepared.plans) {
 		if err := c.dispatcher.DispatchReplay(ctx, runID); err != nil {
 			return nil, err
 		}
@@ -176,7 +228,7 @@ func (c *Constructor) Replay(ctx context.Context, req Request) (*Result, error) 
 	if err != nil {
 		return nil, err
 	}
-	return &Result{Run: created, Decisions: decisions(plans)}, nil
+	return &Result{Run: created, Decisions: decisions(prepared.plans)}, nil
 }
 
 func (c *Constructor) loadBaseline(ctx context.Context, runID uuid.UUID) (models.JobRun, []*baselineTask, error) {
@@ -196,7 +248,7 @@ func (c *Constructor) loadBaseline(ctx context.Context, runID uuid.UUID) (models
 		return models.JobRun{}, nil, err
 	}
 	if len(rows) == 0 {
-		return models.JobRun{}, nil, fmt.Errorf("replay: baseline run %s has no task runs", runID)
+		return models.JobRun{}, nil, fmt.Errorf("%w: baseline run %s has no task runs", ErrUnavailableBaselineProof, runID)
 	}
 
 	tasks := make([]*baselineTask, 0, len(rows))

--- a/internal/replay/replay_test.go
+++ b/internal/replay/replay_test.go
@@ -120,6 +120,14 @@ func TestReplayAbortsUnchangedTaskWithoutCacheOrBaselineResult(t *testing.T) {
 	require.Contains(t, err.Error(), `step "extract"`)
 }
 
+func TestReplayBaselineWithoutTaskRunsIsUnavailableProof(t *testing.T) {
+	f := newReplayFixture(t)
+
+	_, err := New(f.store, &recordingDispatcher{}).Replay(context.Background(), Request{BaselineRunID: f.runID})
+	require.ErrorIs(t, err, ErrUnavailableBaselineProof)
+	require.Contains(t, err.Error(), "has no task runs")
+}
+
 func TestReplayAbortsUnchangedFailedBaselineResult(t *testing.T) {
 	f := newReplayFixture(t)
 	taskID := f.seedTask(t, seedTaskConfig{name: "extract", replaySafe: true, result: "exit_code:1"})

--- a/pkg/sqlerr/constraint.go
+++ b/pkg/sqlerr/constraint.go
@@ -1,0 +1,28 @@
+package sqlerr
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/mattn/go-sqlite3"
+)
+
+// IsUniqueConstraint reports whether err is a unique/primary-key constraint
+// violation from SQLite/dqlite or a compatible SQL driver message.
+func IsUniqueConstraint(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var sqliteErr sqlite3.Error
+	if errors.As(err, &sqliteErr) {
+		return sqliteErr.ExtendedCode == sqlite3.ErrConstraintUnique ||
+			sqliteErr.ExtendedCode == sqlite3.ErrConstraintPrimaryKey
+	}
+
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") ||
+		(strings.Contains(msg, "constraint failed") && strings.Contains(msg, "unique")) ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "duplicate entry")
+}

--- a/test/replay_e2e_test.go
+++ b/test/replay_e2e_test.go
@@ -1,0 +1,279 @@
+//go:build integration
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+type replayResponse struct {
+	ID         string `json:"id"`
+	RunID      string `json:"run_id"`
+	Status     string `json:"status"`
+	Quarantine bool   `json:"quarantine"`
+}
+
+func (s *IntegrationTestSuite) TestReplayRESTEndpointIdempotencyAndSafety() {
+	aliasA := fmt.Sprintf("e2e-replay-safe-a-%d", time.Now().UnixNano())
+	dirA := s.writeJobManifest(replayManifest(aliasA, true))
+	defer os.RemoveAll(dirA)
+	s.runCLI("job", "apply", "--path", dirA, "--server", s.caesiumURL)
+	jobA := s.requireJobByAlias(aliasA)
+	s.Require().NotNil(jobA)
+
+	runA := s.triggerRun(jobA.ID)
+	s.Require().Equal("succeeded", s.awaitRun(jobA.ID, runA, runTimeout).Status)
+
+	key := "replay-key-" + time.Now().Format("150405.000000000")
+	first := s.mustPostReplay(jobA.ID, runA, &key, `{"set":{}}`)
+	s.NotEmpty(first.RunID)
+	s.True(first.Quarantine)
+	firstRun := s.awaitRun(jobA.ID, first.RunID, runTimeout)
+	s.Equal("succeeded", firstRun.Status)
+	s.True(firstRun.Quarantine)
+
+	second := s.mustPostReplay(jobA.ID, runA, &key, `{"set":{}}`)
+	s.Equal(first.RunID, second.RunID, "same scoped fingerprint must return the existing replay run")
+	secondRun := s.fetchRun(jobA.ID, second.RunID)
+	s.True(secondRun.Quarantine)
+
+	distinctKey := key + "-distinct"
+	third := s.mustPostReplay(jobA.ID, runA, &distinctKey, `{"set":{}}`)
+	s.NotEqual(first.RunID, third.RunID, "changed idempotency key must derive a distinct fingerprint")
+	thirdRun := s.fetchRun(jobA.ID, third.RunID)
+	s.True(thirdRun.Quarantine)
+
+	overrideKey := key + "-override-local"
+	overrideBody := s.postReplay(jobA.ID, runA, &overrideKey, `{"set":{"mode":"what-if"}}`)
+	s.Contains([]int{http.StatusConflict, http.StatusUnprocessableEntity}, overrideBody.status, overrideBody.body)
+	s.Contains(overrideBody.body, "distributed execution mode")
+
+	missingBody := s.postReplay(jobA.ID, runA, nil, `{"set":{}}`)
+	s.Equal(http.StatusBadRequest, missingBody.status, missingBody.body)
+	blank := "   "
+	blankBody := s.postReplay(jobA.ID, runA, &blank, `{"set":{}}`)
+	s.Equal(http.StatusBadRequest, blankBody.status, blankBody.body)
+
+	rejectKey := key + "-quarantine"
+	quarantineBody := s.postReplay(jobA.ID, runA, &rejectKey, `{"set":{},"quarantine":false}`)
+	s.Equal(http.StatusBadRequest, quarantineBody.status, quarantineBody.body)
+
+	oversizedKey := key + "-oversized"
+	oversizedBody := s.postReplay(jobA.ID, runA, &oversizedKey, `{"set":{"k":"`+strings.Repeat("x", 70*1024)+`"}}`)
+	s.GreaterOrEqual(oversizedBody.status, 400, oversizedBody.body)
+	s.Less(oversizedBody.status, 500, oversizedBody.body)
+
+	overCapKey := key + "-over-cap"
+	overCapBody := s.postReplay(jobA.ID, runA, &overCapKey, replayOverCapSetPayload())
+	s.GreaterOrEqual(overCapBody.status, 400, overCapBody.body)
+	s.Less(overCapBody.status, 500, overCapBody.body)
+
+	aliasB := fmt.Sprintf("e2e-replay-safe-b-%d", time.Now().UnixNano())
+	dirB := s.writeJobManifest(replayManifest(aliasB, true))
+	defer os.RemoveAll(dirB)
+	s.runCLI("job", "apply", "--path", dirB, "--server", s.caesiumURL)
+	jobB := s.requireJobByAlias(aliasB)
+	s.Require().NotNil(jobB)
+
+	beforeA := len(s.fetchRuns(jobA.ID))
+	beforeB := len(s.fetchRuns(jobB.ID))
+	crossKey := key + "-cross"
+	crossBody := s.postReplay(jobB.ID, runA, &crossKey, `{"set":{}}`)
+	s.Contains([]int{http.StatusNotFound, http.StatusForbidden}, crossBody.status, crossBody.body)
+	s.Len(s.fetchRuns(jobA.ID), beforeA, "cross-job replay must not create a replay under the baseline owner")
+	s.Len(s.fetchRuns(jobB.ID), beforeB, "cross-job replay must not create a replay under the path job")
+
+	aliasUnsafe := fmt.Sprintf("e2e-replay-unsafe-%d", time.Now().UnixNano())
+	dirUnsafe := s.writeJobManifest(replayManifest(aliasUnsafe, false))
+	defer os.RemoveAll(dirUnsafe)
+	s.runCLI("job", "apply", "--path", dirUnsafe, "--server", s.caesiumURL)
+	jobUnsafe := s.requireJobByAlias(aliasUnsafe)
+	s.Require().NotNil(jobUnsafe)
+	runUnsafe := s.triggerRun(jobUnsafe.ID)
+	s.Require().Equal("succeeded", s.awaitRun(jobUnsafe.ID, runUnsafe, runTimeout).Status)
+
+	unsafeKey := key + "-unsafe"
+	unsafeBody := s.postReplay(jobUnsafe.ID, runUnsafe, &unsafeKey, `{"set":{"mode":"force-rerun"}}`)
+	s.Equal(http.StatusUnprocessableEntity, unsafeBody.status, unsafeBody.body)
+	s.Contains(unsafeBody.body, "deploy")
+	s.Len(s.fetchRuns(jobUnsafe.ID), 1, "unsafe replay refusal must not materialize a replay run")
+}
+
+func (s *IntegrationTestSuite) TestReplayRESTEndpointConcurrentIdempotency() {
+	alias := fmt.Sprintf("e2e-replay-concurrent-%d", time.Now().UnixNano())
+	dir := s.writeJobManifest(replayManifest(alias, true))
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	baselineRunID := s.triggerRun(job.ID)
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, baselineRunID, runTimeout).Status)
+
+	const workers = 8
+	key := "replay-concurrent-" + time.Now().Format("150405.000000000")
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	responses := make([]replayPostBody, workers)
+	errs := make([]error, workers)
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			responses[idx], errs[idx] = s.postReplayNoRequire(job.ID, baselineRunID, &key, `{"set":{}}`)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	runIDs := make(map[string]struct{})
+	for i, response := range responses {
+		s.Require().NoError(errs[i])
+		s.Equal(http.StatusAccepted, response.status, response.body)
+		var decoded replayResponse
+		s.Require().NoError(json.Unmarshal([]byte(response.body), &decoded))
+		s.NotEmpty(decoded.RunID)
+		runIDs[decoded.RunID] = struct{}{}
+	}
+	s.Len(runIDs, 1, "parallel identical replays must all resolve to one replay run")
+	for runID := range runIDs {
+		run := s.fetchRun(job.ID, runID)
+		s.True(run.Quarantine)
+		s.Equal("succeeded", run.Status)
+	}
+}
+
+func (s *IntegrationTestSuite) TestReplayRESTEndpointBaselineWithoutTaskRunsIs4xx() {
+	alias := fmt.Sprintf("e2e-replay-empty-%d", time.Now().UnixNano())
+	jobID := s.createEmptyReplayJob(alias)
+	baselineRunID := s.triggerRun(jobID)
+	s.Require().Equal("failed", s.awaitRun(jobID, baselineRunID, runTimeout).Status)
+
+	key := "replay-empty-" + time.Now().Format("150405.000000000")
+	response := s.postReplay(jobID, baselineRunID, &key, `{"set":{}}`)
+	s.GreaterOrEqual(response.status, 400, response.body)
+	s.Less(response.status, 500, response.body)
+	s.NotEqual(http.StatusInternalServerError, response.status, response.body)
+}
+
+type replayPostBody struct {
+	status int
+	body   string
+}
+
+func (s *IntegrationTestSuite) mustPostReplay(jobID, runID string, key *string, payload string) replayResponse {
+	s.T().Helper()
+	observed := s.postReplay(jobID, runID, key, payload)
+	s.Require().Equal(http.StatusAccepted, observed.status, observed.body)
+	var decoded replayResponse
+	s.Require().NoError(json.Unmarshal([]byte(observed.body), &decoded))
+	if decoded.RunID == "" {
+		decoded.RunID = decoded.ID
+	}
+	s.Require().NotEmpty(decoded.RunID)
+	return decoded
+}
+
+func (s *IntegrationTestSuite) fetchRun(jobID, runID string) runResponse {
+	s.T().Helper()
+	var run runResponse
+	s.getJSON(fmt.Sprintf("/v1/jobs/%s/runs/%s", jobID, runID), &run)
+	return run
+}
+
+func (s *IntegrationTestSuite) postReplay(jobID, runID string, key *string, payload string) replayPostBody {
+	s.T().Helper()
+	observed, err := s.postReplayNoRequire(jobID, runID, key, payload)
+	s.Require().NoError(err)
+	return observed
+}
+
+func (s *IntegrationTestSuite) postReplayNoRequire(jobID, runID string, key *string, payload string) (replayPostBody, error) {
+	req, err := http.NewRequestWithContext(
+		context.Background(),
+		http.MethodPost,
+		fmt.Sprintf("%s/v1/jobs/%s/runs/%s/replay", s.caesiumURL, jobID, runID),
+		strings.NewReader(payload),
+	)
+	if err != nil {
+		return replayPostBody{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if key != nil {
+		req.Header.Set("Idempotency-Key", *key)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return replayPostBody{}, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return replayPostBody{}, err
+	}
+	return replayPostBody{status: resp.StatusCode, body: string(body)}, nil
+}
+
+func (s *IntegrationTestSuite) createEmptyReplayJob(alias string) string {
+	s.T().Helper()
+	payload := fmt.Sprintf(`{
+		"alias": %q,
+		"trigger": {"type": "cron", "configuration": {"cron": "0 2 * * *"}},
+		"tasks": []
+	}`, alias)
+	resp, err := s.doJSONRequest(http.MethodPost, fmt.Sprintf("%v/v1/jobs", s.caesiumURL), bytes.NewBufferString(payload))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusCreated, resp.StatusCode, string(body))
+
+	var created struct {
+		ID string `json:"id"`
+	}
+	s.Require().NoError(json.Unmarshal(body, &created))
+	s.Require().NotEmpty(created.ID)
+	return created.ID
+}
+
+func replayOverCapSetPayload() string {
+	var b strings.Builder
+	b.WriteString(`{"set":{`)
+	for i := 0; i < 257; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, "%q:%q", fmt.Sprintf("key-%03d", i), "value")
+	}
+	b.WriteString(`}}`)
+	return b.String()
+}
+
+func replayManifest(alias string, replaySafe bool) string {
+	replaySafeLine := ""
+	if replaySafe {
+		replaySafeLine = "\n  replaySafe: true"
+	}
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s%s
+  cache:
+    ttl: "1h"
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: deploy
+    image: alpine:3.23
+    command: ["sh","-c","echo deploy"]
+`, alias, replaySafeLine)
+}

--- a/test/replay_e2e_test.go
+++ b/test/replay_e2e_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 type replayResponse struct {
-	ID         string `json:"id"`
 	RunID      string `json:"run_id"`
 	Status     string `json:"status"`
 	Quarantine bool   `json:"quarantine"`
@@ -175,11 +174,11 @@ func (s *IntegrationTestSuite) mustPostReplay(jobID, runID string, key *string, 
 	s.T().Helper()
 	observed := s.postReplay(jobID, runID, key, payload)
 	s.Require().Equal(http.StatusAccepted, observed.status, observed.body)
+	var fields map[string]json.RawMessage
+	s.Require().NoError(json.Unmarshal([]byte(observed.body), &fields))
+	s.NotContains(fields, "id")
 	var decoded replayResponse
 	s.Require().NoError(json.Unmarshal([]byte(observed.body), &decoded))
-	if decoded.RunID == "" {
-		decoded.RunID = decoded.ID
-	}
 	s.Require().NotEmpty(decoded.RunID)
 	return decoded
 }

--- a/test/run_test.go
+++ b/test/run_test.go
@@ -14,12 +14,13 @@ import (
 // runResponse matches the JSON returned by POST /v1/jobs/:id/run and
 // GET /v1/jobs/:id/runs/:run_id.
 type runResponse struct {
-	ID     string            `json:"id"`
-	JobID  string            `json:"job_id"`
-	Status string            `json:"status"`
-	Error  string            `json:"error,omitempty"`
-	Params map[string]string `json:"params,omitempty"`
-	Tasks  []runTaskResponse `json:"tasks"`
+	ID         string            `json:"id"`
+	JobID      string            `json:"job_id"`
+	Status     string            `json:"status"`
+	Error      string            `json:"error,omitempty"`
+	Quarantine bool              `json:"quarantine"`
+	Params     map[string]string `json:"params,omitempty"`
+	Tasks      []runTaskResponse `json:"tasks"`
 }
 
 type runTaskResponse struct {


### PR DESCRIPTION
## B4 — REST replay endpoint + idempotent reservation

`POST /v1/jobs/:id/runs/:run_id/replay` (body `{set:{k:v}}`) wiring the B3 `internal/replay` constructor to the wire. New `api/rest/controller/replay/` + `api/rest/service/replay/`.

### Hard invariants (deep review confirmed all hold — no blockers)
- **Always quarantined** — no wire field; `quarantine:false` is rejected `400` via `DisallowUnknownFields`. The created run carries `Quarantine=true`.
- **Atomic idempotent creation** — a non-empty `Idempotency-Key` is required (`400` if missing/blank); a **scoped fingerprint** over `(job_id, baseline_run_id, actor, normalized overrides, key)` is reserved via the `JobRun.ReplayFingerprint` unique index **in the same tx as the JobRun** (no TOCTOU); a duplicate-fingerprint collision returns the **existing** run; reservations commit `pending` and **resume recoverably**.
- **Cross-job ownership** — the handler validates `baselineRun.JobID == :id` and `404`s before construct/dispatch, stopping a cross-job replay that the run-scoped middleware would otherwise pass (same class as A2's guard).
- **No replay-safe bypass** — an unsafe baseline → `422` naming the step.

### Route / RBAC
Echo route `:run_id`; `endpointPolicy` key normalized to `:id` (`"POST /v1/jobs/:id/runs/:id/replay" → RoleRunner`, matching run/retry). `rbac_test.go` asserts the role.

### Pre-publish fixes (review)
Bounded request body + `set`-map caps (DoS); zero-task baseline → `4xx` not `500`; a **typed** `pkg/sqlerr.IsUniqueConstraint` helper (`errors.As` + `ExtendedCode`) replacing a brittle string match; parallel-idempotency + crash-resume unit tests; and a clean **`409`** for a re-executing replay in **local mode** (the in-process executor fail-closed refuses) instead of a `202`-then-async-fail. Deferred follow-ups noted in the plan: dispatcher single-flight, the auth-enabled cross-job regression test (B6), reservation-sentinel controller cases.

### Verification
`test/replay_e2e_test.go` drives the real endpoint: idempotency dedup (incl. an 8-way concurrent burst → one run), missing/blank key `400`, cross-job `404` (+ no run created), quarantine-disable `400`, oversized/over-cap `4xx`, replay-safe refusal `422`, empty-baseline `4xx`. No-override replays cache-hit → `202` succeed; override replays → the `409` local-mode contract. Full chain green (`just lint` + `just unit-test` + `just integration-test`).

### Scope
The full successful **re-executing** replay path runs via the distributed worker (local mode refuses — the tracked follow-up); B5 adds the `caesium run replay` CLID, B6 the full distributed integration matrix.

Plan: `docs/exec-plans/active/data-plane-memory-ii.md` (B4).