### PR TITLE
Cross-link the causal query layer + archive the plan (data-plane-memory-ii N-1)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Forward-looking or partially-shipped designs with open work. Each carries a `> S
 - [design-incremental-execution.md](design-incremental-execution.md): Smart incremental execution and task caching (Phase 1 shipped; follow-on phases planned).
 - [design-sla-management.md](design-sla-management.md): SLA deadline tracking, predictive completion estimates, and escalation chains (proposed).
 - [design-task-templates.md](design-task-templates.md): Reusable, parameterized step templates (proposed).
-- [design-data-plane-memory.md](design-data-plane-memory.md): The second-act substrate (digest pinning, decomposed-hash persistence, DAG versioning, lineage datasets, large-object passing) that makes the data-plane queryable — explain/reproduce/skip. Substrate shipped (streams A–D, #213–#222); the causal query verbs (`run diff`, quarantined `replay`, `blame`) shipped via the completed follow-on plan `exec-plans/completed/data-plane-memory-ii.md`.
+- [design-data-plane-memory.md](design-data-plane-memory.md): The second-act substrate (digest pinning, decomposed-hash persistence, DAG versioning, lineage datasets, large-object passing) that makes the data-plane queryable — explain/reproduce/skip. Substrate shipped (streams A–D, #213–#222); the causal query verbs (`run diff`, quarantined `replay`, `blame`) shipped via the completed follow-on plan [`exec-plans/completed/data-plane-memory-ii.md`](exec-plans/completed/data-plane-memory-ii.md).
 - [design-quarantined-replay.md](design-quarantined-replay.md): Authoritative fail-closed safety model for quarantined replay in the data-plane-memory-ii plan.
 
 ## Load Testing

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Forward-looking or partially-shipped designs with open work. Each carries a `> S
 - [design-incremental-execution.md](design-incremental-execution.md): Smart incremental execution and task caching (Phase 1 shipped; follow-on phases planned).
 - [design-sla-management.md](design-sla-management.md): SLA deadline tracking, predictive completion estimates, and escalation chains (proposed).
 - [design-task-templates.md](design-task-templates.md): Reusable, parameterized step templates (proposed).
-- [design-data-plane-memory.md](design-data-plane-memory.md): The second-act substrate (digest pinning, decomposed-hash persistence, DAG versioning, lineage datasets, large-object passing) that makes the data-plane queryable — explain/reproduce/skip. Substrate shipped (streams A–D, #213–#222); the causal query verbs (`run diff`, quarantined `replay`, `blame`) shipped via the completed follow-on plan [`exec-plans/completed/data-plane-memory-ii.md`](exec-plans/completed/data-plane-memory-ii.md).
+- [design-data-plane-memory.md](design-data-plane-memory.md): The second-act substrate (digest pinning, decomposed-hash persistence, DAG versioning, lineage datasets, large-object passing) that makes the data-plane queryable — explain/reproduce/skip. Substrate shipped (streams A–D, #213–#222); the causal query verbs (`run diff`, quarantined `replay`, `blame`) shipped via the completed follow-on plan `exec-plans/completed/data-plane-memory-ii.md`.
 - [design-quarantined-replay.md](design-quarantined-replay.md): Authoritative fail-closed safety model for quarantined replay in the data-plane-memory-ii plan.
 
 ## Load Testing

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ Forward-looking or partially-shipped designs with open work. Each carries a `> S
 - [design-incremental-execution.md](design-incremental-execution.md): Smart incremental execution and task caching (Phase 1 shipped; follow-on phases planned).
 - [design-sla-management.md](design-sla-management.md): SLA deadline tracking, predictive completion estimates, and escalation chains (proposed).
 - [design-task-templates.md](design-task-templates.md): Reusable, parameterized step templates (proposed).
-- [design-data-plane-memory.md](design-data-plane-memory.md): The second-act substrate (digest pinning, decomposed-hash persistence, DAG versioning, lineage datasets, large-object passing) that makes the data-plane queryable — explain/reproduce/skip. Substrate shipped (streams A–D, #213–#222); the causal query verbs (`run diff`, quarantined `replay`, `blame`) are the active follow-on plan `exec-plans/active/data-plane-memory-ii.md`.
+- [design-data-plane-memory.md](design-data-plane-memory.md): The second-act substrate (digest pinning, decomposed-hash persistence, DAG versioning, lineage datasets, large-object passing) that makes the data-plane queryable — explain/reproduce/skip. Substrate shipped (streams A–D, #213–#222); the causal query verbs (`run diff`, quarantined `replay`, `blame`) shipped via the completed follow-on plan `exec-plans/completed/data-plane-memory-ii.md`.
 - [design-quarantined-replay.md](design-quarantined-replay.md): Authoritative fail-closed safety model for quarantined replay in the data-plane-memory-ii plan.
 
 ## Load Testing

--- a/docs/design-data-plane-memory.md
+++ b/docs/design-data-plane-memory.md
@@ -118,4 +118,4 @@ Each ships behind the existing opt-in cache/lineage config and is independently 
 - [`open_lineage.md`](open_lineage.md) — the shipped OpenLineage emission pipeline this populates.
 - [`roadmap.md`](roadmap.md) — `caesium why` / run-diff overlap with the "live DAG debugging" item (3.4), reimagined here as *causal* rather than a visual state-viewer.
 - [`exec-plans/completed/data-plane-memory.md`](exec-plans/completed/data-plane-memory.md) — the shipped substrate build plan (streams A–D, #213–#222).
-- [`exec-plans/active/data-plane-memory-ii.md`](exec-plans/active/data-plane-memory-ii.md) — the follow-on plan building the causal query verbs (`run diff`, quarantined `replay`, `blame`) on top of this substrate; honors the "What each feature needs" table above.
+- [`exec-plans/completed/data-plane-memory-ii.md`](exec-plans/completed/data-plane-memory-ii.md) — the follow-on plan building the causal query verbs (`run diff`, quarantined `replay`, `blame`) on top of this substrate; honors the "What each feature needs" table above.

--- a/docs/design-quarantined-replay.md
+++ b/docs/design-quarantined-replay.md
@@ -3,7 +3,7 @@
 > Status: Design - authoritative for replay safety invariants (data-plane-memory-ii B1).
 
 This memo is the B1 design gate for
-[`data-plane-memory-ii`](exec-plans/active/data-plane-memory-ii.md). It fixes the
+[`data-plane-memory-ii`](exec-plans/completed/data-plane-memory-ii.md). It fixes the
 replay safety model before B2-B6 add runtime code. It complements
 [`design-data-plane-memory.md`](design-data-plane-memory.md): that older design is
 authoritative for the shipped substrate and honest-scope rules, while this memo

--- a/docs/differentiation-strategy.md
+++ b/docs/differentiation-strategy.md
@@ -54,7 +54,7 @@ The pivot is **invert the ranking**, not discard the data work. All three differ
 |---|---|---|---|
 | **Hook** — reason to clone | DX over raw k8s | *"Why not hand-roll Argo/Kueue?"* | Strong, but a taste argument; needs marketing to win |
 | **Close** — reason to adopt | **Operational sovereignty** | *"Why not Airflow/Dagster/Flyte?"* | **100% built, un-copyable, sells by constraint** |
-| **Retain** — reason to stay | Content-addressed data-plane memory | *"Why not the other zero-dep schedulers (Argo/Kueue/Cronicle)?"* | Second act; ~40% to build (see spec) |
+| **Retain** — reason to stay | Content-addressed data-plane memory | *"Why not the other zero-dep schedulers (Argo/Kueue/Cronicle)?"* | Second act; substrate + the causal query layer (`caesium run diff` / `blame` / quarantined `replay --set … --diff`) **shipped** (see spec + `exec-plans/completed/data-plane-memory*.md`) |
 
 **Lead with sovereignty. Hook with DX. Retain with data-plane memory** — explicitly demoted from north-star to *"the killer differentiator within sovereignty"*: it is what makes Caesium more than "Argo with a nicer binary," once a user is already inside.
 

--- a/docs/differentiation-strategy.md
+++ b/docs/differentiation-strategy.md
@@ -54,7 +54,7 @@ The pivot is **invert the ranking**, not discard the data work. All three differ
 |---|---|---|---|
 | **Hook** — reason to clone | DX over raw k8s | *"Why not hand-roll Argo/Kueue?"* | Strong, but a taste argument; needs marketing to win |
 | **Close** — reason to adopt | **Operational sovereignty** | *"Why not Airflow/Dagster/Flyte?"* | **100% built, un-copyable, sells by constraint** |
-| **Retain** — reason to stay | Content-addressed data-plane memory | *"Why not the other zero-dep schedulers (Argo/Kueue/Cronicle)?"* | Second act; substrate + the causal query layer (`caesium run diff` / `blame` / quarantined `replay --set … --diff`) **shipped** (see spec + `exec-plans/completed/data-plane-memory*.md`) |
+| **Retain** — reason to stay | Content-addressed data-plane memory | *"Why not the other zero-dep schedulers (Argo/Kueue/Cronicle)?"* | Second act; substrate + the causal query layer (`caesium run diff` / `blame` / quarantined `replay --set … --diff`) **shipped** (see spec + the completed [data-plane-memory](exec-plans/completed/data-plane-memory.md) / [data-plane-memory-ii](exec-plans/completed/data-plane-memory-ii.md) plans) |
 
 **Lead with sovereignty. Hook with DX. Retain with data-plane memory** — explicitly demoted from north-star to *"the killer differentiator within sovereignty"*: it is what makes Caesium more than "Argo with a nicer binary," once a user is already inside.
 

--- a/docs/exec-plans/completed/data-plane-memory-ii.md
+++ b/docs/exec-plans/completed/data-plane-memory-ii.md
@@ -1,6 +1,6 @@
 # Data-Plane Memory II — The Causal Query Layer
 
-Last updated: 2026-06-20
+Last updated: 2026-06-26 · **Status: COMPLETE** — all stream items (A, B, C, H minus the optional H-4) shipped across Waves 1–8 (#230–#244); see the `## Progress` dashboard. Archived here from `active/`. Remaining beyond this plan: the optional H-4 distributed CI tier and the deferred local-executor replay-reconstruction follow-up.
 
 This plan ships the three higher-order EXPLAIN verbs that the
 [data-plane-memory](../completed/data-plane-memory.md) substrate plan deferred to

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -184,7 +184,7 @@ steps:
 
 ### 3.4 Live DAG Debugging & Run Diff
 
-**Status**: Partially shipped via the [data-plane-memory](design-data-plane-memory.md) substrate. `caesium why <run> --task <t>` reimagines the causal half of this item — a field-level, machine-checkable explanation of why a task ran/skipped/re-ran (the discriminating `HashInput` field + trigger causation), reconstructed from the persisted decomposed hash + event store rather than a UI state-viewer. A git-committable reproducibility receipt + `caesium verify` and append-only DAG-topology history also land here. The remaining causal verbs — `caesium run diff`, the quarantined what-if `caesium run replay --set … --diff`, and `caesium blame` over commit ranges — are the active build plan [Exec Plan: Data-Plane Memory II](exec-plans/active/data-plane-memory-ii.md). Remaining beyond that: the UI timeline/step-through replay surface.
+**Status**: Partially shipped via the [data-plane-memory](design-data-plane-memory.md) substrate. `caesium why <run> --task <t>` reimagines the causal half of this item — a field-level, machine-checkable explanation of why a task ran/skipped/re-ran (the discriminating `HashInput` field + trigger causation), reconstructed from the persisted decomposed hash + event store rather than a UI state-viewer. A git-committable reproducibility receipt + `caesium verify` and append-only DAG-topology history also land here. The remaining causal verbs have now **shipped** ([Exec Plan: Data-Plane Memory II](exec-plans/completed/data-plane-memory-ii.md)): `caesium run diff` (causal cache-bust attribution across two runs), `caesium blame` (commit/snapshot topology attribution over `dag_snapshot`), and the quarantined what-if `caesium run replay --set … --diff` (a descriptor-reconstructed, replay-safe-gated, side-effect-free run via the distributed worker). Remaining beyond that: the UI timeline/step-through replay surface.
 
 **Current state**: Debugging failed runs requires manual log inspection. No way to compare two runs side-by-side.
 
@@ -244,7 +244,7 @@ Features that were previously on the roadmap and are now shipped:
 - [Exec Plan: Sovereignty Execution](exec-plans/completed/sovereignty-execution.md) — operationalizes the positioning pivot (README repositioning + Kueue delegation); shipped
 - [Design: Data-Plane Memory](design-data-plane-memory.md) — the second-act substrate enabling explain/reproduce/skip
 - [Exec Plan: Data-Plane Memory](exec-plans/completed/data-plane-memory.md) — the substrate build plan (streams A–D); shipped (#213–#222)
-- [Exec Plan: Data-Plane Memory II](exec-plans/active/data-plane-memory-ii.md) — the active follow-on: causal `run diff`, quarantined `replay`, and `blame`
+- [Exec Plan: Data-Plane Memory II](exec-plans/completed/data-plane-memory-ii.md) — the completed follow-on: causal `run diff`, quarantined `replay`, and `blame` (all shipped)
 - [Brainstorm: Killer Features Beyond Airflow Parity](archive/brainstorm-differentiators.md) — original idea backlog
 - [Design: Smart Incremental Execution](design-incremental-execution.md) — shipped cache system
 - [Design: Event-Driven Triggers](design-event-triggers.md) — P0 trigger overhaul


### PR DESCRIPTION
## N-1 — Cross-links + archive (the plan's final item)

Records the shipped trio at the plan level and archives the completed plan.

- **`docs/roadmap.md` §3.4** — the causal verbs (`run diff`, `blame`, quarantined `replay`) are marked **shipped** (was "active build plan").
- **`docs/README.md`** + **`docs/design-data-plane-memory.md`** + **`docs/design-quarantined-replay.md`** — repointed to the **completed** plan (the previously-broken `active/` links fixed).
- **`docs/differentiation-strategy.md`** — the Retain row notes the substrate + causal query layer shipped.
- **Archive:** `exec-plans/active/data-plane-memory-ii.md` → `exec-plans/completed/data-plane-memory-ii.md` with a `Status: COMPLETE` banner.

### Plan completion
With this, **Data-Plane Memory II is complete** — Streams A, B, C, and H (minus the optional H-4) shipped: **18 of 20 items across Waves 1–8 (#230–#244)**. The entire Retain/causal layer is built (`caesium run diff`, `caesium blame`, the full quarantined what-if replay). Deferred follow-ups (tracked in the archived plan): the local-executor replay reconstruction and the optional H-4 distributed CI tier.

Docs-only; `just lint` + `just unit-test` (the doc-index + status-banner guardrails) green.