### PR TITLE
Add caesium run replay CLI + value-diff (data-plane-memory-ii W7-α)

### DIFF
--- a/cmd/run/replay.go
+++ b/cmd/run/replay.go
@@ -55,62 +55,72 @@ var replayCmd = &cobra.Command{
 		"Dedup is scoped per API key/principal: a retry must reuse the same key AND " +
 		"the same credentials to resolve to the existing replay.",
 	Args: cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		baselineRunID := strings.TrimSpace(args[0])
-		jobID := strings.TrimSpace(replayJobID)
-		if jobID == "" {
-			return fmt.Errorf("--job-id is required")
-		}
+	RunE: runReplay,
+}
 
-		set, err := parseReplaySet(replaySets)
+func runReplay(cmd *cobra.Command, args []string) error {
+	baselineRunID := strings.TrimSpace(args[0])
+	jobID := strings.TrimSpace(replayJobID)
+	if jobID == "" {
+		return fmt.Errorf("--job-id is required")
+	}
+
+	set, err := parseReplaySet(replaySets)
+	if err != nil {
+		return err
+	}
+
+	key, err := resolveReplayIdempotencyKey(cmd, replayIdempotencyKey, cmd.Flags().Changed("idempotency-key"), generateReplayIdempotencyKey)
+	if err != nil {
+		return err
+	}
+
+	resp, err := postReplay(cmd, jobID, baselineRunID, key, set)
+	if err != nil {
+		return err
+	}
+
+	if replayDiff {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "awaiting replay run %s\n", resp.RunID)
+		run, err := awaitReplayRun(cmd, jobID, resp.RunID, replayAwaitTimeout)
 		if err != nil {
 			return err
 		}
-
-		key, err := resolveReplayIdempotencyKey(cmd, replayIdempotencyKey, cmd.Flags().Changed("idempotency-key"), generateReplayIdempotencyKey)
+		replayFailed := strings.EqualFold(strings.TrimSpace(run.Status), "failed")
+		diff, err := fetchReplayDiff(cmd, jobID, baselineRunID, resp.RunID)
 		if err != nil {
 			return err
 		}
-
-		resp, err := postReplay(cmd, jobID, baselineRunID, key, set)
-		if err != nil {
-			return err
-		}
-
-		if replayDiff {
-			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "awaiting replay run %s\n", resp.RunID)
-			if _, err := awaitReplayRun(cmd, jobID, resp.RunID, replayAwaitTimeout); err != nil {
-				return err
-			}
-			diff, err := fetchReplayDiff(cmd, jobID, baselineRunID, resp.RunID)
-			if err != nil {
-				return err
-			}
-			if replayJSON {
-				var out interface{}
-				if err := json.Unmarshal(diff, &out); err != nil {
-					return fmt.Errorf("run diff response was not valid JSON: %w", err)
-				}
-				pretty, _ := json.MarshalIndent(out, "", "  ")
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(pretty))
-				return nil
-			}
-			var rendered runDiffResponse
-			if err := json.Unmarshal(diff, &rendered); err != nil {
+		if replayJSON {
+			var out interface{}
+			if err := json.Unmarshal(diff, &out); err != nil {
 				return fmt.Errorf("run diff response was not valid JSON: %w", err)
 			}
-			renderRunDiffTable(cmd, &rendered)
-			return nil
-		}
-
-		if replayJSON {
-			pretty, _ := json.MarshalIndent(resp, "", "  ")
+			pretty, _ := json.MarshalIndent(out, "", "  ")
 			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(pretty))
+			if replayFailed {
+				return fmt.Errorf("replay run %s failed", resp.RunID)
+			}
 			return nil
 		}
-		_, _ = fmt.Fprintln(cmd.OutOrStdout(), resp.RunID)
+		var rendered runDiffResponse
+		if err := json.Unmarshal(diff, &rendered); err != nil {
+			return fmt.Errorf("run diff response was not valid JSON: %w", err)
+		}
+		renderRunDiffTable(cmd, &rendered)
+		if replayFailed {
+			return fmt.Errorf("replay run %s failed", resp.RunID)
+		}
 		return nil
-	},
+	}
+
+	if replayJSON {
+		pretty, _ := json.MarshalIndent(resp, "", "  ")
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(pretty))
+		return nil
+	}
+	_, _ = fmt.Fprintln(cmd.OutOrStdout(), resp.RunID)
+	return nil
 }
 
 func parseReplaySet(values []string) (map[string]string, error) {
@@ -185,6 +195,8 @@ func postReplay(cmd *cobra.Command, jobID, baselineRunID, idempotencyKey string,
 
 func awaitReplayRun(cmd *cobra.Command, jobID, runID string, timeout time.Duration) (*replayRunStatusResponse, error) {
 	deadline := time.Now().Add(timeout)
+	ticker := time.NewTicker(replayPollInterval)
+	defer ticker.Stop()
 	var lastStatus string
 	for {
 		run, err := fetchReplayRunStatus(cmd, jobID, runID)
@@ -202,7 +214,7 @@ func awaitReplayRun(cmd *cobra.Command, jobID, runID string, timeout time.Durati
 		select {
 		case <-cmd.Context().Done():
 			return nil, cmd.Context().Err()
-		case <-time.After(replayPollInterval):
+		case <-ticker.C:
 		}
 	}
 }

--- a/cmd/run/replay.go
+++ b/cmd/run/replay.go
@@ -1,0 +1,323 @@
+package run
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+const (
+	replayAwaitTimeout = 2 * time.Minute
+	replayPollInterval = 500 * time.Millisecond
+)
+
+var (
+	replayJobID          string
+	replayServer         string
+	replayAPIKey         string
+	replayJSON           bool
+	replayDiff           bool
+	replaySets           []string
+	replayIdempotencyKey string
+)
+
+type replayRequest struct {
+	Set map[string]string `json:"set,omitempty"`
+}
+
+type replayResponse struct {
+	RunID      string `json:"run_id"`
+	Status     string `json:"status"`
+	Quarantine bool   `json:"quarantine"`
+}
+
+type replayRunStatusResponse struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+}
+
+var replayCmd = &cobra.Command{
+	Use:   "replay <run-id> --job-id <job-id> [--set k=v]",
+	Short: "Fire a quarantined replay for a completed run",
+	Long: "Fire a quarantined replay through the job-scoped replay REST endpoint. " +
+		"--job-id is required because run lookup is intentionally scoped. " +
+		"Pass --idempotency-key on manual retries to dedupe to the existing replay; " +
+		"omitting it on a re-run intentionally starts another replay. When omitted, " +
+		"the generated key is printed to stderr before dispatch so it can be reused. " +
+		"Dedup is scoped per API key/principal: a retry must reuse the same key AND " +
+		"the same credentials to resolve to the existing replay.",
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		baselineRunID := strings.TrimSpace(args[0])
+		jobID := strings.TrimSpace(replayJobID)
+		if jobID == "" {
+			return fmt.Errorf("--job-id is required")
+		}
+
+		set, err := parseReplaySet(replaySets)
+		if err != nil {
+			return err
+		}
+
+		key, err := resolveReplayIdempotencyKey(cmd, replayIdempotencyKey, cmd.Flags().Changed("idempotency-key"), generateReplayIdempotencyKey)
+		if err != nil {
+			return err
+		}
+
+		resp, err := postReplay(cmd, jobID, baselineRunID, key, set)
+		if err != nil {
+			return err
+		}
+
+		if replayDiff {
+			_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "awaiting replay run %s\n", resp.RunID)
+			if _, err := awaitReplayRun(cmd, jobID, resp.RunID, replayAwaitTimeout); err != nil {
+				return err
+			}
+			diff, err := fetchReplayDiff(cmd, jobID, baselineRunID, resp.RunID)
+			if err != nil {
+				return err
+			}
+			if replayJSON {
+				var out interface{}
+				if err := json.Unmarshal(diff, &out); err != nil {
+					return fmt.Errorf("run diff response was not valid JSON: %w", err)
+				}
+				pretty, _ := json.MarshalIndent(out, "", "  ")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(pretty))
+				return nil
+			}
+			var rendered runDiffResponse
+			if err := json.Unmarshal(diff, &rendered); err != nil {
+				return fmt.Errorf("run diff response was not valid JSON: %w", err)
+			}
+			renderRunDiffTable(cmd, &rendered)
+			return nil
+		}
+
+		if replayJSON {
+			pretty, _ := json.MarshalIndent(resp, "", "  ")
+			_, _ = fmt.Fprintln(cmd.OutOrStdout(), string(pretty))
+			return nil
+		}
+		_, _ = fmt.Fprintln(cmd.OutOrStdout(), resp.RunID)
+		return nil
+	},
+}
+
+func parseReplaySet(values []string) (map[string]string, error) {
+	set := make(map[string]string, len(values))
+	for _, raw := range values {
+		key, value, ok := strings.Cut(raw, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return nil, fmt.Errorf("--set must be k=v; got %q", raw)
+		}
+		set[strings.TrimSpace(key)] = value
+	}
+	return set, nil
+}
+
+func resolveReplayIdempotencyKey(cmd *cobra.Command, supplied string, suppliedSet bool, generate func() (string, error)) (string, error) {
+	if suppliedSet {
+		return supplied, nil
+	}
+	key, err := generate()
+	if err != nil {
+		return "", fmt.Errorf("generate replay idempotency key: %w", err)
+	}
+	_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "replay idempotency key: %s\n", key)
+	return key, nil
+}
+
+func generateReplayIdempotencyKey() (string, error) {
+	return "replay-" + uuid.NewString(), nil
+}
+
+func postReplay(cmd *cobra.Command, jobID, baselineRunID, idempotencyKey string, set map[string]string) (*replayResponse, error) {
+	body, err := json.Marshal(replayRequest{Set: set})
+	if err != nil {
+		return nil, err
+	}
+
+	server := strings.TrimSuffix(replayServer, "/")
+	reqURL := fmt.Sprintf("%s/v1/jobs/%s/runs/%s/replay", server, url.PathEscape(jobID), url.PathEscape(baselineRunID))
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", idempotencyKey)
+	if apiKey := resolveRunDiffAPIKey(cmd, replayAPIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading replay response: %w", err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, replayStatusError(resp.StatusCode, respBody)
+	}
+
+	var decoded replayResponse
+	if err := json.Unmarshal(respBody, &decoded); err != nil {
+		return nil, fmt.Errorf("replay response was not valid JSON (status %d): %w", resp.StatusCode, err)
+	}
+	if strings.TrimSpace(decoded.RunID) == "" {
+		return nil, fmt.Errorf("replay response did not include run_id")
+	}
+	return &decoded, nil
+}
+
+func awaitReplayRun(cmd *cobra.Command, jobID, runID string, timeout time.Duration) (*replayRunStatusResponse, error) {
+	deadline := time.Now().Add(timeout)
+	var lastStatus string
+	for {
+		run, err := fetchReplayRunStatus(cmd, jobID, runID)
+		if err != nil {
+			return nil, err
+		}
+		lastStatus = run.Status
+		if isReplayTerminalStatus(run.Status) {
+			return run, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for replay run %s to finish (last status %q)", runID, lastStatus)
+		}
+
+		select {
+		case <-cmd.Context().Done():
+			return nil, cmd.Context().Err()
+		case <-time.After(replayPollInterval):
+		}
+	}
+}
+
+func fetchReplayRunStatus(cmd *cobra.Command, jobID, runID string) (*replayRunStatusResponse, error) {
+	server := strings.TrimSuffix(replayServer, "/")
+	reqURL := fmt.Sprintf("%s/v1/jobs/%s/runs/%s", server, url.PathEscape(jobID), url.PathEscape(runID))
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := resolveRunDiffAPIKey(cmd, replayAPIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading run status response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("fetch replay run status failed (%d): %s", resp.StatusCode, replayErrorMessage(body))
+	}
+	var run replayRunStatusResponse
+	if err := json.Unmarshal(body, &run); err != nil {
+		return nil, fmt.Errorf("run status response was not valid JSON (status %d): %w", resp.StatusCode, err)
+	}
+	return &run, nil
+}
+
+func fetchReplayDiff(cmd *cobra.Command, jobID, baselineRunID, replayRunID string) ([]byte, error) {
+	server := strings.TrimSuffix(replayServer, "/")
+	params := url.Values{}
+	params.Set("left", baselineRunID)
+	params.Set("right", replayRunID)
+	reqURL := fmt.Sprintf("%s/v1/jobs/%s/runs/diff?%s", server, url.PathEscape(jobID), params.Encode())
+
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := resolveRunDiffAPIKey(cmd, replayAPIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading run diff response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("run diff failed (%d): %s", resp.StatusCode, replayErrorMessage(body))
+	}
+	return body, nil
+}
+
+func isReplayTerminalStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "succeeded", "failed":
+		return true
+	default:
+		return false
+	}
+}
+
+func replayStatusError(status int, body []byte) error {
+	msg := replayErrorMessage(body)
+	switch status {
+	case http.StatusBadRequest:
+		return fmt.Errorf("replay request rejected (400): %s", msg)
+	case http.StatusNotFound:
+		return fmt.Errorf("replay target not found (404): %s", msg)
+	case http.StatusConflict:
+		return fmt.Errorf("replay refused (409): %s", msg)
+	case http.StatusUnprocessableEntity:
+		return fmt.Errorf("replay-safe refusal (422): %s", msg)
+	default:
+		return fmt.Errorf("replay failed (%d): %s", status, msg)
+	}
+}
+
+func replayErrorMessage(body []byte) string {
+	var decoded struct {
+		Message string `json:"message"`
+		Error   string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &decoded); err == nil {
+		if strings.TrimSpace(decoded.Message) != "" {
+			return strings.TrimSpace(decoded.Message)
+		}
+		if strings.TrimSpace(decoded.Error) != "" {
+			return strings.TrimSpace(decoded.Error)
+		}
+	}
+	return strings.TrimSpace(string(body))
+}
+
+func init() {
+	replayCmd.Flags().StringVar(&replayJobID, "job-id", "", "Job ID that owns the baseline run (required)")
+	replayCmd.Flags().StringVar(&replayServer, "server", "http://localhost:8080", "Caesium server base URL")
+	replayCmd.Flags().StringVar(&replayAPIKey, "api-key", "", "API key for authentication (prefer "+runDiffAPIKeyEnvVar+"; --api-key is visible in process listings)")
+	replayCmd.Flags().StringArrayVar(&replaySets, "set", nil, "Override a run parameter for the replay as k=v (repeatable)")
+	replayCmd.Flags().StringVar(&replayIdempotencyKey, "idempotency-key", "", "Replay idempotency key to reuse on retries; omit only when intentionally starting a distinct replay")
+	replayCmd.Flags().BoolVar(&replayDiff, "diff", false, "Wait for the replay to finish and render the run diff against the baseline")
+	replayCmd.Flags().BoolVar(&replayJSON, "json", false, "Emit machine-readable JSON")
+
+	Cmd.AddCommand(replayCmd)
+}

--- a/cmd/run/replay_test.go
+++ b/cmd/run/replay_test.go
@@ -1,0 +1,58 @@
+package run
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseReplaySet(t *testing.T) {
+	got, err := parseReplaySet([]string{"mode=what-if", "flavor=vanilla=bean", " spaced =value"})
+	require.NoError(t, err)
+	require.Equal(t, map[string]string{
+		"mode":   "what-if",
+		"flavor": "vanilla=bean",
+		"spaced": "value",
+	}, got)
+}
+
+func TestParseReplaySetRejectsMalformedValues(t *testing.T) {
+	for _, input := range [][]string{
+		{"missing-equals"},
+		{"=value"},
+		{"   =value"},
+	} {
+		_, err := parseReplaySet(input)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "--set must be k=v")
+	}
+}
+
+func TestResolveReplayIdempotencyKeyPrintsGeneratedKeyToStderr(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	key, err := resolveReplayIdempotencyKey(cmd, "", false, func() (string, error) {
+		return "generated-key", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "generated-key", key)
+	require.Equal(t, "replay idempotency key: generated-key\n", stderr.String())
+}
+
+func TestResolveReplayIdempotencyKeyPassesOperatorValueVerbatim(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+
+	key, err := resolveReplayIdempotencyKey(cmd, "  operator key  ", true, func() (string, error) {
+		return "", errors.New("must not generate")
+	})
+	require.NoError(t, err)
+	require.Equal(t, "  operator key  ", key)
+	require.Empty(t, stderr.String())
+}

--- a/cmd/run/replay_test.go
+++ b/cmd/run/replay_test.go
@@ -2,7 +2,11 @@ package run
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -55,4 +59,91 @@ func TestResolveReplayIdempotencyKeyPassesOperatorValueVerbatim(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "  operator key  ", key)
 	require.Empty(t, stderr.String())
+}
+
+func TestRunReplayDiffRendersDiffThenErrorsForFailedReplay(t *testing.T) {
+	restoreReplayTestGlobals(t)
+
+	const (
+		jobID    = "job-1"
+		baseline = "baseline-run"
+		replayID = "replay-run"
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/jobs/"+jobID+"/runs/"+baseline+"/replay":
+			if got := r.Header.Get("Idempotency-Key"); got != "operator-key" {
+				http.Error(w, "unexpected idempotency key: "+got, http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = w.Write([]byte(`{"run_id":"` + replayID + `","status":"running","quarantine":true}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/jobs/"+jobID+"/runs/"+replayID:
+			_, _ = w.Write([]byte(`{"id":"` + replayID + `","status":"failed"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/jobs/"+jobID+"/runs/diff":
+			if got := r.URL.Query().Get("left"); got != baseline {
+				http.Error(w, "unexpected left run: "+got, http.StatusBadRequest)
+				return
+			}
+			if got := r.URL.Query().Get("right"); got != replayID {
+				http.Error(w, "unexpected right run: "+got, http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"jobId":"job-1",
+				"leftRunId":"baseline-run",
+				"rightRunId":"replay-run",
+				"leftStatus":"succeeded",
+				"rightStatus":"failed",
+				"tasks":[{"taskName":"deploy","leftStatus":"succeeded","rightStatus":"failed","verdict":"changed","hashEqual":false}]
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	replayJobID = jobID
+	replayServer = server.URL
+	replayAPIKey = ""
+	replayJSON = true
+	replayDiff = true
+	replaySets = nil
+	replayIdempotencyKey = "operator-key"
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.SetContext(context.Background())
+	cmd.Flags().String("idempotency-key", "", "")
+	require.NoError(t, cmd.Flags().Set("idempotency-key", "operator-key"))
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := runReplay(cmd, []string{baseline})
+	require.Error(t, err)
+	require.EqualError(t, err, "replay run "+replayID+" failed")
+	require.Contains(t, stderr.String(), "awaiting replay run "+replayID)
+	require.True(t, json.Valid(stdout.Bytes()), "stdout was not JSON:\n%s", stdout.String())
+	require.Contains(t, stdout.String(), `"rightRunId": "replay-run"`)
+	require.Contains(t, stdout.String(), `"rightStatus": "failed"`)
+}
+
+func restoreReplayTestGlobals(t *testing.T) {
+	t.Helper()
+	originalJobID := replayJobID
+	originalServer := replayServer
+	originalAPIKey := replayAPIKey
+	originalJSON := replayJSON
+	originalDiff := replayDiff
+	originalSets := replaySets
+	originalIDKey := replayIdempotencyKey
+	t.Cleanup(func() {
+		replayJobID = originalJobID
+		replayServer = originalServer
+		replayAPIKey = originalAPIKey
+		replayJSON = originalJSON
+		replayDiff = originalDiff
+		replaySets = originalSets
+		replayIdempotencyKey = originalIDKey
+	})
 }

--- a/docs/exec-plans/active/data-plane-memory-ii.md
+++ b/docs/exec-plans/active/data-plane-memory-ii.md
@@ -1060,7 +1060,7 @@ write, lineage emit, or callback.
       (`metadata.cache.ttl: "1h"`), so the no-override replay proves every task
       unchanged and materializes as all-cache-hit instead of re-executing.
       Depends on: B3.
-- [ ] B5. Add `caesium run replay <run-id> --job-id <id> --set k=v [--idempotency-key
+- [x] B5. Add `caesium run replay <run-id> --job-id <id> --set k=v [--idempotency-key
       <k>] [--diff] [--json]`: fires a quarantined replay. **`--job-id` is required**
       (same reason as A3 and `caesium why`): the endpoint is
       `POST /v1/jobs/:id/runs/:run_id/replay`, so the CLI needs the job id to build
@@ -1078,6 +1078,17 @@ write, lineage emit, or callback.
       stdout discipline as in A3.
       Files: new `cmd/run/replay.go` (its own `func init()` calling
       `Cmd.AddCommand(replayCmd)` on `run.Cmd`).
+      B5 implementation note (2026-06-26): `cmd/run/replay.go` now posts the B4
+      request with repeated `--set k=v`, requires `--job-id`, sends the
+      `Idempotency-Key` header, maps B4 refusals to clear non-zero CLI errors,
+      prints auto-generated keys to stderr before dispatch while keeping operator
+      keys verbatim, and keeps stdout reserved for the replay run JSON/id or the
+      `--diff` render. `--diff` waits for the replay run to reach a terminal
+      state via `GET /v1/jobs/:id/runs/:run_id`, then reuses the A2 job-scoped
+      run-diff endpoint and renderer. Added CLI integration coverage with
+      separate stdout/stderr capture for clean JSON, restart-safe key reuse,
+      required `--job-id`, local-mode replay refusal, and no-override `--diff`,
+      plus unit tests for `--set` parsing and generated-key stderr behavior.
       Depends on: B4 + A2 (the `--diff` path consumes the run-diff endpoint).
 - [ ] B6. Add an integration scenario: replay a completed run with a changed
       `--set` param; assert (1) the honest v1 hashing behavior — a **no-override**

--- a/test/data_plane_e2e_test.go
+++ b/test/data_plane_e2e_test.go
@@ -30,16 +30,26 @@ import (
 // drop).
 func (s *IntegrationTestSuite) runCLIStdout(args ...string) (string, error) {
 	s.T().Helper()
+	stdout, stderr, err := s.runCLISeparate(args...)
+	if err != nil {
+		return stdout, fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr))
+	}
+	return stdout, nil
+}
+
+// runCLISeparate runs the CLI while keeping stdout and stderr separate. Use it
+// when a test must prove machine-readable stdout is not contaminated by cobra
+// diagnostics, logs, or operator guidance printed to stderr.
+func (s *IntegrationTestSuite) runCLISeparate(args ...string) (string, string, error) {
+	s.T().Helper()
 	cmd := exec.CommandContext(s.T().Context(), s.cliPath, args...)
 	cmd.Dir = s.projectRoot
 	cmd.Env = os.Environ()
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		return stdout.String(), fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
-	}
-	return stdout.String(), nil
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
 }
 
 // whyExplanation mirrors the fields of the `caesium why --json` output that the

--- a/test/replay_cli_e2e_test.go
+++ b/test/replay_cli_e2e_test.go
@@ -26,7 +26,14 @@ func (s *IntegrationTestSuite) TestRunReplayCLIJSONStdoutIdempotencyAndDiff() {
 	s.Require().True(json.Valid([]byte(stdout)), "caesium run replay --json stdout was not clean JSON:\n%s", stdout)
 	s.Contains(stderr, "replay idempotency key: ")
 	s.NotContains(stdout, "replay idempotency key", "idempotency guidance must stay off stdout")
-	generatedKey := strings.TrimSpace(strings.TrimPrefix(stderr, "replay idempotency key: "))
+	generatedKey := ""
+	for _, line := range strings.Split(stderr, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "replay idempotency key: ") {
+			generatedKey = strings.TrimSpace(strings.TrimPrefix(line, "replay idempotency key: "))
+			break
+		}
+	}
 	s.Require().NotEmpty(generatedKey)
 	s.NotContains(stdout, generatedKey, "generated idempotency key must stay off stdout")
 	var auto replayResponse

--- a/test/replay_cli_e2e_test.go
+++ b/test/replay_cli_e2e_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestRunReplayCLIJSONStdoutIdempotencyAndDiff() {
+	alias := fmt.Sprintf("e2e-replay-cli-%d", time.Now().UnixNano())
+	dir := s.writeJobManifest(replayManifest(alias, true))
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	baselineRunID := s.triggerRun(job.ID)
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, baselineRunID, runTimeout).Status)
+
+	stdout, stderr, err := s.runCLISeparate("run", "replay", baselineRunID, "--job-id", job.ID, "--json", "--server", s.caesiumURL)
+	s.Require().NoError(err, "caesium run replay failed:\nstdout=%s\nstderr=%s", stdout, stderr)
+	s.Require().True(json.Valid([]byte(stdout)), "caesium run replay --json stdout was not clean JSON:\n%s", stdout)
+	s.Contains(stderr, "replay idempotency key: ")
+	s.NotContains(stdout, "replay idempotency key", "idempotency guidance must stay off stdout")
+	generatedKey := strings.TrimSpace(strings.TrimPrefix(stderr, "replay idempotency key: "))
+	s.Require().NotEmpty(generatedKey)
+	s.NotContains(stdout, generatedKey, "generated idempotency key must stay off stdout")
+	var auto replayResponse
+	s.Require().NoError(json.Unmarshal([]byte(stdout), &auto))
+	s.Require().NotEmpty(auto.RunID)
+	s.True(auto.Quarantine)
+	s.Equal("succeeded", s.awaitRun(job.ID, auto.RunID, runTimeout).Status)
+
+	key := "replay-cli-key-" + time.Now().Format("150405.000000000")
+	firstOut, firstErrOut, firstErr := s.runCLISeparate("run", "replay", baselineRunID, "--job-id", job.ID, "--idempotency-key", key, "--json", "--server", s.caesiumURL)
+	s.Require().NoError(firstErr, "first keyed replay failed:\nstdout=%s\nstderr=%s", firstOut, firstErrOut)
+	s.Require().True(json.Valid([]byte(firstOut)), "first keyed replay stdout was not clean JSON:\n%s", firstOut)
+	s.NotContains(firstErrOut, "replay idempotency key: ", "operator-supplied keys must not be echoed")
+	var first replayResponse
+	s.Require().NoError(json.Unmarshal([]byte(firstOut), &first))
+	s.Require().NotEmpty(first.RunID)
+
+	secondOut, secondErrOut, secondErr := s.runCLISeparate("run", "replay", baselineRunID, "--job-id", job.ID, "--idempotency-key", key, "--json", "--server", s.caesiumURL)
+	s.Require().NoError(secondErr, "second keyed replay failed:\nstdout=%s\nstderr=%s", secondOut, secondErrOut)
+	s.Require().True(json.Valid([]byte(secondOut)), "second keyed replay stdout was not clean JSON:\n%s", secondOut)
+	var second replayResponse
+	s.Require().NoError(json.Unmarshal([]byte(secondOut), &second))
+	s.Equal(first.RunID, second.RunID, "same --idempotency-key must dedupe to the existing replay run")
+
+	diffKey := key + "-diff"
+	diffOut, diffErrOut, diffErr := s.runCLISeparate("run", "replay", baselineRunID, "--job-id", job.ID, "--idempotency-key", diffKey, "--diff", "--json", "--server", s.caesiumURL)
+	s.Require().NoError(diffErr, "replay --diff failed:\nstdout=%s\nstderr=%s", diffOut, diffErrOut)
+	s.Require().True(json.Valid([]byte(diffOut)), "replay --diff --json stdout was not clean JSON:\n%s", diffOut)
+	s.Contains(diffErrOut, "awaiting replay run ")
+	s.NotContains(diffOut, "awaiting replay run")
+	var diff runDiffRESTResponse
+	s.Require().NoError(json.Unmarshal([]byte(diffOut), &diff))
+	s.Equal(job.ID, diff.JobID)
+	s.Equal(baselineRunID, diff.LeftRunID)
+	s.NotEmpty(diff.RightRunID)
+	s.NotEqual(baselineRunID, diff.RightRunID)
+	s.NotEmpty(diff.Tasks)
+}
+
+func (s *IntegrationTestSuite) TestRunReplayCLIRequiresJobIDAndRefusesLocalReexec() {
+	alias := fmt.Sprintf("e2e-replay-cli-refusal-%d", time.Now().UnixNano())
+	dir := s.writeJobManifest(replayManifest(alias, true))
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	baselineRunID := s.triggerRun(job.ID)
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, baselineRunID, runTimeout).Status)
+
+	stdout, stderr, err := s.runCLISeparate("run", "replay", baselineRunID, "--json", "--server", s.caesiumURL)
+	s.Require().Error(err)
+	s.Empty(strings.TrimSpace(stdout), "missing --job-id must not write machine output")
+	s.Contains(stderr, "--job-id is required")
+	s.NotContains(stderr, "replay idempotency key", "validation must fail before minting a replay key")
+
+	refusalKey := "replay-cli-refusal-" + time.Now().Format("150405.000000000")
+	stdout, stderr, err = s.runCLISeparate("run", "replay", baselineRunID, "--job-id", job.ID, "--set", "mode=what-if", "--idempotency-key", refusalKey, "--json", "--server", s.caesiumURL)
+	s.Require().Error(err)
+	s.Empty(strings.TrimSpace(stdout), "replay refusal must leave stdout clean")
+	s.Contains(stderr, "replay refused (409)")
+	s.Contains(stderr, "distributed execution mode")
+}


### PR DESCRIPTION
## B5 — `caesium run replay` CLI + value-diff

New `cmd/run/replay.go`: `caesium run replay <run-id> --job-id <id> --set k=v [--idempotency-key <k>] [--diff] [--json]`, driving the B4 endpoint `POST /v1/jobs/:id/runs/:run_id/replay`.

- **`--job-id` required** (the endpoint is job-scoped; a run-id-only lookup would need a global scan that breaks scoped keys) — checked before any key minting; the job id is `url.PathEscape`'d.
- **Restart-safe idempotency** — an operator `--idempotency-key` is passed verbatim (a re-run with the same key **+ same principal** dedupes to the existing replay); when omitted, a UUIDv4 key is generated and **printed to stderr before dispatch** so a manual retry can reuse it. Omitting it on a re-run is documented as "intentionally start another replay."
- **`--diff`** — awaits the replay's terminal state (bounded 2-min deadline) then renders the run-diff vs the baseline via the A2 endpoint, respecting `--json`.
- **Refusals → non-zero exit** — 422 (replay-safe) / 409 (local-mode-requires-distributed) / 404 (cross-job) / 400 (missing key) map to clear stderr messages + a non-zero exit; `202` → success.
- **Stdout discipline** — machine output (`--json`, run id, diff) → `cmd.OutOrStdout()`; the key, await/progress, and errors → stderr. `--json` stdout is clean (the cobra usage-on-error goes to stderr, asserted).

### Review
An Opus review came back **CLEAN** — verified the restart-safe key handling, the stdout/stderr separation (incl. the cobra-usage trap that bit `why --json`/`receipt get`), `--job-id`-required + path-escaping, the refusal exit-code mapping, and the bounded `--diff` await.

### Verification
`test/replay_cli_e2e_test.go` drives the **real CLI binary** against the live server with stdout captured **separately** from stderr (`runCLISeparate`): clean parseable JSON on stdout + the generated key on stderr; idempotency dedup (same key → same run id); `--job-id` required → non-zero exit + empty stdout; the `409` local-mode refusal → non-zero exit + empty stdout. The success/`--diff` path uses a cache-hitting no-override replay (succeeds in the single-server local-executor env). Full chain green (`just lint` + `just unit-test` + `just integration-test`).

### Scope
B6 adds the full distributed integration matrix; the successful **re-executing** replay path runs via the distributed worker (local mode refuses — the tracked follow-up).

Plan: `docs/exec-plans/active/data-plane-memory-ii.md` (B5).