### PR TITLE
Add the run-diff view to RunDetailPage (data-plane-memory-ui W2-β)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory-ui.md
+++ b/docs/exec-plans/active/data-plane-memory-ui.md
@@ -144,7 +144,7 @@ surface. Honest scoping (from the design): this is **cache-bust attribution**
 (which step/output changed + why a task re-ran) — full row/column **value** diffs
 are explicitly handed off to dbt/Datafold; the UI says so.
 
-- [ ] A1. Build the run-diff view: a "Compare to run…" affordance in the
+- [x] A1. Build the run-diff view: a "Compare to run…" affordance in the
       `RunDetailPage` header (a picker over the job's other runs) that opens a diff
       view rendering `getRunDiff` — per-task changed vs. cache-hit, the discriminating
       cache-bust field, and a one-line "value diffs → dbt/Datafold" note. Read-only;
@@ -154,10 +154,12 @@ are explicitly handed off to dbt/Datafold; the UI says so.
       Files: new `ui/src/features/jobs/RunDiffView.tsx` (+ a `TaskDiffRow`),
       `ui/src/features/jobs/RunDetailPage.tsx` (the affordance), `ui/src/router.tsx`.
       Depends on: H-1.
-- [ ] A2. Playwright e2e: apply a job, trigger two runs differing by a `--set`/param,
+      Note: W2-beta added the linkable `RunDiffView`, route, and run-header compare picker against the existing run-diff endpoint.
+- [x] A2. Playwright e2e: apply a job, trigger two runs differing by a `--set`/param,
       open the diff, assert the changed task renders the discriminating field and an
       unchanged task renders as cache-hit. Assert on `data-testid` DOM, not internals.
       Files: `ui/e2e/run-diff.spec.ts`. Depends on: A1.
+      Note: W2-beta added a Playwright spec that creates one command-changed task plus one unchanged cached task because v1 hashes run params into every task.
 
 ### Stream B — Replay (quarantined what-if)
 

--- a/ui/e2e/run-diff.spec.ts
+++ b/ui/e2e/run-diff.spec.ts
@@ -31,8 +31,8 @@ type RunDiffFixture = FixtureDefinition & {
     image: string;
     cache?: boolean;
     command: string[];
-    next?: string | string[];
-    dependsOn?: string;
+    next?: string[];
+    dependsOn?: string[];
   }>;
 };
 
@@ -89,14 +89,14 @@ function buildRunDiffDefinition(alias: string, variant: string): RunDiffFixture 
         engine: "docker",
         image: neutralShellImage,
         command: ["sh", "-c", "echo '##caesium::output {\"rows\": \"42\"}'"],
-        next: "render",
+        next: ["render"],
       },
       {
         name: "render",
         engine: "docker",
         image: neutralShellImage,
         command: ["sh", "-c", `echo render-${variant}`],
-        dependsOn: "stable-source",
+        dependsOn: ["stable-source"],
       },
     ],
   };

--- a/ui/e2e/run-diff.spec.ts
+++ b/ui/e2e/run-diff.spec.ts
@@ -1,0 +1,145 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+import { applyDefinitions, type FixtureDefinition } from "./helpers/fixtures";
+
+type E2EJob = {
+  id: string;
+  alias: string;
+};
+
+type E2ERun = {
+  id: string;
+  status: string;
+};
+
+type RunDiffFixture = FixtureDefinition & {
+  apiVersion: string;
+  kind: string;
+  metadata: Record<string, unknown> & {
+    alias: string;
+    cache: boolean;
+  };
+  trigger: {
+    type: string;
+    configuration: Record<string, unknown> & {
+      cron: string;
+      timezone: string;
+    };
+  };
+  steps: Array<Record<string, unknown> & {
+    name: string;
+    engine: string;
+    image: string;
+    cache?: boolean;
+    command: string[];
+    next?: string | string[];
+    dependsOn?: string;
+  }>;
+};
+
+const neutralShellImage = "debian:12-slim";
+
+test("operator can compare runs and see changed versus cache-hit tasks", async ({ page, request }) => {
+  test.slow();
+
+  const alias = `run-diff-e2e-${Date.now().toString(36)}`;
+
+  await applyDefinitions(request, buildRunDiffDefinition(alias, "v1"));
+  const job = await findJobByAlias(request, alias);
+
+  const leftRun = await triggerRun(request, job.id);
+  await waitForRun(request, job.id, leftRun.id);
+
+  // In v1, changed run params are folded into every task hash. Updating only
+  // the render command gives the UI one RERAN task and one WOULD_CACHE_HIT task
+  // from the real run-diff endpoint without manufacturing selective param hits.
+  await applyDefinitions(request, buildRunDiffDefinition(alias, "v2"));
+  const rightRun = await triggerRun(request, job.id);
+  await waitForRun(request, job.id, rightRun.id);
+
+  await page.goto(`/jobs/${job.id}/runs/${leftRun.id}/diff?to=${rightRun.id}`);
+
+  await expect(page.getByTestId("run-diff-container")).toBeVisible({ timeout: 30_000 });
+
+  const changedRow = page.getByTestId("run-diff-task-row").filter({ hasText: "render" });
+  await expect(changedRow.getByTestId("run-diff-verdict")).toContainText("RERAN");
+  await expect(changedRow.getByTestId("run-diff-discriminating-field")).toContainText("command");
+
+  const unchangedRow = page.getByTestId("run-diff-task-row").filter({ hasText: "stable-source" });
+  await expect(unchangedRow.getByTestId("run-diff-cache-hit-marker")).toContainText("WOULD_CACHE_HIT");
+});
+
+function buildRunDiffDefinition(alias: string, variant: string): RunDiffFixture {
+  return {
+    apiVersion: "v1",
+    kind: "Job",
+    metadata: {
+      alias,
+      cache: true,
+    },
+    trigger: {
+      type: "cron",
+      configuration: {
+        cron: "0 2 * * *",
+        timezone: "UTC",
+      },
+    },
+    steps: [
+      {
+        name: "stable-source",
+        engine: "docker",
+        image: neutralShellImage,
+        command: ["sh", "-c", "echo '##caesium::output {\"rows\": \"42\"}'"],
+        next: "render",
+      },
+      {
+        name: "render",
+        engine: "docker",
+        image: neutralShellImage,
+        command: ["sh", "-c", `echo render-${variant}`],
+        dependsOn: "stable-source",
+      },
+    ],
+  };
+}
+
+async function findJobByAlias(request: APIRequestContext, alias: string): Promise<E2EJob> {
+  const response = await request.get("/v1/jobs");
+  if (!response.ok()) {
+    throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+  }
+
+  const jobs = (await response.json()) as E2EJob[];
+  const job = jobs.find((candidate) => candidate.alias === alias);
+  if (!job) {
+    throw new Error(`job not found after apply: ${alias}`);
+  }
+  return job;
+}
+
+async function triggerRun(request: APIRequestContext, jobId: string): Promise<E2ERun> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`);
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run: ${response.status()} ${await response.text()}`);
+  }
+
+  return (await response.json()) as E2ERun;
+}
+
+async function waitForRun(request: APIRequestContext, jobId: string, runId: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+        if (!response.ok()) {
+          throw new Error(`failed to load run ${runId}: ${response.status()} ${await response.text()}`);
+        }
+        const run = (await response.json()) as E2ERun;
+        return run.status;
+      },
+      {
+        timeout: 120_000,
+        intervals: [1_000, 2_000, 5_000],
+      },
+    )
+    .toBe("succeeded");
+}

--- a/ui/e2e/run-diff.spec.ts
+++ b/ui/e2e/run-diff.spec.ts
@@ -61,7 +61,7 @@ test("operator can compare runs and see changed versus cache-hit tasks", async (
   await expect(page.getByTestId("run-diff-container")).toBeVisible({ timeout: 30_000 });
 
   const changedRow = page.getByTestId("run-diff-task-row").filter({ hasText: "render" });
-  await expect(changedRow.getByTestId("run-diff-verdict")).toContainText("RERAN");
+  await expect(changedRow.getByTestId("run-diff-verdict")).toContainText("Reran");
   await expect(changedRow.getByTestId("run-diff-discriminating-field")).toContainText("command");
 
   const unchangedRow = page.getByTestId("run-diff-task-row").filter({ hasText: "stable-source" });

--- a/ui/src/features/jobs/RunDetailPage.tsx
+++ b/ui/src/features/jobs/RunDetailPage.tsx
@@ -24,6 +24,8 @@ import { RunCacheSummary } from "./RunCacheSummary";
 import { RunTimeline } from "./RunTimeline";
 import { TaskDetailPanel } from "./TaskDetailPanel";
 
+const COMPARE_RUN_PICKER_LIMIT = 50;
+
 export function RunDetailPage() {
   const { jobId, runId } = useParams({ strict: false }) as { jobId: string; runId: string };
   const navigate = useNavigate();
@@ -49,8 +51,8 @@ export function RunDetailPage() {
   });
 
   const { data: jobRuns, isLoading: isLoadingJobRuns } = useQuery({
-    queryKey: ["job", jobId, "runs"],
-    queryFn: () => api.getJobRuns(jobId),
+    queryKey: ["job", jobId, "runs", { limit: COMPARE_RUN_PICKER_LIMIT }],
+    queryFn: () => api.getJobRuns(jobId, { limit: COMPARE_RUN_PICKER_LIMIT }),
   });
 
   const { data: atoms, isLoading: isLoadingAtoms } = useQuery({
@@ -195,10 +197,12 @@ export function RunDetailPage() {
     return (jobRuns ?? [])
       .filter((candidate) => candidate.id !== runId)
       .sort((a, b) => {
-        const aTime = new Date(a.started_at || a.created_at).getTime();
-        const bTime = new Date(b.started_at || b.created_at).getTime();
-        return bTime - aTime;
-      });
+        const aTime = runSortTimestamp(a);
+        const bTime = runSortTimestamp(b);
+        if (aTime !== bTime) return bTime - aTime;
+        return b.id.localeCompare(a.id);
+      })
+      .slice(0, COMPARE_RUN_PICKER_LIMIT);
   }, [jobRuns, runId]);
 
   const triggerMutation = useMutation({
@@ -227,6 +231,11 @@ export function RunDetailPage() {
   const selectedTask = selectedTaskId ? taskDefinitions[selectedTaskId] : undefined;
   const selectedRunTask = selectedTaskId ? runTasks[selectedTaskId] : undefined;
   const isLive = run.status === "running";
+  const compareDisabledReason = isLoadingJobRuns
+    ? "Loading runs to compare"
+    : compareRuns.length === 0
+      ? "No other runs to compare"
+      : undefined;
 
   return (
     <div className="space-y-5">
@@ -271,7 +280,7 @@ export function RunDetailPage() {
                 className="h-8 text-xs"
                 disabled={isLoadingJobRuns || compareRuns.length === 0}
                 data-testid="run-compare-trigger"
-                title={compareRuns.length === 0 ? "No other runs to compare" : undefined}
+                title={compareDisabledReason}
               >
                 <ArrowLeftRight className="mr-1.5 h-3.5 w-3.5" />
                 Compare to run…
@@ -294,7 +303,7 @@ export function RunDetailPage() {
                   <div className="min-w-0">
                     <div className="truncate font-mono text-xs">Run {shortId(candidate.id)}</div>
                     <div className="truncate text-[10px] text-text-3">
-                      {new Date(candidate.started_at || candidate.created_at).toLocaleString()}
+                      {formatRunTimestamp(candidate)}
                     </div>
                   </div>
                   <StatusBadge status={candidate.status} size="sm" />
@@ -426,4 +435,20 @@ export function RunDetailPage() {
       </div>
     </div>
   );
+}
+
+function runSortTimestamp(run: JobRun): number {
+  const parsed = parseTimestamp(run.started_at) ?? parseTimestamp(run.created_at);
+  return parsed ?? Number.NEGATIVE_INFINITY;
+}
+
+function formatRunTimestamp(run: JobRun): string {
+  const parsed = parseTimestamp(run.started_at) ?? parseTimestamp(run.created_at);
+  return parsed !== undefined ? new Date(parsed).toLocaleString() : "Unknown start time";
+}
+
+function parseTimestamp(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const timestamp = new Date(value).getTime();
+  return Number.isFinite(timestamp) ? timestamp : undefined;
 }

--- a/ui/src/features/jobs/RunDetailPage.tsx
+++ b/ui/src/features/jobs/RunDetailPage.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, ChevronDown, ChevronRight, RotateCcw, Square, History } from "lucide-react";
+import { ArrowLeft, ArrowLeftRight, ChevronDown, ChevronRight, RotateCcw, Square, History } from "lucide-react";
 import { toast } from "sonner";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { useDagHeight } from "@/hooks/useDagHeight";
@@ -40,6 +46,11 @@ export function RunDetailPage() {
   const { data: tasks, isLoading: isLoadingTasks } = useQuery({
     queryKey: ["job", jobId, "tasks"],
     queryFn: () => api.getJobTasks(jobId),
+  });
+
+  const { data: jobRuns, isLoading: isLoadingJobRuns } = useQuery({
+    queryKey: ["job", jobId, "runs"],
+    queryFn: () => api.getJobRuns(jobId),
   });
 
   const { data: atoms, isLoading: isLoadingAtoms } = useQuery({
@@ -180,6 +191,16 @@ export function RunDetailPage() {
     return map;
   }, [run?.tasks]);
 
+  const compareRuns = useMemo(() => {
+    return (jobRuns ?? [])
+      .filter((candidate) => candidate.id !== runId)
+      .sort((a, b) => {
+        const aTime = new Date(a.started_at || a.created_at).getTime();
+        const bTime = new Date(b.started_at || b.created_at).getTime();
+        return bTime - aTime;
+      });
+  }, [jobRuns, runId]);
+
   const triggerMutation = useMutation({
     mutationFn: () => api.triggerJob(jobId),
     onSuccess: (newRun) => {
@@ -242,6 +263,45 @@ export function RunDetailPage() {
 
         {/* Action cluster */}
         <div className="flex items-center gap-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 text-xs"
+                disabled={isLoadingJobRuns || compareRuns.length === 0}
+                data-testid="run-compare-trigger"
+                title={compareRuns.length === 0 ? "No other runs to compare" : undefined}
+              >
+                <ArrowLeftRight className="mr-1.5 h-3.5 w-3.5" />
+                Compare to run…
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-72">
+              {compareRuns.map((candidate) => (
+                <DropdownMenuItem
+                  key={candidate.id}
+                  data-testid="run-compare-option"
+                  className="flex items-center justify-between gap-3"
+                  onSelect={() =>
+                    navigate({
+                      to: "/jobs/$jobId/runs/$runId/diff",
+                      params: { jobId, runId },
+                      search: { to: candidate.id },
+                    })
+                  }
+                >
+                  <div className="min-w-0">
+                    <div className="truncate font-mono text-xs">Run {shortId(candidate.id)}</div>
+                    <div className="truncate text-[10px] text-text-3">
+                      {new Date(candidate.started_at || candidate.created_at).toLocaleString()}
+                    </div>
+                  </div>
+                  <StatusBadge status={candidate.status} size="sm" />
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
           <Button
             variant="ghost"
             size="sm"

--- a/ui/src/features/jobs/RunDiffView.tsx
+++ b/ui/src/features/jobs/RunDiffView.tsx
@@ -178,7 +178,7 @@ export function TaskDiffRow({ task }: { task: RunDiffTask }) {
                 <span data-testid="run-diff-verdict">
                   <StatusBadge
                     status={verdictStatus(task.verdict)}
-                    label={task.verdict}
+                    label={verdictLabel(task.verdict)}
                     size="sm"
                   />
                 </span>
@@ -351,7 +351,10 @@ function formatValue(value: string | undefined, change: FieldChange): string {
   return change.redacted ? `${rendered} (redacted)` : rendered;
 }
 
-function formatTrigger(trigger: WhyTrigger): string {
+function formatTrigger(trigger?: WhyTrigger | null): string {
+  if (!trigger) {
+    return "None";
+  }
   const parts = [trigger.type, trigger.alias].filter(Boolean);
   if (trigger.firedAt) {
     parts.push(trigger.firedAt);
@@ -375,6 +378,17 @@ function verdictStatus(verdict: RunDiffVerdict): string {
       return "running";
     case "DEGRADED":
       return "failed";
+  }
+}
+
+function verdictLabel(verdict: RunDiffVerdict): string {
+  switch (verdict) {
+    case "WOULD_CACHE_HIT":
+      return "Cache reusable";
+    case "RERAN":
+      return "Reran";
+    case "DEGRADED":
+      return "Degraded";
   }
 }
 

--- a/ui/src/features/jobs/RunDiffView.tsx
+++ b/ui/src/features/jobs/RunDiffView.tsx
@@ -1,0 +1,384 @@
+import { Link, useParams, useSearch } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { AlertTriangle, ArrowLeft, ArrowLeftRight, Info } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { StatusBadge } from "@/components/ui/status-badge";
+import { api, type FieldChange, type RunDiffTask, type RunDiffVerdict, type WhyTrigger } from "@/lib/api";
+import { cn, shortId } from "@/lib/utils";
+
+export interface RunDiffViewProps {
+  jobId: string;
+  leftRunId: string;
+  rightRunId?: string;
+}
+
+type RunDiffSearch = {
+  to?: string;
+};
+
+export function RunDiffRoutePage() {
+  const { jobId, runId } = useParams({ strict: false }) as { jobId: string; runId: string };
+  const search = useSearch({ strict: false }) as RunDiffSearch;
+
+  return <RunDiffView jobId={jobId} leftRunId={runId} rightRunId={search.to} />;
+}
+
+export function RunDiffView({ jobId, leftRunId, rightRunId }: RunDiffViewProps) {
+  const hasComparison = Boolean(jobId && leftRunId && rightRunId);
+  const { data: diff, isLoading, error } = useQuery({
+    queryKey: ["job", jobId, "runs", "diff", leftRunId, rightRunId],
+    queryFn: () => api.getRunDiff(jobId, leftRunId, rightRunId ?? ""),
+    enabled: hasComparison,
+  });
+
+  if (!rightRunId) {
+    return (
+      <div className="space-y-5" data-testid="run-diff-container">
+        <DiffBreadcrumb jobId={jobId} runId={leftRunId} />
+        <EmptyState
+          title="Choose a comparison run"
+          subtitle="Open a run detail page and use Compare to run… to select the other side."
+          icon={<ArrowLeftRight className="h-12 w-12 text-text-3" />}
+        />
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4 p-8" data-testid="run-diff-container">
+        <Skeleton className="h-8 w-[220px]" />
+        <Skeleton className="h-28 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-5" data-testid="run-diff-container">
+        <DiffBreadcrumb jobId={jobId} runId={leftRunId} />
+        <EmptyState
+          title="Run diff unavailable"
+          subtitle={error instanceof Error ? error.message : "The run diff endpoint returned an error."}
+          icon={<AlertTriangle className="h-12 w-12 text-danger" />}
+        />
+      </div>
+    );
+  }
+
+  if (!diff) {
+    return (
+      <div className="space-y-5" data-testid="run-diff-container">
+        <DiffBreadcrumb jobId={jobId} runId={leftRunId} />
+        <EmptyState
+          title="No diff data"
+          subtitle="The run diff endpoint returned no tasks for this comparison."
+          icon={<ArrowLeftRight className="h-12 w-12 text-text-3" />}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5" data-testid="run-diff-container">
+      <DiffBreadcrumb jobId={jobId} runId={leftRunId} />
+
+      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-3 mb-1">
+            Run diff
+          </div>
+          <div className="flex flex-wrap items-center gap-2.5">
+            <h1 className="text-xl font-semibold text-text-1 font-mono tracking-tight">
+              {shortId(diff.leftRunId)} vs {shortId(diff.rightRunId)}
+            </h1>
+            <StatusBadge status={diff.leftStatus} size="sm" label={`left ${diff.leftStatus}`} />
+            <StatusBadge status={diff.rightStatus} size="sm" label={`right ${diff.rightStatus}`} />
+          </div>
+          <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-3">
+            <span className="font-mono text-text-4 text-[10px]">{diff.jobId}</span>
+            <span className="text-text-4">·</span>
+            <span>{new Date(diff.generatedAt).toLocaleString()}</span>
+          </div>
+        </div>
+        <div className="flex w-fit max-w-full items-start gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2.5 py-1.5 text-xs font-medium text-primary">
+          <Info className="h-3.5 w-3.5" />
+          <span>Value diffs -&gt; dbt/Datafold; Caesium shows cache-bust attribution only.</span>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-sm">Comparison Inputs</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <MetadataCell label="Left Run ID" value={diff.leftRunId} mono />
+            <MetadataCell label="Right Run ID" value={diff.rightRunId} mono />
+            <MetadataCell label="Left Trigger" value={formatTrigger(diff.leftTrigger)} mono />
+            <MetadataCell label="Right Trigger" value={formatTrigger(diff.rightTrigger)} mono />
+          </div>
+          <ChangeList title="Trigger Changes" changes={diff.triggerChanges ?? []} />
+          <ChangeList title="Run Parameter Changes" changes={diff.paramChanges ?? []} />
+          {diff.tasksAdded && diff.tasksAdded.length > 0 ? (
+            <NameList title="Tasks Added" names={diff.tasksAdded} />
+          ) : null}
+          {diff.tasksRemoved && diff.tasksRemoved.length > 0 ? (
+            <NameList title="Tasks Removed" names={diff.tasksRemoved} />
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <div className="space-y-3">
+        {diff.tasks.length > 0 ? (
+          diff.tasks.map((task) => <TaskDiffRow key={task.taskName} task={task} />)
+        ) : (
+          <EmptyState
+            title="No paired tasks"
+            subtitle="The compared runs did not have terminal task runs with matching names."
+            icon={<ArrowLeftRight className="h-12 w-12 text-text-3" />}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function TaskDiffRow({ task }: { task: RunDiffTask }) {
+  const headline = headlineChange(task);
+  const taskTestId = `run-diff-task-${testIdSlug(task.taskName)}`;
+  const isCacheHit = task.verdict === "WOULD_CACHE_HIT";
+
+  return (
+    <Card
+      data-testid="run-diff-task-row"
+      data-task-name={task.taskName}
+      className="overflow-hidden"
+    >
+      <CardContent className="p-0">
+        <div
+          className={cn(
+            "border-l-2 px-4 py-3",
+            task.verdict === "WOULD_CACHE_HIT"
+              ? "border-cached"
+              : task.verdict === "RERAN"
+                ? "border-running"
+                : "border-danger",
+          )}
+          data-testid={taskTestId}
+        >
+          <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <h2 className="font-mono text-sm font-semibold text-text-1">{task.taskName}</h2>
+                <span data-testid="run-diff-verdict">
+                  <StatusBadge
+                    status={verdictStatus(task.verdict)}
+                    label={task.verdict}
+                    size="sm"
+                  />
+                </span>
+                {isCacheHit ? (
+                  <Badge
+                    data-testid="run-diff-cache-hit-marker"
+                    variant="cached"
+                    className="text-[10px]"
+                  >
+                    WOULD_CACHE_HIT
+                  </Badge>
+                ) : null}
+              </div>
+              <div
+                data-testid="run-diff-discriminating-field"
+                className="mt-2 text-xs text-text-3"
+              >
+                <span className="font-semibold text-text-2">{headline.label}</span>
+                {headline.detail ? <span className="ml-1 font-mono">{headline.detail}</span> : null}
+              </div>
+            </div>
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              <StatusBadge status={task.leftStatus} size="sm" label={`left ${task.leftStatus}`} />
+              <StatusBadge status={task.rightStatus} size="sm" label={`right ${task.rightStatus}`} />
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-2 gap-3 md:grid-cols-4">
+            <MetadataCell label="Left Task Run ID" value={task.leftTaskRunId} mono />
+            <MetadataCell label="Right Task Run ID" value={task.rightTaskRunId} mono />
+            <MetadataCell label="Left Task ID" value={task.leftTaskId} mono />
+            <MetadataCell label="Right Task ID" value={task.rightTaskId} mono />
+            <MetadataCell label="Left Attempt" value={String(task.leftAttempt)} mono />
+            <MetadataCell label="Right Attempt" value={String(task.rightAttempt)} mono />
+            <MetadataCell label="Hash Equal" value={String(task.hashEqual)} mono />
+            <MetadataCell label="Left Hash" value={task.leftHash || "None"} mono />
+            <MetadataCell label="Right Hash" value={task.rightHash || "None"} mono />
+            {task.degraded ? <MetadataCell label="Degraded" value={task.degraded} /> : null}
+          </div>
+
+          {task.changes && task.changes.length > 0 ? (
+            <div className="mt-4">
+              <ChangeList title={`${task.taskName} Changes`} changes={task.changes} />
+            </div>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function DiffBreadcrumb({ jobId, runId }: { jobId: string; runId: string }) {
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-text-3">
+      <Link
+        to="/jobs/$jobId/runs/$runId"
+        params={{ jobId, runId }}
+        className="flex items-center gap-1 hover:text-text-2 transition-colors"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        Run
+      </Link>
+      <span className="text-text-4">/</span>
+      <span>Diff</span>
+    </div>
+  );
+}
+
+function ChangeList({ title, changes }: { title: string; changes: FieldChange[] }) {
+  if (changes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <div className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="space-y-1.5 rounded-lg border bg-muted/35 p-3">
+        {changes.map((change) => (
+          <div
+            key={`${change.field}:${change.before ?? ""}:${change.after ?? ""}`}
+            className="grid gap-1 text-xs md:grid-cols-[minmax(160px,0.8fr)_minmax(0,1.2fr)]"
+          >
+            <span className="font-mono font-semibold text-text-2">{change.field}</span>
+            <span className="min-w-0 break-all font-mono text-text-3">
+              {formatFieldChange(change)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function NameList({ title, names }: { title: string; names: string[] }) {
+  return (
+    <div>
+      <div className="mb-1.5 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="flex flex-wrap gap-1.5">
+        {names.map((name) => (
+          <Badge key={name} variant="outline" className="font-mono text-[10px]">
+            {name}
+          </Badge>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MetadataCell({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="mb-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className={cn("break-all text-xs text-foreground", mono && "font-mono")}>{value}</div>
+    </div>
+  );
+}
+
+function headlineChange(task: RunDiffTask): { label: string; detail?: string } {
+  if (task.degraded) {
+    return { label: "Degraded", detail: task.degraded };
+  }
+  if (task.verdict === "WOULD_CACHE_HIT") {
+    return { label: "Discriminating field", detail: "none; compared hashes match" };
+  }
+
+  const first = task.changes?.[0];
+  if (!first) {
+    return { label: "Discriminating field", detail: "hash changed; no field detail returned" };
+  }
+
+  return { label: "Discriminating field", detail: formatFieldHeadline(first) };
+}
+
+function formatFieldHeadline(change: FieldChange): string {
+  const direction = formatFieldChange(change);
+  return `${change.field} (${direction})`;
+}
+
+function formatFieldChange(change: FieldChange): string {
+  const kind = change.kind ? `${change.kind}: ` : "";
+  if (change.added) {
+    return `${kind}added ${formatValue(change.after, change)}`;
+  }
+  if (change.removed) {
+    return `${kind}removed ${formatValue(change.before, change)}`;
+  }
+  if (change.kind === "structural") {
+    return `${kind}changed`;
+  }
+
+  return `${kind}${formatValue(change.before, change)} -> ${formatValue(change.after, change)}`;
+}
+
+function formatValue(value: string | undefined, change: FieldChange): string {
+  const rendered = value || "None";
+  return change.redacted ? `${rendered} (redacted)` : rendered;
+}
+
+function formatTrigger(trigger: WhyTrigger): string {
+  const parts = [trigger.type, trigger.alias].filter(Boolean);
+  if (trigger.firedAt) {
+    parts.push(trigger.firedAt);
+  }
+  if (trigger.params && Object.keys(trigger.params).length > 0) {
+    parts.push(
+      Object.entries(trigger.params)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, value]) => `${key}=${value}`)
+        .join(", "),
+    );
+  }
+  return parts.length > 0 ? parts.join(" / ") : "None";
+}
+
+function verdictStatus(verdict: RunDiffVerdict): string {
+  switch (verdict) {
+    case "WOULD_CACHE_HIT":
+      return "cached";
+    case "RERAN":
+      return "running";
+    case "DEGRADED":
+      return "failed";
+  }
+}
+
+function testIdSlug(value: string): string {
+  const slug = value.toLowerCase().replace(/[^a-z0-9_-]+/g, "-").replace(/^-+|-+$/g, "");
+  return slug || "task";
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -732,10 +732,19 @@ function parseJobDefinitions(yaml: string) {
     .filter((doc): doc is Record<string, unknown> => !!doc && typeof doc === "object");
 }
 
+export interface JobRunsQuery {
+  limit?: number;
+  offset?: number;
+}
+
 export const api = {
   getJobs: () => request<Job[]>("/jobs"),
   getJob: (id: string) => request<Job>(`/jobs/${id}`),
-  getJobRuns: (jobId: string) => request<JobRun[]>(`/jobs/${jobId}/runs`),
+  getJobRuns: (jobId: string, query?: JobRunsQuery) => {
+    const params = queryString({ limit: query?.limit, offset: query?.offset });
+    const suffix = params ? `?${params}` : "";
+    return request<JobRun[]>(`/jobs/${jobId}/runs${suffix}`);
+  },
   getJobRun: (jobId: string, runId: string) => request<JobRun>(`/jobs/${jobId}/runs/${runId}`),
   getRunDiff: (jobId: string, left: string, right: string) =>
     request<RunDiff>(

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -7,6 +7,7 @@ import { JobDefsPage } from "./features/jobdefs/JobDefsPage";
 import { JobsPage } from "./features/jobs/JobsPage";
 import { JobDetailPage } from "./features/jobs/JobDetailPage";
 import { RunDetailPage } from "./features/jobs/RunDetailPage";
+import { RunDiffRoutePage } from "./features/jobs/RunDiffView";
 import { StatsPage } from "./features/stats/StatsPage";
 import { SystemPage } from "./features/system/SystemPage";
 import { TriggersPage } from "./features/triggers/TriggersPage";
@@ -37,6 +38,15 @@ const runDetailRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "jobs/$jobId/runs/$runId",
   component: RunDetailPage,
+});
+
+const runDiffRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "jobs/$jobId/runs/$runId/diff",
+  validateSearch: (search: Record<string, unknown>) => ({
+    to: typeof search.to === "string" ? search.to : undefined,
+  }),
+  component: RunDiffRoutePage,
 });
 
 const statsRoute = createRoute({
@@ -91,6 +101,7 @@ const routeTree = rootRoute.addChildren([
   indexRoute,
   jobsRoute,
   jobDetailRoute,
+  runDiffRoute,
   runDetailRoute,
   statsRoute,
   triggersRoute,


### PR DESCRIPTION
## A1+A2 — run-diff view + e2e (Wave 2)

A `RunDiffView` rendering the H-1 `getRunDiff` per-task cache-bust attribution (RERAN / WOULD_CACHE_HIT / DEGRADED + the discriminating field, value-diffs→dbt note), a 'Compare to run…' affordance on `RunDetailPage`, a linkable `/jobs/$jobId/runs/$runId/diff?to=` route, and a Playwright `run-diff.spec.ts`. Cleanly exported for B's reuse. **Frontend-only; drives the existing endpoint.**

**Opus review: CLEAN** (0 blockers, 0 should-fix). `ui-lint` + `ui-test` green; `ui-e2e` runs in CI (the recipe's $$-arithmetic can't run in my local shell, but passes in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvA6zFvnhXRHHHVccZy1em