### PR TITLE
Retain principal role/scope for UI affordance-gating (data-plane-memory-ui W2-α)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory-ui.md
+++ b/docs/exec-plans/active/data-plane-memory-ui.md
@@ -120,7 +120,7 @@ shared file. This item adds typed client methods + response types only — no UI
       asserting the URL/headers/error-mapping each method builds.
       Files: `ui/src/lib/api.ts`.
       Note: Landed getRunDiff (`/jobs/:id/runs/diff`), postReplay (`/jobs/:id/runs/:run_id/replay`), getTaskWhy (`/jobs/:id/runs/:run_id/why`), getBlame (`/jobs/:id/blame`), getReceipt (`/jobs/:id/runs/:run_id/receipt`), postVerify (`/jobs/:id/runs/:run_id/receipt/verify`), and getLineageImpact (`/lineage/impact`) with `ApiError.kind` typed 403/replay refusals.
-- [ ] H-2. Retain the principal's **role + scope** for affordance-gating. The UI already
+- [x] H-2. Retain the principal's **role + scope** for affordance-gating. The UI already
       calls `GET /auth/whoami` (`ui/src/lib/auth.ts:166`; the endpoint returns `role`,
       `api/rest/controller/auth/sso.go`) but discards the role — capture it (and any scope
       marker) into the auth store and expose a `usePrincipal()` accessor (`role`,
@@ -128,6 +128,7 @@ shared file. This item adds typed client methods + response types only — no UI
       renders the typed **403** (insufficient role / scoped-principal-denied) as an inline
       explanation, not a raw error. This is what B/F gate on. Files: `ui/src/lib/auth.ts`,
       `ui/src/features/auth/` (+ a small shared component). Depends on: H-1.
+      Note: Retained `whoami` role/principal state in `usePrincipal()`; current `whoami` has no scope/jobs marker, so API-key scopedness remains unknown without backend support.
 - [ ] H-3. Add an **auth-enabled ui-e2e lane** so the RBAC gating is actually exercised
       (today `just ui-e2e` runs auth-disabled — `justfile`/`.github/workflows/ci.yml` — so a
       viewer-sees-Replay or scoped-sees-lineage bug would never be caught). Add a Playwright

--- a/ui/src/features/auth/InsufficientAccess.tsx
+++ b/ui/src/features/auth/InsufficientAccess.tsx
@@ -1,0 +1,32 @@
+import { ShieldAlert } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { isInsufficientAccessError } from "./access";
+
+interface InsufficientAccessProps {
+  error?: unknown;
+  message?: string;
+  className?: string;
+}
+
+export function InsufficientAccess({
+  error,
+  message = "Your key does not have permission for this action.",
+  className,
+}: InsufficientAccessProps) {
+  if (!isInsufficientAccessError(error)) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "inline-flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive",
+        className,
+      )}
+    >
+      <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/ui/src/features/auth/InsufficientAccess.tsx
+++ b/ui/src/features/auth/InsufficientAccess.tsx
@@ -10,12 +10,16 @@ interface InsufficientAccessProps {
 
 export function InsufficientAccess({
   error,
-  message = "Your key does not have permission for this action.",
+  message,
   className,
 }: InsufficientAccessProps) {
-  if (!isInsufficientAccessError(error)) {
+  const hasExplicitMessage = typeof message === "string" && message.trim() !== "";
+  if (!isInsufficientAccessError(error) && !hasExplicitMessage) {
     return null;
   }
+  const displayMessage = hasExplicitMessage
+    ? message
+    : "Your key does not have permission for this action.";
 
   return (
     <div
@@ -26,7 +30,7 @@ export function InsufficientAccess({
       )}
     >
       <ShieldAlert className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
-      <span>{message}</span>
+      <span>{displayMessage}</span>
     </div>
   );
 }

--- a/ui/src/features/auth/LoginPage.tsx
+++ b/ui/src/features/auth/LoginPage.tsx
@@ -1,13 +1,13 @@
 import { useState, useCallback } from "react";
 import { LogIn } from "lucide-react";
 import {
+  apiKeyLogin,
   type AuthMethod,
   authMethodKey,
   authMethodLabel,
   credentialLogin,
   isCredentialAuthMethod,
   isRedirectAuthMethod,
-  setApiKey,
   ssoLoginUrl,
 } from "@/lib/auth";
 
@@ -70,24 +70,20 @@ export function LoginPage({
       setLoading(true);
 
       try {
-        // Verify the key against a viewer-level REST endpoint so scoped keys can log in.
-        const response = await fetch("/v1/jobs?limit=1", {
-          headers: { Authorization: `Bearer ${trimmed}` },
-        });
-
-        if (response.status === 401) {
+        const result = await apiKeyLogin(trimmed);
+        if (result === "success") {
+          onLogin();
+          return;
+        }
+        if (result === "invalid") {
           setError("Invalid or expired API key");
           return;
         }
-
-        if (response.status === 403) {
+        if (result === "denied") {
           setError("API key does not have sufficient permissions");
           return;
         }
-
-        // Key is valid — store in memory and proceed.
-        setApiKey(trimmed);
-        onLogin();
+        setError("Unable to reach the server");
       } catch {
         setError("Unable to reach the server");
       } finally {

--- a/ui/src/features/auth/__tests__/AuthGate.test.tsx
+++ b/ui/src/features/auth/__tests__/AuthGate.test.tsx
@@ -191,7 +191,13 @@ describe("AuthGate", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ kind: "user", email: "ops@example.com", csrf_token: "csrf-secret" }),
+        json: async () => ({
+          kind: "user",
+          subject: "ops@example.com",
+          email: "ops@example.com",
+          role: "viewer",
+          csrf_token: "csrf-secret",
+        }),
       });
 
     render(

--- a/ui/src/features/auth/__tests__/InsufficientAccess.test.tsx
+++ b/ui/src/features/auth/__tests__/InsufficientAccess.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { InsufficientAccess } from "../InsufficientAccess";
+
+describe("InsufficientAccess", () => {
+  it("renders an explicit message without an error object", () => {
+    render(<InsufficientAccess message="This view requires a runner key." />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "This view requires a runner key.",
+    );
+  });
+
+  it("renders the default message for insufficient-access errors", () => {
+    render(
+      <InsufficientAccess error={{ status: 403, kind: "insufficient_access" }} />,
+    );
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Your key does not have permission for this action.",
+    );
+  });
+
+  it("renders nothing for unrelated errors without an explicit message", () => {
+    const { container } = render(
+      <InsufficientAccess error={{ status: 403, kind: "other" }} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/src/features/auth/__tests__/LoginPage.test.tsx
+++ b/ui/src/features/auth/__tests__/LoginPage.test.tsx
@@ -92,7 +92,12 @@ describe("LoginPage", () => {
       .mockResolvedValueOnce({ status: 204, ok: true })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ csrf_token: "csrf-secret" }),
+        json: async () => ({
+          kind: "user",
+          subject: "ops@example.com",
+          role: "viewer",
+          csrf_token: "csrf-secret",
+        }),
       });
 
     render(
@@ -192,7 +197,15 @@ describe("LoginPage", () => {
 
   it("stores the api key and calls onLogin on success", async () => {
     const onLogin = vi.fn();
-    mockFetch.mockResolvedValue({ status: 200 });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        kind: "api_key",
+        subject: "csk_live_good",
+        role: "runner",
+      }),
+    });
 
     render(<LoginPage onLogin={onLogin} />);
 
@@ -205,7 +218,8 @@ describe("LoginPage", () => {
       expect(onLogin).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockFetch).toHaveBeenCalledWith("/v1/jobs?limit=1", {
+    expect(mockFetch).toHaveBeenCalledWith("/auth/whoami", {
+      credentials: "include",
       headers: { Authorization: "Bearer csk_live_good" },
     });
     expect(isAuthenticated()).toBe(true);

--- a/ui/src/features/auth/access.ts
+++ b/ui/src/features/auth/access.ts
@@ -1,0 +1,16 @@
+import { type ApiError } from "@/lib/api";
+
+/**
+ * Type-guard for a typed 403 insufficient-access error from the API client.
+ * Lives in a non-component module so the `InsufficientAccess` component file
+ * only exports components (react-refresh/only-export-components). Stream B/F
+ * import this to detect 403s.
+ */
+export function isInsufficientAccessError(error: unknown): error is ApiError {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    (error as { status?: unknown }).status === 403 &&
+    (error as { kind?: unknown }).kind === "insufficient_access"
+  );
+}

--- a/ui/src/lib/__tests__/auth.test.ts
+++ b/ui/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,7 @@
+import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  apiKeyLogin,
   authMethodKey,
   authMethodLabel,
   checkSession,
@@ -11,14 +13,25 @@ import {
   isAuthenticated,
   logout,
   onAuthChange,
+  type PrincipalRole,
   type RedirectAuthMethod,
   setApiKey,
   ssoLoginUrl,
+  usePrincipal,
   withAuthHeaders,
 } from "@/lib/auth";
 
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
+
+function whoami(role: PrincipalRole, extra: Record<string, unknown> = {}) {
+  return {
+    kind: "api_key",
+    subject: "csk_live_good",
+    role,
+    ...extra,
+  };
+}
 
 describe("auth", () => {
   beforeEach(() => {
@@ -57,7 +70,12 @@ describe("auth", () => {
   it("checks cookie sessions with credentials and caches the csrf token", async () => {
     mockFetch.mockResolvedValue({
       ok: true,
-      json: async () => ({ csrf_token: "csrf-secret" }),
+      json: async () =>
+        whoami("viewer", {
+          kind: "user",
+          subject: "ops@example.com",
+          csrf_token: "csrf-secret",
+        }),
     });
 
     await expect(checkSession()).resolves.toBe(true);
@@ -74,7 +92,12 @@ describe("auth", () => {
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ csrf_token: "csrf-secret" }),
+        json: async () =>
+          whoami("viewer", {
+            kind: "user",
+            subject: "ops@example.com",
+            csrf_token: "csrf-secret",
+          }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -141,7 +164,12 @@ describe("auth", () => {
       .mockResolvedValueOnce({ status: 204, ok: true })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ csrf_token: "csrf-secret" }),
+        json: async () =>
+          whoami("viewer", {
+            kind: "user",
+            subject: "ops@example.com",
+            csrf_token: "csrf-secret",
+          }),
       });
 
     await expect(credentialLogin("/auth/sso/ldap/login", "ada", "secret")).resolves.toBe("success");
@@ -162,7 +190,12 @@ describe("auth", () => {
   it("posts logout with the csrf header and clears local state on 401", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ csrf_token: "csrf-secret" }),
+      json: async () =>
+        whoami("viewer", {
+          kind: "user",
+          subject: "ops@example.com",
+          csrf_token: "csrf-secret",
+        }),
     });
 
     await expect(checkSession()).resolves.toBe(true);
@@ -238,5 +271,117 @@ describe("auth", () => {
 
     expect(isAuthenticated()).toBe(false);
     expect(withAuthHeaders()).not.toHaveProperty("X-CSRF-Token");
+  });
+
+  it.each([
+    { role: "viewer" as const, canRunner: false },
+    { role: "runner" as const, canRunner: true },
+    { role: "operator" as const, canRunner: true },
+    { role: "admin" as const, canRunner: true },
+  ])("usePrincipal reflects a $role whoami response", async ({ role, canRunner }) => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => whoami(role),
+    });
+    const { result } = renderHook(() => usePrincipal());
+
+    await act(async () => {
+      await expect(apiKeyLogin("csk_live_secret")).resolves.toBe("success");
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/auth/whoami", {
+      credentials: "include",
+      headers: { Authorization: "Bearer csk_live_secret" },
+    });
+    expect(result.current).toMatchObject({
+      kind: "api_key",
+      subject: "csk_live_good",
+      role,
+      canRunner,
+      isScoped: false,
+      scopeKnown: false,
+    });
+  });
+
+  it.each([
+    {
+      label: "explicit is_scoped true",
+      extra: { is_scoped: true },
+      isScoped: true,
+      scopeKnown: true,
+    },
+    {
+      label: "non-empty scope.jobs",
+      extra: { scope: { jobs: ["billing"] } },
+      isScoped: true,
+      scopeKnown: true,
+    },
+    {
+      label: "empty scope.jobs",
+      extra: { scope: { jobs: [] } },
+      isScoped: false,
+      scopeKnown: true,
+    },
+  ])(
+    "usePrincipal derives scope from whoami ($label)",
+    async ({ extra, isScoped, scopeKnown }) => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => whoami("runner", extra),
+      });
+      const { result } = renderHook(() => usePrincipal());
+
+      await act(async () => {
+        await expect(apiKeyLogin("csk_live_secret")).resolves.toBe("success");
+      });
+
+      expect(result.current).toMatchObject({ role: "runner", isScoped, scopeKnown });
+    },
+  );
+
+  it("clears the retained principal role on logout", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => whoami("runner"),
+    });
+    const { result } = renderHook(() => usePrincipal());
+
+    await act(async () => {
+      await expect(apiKeyLogin("csk_live_secret")).resolves.toBe("success");
+    });
+    expect(result.current).toMatchObject({ role: "runner", canRunner: true });
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200 });
+    await act(async () => {
+      await expect(logout()).resolves.toBeUndefined();
+    });
+    expect(result.current).toMatchObject({ role: null, canRunner: false });
+  });
+
+  it("clears the principal snapshot when auth state is cleared", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => whoami("runner"),
+    });
+    const { result } = renderHook(() => usePrincipal());
+
+    await act(async () => {
+      await apiKeyLogin("csk_live_secret");
+    });
+    expect(result.current.role).toBe("runner");
+
+    act(() => {
+      clearApiKey();
+    });
+
+    expect(result.current).toMatchObject({
+      role: null,
+      canRunner: false,
+      isScoped: false,
+    });
   });
 });

--- a/ui/src/lib/__tests__/auth.test.ts
+++ b/ui/src/lib/__tests__/auth.test.ts
@@ -8,6 +8,7 @@ import {
   clearApiKey,
   credentialLogin,
   currentReturnTo,
+  getPrincipal,
   isCredentialAuthMethod,
   isRedirectAuthMethod,
   isAuthenticated,
@@ -86,6 +87,42 @@ describe("auth", () => {
       "X-CSRF-Token": "csrf-secret",
     });
     expect(withAuthHeaders()).not.toHaveProperty("Authorization");
+  });
+
+  it.each([
+    {
+      label: "missing role",
+      body: {
+        kind: "user",
+        subject: "ops@example.com",
+        csrf_token: "csrf-secret",
+      },
+    },
+    {
+      label: "unrecognized role",
+      body: {
+        kind: "user",
+        subject: "ops@example.com",
+        role: "future-operator",
+        csrf_token: "csrf-secret",
+      },
+    },
+  ])("keeps a valid cookie session when whoami has a $label", async ({ body }) => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => body,
+    });
+
+    await expect(checkSession()).resolves.toBe(true);
+
+    expect(isAuthenticated()).toBe(true);
+    expect(withAuthHeaders()).toMatchObject({
+      "X-CSRF-Token": "csrf-secret",
+    });
+    expect(getPrincipal()).toMatchObject({
+      role: "viewer",
+      canRunner: false,
+    });
   });
 
   it("fails closed when a cookie session response omits the csrf token", async () => {
@@ -247,6 +284,29 @@ describe("auth", () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(isAuthenticated()).toBe(false);
+  });
+
+  it("does not clear current auth state when pending api key verification is malformed", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => whoami("runner"),
+    });
+    await expect(apiKeyLogin("csk_live_current")).resolves.toBe("success");
+    expect(getPrincipal()).toMatchObject({ role: "runner", canRunner: true });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => null,
+    });
+    await expect(apiKeyLogin("csk_live_candidate")).resolves.toBe("error");
+
+    expect(isAuthenticated()).toBe(true);
+    expect(withAuthHeaders()).toMatchObject({
+      Authorization: "Bearer csk_live_current",
+    });
+    expect(getPrincipal()).toMatchObject({ role: "runner", canRunner: true });
   });
 
   it("falls back to SSO labels for malformed auth methods", () => {

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -6,6 +6,8 @@
  * tab is closed or the user logs out.
  */
 
+import { useSyncExternalStore } from "react";
+
 type AuthChangeListener = () => void;
 
 export interface AuthMethod {
@@ -29,10 +31,30 @@ export type CredentialLoginResult =
   | "denied"
   | "error"
   | "network";
+export type ApiKeyLoginResult = CredentialLoginResult;
+export type PrincipalRole = "viewer" | "runner" | "operator" | "admin";
+
+export interface PrincipalState {
+  kind: string | null;
+  subject: string | null;
+  role: PrincipalRole | null;
+  canRunner: boolean;
+  isScoped: boolean;
+  scopeKnown: boolean;
+}
 
 let apiKey: string | null = null;
 let cookieSession = false;
 let csrfToken: string | null = null;
+const anonymousPrincipal: PrincipalState = Object.freeze({
+  kind: null,
+  subject: null,
+  role: null,
+  canRunner: false,
+  isScoped: false,
+  scopeKnown: false,
+});
+let principal: PrincipalState = anonymousPrincipal;
 const listeners: Set<AuthChangeListener> = new Set();
 
 function notifyAuthChange(): void {
@@ -52,9 +74,113 @@ function cloneHeaders(headers?: HeadersInit): Record<string, string> {
   return { ...headers };
 }
 
+function roleLevel(role: PrincipalRole | null): number {
+  switch (role) {
+    case "admin":
+      return 40;
+    case "operator":
+      return 30;
+    case "runner":
+      return 20;
+    case "viewer":
+      return 10;
+    default:
+      return 0;
+  }
+}
+
+function normalizeRole(value: unknown): PrincipalRole | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const role = value.trim().toLowerCase();
+  switch (role) {
+    case "viewer":
+    case "runner":
+    case "operator":
+    case "admin":
+      return role;
+    default:
+      return null;
+  }
+}
+
+function scopeFromWhoami(
+  body: Record<string, unknown>,
+  kind: string | null,
+): Pick<PrincipalState, "isScoped" | "scopeKnown"> {
+  const explicitScoped = body.is_scoped ?? body.isScoped ?? body.scoped;
+  if (typeof explicitScoped === "boolean") {
+    return { isScoped: explicitScoped, scopeKnown: true };
+  }
+
+  const scope = body.scope;
+  if (scope && typeof scope === "object" && !Array.isArray(scope)) {
+    const jobs = (scope as { jobs?: unknown }).jobs;
+    if (Array.isArray(jobs)) {
+      return {
+        isScoped: jobs.some((job) => typeof job === "string" && job.trim() !== ""),
+        scopeKnown: true,
+      };
+    }
+  }
+
+  // Current /auth/whoami serializes kind/subject/role only. User principals are
+  // unscoped by construction; API-key scope cannot be inferred until the backend
+  // exposes a scope marker, so leave isScoped false and scopeKnown false.
+  if (kind === "user") {
+    return { isScoped: false, scopeKnown: true };
+  }
+
+  return { isScoped: false, scopeKnown: false };
+}
+
+function principalFromWhoami(body: unknown): PrincipalState | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return null;
+  }
+
+  const obj = body as Record<string, unknown>;
+  const role = normalizeRole(obj.role);
+  if (!role) {
+    return null;
+  }
+
+  const kind =
+    typeof obj.kind === "string" && obj.kind.trim() !== "" ? obj.kind.trim() : null;
+  const subject =
+    typeof obj.subject === "string" && obj.subject.trim() !== ""
+      ? obj.subject.trim()
+      : null;
+  const scope = scopeFromWhoami(obj, kind);
+  return {
+    kind,
+    subject,
+    role,
+    canRunner: roleLevel(role) >= roleLevel("runner"),
+    isScoped: scope.isScoped,
+    scopeKnown: scope.scopeKnown,
+  };
+}
+
+function clearPrincipal(): void {
+  principal = anonymousPrincipal;
+}
+
+function setPrincipal(nextPrincipal: PrincipalState): void {
+  principal = nextPrincipal;
+}
+
+async function readWhoami(response: Response): Promise<PrincipalState | null> {
+  return principalFromWhoami(await response.json());
+}
+
 /** Store the API key in memory (never persisted to disk). */
 export function setApiKey(key: string): void {
   apiKey = key;
+  cookieSession = false;
+  csrfToken = null;
+  clearPrincipal();
   notifyAuthChange();
 }
 
@@ -63,13 +189,17 @@ export function clearApiKey(): void {
   apiKey = null;
   cookieSession = false;
   csrfToken = null;
+  clearPrincipal();
   notifyAuthChange();
 }
 
 function clearCookieSession(): void {
-  if (cookieSession || csrfToken) {
+  if (cookieSession || csrfToken || (apiKey === null && principal !== anonymousPrincipal)) {
     cookieSession = false;
     csrfToken = null;
+    if (apiKey === null) {
+      clearPrincipal();
+    }
     notifyAuthChange();
   }
 }
@@ -82,6 +212,16 @@ export function isAuthenticated(): boolean {
 /** Return the cached CSRF header for cookie-session requests. */
 export function csrfHeader(): Record<string, string> {
   return csrfToken ? { "X-CSRF-Token": csrfToken } : {};
+}
+
+/** Return the current principal snapshot for non-React call sites. */
+export function getPrincipal(): PrincipalState {
+  return principal;
+}
+
+/** React accessor for the current principal and derived affordance flags. */
+export function usePrincipal(): PrincipalState {
+  return useSyncExternalStore(onAuthChange, getPrincipal, getPrincipal);
 }
 
 /** Return the same-origin path the SSO callback should send the user back to. */
@@ -169,17 +309,22 @@ export async function checkSession(): Promise<boolean> {
       return false;
     }
 
-    const body = (await response.json()) as { csrf_token?: unknown };
+    const body = (await response.json()) as Record<string, unknown>;
     if (typeof body.csrf_token !== "string" || body.csrf_token.length === 0) {
+      clearCookieSession();
+      return false;
+    }
+    const nextPrincipal = principalFromWhoami(body);
+    if (!nextPrincipal) {
       clearCookieSession();
       return false;
     }
 
     csrfToken = body.csrf_token;
-    if (!cookieSession) {
-      cookieSession = true;
-      notifyAuthChange();
-    }
+    cookieSession = true;
+    apiKey = null;
+    setPrincipal(nextPrincipal);
+    notifyAuthChange();
     return true;
   } catch {
     clearCookieSession();
@@ -227,6 +372,41 @@ export async function credentialLogin(
     }
 
     return (await checkSession()) ? "success" : "error";
+  } catch {
+    return "network";
+  }
+}
+
+/** Verify an API key via /auth/whoami, then cache the key and principal. */
+export async function apiKeyLogin(key: string): Promise<ApiKeyLoginResult> {
+  try {
+    const response = await fetch("/auth/whoami", {
+      credentials: "include",
+      headers: { Authorization: `Bearer ${key}` },
+    });
+
+    if (response.status === 401) {
+      return "invalid";
+    }
+    if (response.status === 403) {
+      return "denied";
+    }
+    if (!response.ok) {
+      return "error";
+    }
+
+    const nextPrincipal = await readWhoami(response);
+    if (!nextPrincipal) {
+      clearApiKey();
+      return "error";
+    }
+
+    apiKey = key;
+    cookieSession = false;
+    csrfToken = null;
+    setPrincipal(nextPrincipal);
+    notifyAuthChange();
+    return "success";
   } catch {
     return "network";
   }

--- a/ui/src/lib/auth.ts
+++ b/ui/src/lib/auth.ts
@@ -141,10 +141,7 @@ function principalFromWhoami(body: unknown): PrincipalState | null {
   }
 
   const obj = body as Record<string, unknown>;
-  const role = normalizeRole(obj.role);
-  if (!role) {
-    return null;
-  }
+  const role = normalizeRole(obj.role) ?? "viewer";
 
   const kind =
     typeof obj.kind === "string" && obj.kind.trim() !== "" ? obj.kind.trim() : null;
@@ -314,6 +311,8 @@ export async function checkSession(): Promise<boolean> {
       clearCookieSession();
       return false;
     }
+    // Authentication is proven by the successful whoami response and CSRF token.
+    // Missing or future roles fall back to viewer so UI affordances stay fail-closed.
     const nextPrincipal = principalFromWhoami(body);
     if (!nextPrincipal) {
       clearCookieSession();
@@ -397,7 +396,6 @@ export async function apiKeyLogin(key: string): Promise<ApiKeyLoginResult> {
 
     const nextPrincipal = await readWhoami(response);
     if (!nextPrincipal) {
-      clearApiKey();
       return "error";
     }
 


### PR DESCRIPTION
## H-2 — principal role/scope retention (Wave 2)

Captures the principal **role** (and an honestly-degraded **scope** signal) from the existing `GET /auth/whoami` call into the auth store, exposing `usePrincipal()` (`role`, `canRunner`, `isScoped`) for affordance-gating, plus a shared `InsufficientAccess` component that renders a typed 403 inline. Unblocks B's runner-gated Replay and F's scoped-lineage handling. **Frontend-only; no backend changes** — UI gating is convenience-only, the backend stays authoritative (clears on logout + 401).

**Opus review:** 0 blockers; 2 should-fix applied (isScoped truthy-branch test coverage; assert logout clears the retained role); lint fix (moved `isInsufficientAccessError` to a non-component module). `just ui-lint` + `just ui-test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvA6zFvnhXRHHHVccZy1em