### PR TITLE
Add the data-verb API client surface to the UI (data-plane-memory-ui W1-α)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory-ui.md
+++ b/docs/exec-plans/active/data-plane-memory-ui.md
@@ -83,7 +83,7 @@ H-2/H-3.
 all the new methods into ONE item keeps the feature streams from colliding on that
 shared file. This item adds typed client methods + response types only — no UI.
 
-- [ ] H-1. Add the data-verb client surface to `ui/src/lib/api.ts`, mirroring the
+- [x] H-1. Add the data-verb client surface to `ui/src/lib/api.ts`, mirroring the
       existing `request<T>` / `requestURL<T>` + `withAuthHeaders` pattern (no new
       backend). **All six endpoints are confirmed to exist as REST controllers** (codex
       round-1 verification) — derive each exact path + response type from the controller
@@ -119,6 +119,7 @@ shared file. This item adds typed client methods + response types only — no UI
       Add the TypeScript response types next to the existing ones, and a vitest unit
       asserting the URL/headers/error-mapping each method builds.
       Files: `ui/src/lib/api.ts`.
+      Note: Landed getRunDiff (`/jobs/:id/runs/diff`), postReplay (`/jobs/:id/runs/:run_id/replay`), getTaskWhy (`/jobs/:id/runs/:run_id/why`), getBlame (`/jobs/:id/blame`), getReceipt (`/jobs/:id/runs/:run_id/receipt`), postVerify (`/jobs/:id/runs/:run_id/receipt/verify`), and getLineageImpact (`/lineage/impact`) with `ApiError.kind` typed 403/replay refusals.
 - [ ] H-2. Retain the principal's **role + scope** for affordance-gating. The UI already
       calls `GET /auth/whoami` (`ui/src/lib/auth.ts:166`; the endpoint returns `role`,
       `api/rest/controller/auth/sso.go`) but discards the role — capture it (and any scope

--- a/ui/src/lib/__tests__/api.data-verbs.test.ts
+++ b/ui/src/lib/__tests__/api.data-verbs.test.ts
@@ -218,4 +218,21 @@ describe("data verb api methods", () => {
 
     await expect(api.postReplay("job-1", "run-1", { set: {} }, "idem-123")).rejects.toBeInstanceOf(ApiError);
   });
+
+  it("clears the API key and throws authentication_required on 401", async () => {
+    setApiKey("csk_test_secret");
+    mockFetch.mockResolvedValue(errorResponse(401, { message: "unauthorized" }));
+
+    await expect(api.getRunDiff("job-1", "left", "right")).rejects.toMatchObject({
+      status: 401,
+      kind: "authentication_required",
+    });
+
+    // The 401 cleared the key: a subsequent call carries no Authorization header.
+    mockFetch.mockResolvedValue(okResponse({}, 200));
+    await api.getReceipt("job-1", "run-1");
+    const [, init] = mockFetch.mock.calls.at(-1) as [string, RequestInit];
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
 });

--- a/ui/src/lib/__tests__/api.data-verbs.test.ts
+++ b/ui/src/lib/__tests__/api.data-verbs.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ApiError, api, type Receipt } from "@/lib/api";
+import { clearApiKey, setApiKey } from "@/lib/auth";
+
+const mockFetch = vi.fn();
+globalThis.fetch = mockFetch;
+
+function okResponse(body: unknown, status = 200) {
+  return {
+    ok: true,
+    status,
+    text: () => Promise.resolve(JSON.stringify(body)),
+  };
+}
+
+function errorResponse(status: number, body: unknown) {
+  return {
+    ok: false,
+    status,
+    text: () => Promise.resolve(typeof body === "string" ? body : JSON.stringify(body)),
+  };
+}
+
+const committedReceipt: Receipt = {
+  receipt_version: 1,
+  run_id: "run-1",
+  job_id: "job-1",
+  job_alias: "daily",
+  git_commit: "abc123",
+  manifest_content_hash: "manifest-sha",
+  tasks: [
+    {
+      task_name: "extract",
+      identity_hash: "task-hash",
+      image: "alpine@sha256:abc",
+      resolved_image_digest: "sha256:abc",
+      digest_pinned: true,
+      degraded: false,
+    },
+  ],
+  degraded: false,
+  receipt_digest: "receipt-sha",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearApiKey();
+});
+
+describe("data verb api methods", () => {
+  it.each([
+    {
+      name: "getRunDiff",
+      call: () => api.getRunDiff("job-1", "left-run", "right-run"),
+      response: {
+        jobId: "job-1",
+        leftRunId: "left-run",
+        rightRunId: "right-run",
+        leftStatus: "succeeded",
+        rightStatus: "succeeded",
+        leftTrigger: {},
+        rightTrigger: {},
+        tasks: [],
+        generatedAt: "2026-06-26T00:00:00Z",
+      },
+      expectedUrl: "/v1/jobs/job-1/runs/diff?left=left-run&right=right-run",
+      expectedMethod: undefined,
+    },
+    {
+      name: "postReplay",
+      call: () => api.postReplay("job-1", "run-1", { set: { day: "2026-06-26" } }, "idem-123"),
+      response: { run_id: "replay-run", status: "running", quarantine: true },
+      status: 202,
+      expectedUrl: "/v1/jobs/job-1/runs/run-1/replay",
+      expectedMethod: "POST",
+      expectedBody: { set: { day: "2026-06-26" } },
+      expectedExtraHeaders: { "Idempotency-Key": "idem-123" },
+    },
+    {
+      name: "getTaskWhy",
+      call: () => api.getTaskWhy("job-1", "run-1", "extract data"),
+      response: {
+        runId: "run-1",
+        jobId: "job-1",
+        taskId: "task-1",
+        taskName: "extract data",
+        taskRunId: "task-run-1",
+        verdict: "CACHE_MISS",
+        status: "succeeded",
+        cacheEnabled: true,
+        summary: "CACHE_MISS",
+        trigger: {},
+        baseline: { kind: "prior_run" },
+      },
+      expectedUrl: "/v1/jobs/job-1/runs/run-1/why?task=extract+data",
+      expectedMethod: undefined,
+    },
+    {
+      name: "getBlame",
+      call: () => api.getBlame("job-1", { from: "abc123", to: "def456" }),
+      response: {
+        job_id: "job-1",
+        coverage: "topology+image+command",
+        from_commit: "abc123",
+        to_commit: "def456",
+        tasks: [],
+        edges: [],
+      },
+      expectedUrl: "/v1/jobs/job-1/blame?from=abc123&to=def456",
+      expectedMethod: undefined,
+    },
+    {
+      name: "getReceipt",
+      call: () => api.getReceipt("job-1", "run-1"),
+      response: committedReceipt,
+      expectedUrl: "/v1/jobs/job-1/runs/run-1/receipt",
+      expectedMethod: undefined,
+    },
+    {
+      name: "postVerify",
+      call: () => api.postVerify(committedReceipt),
+      response: {
+        run_id: "run-1",
+        match: true,
+        degraded: false,
+        expected_digest: "receipt-sha",
+        actual_digest: "receipt-sha",
+        rederived: committedReceipt,
+      },
+      expectedUrl: "/v1/jobs/job-1/runs/run-1/receipt/verify",
+      expectedMethod: "POST",
+      expectedBody: committedReceipt,
+    },
+    {
+      name: "getLineageImpact",
+      call: () => api.getLineageImpact({ namespace: "warehouse", name: "analytics.fact orders", maxDepth: 3 }),
+      response: {
+        root_namespace: "warehouse",
+        root_name: "analytics.fact orders",
+        downstream: [],
+      },
+      expectedUrl: "/v1/lineage/impact?namespace=warehouse&name=analytics.fact+orders&max_depth=3",
+      expectedMethod: undefined,
+    },
+  ])(
+    "$name builds the expected request and includes auth headers",
+    async ({ call, response, status, expectedUrl, expectedMethod, expectedBody, expectedExtraHeaders }) => {
+      setApiKey("csk_test_secret");
+      mockFetch.mockResolvedValue(okResponse(response, status));
+
+      const result = await call();
+      // Round-trip: the method must return the parsed response body, not drop/transform it.
+      expect(result).toEqual(response);
+
+      const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(expectedUrl);
+      expect(init.method).toBe(expectedMethod);
+      expect(init).toEqual(
+        expect.objectContaining({
+          credentials: "include",
+          headers: expect.objectContaining({
+            "Content-Type": "application/json",
+            Authorization: "Bearer csk_test_secret",
+            ...(expectedExtraHeaders ?? {}),
+          }),
+        }),
+      );
+      if (expectedBody) {
+        expect(JSON.parse(String(init.body))).toEqual(expectedBody);
+      }
+    },
+  );
+
+  it.each([
+    { name: "getRunDiff", call: () => api.getRunDiff("job-1", "left-run", "right-run") },
+    { name: "postReplay", call: () => api.postReplay("job-1", "run-1", { set: {} }, "idem-123") },
+    { name: "getTaskWhy", call: () => api.getTaskWhy("job-1", "run-1", "extract") },
+    { name: "getBlame", call: () => api.getBlame("job-1") },
+    { name: "getReceipt", call: () => api.getReceipt("job-1", "run-1") },
+    { name: "postVerify", call: () => api.postVerify(committedReceipt) },
+    { name: "getLineageImpact", call: () => api.getLineageImpact({ namespace: "warehouse", name: "raw.orders" }) },
+  ])("$name maps 403 to a typed insufficient-access error", async ({ call }) => {
+    mockFetch.mockResolvedValue(errorResponse(403, { message: "insufficient permissions" }));
+
+    await expect(call()).rejects.toMatchObject({
+      status: 403,
+      kind: "insufficient_access",
+      message: "insufficient permissions",
+    });
+  });
+
+  it.each([
+    { status: 400, kind: "replay_missing_idempotency_key", message: "Idempotency-Key header is required" },
+    { status: 404, kind: "replay_target_not_found", message: "Not Found" },
+    {
+      status: 409,
+      kind: "replay_requires_distributed_execution",
+      message: "replay requires distributed execution mode for re-executing tasks",
+    },
+    { status: 422, kind: "replay_safe_refusal", message: "replay: baseline task is not replay safe" },
+    // Overloaded codes: same status, different cause -> neutral kind (not the specific one).
+    { status: 400, kind: "replay_bad_request", message: "bad request" },
+    { status: 409, kind: "replay_conflict", message: "replay: baseline run is quarantined" },
+    { status: 413, kind: "replay_request_too_large", message: "request body too large" },
+    { status: 422, kind: "replay_refused", message: "replay: missing execution descriptor" },
+  ])("postReplay maps $status to $kind", async ({ status, kind, message }) => {
+    mockFetch.mockResolvedValue(errorResponse(status, { message }));
+
+    await expect(api.postReplay("job-1", "run-1", { set: {} }, "idem-123")).rejects.toMatchObject({
+      status,
+      kind,
+      message,
+    });
+  });
+
+  it("throws ApiError instances for typed data-verb failures", async () => {
+    mockFetch.mockResolvedValue(errorResponse(409, { message: "replay requires distributed execution mode" }));
+
+    await expect(api.postReplay("job-1", "run-1", { set: {} }, "idem-123")).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/ui/src/lib/__tests__/api.data-verbs.test.ts
+++ b/ui/src/lib/__tests__/api.data-verbs.test.ts
@@ -32,7 +32,7 @@ const committedReceipt: Receipt = {
     {
       task_name: "extract",
       identity_hash: "task-hash",
-      image: "alpine@sha256:abc",
+      image: "ghcr.io/acme/etl@sha256:abc",
       resolved_image_digest: "sha256:abc",
       digest_pinned: true,
       degraded: false,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -648,12 +648,17 @@ function parseErrorMessage(text: string): string {
   }
 
   try {
-    const body = JSON.parse(text) as { message?: unknown; error?: unknown };
-    if (typeof body.message === "string" && body.message.trim() !== "") {
-      return body.message.trim();
-    }
-    if (typeof body.error === "string" && body.error.trim() !== "") {
-      return body.error.trim();
+    const body = JSON.parse(text) as unknown;
+    // Guard: JSON.parse can yield null or a non-object primitive (e.g. body "null");
+    // only index into it when it is actually an object.
+    if (body && typeof body === "object") {
+      const obj = body as { message?: unknown; error?: unknown };
+      if (typeof obj.message === "string" && obj.message.trim() !== "") {
+        return obj.message.trim();
+      }
+      if (typeof obj.error === "string" && obj.error.trim() !== "") {
+        return obj.error.trim();
+      }
     }
   } catch {
     // Non-JSON error bodies are common in older handlers; keep the raw text.
@@ -746,9 +751,9 @@ export const api = {
       },
       replayErrorKind,
     ),
-  getTaskWhy: (jobId: string, runId: string, taskId: string) =>
+  getTaskWhy: (jobId: string, runId: string, taskName: string) =>
     request<WhyExplanation>(
-      `/jobs/${encodeURIComponent(jobId)}/runs/${encodeURIComponent(runId)}/why?${queryString({ task: taskId })}`,
+      `/jobs/${encodeURIComponent(jobId)}/runs/${encodeURIComponent(runId)}/why?${queryString({ task: taskName })}`,
     ),
   getBlame: (jobId: string, options: BlameOptions = {}) => {
     const query = queryString({ from: options.from, to: options.to, task: options.task });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -355,23 +355,260 @@ export interface DatabaseQueryResponse {
   rows: unknown[][];
 }
 
+export type ApiErrorKind =
+  | "unknown"
+  | "authentication_required"
+  | "insufficient_access"
+  | "replay_missing_idempotency_key"
+  | "replay_bad_request"
+  | "replay_target_not_found"
+  | "replay_requires_distributed_execution"
+  | "replay_conflict"
+  | "replay_request_too_large"
+  | "replay_safe_refusal"
+  | "replay_refused";
+
+export interface FieldChange {
+  field: string;
+  kind: "scalar" | "map_entry" | "structural" | string;
+  before?: string;
+  after?: string;
+  added?: boolean;
+  removed?: boolean;
+  redacted?: boolean;
+}
+
+export interface WhyTrigger {
+  type?: string;
+  alias?: string;
+  params?: Record<string, string>;
+  firedAt?: string;
+}
+
+export interface BlobDiff {
+  hashEqual: boolean;
+  subjectHash?: string;
+  baselineHash?: string;
+  changes?: FieldChange[];
+  degraded?: string;
+}
+
+export type RunDiffVerdict = "WOULD_CACHE_HIT" | "RERAN" | "DEGRADED";
+
+export interface RunDiffTask {
+  taskName: string;
+  leftTaskRunId: string;
+  rightTaskRunId: string;
+  leftTaskId: string;
+  rightTaskId: string;
+  leftStatus: string;
+  rightStatus: string;
+  leftAttempt: number;
+  rightAttempt: number;
+  leftHash?: string;
+  rightHash?: string;
+  verdict: RunDiffVerdict;
+  hashEqual: boolean;
+  changes?: FieldChange[];
+  degraded?: string;
+}
+
+export interface RunDiff {
+  jobId: string;
+  leftRunId: string;
+  rightRunId: string;
+  leftStatus: string;
+  rightStatus: string;
+  leftTrigger: WhyTrigger;
+  rightTrigger: WhyTrigger;
+  triggerChanges?: FieldChange[];
+  paramChanges?: FieldChange[];
+  tasks: RunDiffTask[];
+  tasksAdded?: string[];
+  tasksRemoved?: string[];
+  generatedAt: string;
+}
+
+export interface ReplayRequest {
+  set?: Record<string, string>;
+}
+
+export interface ReplayResponse {
+  run_id: string;
+  status: string;
+  quarantine: boolean;
+}
+
+export interface WhyBaseline {
+  kind: string;
+  runId?: string;
+  taskRunId?: string;
+  startedAt?: string;
+}
+
+export type WhyVerdict = "CACHE_HIT" | "CACHE_MISS" | "CACHE_DISABLED" | "UNKNOWN";
+
+export interface WhyExplanation {
+  runId: string;
+  jobId: string;
+  taskId: string;
+  taskName: string;
+  taskRunId: string;
+  verdict: WhyVerdict;
+  status: string;
+  cacheEnabled: boolean;
+  hash?: string;
+  summary: string;
+  trigger: WhyTrigger;
+  baseline: WhyBaseline;
+  diff?: BlobDiff;
+}
+
+export interface BlameOptions {
+  from?: string;
+  to?: string;
+  task?: string;
+}
+
+export interface BlameTaskElement {
+  name: string;
+  image: string;
+  command?: string[];
+}
+
+export interface BlameTaskAttribution {
+  element: BlameTaskElement;
+  introducing_commit: string;
+  snapshot_id: string;
+}
+
+export interface BlameEdgeElement {
+  from: string;
+  to: string;
+}
+
+export interface BlameEdgeAttribution {
+  element: BlameEdgeElement;
+  introducing_commit: string;
+  snapshot_id: string;
+  provenance_commit?: string;
+}
+
+export interface BlameResult {
+  job_id: string;
+  coverage: string;
+  from_commit?: string;
+  to_commit?: string;
+  tasks: BlameTaskAttribution[];
+  edges: BlameEdgeAttribution[];
+}
+
+export interface ReceiptTaskEntry {
+  task_name: string;
+  identity_hash: string;
+  image: string;
+  resolved_image_digest?: string;
+  digest_pinned: boolean;
+  degraded: boolean;
+  degraded_reason?: string;
+}
+
+export interface Receipt {
+  receipt_version: number;
+  run_id: string;
+  job_id: string;
+  job_alias?: string;
+  git_commit?: string;
+  manifest_content_hash?: string;
+  tasks: ReceiptTaskEntry[];
+  degraded: boolean;
+  degraded_tasks?: string[];
+  receipt_digest: string;
+}
+
+export type ReceiptDriftKind =
+  | "receipt_digest_mismatch"
+  | "image_digest_mismatch"
+  | "identity_hash_mismatch"
+  | "manifest_changed"
+  | "git_commit_changed"
+  | "task_missing"
+  | "task_added"
+  | "receipt_version_mismatch";
+
+export interface ReceiptDrift {
+  kind: ReceiptDriftKind;
+  task?: string;
+  expected?: string;
+  actual?: string;
+  detail: string;
+}
+
+export interface VerifyResult {
+  run_id: string;
+  match: boolean;
+  degraded: boolean;
+  degraded_tasks?: string[];
+  expected_digest: string;
+  actual_digest: string;
+  drifts?: ReceiptDrift[];
+  rederived: Receipt | null;
+}
+
+export interface LineageImpactQuery {
+  namespace: string;
+  name: string;
+  maxDepth?: number;
+}
+
+export interface ImpactNode {
+  dataset_namespace: string;
+  dataset_name: string;
+  direction: string;
+  producing_step?: string;
+  job_id: string;
+  job_alias: string;
+  provenance_commit?: string;
+  provenance_repo?: string;
+  last_seen: string;
+  depth: number;
+}
+
+export interface ImpactResult {
+  root_namespace: string;
+  root_name: string;
+  downstream: ImpactNode[];
+}
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "/v1";
 
 export class ApiError extends Error {
   public status: number;
-  constructor(status: number, message: string) {
+  public kind: ApiErrorKind;
+  constructor(status: number, message: string, kind: ApiErrorKind = "unknown") {
     super(message);
     this.status = status;
+    this.kind = kind;
     this.name = "ApiError";
   }
 }
 
-async function request<T>(endpoint: string, options?: RequestInit): Promise<T> {
+type ErrorKindMapper = (status: number, message: string) => ApiErrorKind | undefined;
+
+async function request<T>(
+  endpoint: string,
+  options?: RequestInit,
+  errorKindForStatus?: ErrorKindMapper,
+): Promise<T> {
   const url = `${API_BASE_URL}${endpoint}`;
-  return requestURL<T>(url, options);
+  return requestURL<T>(url, options, errorKindForStatus);
 }
 
-async function requestURL<T>(url: string, options?: RequestInit): Promise<T> {
+async function requestURL<T>(
+  url: string,
+  options?: RequestInit,
+  errorKindForStatus?: ErrorKindMapper,
+): Promise<T> {
   const headers = withAuthHeaders({
     "Content-Type": "application/json",
     ...(options?.headers as Record<string, string>),
@@ -385,11 +622,12 @@ async function requestURL<T>(url: string, options?: RequestInit): Promise<T> {
 
   if (response.status === 401) {
     clearApiKey();
-    throw new ApiError(401, "Authentication required");
+    throw new ApiError(401, "Authentication required", "authentication_required");
   }
 
   if (!response.ok) {
-    throw new ApiError(response.status, await response.text());
+    const message = parseErrorMessage(await response.text());
+    throw new ApiError(response.status, message, classifyApiError(response.status, message, errorKindForStatus));
   }
 
   if (response.status === 204) {
@@ -402,6 +640,79 @@ async function requestURL<T>(url: string, options?: RequestInit): Promise<T> {
   }
 
   return JSON.parse(text) as T;
+}
+
+function parseErrorMessage(text: string): string {
+  if (!text) {
+    return "";
+  }
+
+  try {
+    const body = JSON.parse(text) as { message?: unknown; error?: unknown };
+    if (typeof body.message === "string" && body.message.trim() !== "") {
+      return body.message.trim();
+    }
+    if (typeof body.error === "string" && body.error.trim() !== "") {
+      return body.error.trim();
+    }
+  } catch {
+    // Non-JSON error bodies are common in older handlers; keep the raw text.
+  }
+
+  return text.trim();
+}
+
+function classifyApiError(
+  status: number,
+  message: string,
+  errorKindForStatus?: ErrorKindMapper,
+): ApiErrorKind {
+  if (status === 403) {
+    return "insufficient_access";
+  }
+  return errorKindForStatus?.(status, message) ?? "unknown";
+}
+
+// The replay controller overloads several status codes across distinct service
+// errors (api/rest/controller/replay/replay.go), emitting err.Error() as the body.
+// Classify by status AND a stable substring of that body so the UI does not assert
+// a single cause for an overloaded code (e.g. 409 is also returned for a quarantined
+// or non-terminal baseline, not only "requires distributed execution").
+function replayErrorKind(status: number, message: string): ApiErrorKind | undefined {
+  const body = message.toLowerCase();
+  switch (status) {
+    case 400:
+      // Missing key emits a literal message; malformed ids / body-decode emit "bad request".
+      return body.includes("idempotency-key")
+        ? "replay_missing_idempotency_key"
+        : "replay_bad_request";
+    case 404:
+      return "replay_target_not_found";
+    case 409:
+      // ErrReplayRequiresDistributedMode vs unavailable-proof / quarantined / not-terminal baseline.
+      return body.includes("distributed execution mode")
+        ? "replay_requires_distributed_execution"
+        : "replay_conflict";
+    case 413:
+      return "replay_request_too_large";
+    case 422:
+      // ErrReplayUnsafe vs missing/unsupported descriptor or secret-identity refusal.
+      return body.includes("not replay safe")
+        ? "replay_safe_refusal"
+        : "replay_refused";
+    default:
+      return undefined;
+  }
+}
+
+function queryString(params: Record<string, string | number | undefined>): string {
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined) {
+      query.set(key, String(value));
+    }
+  });
+  return query.toString();
 }
 
 function parseJobDefinitions(yaml: string) {
@@ -421,6 +732,38 @@ export const api = {
   getJob: (id: string) => request<Job>(`/jobs/${id}`),
   getJobRuns: (jobId: string) => request<JobRun[]>(`/jobs/${jobId}/runs`),
   getJobRun: (jobId: string, runId: string) => request<JobRun>(`/jobs/${jobId}/runs/${runId}`),
+  getRunDiff: (jobId: string, left: string, right: string) =>
+    request<RunDiff>(
+      `/jobs/${encodeURIComponent(jobId)}/runs/diff?${queryString({ left, right })}`,
+    ),
+  postReplay: (jobId: string, runId: string, body: ReplayRequest, idempotencyKey: string) =>
+    request<ReplayResponse>(
+      `/jobs/${encodeURIComponent(jobId)}/runs/${encodeURIComponent(runId)}/replay`,
+      {
+        method: "POST",
+        headers: { "Idempotency-Key": idempotencyKey },
+        body: JSON.stringify(body),
+      },
+      replayErrorKind,
+    ),
+  getTaskWhy: (jobId: string, runId: string, taskId: string) =>
+    request<WhyExplanation>(
+      `/jobs/${encodeURIComponent(jobId)}/runs/${encodeURIComponent(runId)}/why?${queryString({ task: taskId })}`,
+    ),
+  getBlame: (jobId: string, options: BlameOptions = {}) => {
+    const query = queryString({ from: options.from, to: options.to, task: options.task });
+    return request<BlameResult>(`/jobs/${encodeURIComponent(jobId)}/blame${query ? `?${query}` : ""}`);
+  },
+  getReceipt: (jobId: string, runId: string) =>
+    request<Receipt>(`/jobs/${encodeURIComponent(jobId)}/runs/${encodeURIComponent(runId)}/receipt`),
+  postVerify: (committedReceiptBody: Receipt) =>
+    request<VerifyResult>(
+      `/jobs/${encodeURIComponent(committedReceiptBody.job_id)}/runs/${encodeURIComponent(committedReceiptBody.run_id)}/receipt/verify`,
+      {
+        method: "POST",
+        body: JSON.stringify(committedReceiptBody),
+      },
+    ),
   getJobDAG: (jobId: string) => request<JobDAGResponse>(`/jobs/${jobId}/dag`),
   getJobTasks: (jobId: string) => request<JobTask[]>(`/jobs/${jobId}/tasks`),
   getJobCache: (jobId: string) => request<JobCacheResponse>(`/jobs/${jobId}/cache`),
@@ -469,6 +812,14 @@ export const api = {
   deleteAtom: (id: string) => request<void>(`/atoms/${id}`, { method: "DELETE" }),
   getStats: () => request<StatsResponse>("/stats"),
   getStatsSummary: (window: string = "7d") => request<StatsResponse>(`/stats/summary?window=${window}`),
+  getLineageImpact: (query: LineageImpactQuery) =>
+    request<ImpactResult>(
+      `/lineage/impact?${queryString({
+        namespace: query.namespace,
+        name: query.name,
+        max_depth: query.maxDepth,
+      })}`,
+    ),
   getHealth: () => requestURL<HealthResponse>("/health"),
   /**
    * Like `getHealth` but reads the response body on any non-401 status code.
@@ -483,7 +834,7 @@ export const api = {
     const response = await fetch("/health", { credentials: "include", headers });
     if (response.status === 401) {
       clearApiKey();
-      throw new ApiError(401, "Authentication required");
+      throw new ApiError(401, "Authentication required", "authentication_required");
     }
     const text = await response.text();
     if (!text) throw new ApiError(response.status, "Empty health response");


### PR DESCRIPTION
## H-1 — the shared data-verb API client (Wave 1, the foundation)

First wave of the [Data-Plane Memory UI plan](../blob/master/docs/exec-plans/active/data-plane-memory-ui.md). Adds typed `ui/src/lib/api.ts` client methods + response types for the six causal verbs — the foundation every feature stream (A–F) consumes. **Frontend-only; no backend changes** (drives existing REST).

### Methods (each derived from the actual controller/service, not the plan's prose)
- `getRunDiff` → `GET /v1/jobs/:id/runs/diff?left=&right=`
- `postReplay` → `POST /v1/jobs/:id/runs/:run_id/replay` (Idempotency-Key header; typed errors)
- `getTaskWhy` → the `why` endpoint (`WhyExplanation` + `BlobDiff`)
- `getBlame` → `GET /v1/jobs/:id/blame` (incl. the `task` filter param)
- `getReceipt` + `postVerify` (verify takes a **committed** receipt body)
- `getLineageImpact` → `GET /v1/lineage/impact?namespace=&name=&max_depth=` (dataset-keyed, downstream-only)

### Review
Opus adversarial review (3 lenses: type-fidelity vs Go structs, request correctness, test quality) — **0 blockers, 4 should-fix, all applied**:
- Replay error classification is now **message-aware** — the backend overloads 400/409/422 across distinct causes, so the UI no longer asserts a single cause (409 quarantined/non-terminal baseline → `replay_conflict` not `requires_distributed`; 422 descriptor/secret → `replay_refused` not `replay_safe`; 400 body/malformed-uuid → `replay_bad_request`). Added 413.
- Added `BlameOptions.task` (backend supports it) and a per-verb response round-trip assertion in the test.

### Verification
`just ui-lint` + `just ui-test` green (vitest + production build + bundle-size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvA6zFvnhXRHHHVccZy1em