### PR TITLE
Add the per-task why causal explainer to TaskDetailPanel (data-plane-memory-ui W2-γ)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory-ui.md
+++ b/docs/exec-plans/active/data-plane-memory-ui.md
@@ -212,7 +212,7 @@ execution mode"). Exposing execution-mode for a pre-emptive affordance is a
 
 Answer "why did this task run / skip / re-run / cache-hit" inline on the task.
 
-- [ ] C1. Add a "Why this status?" section to the `TaskDetailPanel` **Details** tab
+- [x] C1. Add a "Why this status?" section to the `TaskDetailPanel` **Details** tab
       driving `getTaskWhy`: render the `WhyExplanation` (cache/hash/trigger/baseline) and
       the discriminating `HashInput` field for why the task ran/skipped/re-ran/cache-hit.
       Render ONLY the backend-provided state — when `BlobDiff.degraded` is set, show the
@@ -222,9 +222,11 @@ Answer "why did this task run / skip / re-run / cache-hit" inline on the task.
       For a cache-hit, link to the source run/task.
       Files: new `ui/src/features/jobs/TaskWhyView.tsx`,
       `ui/src/features/jobs/TaskDetailPanel.tsx`. Depends on: H-1.
-- [ ] C2. Playwright e2e: run a job, open a re-run task and a cache-hit task, assert the
+      Note: Added `TaskWhyView` in the Details tab, rendering verdict, trigger, baseline, diff/degraded reason, hash values, and cache-hit source run/task from `getTaskWhy`.
+- [x] C2. Playwright e2e: run a job, open a re-run task and a cache-hit task, assert the
       "why" section renders the discriminating field for each (and the source-run link for
       the cache-hit). Files: `ui/e2e/why.spec.ts`. Depends on: C1.
+      Note: Added an e2e that enables cache on an existing fixture, runs changed params for a `runParams.scenario` miss, then reruns matching params for a cache hit.
 
 ### Stream D — Blame (topology attribution)
 

--- a/ui/e2e/why.spec.ts
+++ b/ui/e2e/why.spec.ts
@@ -48,9 +48,11 @@ test("task details explain cache miss and cache hit causation", async ({ page, r
   await waitForSucceededRun(request, job.id, cachedRun.id);
 
   await openFirstTaskDetails(page, job.id, changedRun.id);
+  await expect(page.getByTestId("task-why-container")).toContainText("CACHE MISS", {
+    timeout: 30_000,
+  });
   await expect(page.getByTestId("task-why-discriminating-field")).toContainText(
     "runParams.scenario",
-    { timeout: 30_000 },
   );
 
   await openFirstTaskDetails(page, job.id, cachedRun.id);
@@ -65,7 +67,7 @@ test("task details explain cache miss and cache hit causation", async ({ page, r
   await expect(sourceRunLink).toBeVisible();
   await expect(sourceRunLink).toHaveAttribute(
     "href",
-    new RegExp(`/jobs/${job.id}/runs/${changedRun.id}$`),
+    `/jobs/${job.id}/runs/${changedRun.id}`,
   );
 });
 

--- a/ui/e2e/why.spec.ts
+++ b/ui/e2e/why.spec.ts
@@ -1,0 +1,144 @@
+import {
+  expect,
+  type APIRequestContext,
+  type Page,
+  test,
+} from "@playwright/test";
+import {
+  applyDefinitions,
+  loadFixtureDefinition,
+  type FixtureDefinition,
+} from "./helpers/fixtures";
+
+type CacheableFixtureDefinition = FixtureDefinition & {
+  metadata?: FixtureDefinition["metadata"] & {
+    cache?: {
+      enabled: boolean;
+    };
+  };
+};
+
+type JobSummary = {
+  id: string;
+  alias: string;
+};
+
+type RunSummary = {
+  id: string;
+  job_id: string;
+  status: string;
+};
+
+test("task details explain cache miss and cache hit causation", async ({ page, request }) => {
+  test.slow();
+
+  const definition = await loadCacheableFixture();
+  const alias = String(definition.metadata?.alias);
+  await applyDefinitions(request, definition);
+
+  const job = await findJobByAlias(request, alias);
+
+  const seedRun = await triggerRun(request, job.id, { scenario: "seed" });
+  await waitForSucceededRun(request, job.id, seedRun.id);
+
+  const changedRun = await triggerRun(request, job.id, { scenario: "changed" });
+  await waitForSucceededRun(request, job.id, changedRun.id);
+
+  const cachedRun = await triggerRun(request, job.id, { scenario: "changed" });
+  await waitForSucceededRun(request, job.id, cachedRun.id);
+
+  await openFirstTaskDetails(page, job.id, changedRun.id);
+  await expect(page.getByTestId("task-why-discriminating-field")).toContainText(
+    "runParams.scenario",
+    { timeout: 30_000 },
+  );
+
+  await openFirstTaskDetails(page, job.id, cachedRun.id);
+  await expect(page.getByTestId("task-why-container")).toContainText("CACHE HIT", {
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("task-why-discriminating-field")).toContainText(
+    "hashEqual=true",
+  );
+
+  const sourceRunLink = page.getByTestId("task-why-source-run-link");
+  await expect(sourceRunLink).toBeVisible();
+  await expect(sourceRunLink).toHaveAttribute(
+    "href",
+    new RegExp(`/jobs/${job.id}/runs/${changedRun.id}$`),
+  );
+});
+
+async function loadCacheableFixture(): Promise<CacheableFixtureDefinition> {
+  const definition = (await loadFixtureDefinition(
+    "minimal.job.yaml",
+  )) as CacheableFixtureDefinition;
+  definition.metadata = {
+    ...(definition.metadata ?? {}),
+    cache: { enabled: true },
+  };
+  return definition;
+}
+
+async function findJobByAlias(request: APIRequestContext, alias: string): Promise<JobSummary> {
+  const response = await request.get("/v1/jobs");
+  if (!response.ok()) {
+    throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+  }
+
+  const jobs = (await response.json()) as JobSummary[];
+  const job = jobs.find((candidate) => candidate.alias === alias);
+  if (!job) {
+    throw new Error(`failed to find applied job ${alias}`);
+  }
+  return job;
+}
+
+async function triggerRun(
+  request: APIRequestContext,
+  jobId: string,
+  params: Record<string, string>,
+): Promise<RunSummary> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`, {
+    data: { params },
+  });
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as RunSummary;
+}
+
+async function waitForSucceededRun(
+  request: APIRequestContext,
+  jobId: string,
+  runId: string,
+) {
+  await expect.poll(
+    async () => {
+      const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+      if (!response.ok()) {
+        return `HTTP ${response.status()}`;
+      }
+      const run = (await response.json()) as RunSummary;
+      return run.status;
+    },
+    {
+      timeout: 90_000,
+      intervals: [500, 1_000, 2_000],
+    },
+  ).toBe("succeeded");
+}
+
+async function openFirstTaskDetails(page: Page, jobId: string, runId: string) {
+  await page.goto(`/jobs/${jobId}/runs/${runId}`);
+  await expect(page.getByRole("heading", { name: /Run / })).toBeVisible();
+
+  const node = page.locator(".react-flow__node").first();
+  await expect(node).toBeVisible({ timeout: 30_000 });
+  await node.click();
+
+  const panel = page.getByTestId("task-detail-panel");
+  await expect(panel).toBeVisible();
+  await panel.getByRole("button", { name: "Details" }).click();
+  await expect(page.getByTestId("task-why-container")).toBeVisible();
+}

--- a/ui/src/features/jobs/JobDAG.tsx
+++ b/ui/src/features/jobs/JobDAG.tsx
@@ -121,6 +121,7 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
         if (!dag.nodes) return [];
         return dag.nodes.map(n => {
             const atom = atoms[n.atom_id];
+            const taskDefinition = taskDefinitions?.[n.id];
             const meta = taskMetadata?.[n.id];
             const status = resolvedTaskStatus[n.id] || 'pending';
 
@@ -130,7 +131,7 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
                 id: n.id,
                 type: nodeType,
                 data: {
-                  label: n.id,
+                  label: taskDefinition?.name || n.id,
                   atom: atom,
                   status: status,
                   isSelected: selectedTaskId === n.id,
@@ -142,7 +143,7 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
                 position: { x: 0, y: 0 }
             }
         });
-    }, [dag, atoms, resolvedTaskStatus, taskMetadata, selectedTaskId]);
+    }, [dag, atoms, taskDefinitions, resolvedTaskStatus, taskMetadata, selectedTaskId]);
 
     const initialEdges: Edge[] = useMemo(() => {
         if (!dag.edges) return [];

--- a/ui/src/features/jobs/TaskDetailPanel.tsx
+++ b/ui/src/features/jobs/TaskDetailPanel.tsx
@@ -16,6 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { api, type JobTask, type TaskRun } from "@/lib/api";
 import { LogViewer } from "./LogViewer";
+import { TaskWhyView } from "./TaskWhyView";
 import { isTaskCached } from "./cache-utils";
 
 interface TaskDetailPanelProps {
@@ -300,6 +301,12 @@ export function TaskDetailPanel({
                   mono
                 />
               </div>
+
+              <TaskWhyView
+                jobId={jobId}
+                runId={runId}
+                taskName={task?.name}
+              />
 
               {/* Outputs */}
               {runTask?.output && Object.keys(runTask.output).length > 0 && (

--- a/ui/src/features/jobs/TaskWhyView.tsx
+++ b/ui/src/features/jobs/TaskWhyView.tsx
@@ -1,0 +1,428 @@
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { type ReactNode } from "react";
+import { AlertTriangle, Archive, Info } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  ApiError,
+  api,
+  type BlobDiff,
+  type FieldChange,
+  type WhyBaseline,
+  type WhyExplanation,
+  type WhyTrigger,
+  type WhyVerdict,
+} from "@/lib/api";
+import { cn, shortId } from "@/lib/utils";
+
+interface TaskWhyViewProps {
+  jobId: string;
+  runId: string;
+  taskName?: string;
+}
+
+export function TaskWhyView({ jobId, runId, taskName }: TaskWhyViewProps) {
+  const taskRef = taskName?.trim() ?? "";
+  const whyQuery = useQuery({
+    queryKey: ["job", jobId, "runs", runId, "why", taskRef],
+    queryFn: () => api.getTaskWhy(jobId, runId, taskRef),
+    enabled: Boolean(jobId && runId && taskRef),
+    staleTime: 15_000,
+  });
+
+  return (
+    <section
+      data-testid="task-why-container"
+      className="rounded-lg border border-border/60 bg-muted/30 p-3"
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <Info className="h-4 w-4 text-primary" />
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Why this status?
+          </div>
+          <div className="text-xs text-text-3">
+            Cache, hash input, trigger, and baseline causation from the run record.
+          </div>
+        </div>
+      </div>
+
+      {!taskRef ? (
+        <EmptyState
+          title="Task name unavailable"
+          subtitle="The why endpoint explains a task by its step name."
+          icon={<AlertTriangle className="h-8 w-8 text-warning" />}
+          className="py-5"
+        />
+      ) : whyQuery.isLoading ? (
+        <WhySkeleton />
+      ) : whyQuery.error ? (
+        <WhyError error={whyQuery.error} />
+      ) : whyQuery.data ? (
+        <WhyContent explanation={whyQuery.data} />
+      ) : (
+        <EmptyState
+          title="No explanation returned"
+          subtitle="The server returned an empty why response for this task."
+          icon={<Info className="h-8 w-8 text-muted-foreground" />}
+          className="py-5"
+        />
+      )}
+    </section>
+  );
+}
+
+function WhySkeleton() {
+  return (
+    <div className="space-y-3">
+      <Skeleton className="h-8 w-44" />
+      <Skeleton className="h-16 w-full" />
+      <Skeleton className="h-20 w-full" />
+    </div>
+  );
+}
+
+function WhyError({ error }: { error: Error }) {
+  const isAccessError = error instanceof ApiError && error.kind === "insufficient_access";
+  return (
+    <div className="rounded-md border border-warning/25 bg-warning/10 p-3 text-xs text-warning">
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <div>
+          <div className="font-semibold">
+            {isAccessError
+              ? "Insufficient access for task explanation"
+              : "Could not load task explanation"}
+          </div>
+          <div className="mt-1 text-warning/80">
+            {isAccessError
+              ? "Your current role cannot read this why endpoint."
+              : error.message}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function WhyContent({ explanation }: { explanation: WhyExplanation }) {
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={verdictBadgeVariant(explanation.verdict)}>
+          {formatVerdict(explanation.verdict)}
+        </Badge>
+        <span className="rounded border border-border/60 px-1.5 py-0.5 font-mono text-[10px] text-text-3">
+          {explanation.status}
+        </span>
+        <span className="rounded border border-border/60 px-1.5 py-0.5 text-[10px] text-text-3">
+          cache {explanation.cacheEnabled ? "enabled" : "disabled"}
+        </span>
+      </div>
+
+      <div className="rounded-md border border-border/50 bg-background/40 p-3">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          Server summary
+        </div>
+        <p className="mt-1 text-xs leading-relaxed text-foreground">
+          {explanation.summary}
+        </p>
+      </div>
+
+      <DiscriminatingField explanation={explanation} />
+      <DiffDetails diff={explanation.diff} />
+      <BaselineDetails
+        baseline={explanation.baseline}
+        jobId={explanation.jobId}
+        isCacheHit={explanation.verdict === "CACHE_HIT"}
+      />
+      <TriggerDetails trigger={explanation.trigger} />
+      <HashDetails explanation={explanation} />
+    </div>
+  );
+}
+
+function DiscriminatingField({ explanation }: { explanation: WhyExplanation }) {
+  const change = explanation.diff?.changes?.[0];
+  if (change) {
+    return (
+      <div>
+        <SectionLabel>Discriminating hash input</SectionLabel>
+        <FieldChangeRow change={change} highlighted />
+      </div>
+    );
+  }
+
+  if (explanation.diff?.hashEqual) {
+    return (
+      <div>
+        <SectionLabel>Discriminating hash input</SectionLabel>
+        <div
+          data-testid="task-why-discriminating-field"
+          className="rounded-md border border-cached/30 bg-cached/10 p-3"
+        >
+          <div className="flex items-center gap-2">
+            <Archive className="h-3.5 w-3.5 text-cached" />
+            <span className="font-mono text-xs text-cached">hashEqual=true</span>
+          </div>
+          <div className="mt-1 text-xs text-cached/90">
+            The backend reported identical subject and baseline hash inputs.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (explanation.verdict === "CACHE_DISABLED") {
+    return (
+      <div>
+        <SectionLabel>Discriminating hash input</SectionLabel>
+        <div
+          data-testid="task-why-discriminating-field"
+          className="rounded-md border border-border/50 bg-background/40 p-3 text-xs text-text-3"
+        >
+          cacheEnabled=false
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function DiffDetails({ diff }: { diff?: BlobDiff }) {
+  if (!diff) {
+    return null;
+  }
+
+  const changes = diff.changes ?? [];
+  return (
+    <div className="space-y-2">
+      {diff.degraded ? (
+        <div
+          data-testid="task-why-degraded-reason"
+          className="rounded-md border border-warning/25 bg-warning/10 p-3 text-xs text-warning"
+        >
+          <div className="font-semibold">Field-level diff unavailable</div>
+          <div className="mt-1 text-warning/85">{diff.degraded}</div>
+        </div>
+      ) : null}
+
+      {changes.length > 1 ? (
+        <div>
+          <SectionLabel>Additional changed fields</SectionLabel>
+          <div className="space-y-2">
+            {changes.slice(1).map((change) => (
+              <FieldChangeRow
+                key={`${change.field}:${change.before}:${change.after}`}
+                change={change}
+              />
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function BaselineDetails({
+  baseline,
+  jobId,
+  isCacheHit,
+}: {
+  baseline: WhyBaseline;
+  jobId: string;
+  isCacheHit: boolean;
+}) {
+  return (
+    <div className="rounded-md border border-border/50 bg-background/40 p-3">
+      <SectionLabel>Baseline</SectionLabel>
+      <div className="grid gap-2 text-xs">
+        <DetailRow label="Kind" value={baseline.kind || "none"} mono />
+        <div className="grid grid-cols-[96px_1fr] gap-2">
+          <span className="text-muted-foreground">Run</span>
+          {baseline.runId ? (
+            <Link
+              to="/jobs/$jobId/runs/$runId"
+              params={{ jobId, runId: baseline.runId }}
+              data-testid={isCacheHit ? "task-why-source-run-link" : undefined}
+              className="font-mono text-primary hover:underline"
+            >
+              {isCacheHit ? "Source run " : "Baseline run "}
+              {shortId(baseline.runId)}
+              {isCacheHit && baseline.taskRunId ? (
+                <span className="text-primary/80">
+                  {" "}
+                  / task {shortId(baseline.taskRunId)}
+                </span>
+              ) : null}
+            </Link>
+          ) : (
+            <span className="text-text-3">none</span>
+          )}
+        </div>
+        <DetailRow
+          label="Task run"
+          value={baseline.taskRunId ? shortId(baseline.taskRunId) : "none"}
+          mono
+        />
+        <DetailRow
+          label="Started"
+          value={baseline.startedAt ? formatDateTime(baseline.startedAt) : "unknown"}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TriggerDetails({ trigger }: { trigger: WhyTrigger }) {
+  const params = Object.entries(trigger.params ?? {});
+  return (
+    <div className="rounded-md border border-border/50 bg-background/40 p-3">
+      <SectionLabel>Trigger causation</SectionLabel>
+      <div className="grid gap-2 text-xs">
+        <DetailRow label="Type" value={trigger.type || "unknown"} mono />
+        <DetailRow label="Alias" value={trigger.alias || "none"} mono />
+        <DetailRow
+          label="Fired"
+          value={trigger.firedAt ? formatDateTime(trigger.firedAt) : "unknown"}
+        />
+        <div className="grid grid-cols-[96px_1fr] gap-2">
+          <span className="text-muted-foreground">Params</span>
+          {params.length > 0 ? (
+            <div className="space-y-1">
+              {params.map(([key, value]) => (
+                <div key={key} className="font-mono text-text-2">
+                  {key}={value}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <span className="text-text-3">none</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HashDetails({ explanation }: { explanation: WhyExplanation }) {
+  return (
+    <div className="rounded-md border border-border/50 bg-background/40 p-3">
+      <SectionLabel>Hashes</SectionLabel>
+      <div className="grid gap-2 text-xs">
+        <DetailRow label="Task hash" value={explanation.hash || "none"} mono wrap />
+        <DetailRow label="Subject" value={explanation.diff?.subjectHash || "none"} mono wrap />
+        <DetailRow label="Baseline" value={explanation.diff?.baselineHash || "none"} mono wrap />
+      </div>
+    </div>
+  );
+}
+
+function FieldChangeRow({
+  change,
+  highlighted = false,
+}: {
+  change: FieldChange;
+  highlighted?: boolean;
+}) {
+  return (
+    <div
+      data-testid={highlighted ? "task-why-discriminating-field" : undefined}
+      className={cn(
+        "rounded-md border p-3",
+        highlighted
+          ? "border-primary/30 bg-primary/10"
+          : "border-border/50 bg-background/40",
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-xs font-semibold text-foreground">
+          {change.field}
+        </span>
+        <span className="rounded border border-border/60 px-1.5 py-0.5 text-[10px] text-text-3">
+          {change.kind}
+        </span>
+        {change.redacted ? (
+          <span className="rounded border border-warning/30 px-1.5 py-0.5 text-[10px] text-warning">
+            redacted digest
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-2 text-xs text-text-2">
+        {describeChange(change)}
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  mono = false,
+  wrap = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  wrap?: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-[96px_1fr] gap-2">
+      <span className="text-muted-foreground">{label}</span>
+      <span className={cn("text-text-2", mono && "font-mono", wrap && "break-all")}>
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function describeChange(change: FieldChange) {
+  if (change.added) {
+    return `Added ${formatFieldValue(change.after)}`;
+  }
+  if (change.removed) {
+    return `Removed ${formatFieldValue(change.before)}`;
+  }
+  if (change.kind === "structural") {
+    return "Structural value changed";
+  }
+  return `Before ${formatFieldValue(change.before)}; after ${formatFieldValue(change.after)}`;
+}
+
+function formatFieldValue(value?: string) {
+  return value && value.trim() ? value : "empty";
+}
+
+function verdictBadgeVariant(
+  verdict: WhyVerdict,
+): "default" | "secondary" | "outline" | "cached" {
+  switch (verdict) {
+    case "CACHE_HIT":
+      return "cached";
+    case "CACHE_MISS":
+      return "outline";
+    case "CACHE_DISABLED":
+      return "secondary";
+    case "UNKNOWN":
+      return "default";
+  }
+}
+
+function formatVerdict(verdict: WhyVerdict) {
+  return verdict.replaceAll("_", " ");
+}
+
+function formatDateTime(value: string) {
+  return new Date(value).toLocaleString();
+}

--- a/ui/src/features/jobs/TaskWhyView.tsx
+++ b/ui/src/features/jobs/TaskWhyView.tsx
@@ -108,6 +108,8 @@ function WhyError({ error }: { error: Error }) {
 }
 
 function WhyContent({ explanation }: { explanation: WhyExplanation }) {
+  const discriminatingChange = getDiscriminatingChange(explanation);
+
   return (
     <div className="space-y-3">
       <div className="flex flex-wrap items-center gap-2">
@@ -131,8 +133,14 @@ function WhyContent({ explanation }: { explanation: WhyExplanation }) {
         </p>
       </div>
 
-      <DiscriminatingField explanation={explanation} />
-      <DiffDetails diff={explanation.diff} />
+      <DiscriminatingField
+        explanation={explanation}
+        discriminatingChange={discriminatingChange}
+      />
+      <DiffDetails
+        diff={explanation.diff}
+        skipFirstChange={Boolean(discriminatingChange)}
+      />
       <BaselineDetails
         baseline={explanation.baseline}
         jobId={explanation.jobId}
@@ -144,13 +152,25 @@ function WhyContent({ explanation }: { explanation: WhyExplanation }) {
   );
 }
 
-function DiscriminatingField({ explanation }: { explanation: WhyExplanation }) {
-  const change = explanation.diff?.changes?.[0];
-  if (change) {
+function getDiscriminatingChange(explanation: WhyExplanation) {
+  if (explanation.verdict !== "CACHE_MISS") {
+    return undefined;
+  }
+  return explanation.diff?.changes?.[0];
+}
+
+function DiscriminatingField({
+  explanation,
+  discriminatingChange,
+}: {
+  explanation: WhyExplanation;
+  discriminatingChange?: FieldChange;
+}) {
+  if (discriminatingChange) {
     return (
       <div>
         <SectionLabel>Discriminating hash input</SectionLabel>
-        <FieldChangeRow change={change} highlighted />
+        <FieldChangeRow change={discriminatingChange} highlighted />
       </div>
     );
   }
@@ -192,12 +212,21 @@ function DiscriminatingField({ explanation }: { explanation: WhyExplanation }) {
   return null;
 }
 
-function DiffDetails({ diff }: { diff?: BlobDiff }) {
+function DiffDetails({
+  diff,
+  skipFirstChange = false,
+}: {
+  diff?: BlobDiff;
+  skipFirstChange?: boolean;
+}) {
   if (!diff) {
     return null;
   }
 
   const changes = diff.changes ?? [];
+  const visibleChanges = changes
+    .map((change, index) => ({ change, index }))
+    .slice(skipFirstChange ? 1 : 0);
   return (
     <div className="space-y-2">
       {diff.degraded ? (
@@ -210,13 +239,15 @@ function DiffDetails({ diff }: { diff?: BlobDiff }) {
         </div>
       ) : null}
 
-      {changes.length > 1 ? (
+      {visibleChanges.length > 0 ? (
         <div>
-          <SectionLabel>Additional changed fields</SectionLabel>
+          <SectionLabel>
+            {skipFirstChange ? "Additional changed fields" : "Changed fields"}
+          </SectionLabel>
           <div className="space-y-2">
-            {changes.slice(1).map((change) => (
+            {visibleChanges.map(({ change, index }) => (
               <FieldChangeRow
-                key={`${change.field}:${change.before}:${change.after}`}
+                key={`${change.field}:${index}`}
                 change={change}
               />
             ))}
@@ -232,7 +263,7 @@ function BaselineDetails({
   jobId,
   isCacheHit,
 }: {
-  baseline: WhyBaseline;
+  baseline?: WhyBaseline | null;
   jobId: string;
   isCacheHit: boolean;
 }) {
@@ -240,10 +271,10 @@ function BaselineDetails({
     <div className="rounded-md border border-border/50 bg-background/40 p-3">
       <SectionLabel>Baseline</SectionLabel>
       <div className="grid gap-2 text-xs">
-        <DetailRow label="Kind" value={baseline.kind || "none"} mono />
+        <DetailRow label="Kind" value={baseline?.kind || "none"} mono />
         <div className="grid grid-cols-[96px_1fr] gap-2">
           <span className="text-muted-foreground">Run</span>
-          {baseline.runId ? (
+          {baseline?.runId ? (
             <Link
               to="/jobs/$jobId/runs/$runId"
               params={{ jobId, runId: baseline.runId }}
@@ -265,29 +296,29 @@ function BaselineDetails({
         </div>
         <DetailRow
           label="Task run"
-          value={baseline.taskRunId ? shortId(baseline.taskRunId) : "none"}
+          value={baseline?.taskRunId ? shortId(baseline.taskRunId) : "none"}
           mono
         />
         <DetailRow
           label="Started"
-          value={baseline.startedAt ? formatDateTime(baseline.startedAt) : "unknown"}
+          value={baseline?.startedAt ? formatDateTime(baseline.startedAt) : "unknown"}
         />
       </div>
     </div>
   );
 }
 
-function TriggerDetails({ trigger }: { trigger: WhyTrigger }) {
-  const params = Object.entries(trigger.params ?? {});
+function TriggerDetails({ trigger }: { trigger?: WhyTrigger | null }) {
+  const params = Object.entries(trigger?.params ?? {});
   return (
     <div className="rounded-md border border-border/50 bg-background/40 p-3">
       <SectionLabel>Trigger causation</SectionLabel>
       <div className="grid gap-2 text-xs">
-        <DetailRow label="Type" value={trigger.type || "unknown"} mono />
-        <DetailRow label="Alias" value={trigger.alias || "none"} mono />
+        <DetailRow label="Type" value={trigger?.type || "unknown"} mono />
+        <DetailRow label="Alias" value={trigger?.alias || "none"} mono />
         <DetailRow
           label="Fired"
-          value={trigger.firedAt ? formatDateTime(trigger.firedAt) : "unknown"}
+          value={trigger?.firedAt ? formatDateTime(trigger.firedAt) : "unknown"}
         />
         <div className="grid grid-cols-[96px_1fr] gap-2">
           <span className="text-muted-foreground">Params</span>
@@ -416,7 +447,13 @@ function verdictBadgeVariant(
       return "secondary";
     case "UNKNOWN":
       return "default";
+    default:
+      return assertNever(verdict);
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled why verdict: ${value}`);
 }
 
 function formatVerdict(verdict: WhyVerdict) {

--- a/ui/src/features/jobs/__tests__/JobDAG.test.tsx
+++ b/ui/src/features/jobs/__tests__/JobDAG.test.tsx
@@ -149,6 +149,38 @@ describe("JobDAG", () => {
     expect(onNodeClick).toHaveBeenCalledWith("task-1");
   });
 
+  it("labels nodes with the resolved task name", () => {
+    const dag: JobDAGResponse = {
+      job_id: "job-1",
+      nodes: [{ id: "task-1", atom_id: "atom-1" }],
+      edges: [],
+    };
+
+    render(
+      <JobDAG
+        dag={dag}
+        atoms={atoms}
+        taskDefinitions={{
+          "task-1": {
+            id: "task-1",
+            job_id: "job-1",
+            atom_id: "atom-1",
+            name: "extract",
+            node_selector: {},
+            retries: 0,
+            retry_delay: 0,
+            retry_backoff: false,
+            trigger_rule: "all_success",
+            created_at: "",
+            updated_at: "",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("node-task-1")).toHaveTextContent("extract");
+  });
+
   it("marks output-bearing contract edges and skipped branch paths", () => {
     const dag: JobDAGResponse = {
       job_id: "job-1",

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -74,6 +74,42 @@ describe('api', () => {
     expect(mockFetch).toHaveBeenCalledWith('/v1/jobs/job-42/cache', expect.anything());
   });
 
+  it('getJobTasks normalizes task IDs from Go model casing', async () => {
+    mockFetch.mockResolvedValue(okResponse([
+      {
+        ID: 'task-1',
+        JobID: 'job-1',
+        AtomID: 'atom-1',
+        name: 'extract',
+        node_selector: { disk: 'ssd' },
+        retries: 2,
+        retry_delay: 1000,
+        retry_backoff: true,
+        trigger_rule: 'all_success',
+        cache_config: null,
+        CreatedAt: '2026-06-26T00:00:00Z',
+        UpdatedAt: '2026-06-26T00:00:01Z',
+      },
+    ]));
+
+    await expect(api.getJobTasks('job-1')).resolves.toEqual([
+      {
+        id: 'task-1',
+        job_id: 'job-1',
+        atom_id: 'atom-1',
+        name: 'extract',
+        node_selector: { disk: 'ssd' },
+        retries: 2,
+        retry_delay: 1000,
+        retry_backoff: true,
+        trigger_rule: 'all_success',
+        cache_config: null,
+        created_at: '2026-06-26T00:00:00Z',
+        updated_at: '2026-06-26T00:00:01Z',
+      },
+    ]);
+  });
+
   it('applyJobDef preserves volume and workload identity fields in the request payload', async () => {
     mockFetch.mockResolvedValue(okResponse({ applied: 1 }));
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -131,6 +131,24 @@ export interface JobTask {
   updated_at: string;
 }
 
+type RawJobTask = Partial<JobTask> & {
+  ID?: string;
+  JobID?: string;
+  AtomID?: string;
+  Name?: string;
+  NextID?: string;
+  NodeSelector?: Record<string, unknown>;
+  Retries?: number;
+  RetryDelay?: number;
+  RetryBackoff?: boolean;
+  TriggerRule?: string;
+  CacheConfig?: CacheConfigValue;
+  OutputSchema?: Record<string, unknown>;
+  InputSchema?: Record<string, Record<string, unknown>>;
+  CreatedAt?: string;
+  UpdatedAt?: string;
+};
+
 export type CacheConfigValue =
   | boolean
   | {
@@ -737,6 +755,52 @@ export interface JobRunsQuery {
   offset?: number;
 }
 
+function pickDefined<T>(...values: Array<T | undefined>): T | undefined {
+  return values.find((value) => value !== undefined);
+}
+
+function normalizeJobTask(raw: RawJobTask): JobTask {
+  const task: JobTask = {
+    id: pickDefined(raw.id, raw.ID) ?? "",
+    job_id: pickDefined(raw.job_id, raw.JobID) ?? "",
+    atom_id: pickDefined(raw.atom_id, raw.AtomID) ?? "",
+    name: pickDefined(raw.name, raw.Name) ?? "",
+    node_selector: pickDefined(raw.node_selector, raw.NodeSelector) ?? {},
+    retries: pickDefined(raw.retries, raw.Retries) ?? 0,
+    retry_delay: pickDefined(raw.retry_delay, raw.RetryDelay) ?? 0,
+    retry_backoff: pickDefined(raw.retry_backoff, raw.RetryBackoff) ?? false,
+    trigger_rule: pickDefined(raw.trigger_rule, raw.TriggerRule) ?? "all_success",
+    created_at: pickDefined(raw.created_at, raw.CreatedAt) ?? "",
+    updated_at: pickDefined(raw.updated_at, raw.UpdatedAt) ?? "",
+  };
+
+  const nextId = pickDefined(raw.next_id, raw.NextID);
+  if (nextId !== undefined) {
+    task.next_id = nextId;
+  }
+
+  const cacheConfig = pickDefined(raw.cache_config, raw.CacheConfig);
+  if (cacheConfig !== undefined) {
+    task.cache_config = cacheConfig;
+  }
+
+  const outputSchema = pickDefined(raw.output_schema, raw.OutputSchema);
+  if (outputSchema !== undefined) {
+    task.output_schema = outputSchema;
+  }
+
+  const inputSchema = pickDefined(raw.input_schema, raw.InputSchema);
+  if (inputSchema !== undefined) {
+    task.input_schema = inputSchema;
+  }
+
+  return task;
+}
+
+function normalizeJobTasks(raw: RawJobTask[]): JobTask[] {
+  return raw.map(normalizeJobTask);
+}
+
 export const api = {
   getJobs: () => request<Job[]>("/jobs"),
   getJob: (id: string) => request<Job>(`/jobs/${id}`),
@@ -779,7 +843,7 @@ export const api = {
       },
     ),
   getJobDAG: (jobId: string) => request<JobDAGResponse>(`/jobs/${jobId}/dag`),
-  getJobTasks: (jobId: string) => request<JobTask[]>(`/jobs/${jobId}/tasks`),
+  getJobTasks: async (jobId: string) => normalizeJobTasks(await request<RawJobTask[]>(`/jobs/${jobId}/tasks`)),
   getJobCache: (jobId: string) => request<JobCacheResponse>(`/jobs/${jobId}/cache`),
   deleteJobCache: (jobId: string) => request<void>(`/jobs/${jobId}/cache`, { method: "DELETE" }),
   deleteTaskCache: (jobId: string, taskName: string) =>


### PR DESCRIPTION
## C1+C2 — per-task 'why' explainer + e2e (Wave 2)

A `TaskWhyView` in the `TaskDetailPanel` Details tab rendering the H-1 `getTaskWhy` `WhyExplanation` — the verdict, the discriminating `HashInput` field, trigger/baseline, and a cache-hit source link. Honest about `BlobDiff.degraded` (field-diff-unavailable, NOT the receipt's unpinned state). Playwright `why.spec.ts`. **Frontend-only; drives the existing endpoint.**

**Opus review: CLEAN** (0 blockers, 0 should-fix). `ui-lint` + `ui-test` green; `ui-e2e` runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvA6zFvnhXRHHHVccZy1em