### PR TITLE
Add the receipt + verify panel (data-plane-memory-ui W3-β)

### DIFF
--- a/docs/exec-plans/active/data-plane-memory-ui.md
+++ b/docs/exec-plans/active/data-plane-memory-ui.md
@@ -268,13 +268,18 @@ freshly re-derived state (`cmd/verify/verify.go`; `api/rest/controller/receipt/`
 tautology (current-vs-current → always passes) and would NOT detect drift. So the UI
 must let the user **provide the committed receipt** to verify against.
 
-- [ ] E1. Receipt display: a run-level panel on `RunDetailPage` driving `getReceipt` —
+- [x] E1. Receipt display: a run-level panel on `RunDetailPage` driving `getReceipt` —
       render the current content-addressed receipt (atoms/digests/inputs), with the
       **unverifiable markers the backend emits** (an unpinned mutable-tag task shown
       unverifiable, never silently presented as reproducible). Display only; no verify yet.
       Files: new `ui/src/features/jobs/ReceiptPanel.tsx`,
       `ui/src/features/jobs/RunDetailPage.tsx`. Depends on: H-1.
-- [ ] E2. Verify action: in the receipt panel, accept a **committed receipt** as input
+      Note (W3-beta): `ReceiptPanel` renders the exact receipt fields from `getReceipt`
+      (`receipt_version`, run/job identity, `git_commit`, `manifest_content_hash`,
+      `receipt_digest`, per-task `identity_hash`/image digest/pinning/degraded reason)
+      and mounts once on `RunDetailPage`; unpinned/degraded tasks are surfaced as
+      `degraded-unverifiable`, not as reproducible.
+- [x] E2. Verify action: in the receipt panel, accept a **committed receipt** as input
       (paste JSON / upload a receipt file — mirroring how `caesium verify` reads a committed
       receipt from disk), `postVerify` it, and render the **actual `VerifyResult.drifts`
       kinds the backend returns** (`internal/receipt/verify.go`) — reproducible /
@@ -285,11 +290,21 @@ must let the user **provide the committed receipt** to verify against.
       a UI re-apply (it needs the run's task rows to differ) — do NOT promise it; per-field
       image/command attribution is a **backend follow-up**, out of scope here.
       Files: `ui/src/features/jobs/ReceiptPanel.tsx`. Depends on: E1.
-- [ ] E3. Playwright e2e: run a job, assert the receipt renders (incl. an unpinned-tag job
+      Note (W3-beta): Verify accepts pasted JSON or uploaded `.receipt`/JSON, validates that
+      the committed receipt targets the current run, posts it through `postVerify`, and renders
+      `match`, degraded tasks, expected/actual digest, plus backend drift `kind`/detail without
+      promising field-level image/command drift from a UI re-apply.
+- [x] E3. Playwright e2e: run a job, assert the receipt renders (incl. an unpinned-tag job
       → unverifiable markers); capture the committed receipt from `getReceipt`; verify it
       against UNCHANGED state → reproducible; then re-apply a changed definition and verify
       again → assert the **reachable** drift kind (`manifest_changed` / `git_commit_changed`),
       NOT a field-level image/command field. Files: `ui/e2e/receipt-verify.spec.ts`. Depends on: E2.
+      Note (W3-beta): `receipt-verify.spec.ts` mirrors the operator-flow pattern with
+      `test.slow()`, captures the committed receipt via REST, pastes it into the panel,
+      asserts unchanged verification as `reproducible`, then re-applies a changed definition
+      and asserts displayed `manifest_changed`/`git_commit_changed` drift while rejecting
+      image/identity drift; a separate unpinned-tag run asserts the displayed unverifiable
+      marker and degraded reason.
 
 ### Stream F — Lineage / impact graph
 

--- a/ui/e2e/receipt-verify.spec.ts
+++ b/ui/e2e/receipt-verify.spec.ts
@@ -1,0 +1,200 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+import { applyDefinitions, type FixtureDefinition } from "./helpers/fixtures";
+
+type E2EJob = {
+  id: string;
+  alias: string;
+};
+
+type E2ERun = {
+  id: string;
+  status: string;
+};
+
+type E2EReceipt = {
+  receipt_version: number;
+  run_id: string;
+  job_id: string;
+  job_alias?: string;
+  git_commit?: string;
+  manifest_content_hash?: string;
+  tasks: Array<{
+    task_name: string;
+    identity_hash: string;
+    image: string;
+    resolved_image_digest?: string;
+    digest_pinned: boolean;
+    degraded: boolean;
+    degraded_reason?: string;
+  }>;
+  degraded: boolean;
+  degraded_tasks?: string[];
+  receipt_digest: string;
+};
+
+type ReceiptFixture = FixtureDefinition & {
+  apiVersion: string;
+  kind: string;
+  metadata: Record<string, unknown> & {
+    alias: string;
+    cache: Record<string, unknown>;
+  };
+  trigger: {
+    type: string;
+    configuration: Record<string, unknown> & {
+      cron: string;
+      timezone: string;
+    };
+  };
+  steps: Array<Record<string, unknown> & {
+    name: string;
+    engine: string;
+    image: string;
+    command: string[];
+    next?: string[];
+    dependsOn?: string[];
+  }>;
+};
+
+const shellImage = "debian:12-slim";
+
+test("operator can inspect receipts and verify a committed receipt against drift", async ({ page, request }) => {
+  test.slow();
+
+  const pinnedAlias = `receipt-verify-e2e-${Date.now().toString(36)}`;
+  await applyDefinitions(request, buildReceiptDefinition(pinnedAlias, "v1", true));
+  const pinnedJob = await findJobByAlias(request, pinnedAlias);
+  const pinnedRun = await triggerRun(request, pinnedJob.id);
+  await waitForSucceededRun(request, pinnedJob.id, pinnedRun.id);
+
+  const committedReceipt = await getReceipt(request, pinnedJob.id, pinnedRun.id);
+  // Reliable in CI: digest pinning resolves via the LOCAL docker daemon by
+  // inspecting the image the run already pulled (internal/imagecheck/resolve.go),
+  // not a remote registry round-trip — so the pinned job is non-degraded.
+  expect(committedReceipt.degraded).toBe(false);
+
+  await page.goto(`/jobs/${pinnedJob.id}/runs/${pinnedRun.id}`);
+  await expect(page.getByTestId("receipt-panel")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("receipt-digest")).toContainText(committedReceipt.receipt_digest);
+  await expect(page.getByTestId("receipt-task-row").filter({ hasText: "prepare" })).toContainText("digest_pinned=true");
+  await expect(page.getByTestId("receipt-task-row").filter({ hasText: "render" })).toContainText("identity_hash");
+
+  await page.getByTestId("receipt-verify-input").fill(JSON.stringify(committedReceipt, null, 2));
+  await page.getByTestId("receipt-verify-submit").click();
+  await expect(page.getByTestId("receipt-verify-verdict")).toContainText("reproducible", {
+    timeout: 30_000,
+  });
+  await expect(page.getByTestId("receipt-verify-no-drifts")).toContainText("No drift returned by the backend.");
+
+  await applyDefinitions(request, buildReceiptDefinition(pinnedAlias, "v2", true));
+
+  await page.getByTestId("receipt-verify-submit").click();
+  await expect(page.getByTestId("receipt-verify-verdict")).toContainText(/manifest_changed|git_commit_changed/, {
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByTestId("receipt-verify-drift-kind").filter({ hasText: /manifest_changed|git_commit_changed/ }),
+  ).toBeVisible();
+  await expect(page.getByTestId("receipt-verify-drift-kind").filter({ hasText: "image_digest_mismatch" })).toHaveCount(0);
+  await expect(page.getByTestId("receipt-verify-drift-kind").filter({ hasText: "identity_hash_mismatch" })).toHaveCount(0);
+
+  const unpinnedAlias = `receipt-unpinned-e2e-${Date.now().toString(36)}`;
+  await applyDefinitions(request, buildReceiptDefinition(unpinnedAlias, "v1", false));
+  const unpinnedJob = await findJobByAlias(request, unpinnedAlias);
+  const unpinnedRun = await triggerRun(request, unpinnedJob.id);
+  await waitForSucceededRun(request, unpinnedJob.id, unpinnedRun.id);
+
+  await page.goto(`/jobs/${unpinnedJob.id}/runs/${unpinnedRun.id}`);
+  await expect(page.getByTestId("receipt-panel")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("receipt-degraded-status")).toContainText("degraded-unverifiable");
+  await expect(page.getByTestId("receipt-task-unverifiable-marker").first()).toContainText("unverifiable");
+  await expect(page.getByTestId("receipt-task-degraded-reason").first()).toContainText("image not digest-pinned");
+  await expect(page.getByTestId("receipt-unverifiable-summary")).toContainText("Unverifiable tasks");
+});
+
+function buildReceiptDefinition(alias: string, variant: string, pinDigests: boolean): ReceiptFixture {
+  return {
+    apiVersion: "v1",
+    kind: "Job",
+    metadata: {
+      alias,
+      cache: {
+        pinDigests,
+        digestTTL: 0,
+      },
+    },
+    trigger: {
+      type: "cron",
+      configuration: {
+        cron: "0 2 * * *",
+        timezone: "UTC",
+      },
+    },
+    steps: [
+      {
+        name: "prepare",
+        engine: "docker",
+        image: shellImage,
+        command: ["sh", "-c", "echo '##caesium::output {\"rows\": \"42\"}'"],
+        next: ["render"],
+      },
+      {
+        name: "render",
+        engine: "docker",
+        image: shellImage,
+        command: ["sh", "-c", `echo receipt-${variant}`],
+        dependsOn: ["prepare"],
+      },
+    ],
+  };
+}
+
+async function findJobByAlias(request: APIRequestContext, alias: string): Promise<E2EJob> {
+  const response = await request.get("/v1/jobs");
+  if (!response.ok()) {
+    throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+  }
+
+  const jobs = (await response.json()) as E2EJob[];
+  const job = jobs.find((candidate) => candidate.alias === alias);
+  if (!job) {
+    throw new Error(`job not found after apply: ${alias}`);
+  }
+  return job;
+}
+
+async function triggerRun(request: APIRequestContext, jobId: string): Promise<E2ERun> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`);
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run: ${response.status()} ${await response.text()}`);
+  }
+
+  return (await response.json()) as E2ERun;
+}
+
+async function waitForSucceededRun(request: APIRequestContext, jobId: string, runId: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+        if (!response.ok()) {
+          return `HTTP ${response.status()}`;
+        }
+        const run = (await response.json()) as E2ERun;
+        return run.status;
+      },
+      {
+        timeout: 120_000,
+        intervals: [1_000, 2_000, 5_000],
+      },
+    )
+    .toBe("succeeded");
+}
+
+async function getReceipt(request: APIRequestContext, jobId: string, runId: string): Promise<E2EReceipt> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}/receipt`);
+  if (!response.ok()) {
+    throw new Error(`failed to get receipt: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2EReceipt;
+}

--- a/ui/src/features/jobs/ReceiptPanel.tsx
+++ b/ui/src/features/jobs/ReceiptPanel.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { api, type Receipt, type ReceiptDrift, type ReceiptDriftKind, type VerifyResult } from "@/lib/api";
+import { api, type Receipt, type ReceiptDrift, type ReceiptDriftKind, type ReceiptTaskEntry, type VerifyResult } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface ReceiptPanelProps {
@@ -63,6 +63,13 @@ export function ReceiptPanel({ jobId, runId }: ReceiptPanelProps) {
     }
   };
 
+  const handleCommittedReceiptChange = (value: string) => {
+    setCommittedReceiptText(value);
+    if (inputError) {
+      setInputError(null);
+    }
+  };
+
   return (
     <Card data-testid="receipt-panel">
       <CardHeader className="pb-3">
@@ -109,7 +116,7 @@ export function ReceiptPanel({ jobId, runId }: ReceiptPanelProps) {
           inputError={inputError}
           isPending={verifyMutation.isPending}
           result={verifyMutation.data}
-          onChange={setCommittedReceiptText}
+          onChange={handleCommittedReceiptChange}
           onUpload={handleUpload}
           onVerify={handleVerify}
         />
@@ -129,7 +136,7 @@ function ReceiptSkeleton() {
 }
 
 function ReceiptStatus({ receipt }: { receipt: Receipt }) {
-  return receipt.degraded ? (
+  return receipt.degraded === true ? (
     <Badge data-testid="receipt-degraded-status" variant="destructive" className="h-fit gap-1.5">
       <ShieldAlert className="h-3.5 w-3.5" />
       degraded-unverifiable
@@ -143,6 +150,8 @@ function ReceiptStatus({ receipt }: { receipt: Receipt }) {
 }
 
 function ReceiptContent({ receipt }: { receipt: Receipt }) {
+  const tasks = receipt.tasks ?? [];
+
   return (
     <div data-testid="receipt-summary" className="space-y-4">
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
@@ -157,8 +166,8 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
           value={receipt.manifest_content_hash || "None"}
           mono
         />
-        <MetadataCell testId="receipt-task-count" label="tasks" value={String(receipt.tasks.length)} mono />
-        <MetadataCell testId="receipt-degraded" label="degraded" value={String(receipt.degraded)} mono />
+        <MetadataCell testId="receipt-task-count" label="tasks" value={String(tasks.length)} mono />
+        <MetadataCell testId="receipt-degraded" label="degraded" value={String(receipt.degraded ?? false)} mono />
       </div>
 
       <div className="rounded-md border border-border/60 bg-background/40 p-3">
@@ -177,14 +186,14 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
       <div className="space-y-2">
         <SectionLabel>tasks</SectionLabel>
         <div className="space-y-2">
-          {receipt.tasks.map((task) => (
+          {tasks.map((task) => (
             <div
               key={`${task.task_name}:${task.identity_hash}`}
               data-testid="receipt-task-row"
               data-task-name={task.task_name}
               className={cn(
                 "rounded-md border bg-background/40 p-3",
-                task.degraded ? "border-warning/35" : "border-border/50",
+                task.degraded === true ? "border-warning/35" : "border-border/50",
               )}
             >
               <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
@@ -203,7 +212,7 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
                   <Badge variant={task.digest_pinned ? "success" : "destructive"} className="text-[10px]">
                     digest_pinned={String(task.digest_pinned)}
                   </Badge>
-                  {task.degraded ? (
+                  {task.degraded === true ? (
                     <Badge data-testid="receipt-task-unverifiable-marker" variant="destructive" className="text-[10px]">
                       unverifiable
                     </Badge>
@@ -221,7 +230,7 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
                 <MetadataCell
                   testId="receipt-task-resolved-image-digest"
                   label="resolved_image_digest"
-                  value={task.resolved_image_digest || "None"}
+                  value={task.resolved_image_digest ?? "None"}
                   mono
                 />
                 <MetadataCell
@@ -233,7 +242,7 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
                 <MetadataCell
                   testId="receipt-task-degraded"
                   label="degraded"
-                  value={String(task.degraded)}
+                  value={String(task.degraded ?? false)}
                   mono
                 />
               </div>
@@ -270,9 +279,12 @@ function UnverifiableSummary({ tasks }: { tasks: string[] }) {
           <div className="font-semibold">This receipt is degraded-unverifiable.</div>
           <div className="mt-1 text-warning/85">
             Unverifiable tasks:{" "}
-            {tasks.map((task) => (
-              <span key={task} data-testid="receipt-degraded-task" className="font-mono">
-                {task}
+            {tasks.map((task, index) => (
+              <span key={`${task}:${index}`}>
+                {index > 0 ? ", " : null}
+                <span data-testid="receipt-degraded-task" className="font-mono">
+                  {task}
+                </span>
               </span>
             ))}
           </div>
@@ -363,6 +375,7 @@ function VerifyForm({
 
 function VerifyResultView({ result }: { result: VerifyResult }) {
   const verdict = verifyVerdict(result);
+  const degradedTasks = result.degraded_tasks ?? [];
   const drifts = result.drifts ?? [];
 
   return (
@@ -401,15 +414,18 @@ function VerifyResultView({ result }: { result: VerifyResult }) {
           mono
         />
         <MetadataCell testId="receipt-verify-match" label="match" value={String(result.match)} mono />
-        <MetadataCell testId="receipt-verify-degraded" label="degraded" value={String(result.degraded)} mono />
+        <MetadataCell testId="receipt-verify-degraded" label="degraded" value={String(result.degraded ?? false)} mono />
       </div>
 
-      {result.degraded_tasks && result.degraded_tasks.length > 0 ? (
+      {degradedTasks.length > 0 ? (
         <div className="rounded-md border border-warning/25 bg-warning/10 p-2 text-xs text-warning">
           <span className="font-semibold">degraded_tasks </span>
-          {result.degraded_tasks.map((task) => (
-            <span key={task} data-testid="receipt-verify-degraded-task" className="font-mono">
-              {task}
+          {degradedTasks.map((task, index) => (
+            <span key={`${task}:${index}`}>
+              {index > 0 ? ", " : null}
+              <span data-testid="receipt-verify-degraded-task" className="font-mono">
+                {task}
+              </span>
             </span>
           ))}
         </div>
@@ -515,45 +531,103 @@ function parseCommittedReceipt(raw: string, currentJobId: string, currentRunId: 
     return { error: `Committed receipt JSON could not be parsed: ${detail}` };
   }
 
-  if (!isReceipt(parsed)) {
+  const receipt = normalizeReceipt(parsed);
+  if (!receipt) {
     return { error: "Committed receipt JSON does not match the Receipt shape." };
   }
 
-  if (parsed.job_id !== currentJobId || parsed.run_id !== currentRunId) {
+  if (receipt.job_id !== currentJobId || receipt.run_id !== currentRunId) {
     return { error: "Committed receipt job_id and run_id must match the current run." };
   }
 
-  return { receipt: parsed };
+  return { receipt };
 }
 
-function isReceipt(value: unknown): value is Receipt {
+function normalizeReceipt(value: unknown): Receipt | null {
   if (!isObject(value)) {
-    return false;
+    return null;
   }
-  return (
-    typeof value.receipt_version === "number" &&
-    typeof value.run_id === "string" &&
-    typeof value.job_id === "string" &&
-    Array.isArray(value.tasks) &&
-    value.tasks.every(isReceiptTaskEntry) &&
-    typeof value.degraded === "boolean" &&
-    typeof value.receipt_digest === "string"
-  );
+
+  const tasks = value.tasks ?? [];
+  if (!Array.isArray(tasks)) {
+    return null;
+  }
+
+  const normalizedTasks = tasks.map(normalizeReceiptTaskEntry);
+  if (normalizedTasks.some((task) => task === null)) {
+    return null;
+  }
+
+  const degradedTasks = value.degraded_tasks ?? undefined;
+  if (degradedTasks !== undefined && !isStringArray(degradedTasks)) {
+    return null;
+  }
+
+  if (
+    typeof value.receipt_version !== "number" ||
+    typeof value.run_id !== "string" ||
+    typeof value.job_id !== "string" ||
+    !isOptionalString(value.job_alias) ||
+    !isOptionalString(value.git_commit) ||
+    !isOptionalString(value.manifest_content_hash) ||
+    !isOptionalBoolean(value.degraded) ||
+    typeof value.receipt_digest !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    receipt_version: value.receipt_version,
+    run_id: value.run_id,
+    job_id: value.job_id,
+    job_alias: value.job_alias ?? undefined,
+    git_commit: value.git_commit ?? undefined,
+    manifest_content_hash: value.manifest_content_hash ?? undefined,
+    tasks: normalizedTasks as ReceiptTaskEntry[],
+    degraded: value.degraded ?? false,
+    degraded_tasks: degradedTasks,
+    receipt_digest: value.receipt_digest,
+  };
 }
 
-function isReceiptTaskEntry(value: unknown) {
+function normalizeReceiptTaskEntry(value: unknown): ReceiptTaskEntry | null {
   if (!isObject(value)) {
-    return false;
+    return null;
   }
-  return (
+
+  if (
     typeof value.task_name === "string" &&
     typeof value.identity_hash === "string" &&
     typeof value.image === "string" &&
+    isOptionalString(value.resolved_image_digest) &&
     typeof value.digest_pinned === "boolean" &&
-    typeof value.degraded === "boolean" &&
-    (value.resolved_image_digest === undefined || typeof value.resolved_image_digest === "string") &&
-    (value.degraded_reason === undefined || typeof value.degraded_reason === "string")
-  );
+    isOptionalBoolean(value.degraded) &&
+    isOptionalString(value.degraded_reason)
+  ) {
+    return {
+      task_name: value.task_name,
+      identity_hash: value.identity_hash,
+      image: value.image,
+      resolved_image_digest: value.resolved_image_digest ?? undefined,
+      digest_pinned: value.digest_pinned,
+      degraded: value.degraded ?? false,
+      degraded_reason: value.degraded_reason ?? undefined,
+    };
+  }
+
+  return null;
+}
+
+function isOptionalString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isOptionalBoolean(value: unknown): value is boolean | null | undefined {
+  return value === undefined || value === null || typeof value === "boolean";
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {

--- a/ui/src/features/jobs/ReceiptPanel.tsx
+++ b/ui/src/features/jobs/ReceiptPanel.tsx
@@ -1,0 +1,561 @@
+import { type ChangeEvent, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { AlertTriangle, FileJson, Loader2, ShieldAlert, ShieldCheck, Upload } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { api, type Receipt, type ReceiptDrift, type ReceiptDriftKind, type VerifyResult } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface ReceiptPanelProps {
+  jobId: string;
+  runId: string;
+}
+
+export function ReceiptPanel({ jobId, runId }: ReceiptPanelProps) {
+  const [committedReceiptText, setCommittedReceiptText] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+
+  const receiptQuery = useQuery({
+    queryKey: ["job", jobId, "runs", runId, "receipt"],
+    queryFn: () => api.getReceipt(jobId, runId),
+    enabled: Boolean(jobId && runId),
+    staleTime: 15_000,
+  });
+
+  const verifyMutation = useMutation({
+    mutationFn: (receipt: Receipt) => api.postVerify(receipt),
+    onSuccess: (result) => {
+      toast.success(result.match ? "Committed receipt is reproducible" : "Committed receipt drift detected");
+    },
+    onError: (err: Error) => toast.error(`Receipt verify failed: ${err.message}`),
+  });
+
+  const degradedTasks = receiptQuery.data?.degraded_tasks ?? [];
+
+  const handleVerify = () => {
+    const parsed = parseCommittedReceipt(committedReceiptText, jobId, runId);
+    if ("error" in parsed) {
+      setInputError(parsed.error);
+      return;
+    }
+
+    setInputError(null);
+    verifyMutation.mutate(parsed.receipt);
+  };
+
+  const handleUpload = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    try {
+      setInputError(null);
+      setCommittedReceiptText(await file.text());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Could not read receipt file";
+      setInputError(message);
+    } finally {
+      event.target.value = "";
+    }
+  };
+
+  return (
+    <Card data-testid="receipt-panel">
+      <CardHeader className="pb-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <FileJson className="h-4 w-4 text-primary" />
+              Reproducibility Receipt
+            </CardTitle>
+            <p className="mt-1 max-w-3xl text-xs text-text-3">
+              Verify checks a committed receipt you provide against the server's freshly re-derived state for this run. It is not a self-check of the receipt displayed here.
+            </p>
+          </div>
+          {receiptQuery.data ? <ReceiptStatus receipt={receiptQuery.data} /> : null}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {receiptQuery.isLoading ? (
+          <ReceiptSkeleton />
+        ) : receiptQuery.error ? (
+          <div
+            data-testid="receipt-error"
+            className="rounded-md border border-warning/25 bg-warning/10 p-3 text-xs text-warning"
+          >
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <div>
+                <div className="font-semibold">Receipt unavailable</div>
+                <div className="mt-1 text-warning/80">{receiptQuery.error.message}</div>
+              </div>
+            </div>
+          </div>
+        ) : receiptQuery.data ? (
+          <>
+            <ReceiptContent receipt={receiptQuery.data} />
+            {receiptQuery.data.degraded ? <UnverifiableSummary tasks={degradedTasks} /> : null}
+          </>
+        ) : (
+          <div className="text-xs text-text-3">No receipt returned for this run.</div>
+        )}
+
+        <VerifyForm
+          committedReceiptText={committedReceiptText}
+          inputError={inputError}
+          isPending={verifyMutation.isPending}
+          result={verifyMutation.data}
+          onChange={setCommittedReceiptText}
+          onUpload={handleUpload}
+          onVerify={handleVerify}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReceiptSkeleton() {
+  return (
+    <div className="space-y-3" data-testid="receipt-loading">
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-28 w-full" />
+    </div>
+  );
+}
+
+function ReceiptStatus({ receipt }: { receipt: Receipt }) {
+  return receipt.degraded ? (
+    <Badge data-testid="receipt-degraded-status" variant="destructive" className="h-fit gap-1.5">
+      <ShieldAlert className="h-3.5 w-3.5" />
+      degraded-unverifiable
+    </Badge>
+  ) : (
+    <Badge data-testid="receipt-degraded-status" variant="success" className="h-fit gap-1.5">
+      <ShieldCheck className="h-3.5 w-3.5" />
+      reproducible
+    </Badge>
+  );
+}
+
+function ReceiptContent({ receipt }: { receipt: Receipt }) {
+  return (
+    <div data-testid="receipt-summary" className="space-y-4">
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <MetadataCell testId="receipt-version" label="receipt_version" value={`v${receipt.receipt_version}`} mono />
+        <MetadataCell testId="receipt-run-id" label="run_id" value={receipt.run_id} mono />
+        <MetadataCell testId="receipt-job-id" label="job_id" value={receipt.job_id} mono />
+        <MetadataCell testId="receipt-job-alias" label="job_alias" value={receipt.job_alias || "None"} mono />
+        <MetadataCell testId="receipt-git-commit" label="git_commit" value={receipt.git_commit || "None"} mono />
+        <MetadataCell
+          testId="receipt-manifest-content-hash"
+          label="manifest_content_hash"
+          value={receipt.manifest_content_hash || "None"}
+          mono
+        />
+        <MetadataCell testId="receipt-task-count" label="tasks" value={String(receipt.tasks.length)} mono />
+        <MetadataCell testId="receipt-degraded" label="degraded" value={String(receipt.degraded)} mono />
+      </div>
+
+      <div className="rounded-md border border-border/60 bg-background/40 p-3">
+        <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+          receipt_digest
+        </div>
+        <div
+          data-testid="receipt-digest"
+          className="mt-1 break-all font-mono text-xs text-text-1"
+          title={receipt.receipt_digest}
+        >
+          {receipt.receipt_digest}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <SectionLabel>tasks</SectionLabel>
+        <div className="space-y-2">
+          {receipt.tasks.map((task) => (
+            <div
+              key={`${task.task_name}:${task.identity_hash}`}
+              data-testid="receipt-task-row"
+              data-task-name={task.task_name}
+              className={cn(
+                "rounded-md border bg-background/40 p-3",
+                task.degraded ? "border-warning/35" : "border-border/50",
+              )}
+            >
+              <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
+                <div className="min-w-0">
+                  <div
+                    data-testid="receipt-task-name"
+                    className="break-words font-mono text-sm font-semibold text-text-1"
+                  >
+                    {task.task_name}
+                  </div>
+                  <div className="mt-1 break-all font-mono text-xs text-text-3" data-testid="receipt-task-image">
+                    {task.image}
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Badge variant={task.digest_pinned ? "success" : "destructive"} className="text-[10px]">
+                    digest_pinned={String(task.digest_pinned)}
+                  </Badge>
+                  {task.degraded ? (
+                    <Badge data-testid="receipt-task-unverifiable-marker" variant="destructive" className="text-[10px]">
+                      unverifiable
+                    </Badge>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="mt-3 grid gap-3 md:grid-cols-2">
+                <MetadataCell
+                  testId="receipt-task-identity-hash"
+                  label="identity_hash"
+                  value={task.identity_hash || "None"}
+                  mono
+                />
+                <MetadataCell
+                  testId="receipt-task-resolved-image-digest"
+                  label="resolved_image_digest"
+                  value={task.resolved_image_digest || "None"}
+                  mono
+                />
+                <MetadataCell
+                  testId="receipt-task-digest-pinned"
+                  label="digest_pinned"
+                  value={String(task.digest_pinned)}
+                  mono
+                />
+                <MetadataCell
+                  testId="receipt-task-degraded"
+                  label="degraded"
+                  value={String(task.degraded)}
+                  mono
+                />
+              </div>
+
+              {task.degraded_reason ? (
+                <div
+                  data-testid="receipt-task-degraded-reason"
+                  className="mt-3 rounded-md border border-warning/25 bg-warning/10 p-2 text-xs text-warning"
+                >
+                  {task.degraded_reason}
+                </div>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function UnverifiableSummary({ tasks }: { tasks: string[] }) {
+  if (tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      data-testid="receipt-unverifiable-summary"
+      className="rounded-md border border-warning/25 bg-warning/10 p-3 text-xs text-warning"
+    >
+      <div className="flex items-start gap-2">
+        <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <div>
+          <div className="font-semibold">This receipt is degraded-unverifiable.</div>
+          <div className="mt-1 text-warning/85">
+            Unverifiable tasks:{" "}
+            {tasks.map((task) => (
+              <span key={task} data-testid="receipt-degraded-task" className="font-mono">
+                {task}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface VerifyFormProps {
+  committedReceiptText: string;
+  inputError: string | null;
+  isPending: boolean;
+  result?: VerifyResult;
+  onChange: (value: string) => void;
+  onUpload: (event: ChangeEvent<HTMLInputElement>) => void;
+  onVerify: () => void;
+}
+
+function VerifyForm({
+  committedReceiptText,
+  inputError,
+  isPending,
+  result,
+  onChange,
+  onUpload,
+  onVerify,
+}: VerifyFormProps) {
+  return (
+    <div className="space-y-3 rounded-md border border-border/60 bg-muted/25 p-3" data-testid="receipt-verify-form">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <SectionLabel>verify committed receipt</SectionLabel>
+          <p className="mt-1 text-xs text-text-3">
+            Paste or upload the receipt JSON committed with this run.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            id="receipt-file-upload"
+            data-testid="receipt-verify-upload"
+            type="file"
+            accept=".receipt,.json,application/json"
+            className="sr-only"
+            onChange={onUpload}
+          />
+          <Button asChild variant="outline" size="sm">
+            <label htmlFor="receipt-file-upload" className="cursor-pointer">
+              <Upload className="h-3.5 w-3.5" />
+              Upload .receipt
+            </label>
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={onVerify}
+            disabled={isPending || committedReceiptText.trim().length === 0}
+            data-testid="receipt-verify-submit"
+          >
+            {isPending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
+            Verify
+          </Button>
+        </div>
+      </div>
+
+      <textarea
+        data-testid="receipt-verify-input"
+        value={committedReceiptText}
+        onChange={(event) => onChange(event.target.value)}
+        spellCheck={false}
+        className="min-h-[128px] w-full resize-y rounded-md border border-border/70 bg-background/60 p-3 font-mono text-xs text-text-1 outline-none focus:border-primary"
+        placeholder='{"receipt_version":1,"run_id":"...","job_id":"...","tasks":[],"degraded":false,"receipt_digest":"..."}'
+      />
+
+      {inputError ? (
+        <div
+          data-testid="receipt-verify-input-error"
+          className="rounded-md border border-danger/25 bg-danger/10 p-2 text-xs text-danger"
+        >
+          {inputError}
+        </div>
+      ) : null}
+
+      {result ? <VerifyResultView result={result} /> : null}
+    </div>
+  );
+}
+
+function VerifyResultView({ result }: { result: VerifyResult }) {
+  const verdict = verifyVerdict(result);
+  const drifts = result.drifts ?? [];
+
+  return (
+    <div
+      data-testid="receipt-verify-result"
+      className={cn(
+        "space-y-3 rounded-md border p-3",
+        verdict === "reproducible"
+          ? "border-success/30 bg-success/10"
+          : verdict === "degraded-unverifiable"
+            ? "border-warning/30 bg-warning/10"
+            : "border-danger/30 bg-danger/10",
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge
+          data-testid="receipt-verify-verdict"
+          variant={verdict === "reproducible" ? "success" : verdict === "degraded-unverifiable" ? "destructive" : "outline"}
+        >
+          {verdict}
+        </Badge>
+        <span className="font-mono text-[10px] text-text-3">run_id={result.run_id}</span>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <MetadataCell
+          testId="receipt-verify-expected-digest"
+          label="expected_digest"
+          value={result.expected_digest}
+          mono
+        />
+        <MetadataCell
+          testId="receipt-verify-actual-digest"
+          label="actual_digest"
+          value={result.actual_digest}
+          mono
+        />
+        <MetadataCell testId="receipt-verify-match" label="match" value={String(result.match)} mono />
+        <MetadataCell testId="receipt-verify-degraded" label="degraded" value={String(result.degraded)} mono />
+      </div>
+
+      {result.degraded_tasks && result.degraded_tasks.length > 0 ? (
+        <div className="rounded-md border border-warning/25 bg-warning/10 p-2 text-xs text-warning">
+          <span className="font-semibold">degraded_tasks </span>
+          {result.degraded_tasks.map((task) => (
+            <span key={task} data-testid="receipt-verify-degraded-task" className="font-mono">
+              {task}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {drifts.length > 0 ? (
+        <div className="space-y-2">
+          <SectionLabel>drifts</SectionLabel>
+          {drifts.map((drift, index) => (
+            <DriftRow key={`${drift.kind}:${drift.task ?? "run"}:${index}`} drift={drift} />
+          ))}
+        </div>
+      ) : (
+        <div data-testid="receipt-verify-no-drifts" className="text-xs text-text-3">
+          No drift returned by the backend.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DriftRow({ drift }: { drift: ReceiptDrift }) {
+  return (
+    <div data-testid="receipt-verify-drift-row" className="rounded-md border border-border/50 bg-background/40 p-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge data-testid="receipt-verify-drift-kind" variant="outline" className="font-mono text-[10px]">
+          {drift.kind}
+        </Badge>
+        {drift.task ? (
+          <span data-testid="receipt-verify-drift-task" className="font-mono text-[10px] text-text-3">
+            {drift.task}
+          </span>
+        ) : null}
+      </div>
+      <div data-testid="receipt-verify-drift-detail" className="mt-1 text-xs text-text-3">
+        {drift.detail}
+      </div>
+      {drift.expected || drift.actual ? (
+        <div className="mt-2 grid gap-2 md:grid-cols-2">
+          <MetadataCell label="expected" value={drift.expected || "None"} mono />
+          <MetadataCell label="actual" value={drift.actual || "None"} mono />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function MetadataCell({
+  label,
+  value,
+  mono,
+  testId,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  testId?: string;
+}) {
+  return (
+    <div className="min-w-0 rounded-md border border-border/50 bg-background/40 p-2">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div
+        data-testid={testId}
+        className={cn("mt-1 break-all text-xs text-text-1", mono ? "font-mono" : undefined)}
+        title={value}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: string }) {
+  return (
+    <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function verifyVerdict(result: VerifyResult): "reproducible" | "degraded-unverifiable" | ReceiptDriftKind | "drift" {
+  if (result.match) {
+    return "reproducible";
+  }
+  if (result.degraded) {
+    return "degraded-unverifiable";
+  }
+
+  const drifts = result.drifts ?? [];
+  return drifts.find((drift) => drift.kind !== "receipt_digest_mismatch")?.kind ?? drifts[0]?.kind ?? "drift";
+}
+
+type ParseResult = { receipt: Receipt } | { error: string };
+
+function parseCommittedReceipt(raw: string, currentJobId: string, currentRunId: string): ParseResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : "invalid JSON";
+    return { error: `Committed receipt JSON could not be parsed: ${detail}` };
+  }
+
+  if (!isReceipt(parsed)) {
+    return { error: "Committed receipt JSON does not match the Receipt shape." };
+  }
+
+  if (parsed.job_id !== currentJobId || parsed.run_id !== currentRunId) {
+    return { error: "Committed receipt job_id and run_id must match the current run." };
+  }
+
+  return { receipt: parsed };
+}
+
+function isReceipt(value: unknown): value is Receipt {
+  if (!isObject(value)) {
+    return false;
+  }
+  return (
+    typeof value.receipt_version === "number" &&
+    typeof value.run_id === "string" &&
+    typeof value.job_id === "string" &&
+    Array.isArray(value.tasks) &&
+    value.tasks.every(isReceiptTaskEntry) &&
+    typeof value.degraded === "boolean" &&
+    typeof value.receipt_digest === "string"
+  );
+}
+
+function isReceiptTaskEntry(value: unknown) {
+  if (!isObject(value)) {
+    return false;
+  }
+  return (
+    typeof value.task_name === "string" &&
+    typeof value.identity_hash === "string" &&
+    typeof value.image === "string" &&
+    typeof value.digest_pinned === "boolean" &&
+    typeof value.degraded === "boolean" &&
+    (value.resolved_image_digest === undefined || typeof value.resolved_image_digest === "string") &&
+    (value.degraded_reason === undefined || typeof value.degraded_reason === "string")
+  );
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ui/src/features/jobs/RunDetailPage.tsx
+++ b/ui/src/features/jobs/RunDetailPage.tsx
@@ -20,6 +20,7 @@ import { events, type CaesiumEvent } from "@/lib/events";
 import { shortId } from "@/lib/utils";
 import { getRunCacheStats } from "./cache-utils";
 import { JobDAG } from "./JobDAG";
+import { ReceiptPanel } from "./ReceiptPanel";
 import { RunCacheSummary } from "./RunCacheSummary";
 import { RunTimeline } from "./RunTimeline";
 import { TaskDetailPanel } from "./TaskDetailPanel";
@@ -349,6 +350,8 @@ export function RunDetailPage() {
       <div className="flex items-center gap-4">
         <RunCacheSummary run={run} />
       </div>
+
+      <ReceiptPanel jobId={jobId} runId={runId} />
 
       {/* Gantt timeline */}
       <div className="rounded-md border border-border/50 bg-card overflow-hidden">


### PR DESCRIPTION
## E1+E2+E3 — receipt display + verify + e2e (Wave 3)

A `ReceiptPanel` on `RunDetailPage` driving `getReceipt` (content-addressed receipt + unverifiable markers) and `postVerify` of a **user-supplied committed receipt** (paste/upload) — rendering the reachable drift verdict (reproducible / manifest_changed / git_commit_changed / degraded), NOT a self-check and NOT promising field-level image/command drift. e2e captures the committed receipt, verifies vs unchanged → reproducible, re-applies changed → asserts the reachable drift kind. **Frontend-only.**

**Opus review:** 0 blockers, 1 should-fix addressed (documented that digest pinning resolves via the local docker daemon, so the pinned scenario's `degraded=false` is reliable in CI — not a registry round-trip). `ui-lint`+`ui-test` green; `ui-e2e` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvA6zFvnhXRHHHVccZy1em