### PR TITLE
Add the lineage-impact graph (data-plane-memory-ui W4-β)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,7 @@ jobs:
       - name: Pre-pull job images
         run: |
           docker pull alpine:3.23
+          docker pull debian:12-slim
       - name: Start Caesium server
         run: |
           docker rm -f caesium-server >/dev/null 2>&1 || true
@@ -223,6 +224,8 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e DOCKER_HOST=unix:///var/run/docker.sock \
             -e CAESIUM_MANUAL_TRIGGER_API_KEY=e2e-test-key \
+            -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
+            -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
           tries=0
@@ -277,6 +280,8 @@ jobs:
             -e CAESIUM_AUTH_MODE=api-key \
             -e CAESIUM_AUTH_KEY_HASH_SECRET=ui-e2e-auth-key-hash-secret-000001 \
             -e CAESIUM_AUTH_REQUIRE_TLS=false \
+            -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
+            -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
           tries=0

--- a/docs/exec-plans/active/data-plane-memory-ui.md
+++ b/docs/exec-plans/active/data-plane-memory-ui.md
@@ -342,7 +342,7 @@ DOWNSTREAM only** (`api/rest/controller/lineage/impact.go`; `internal/lineage/im
 — there is no run-scoped or upstream graph API, and no lineage CLI. So Stream F is a
 **dataset-keyed downstream-impact** view, not a run-scoped bidirectional one.
 
-- [ ] F1. Build a dataset-impact view (route `/lineage?namespace=&name=`) driving
+- [x] F1. Build a dataset-impact view (route `/lineage?namespace=&name=`) driving
       `getLineageImpact`: a ReactFlow graph **reusing the dagre layout from `JobDAG.tsx`**
       rendering the root dataset + its DOWNSTREAM impact (the actual response shape; no
       upstream). **Codex round 2 constraints:** (a) `ImpactNode` carries `job_id`/`job_alias`
@@ -356,17 +356,24 @@ DOWNSTREAM only** (`api/rest/controller/lineage/impact.go`; `internal/lineage/im
       (lineage datasets populate as jobs declare/consume outputs)" when downstream is empty.
       Files: new `ui/src/features/jobs/LineageGraph.tsx`, `ui/src/router.tsx`.
       Depends on: H-1, H-2.
-- [ ] F2. Enable lineage on the ui-e2e backend so F's success path is actually exercised:
+- [x] F2. Enable lineage on the ui-e2e backend so F's success path is actually exercised:
       add `CAESIUM_OPEN_LINEAGE_ENABLED=true` (+ a console transport) to the `ui-e2e` server
       startup in the `justfile` and the CI `ui-e2e` job — today neither sets it, so an
       empty-state-only test would go green without ever rendering a real impact graph.
       Files: `justfile`, `.github/workflows/ci.yml`. Depends on: (none; can land with F1).
-- [ ] F3. Playwright e2e (lineage enabled per F2): run jobs that declare/consume a dataset,
+- [x] F3. Playwright e2e (lineage enabled per F2): run jobs that declare/consume a dataset,
       open the impact view for that dataset (namespace/name), assert the **downstream** graph
       renders nodes/edges with **job-level** click-through; assert the honest empty state for a
       dataset with no downstream. On the **auth-enabled lane (H-3)**: assert a *scoped* key
       gets the "requires an unscoped key" explanation, not a raw 403.
-      Files: `ui/e2e/lineage.spec.ts`. Depends on: F1, F2, H-3.
+      Files: `ui/e2e/lineage.spec.ts`, `ui/e2e/auth/lineage-scope.spec.ts`. Depends on: F1,
+      F2, H-3.
+      W4-β note: scoped keys cannot complete UI login because `GET /auth/whoami` is denied by
+      the scope middleware, so the scoped lineage denial is asserted API-level only in
+      `ui/e2e/auth/lineage-scope.spec.ts` with a 403 from `/v1/lineage/impact`.
+      Backend follow-up: lineage facet shape mismatch — `persistTaskDatasets` writes a flat
+      `caesium_dataset` facet, but `stepNameFromFacet` reads nested
+      `{"caesium_dataset":{"step_name":...}}`, so `producing_step` never resolves.
 
 ## Navigational / Organizational Improvements — Stream N
 

--- a/justfile
+++ b/justfile
@@ -264,6 +264,8 @@ ui-e2e: build-release
             -v {{ sock }}:/var/run/docker.sock \
             -e DOCKER_HOST=unix:///var/run/docker.sock \
             -e CAESIUM_MANUAL_TRIGGER_API_KEY=e2e-test-key \
+            -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
+            -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             --user 0:0 {{ local_image_ref }}:{{ tag }} start >/dev/null; \
         tries=0; \
         until curl -sf http://127.0.0.1:{{ port }}/health >/dev/null; do \
@@ -295,6 +297,8 @@ ui-e2e-auth: build-release
         -e CAESIUM_AUTH_MODE=api-key \
         -e CAESIUM_AUTH_KEY_HASH_SECRET=ui-e2e-auth-key-hash-secret-000001 \
         -e CAESIUM_AUTH_REQUIRE_TLS=false \
+        -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
+        -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         --user 0:0 {{ local_image_ref }}:{{ tag }} start >/dev/null
     tries=0
     until node -e "fetch('http://127.0.0.1:{{ port }}/health').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"; do

--- a/ui/e2e/auth/lineage-scope.spec.ts
+++ b/ui/e2e/auth/lineage-scope.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+import { authHeaders, obtainAuthKeys, type AuthLaneKeys } from "../helpers/auth";
+
+let keys: AuthLaneKeys;
+
+test.beforeAll(async ({ request }) => {
+  keys = await obtainAuthKeys(request);
+});
+
+test("a job-scoped key is denied the global lineage impact query", async ({ request }) => {
+  const response = await request.get("/v1/lineage/impact?namespace=caesium&name=missing", {
+    headers: authHeaders(keys.scoped),
+  });
+
+  expect(response.status()).toBe(403);
+  const body = await response.text();
+  expect(body).toContain(
+    "lineage impact is a global cross-job query and requires an unscoped principal",
+  );
+});

--- a/ui/e2e/lineage.spec.ts
+++ b/ui/e2e/lineage.spec.ts
@@ -63,12 +63,18 @@ test("operator can inspect a dataset-keyed downstream lineage graph", async ({ p
   await waitForRun(request, job.id, run.id);
 
   const rootName = `${alias}.extract.output`;
-  const downstreamName = `${alias}.transform.output`;
-  const impact = await waitForImpact(request, "caesium", rootName, downstreamName);
-  const downstream = impact.downstream.find((node) => node.dataset_name === downstreamName);
+  const transformName = `${alias}.transform.output`;
+  const publishName = `${alias}.publish.output`;
+  const impact = await waitForImpact(request, "caesium", rootName, publishName);
+  const transform = impact.downstream.find((node) => node.dataset_name === transformName);
+  const publish = impact.downstream.find((node) => node.dataset_name === publishName);
 
-  expect(downstream?.job_id).toBe(job.id);
-  expect(downstream?.job_alias).toBe(alias);
+  expect(transform?.job_id).toBe(job.id);
+  expect(transform?.job_alias).toBe(alias);
+  expect(transform?.depth).toBe(0);
+  expect(publish?.job_id).toBe(job.id);
+  expect(publish?.job_alias).toBe(alias);
+  expect(publish?.depth).toBe(1);
 
   await page.goto(`/lineage?namespace=caesium&name=${encodeURIComponent(rootName)}`);
 
@@ -80,13 +86,22 @@ test("operator can inspect a dataset-keyed downstream lineage graph", async ({ p
   await expect(page.getByTestId("lineage-root-node")).toContainText(rootName);
   await expect(page.getByTestId("lineage-root-node")).toContainText("caesium");
 
-  const impactNode = page.getByTestId(lineageImpactNodeTestId("caesium", downstreamName, job.id));
-  await expect(impactNode).toBeVisible();
-  await expect(impactNode).toContainText(downstreamName);
-  await expect(impactNode).toContainText(alias);
-  await expect(page.getByTestId("lineage-edge").first()).toContainText("downstream");
+  const transformNode = page.getByTestId(lineageImpactNodeTestId("caesium", transformName, job.id));
+  await expect(transformNode).toBeVisible();
+  await expect(transformNode).toContainText(transformName);
+  await expect(transformNode).toContainText(alias);
+  await expect(transformNode).toContainText("Hop 1");
 
-  await impactNode.click();
+  const publishNode = page.getByTestId(lineageImpactNodeTestId("caesium", publishName, job.id));
+  await expect(publishNode).toBeVisible();
+  await expect(publishNode).toContainText(publishName);
+  await expect(publishNode).toContainText(alias);
+  await expect(publishNode).toContainText("Hop 2");
+
+  await expect(page.getByTestId(lineageImpactEdgeTestId(rootName, transformName, 0))).toContainText("downstream");
+  await expect(page.getByTestId(lineageImpactEdgeTestId(transformName, publishName, 1))).toContainText("depth 2");
+
+  await transformNode.click();
   await page.waitForURL(new RegExp(`/jobs/${job.id}$`));
   await expect(page.getByRole("heading", { name: alias, exact: true })).toBeVisible();
 
@@ -99,6 +114,10 @@ test("operator can inspect a dataset-keyed downstream lineage graph", async ({ p
 
 function lineageImpactNodeTestId(namespace: string, name: string, jobId: string): string {
   return `lineage-impact-node:${namespace}:${name}:${jobId}`;
+}
+
+function lineageImpactEdgeTestId(sourceName: string, targetName: string, index: number): string {
+  return `lineage-edge:${sourceName}:${targetName}:${index}`;
 }
 
 function buildLineageDefinition(alias: string): LineageFixture {
@@ -153,6 +172,32 @@ function buildLineageDefinition(alias: string): LineageFixture {
           "echo got $CAESIUM_OUTPUT_EXTRACT_ROWS; echo '##caesium::output {\"clean\": \"yes\"}'",
         ],
         dependsOn: ["extract"],
+        next: ["publish"],
+      },
+      {
+        name: "publish",
+        engine: "docker",
+        image: shellImage,
+        inputSchema: {
+          transform: {
+            required: ["clean"],
+            properties: {
+              clean: { type: "string" },
+            },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            sent: { type: "string" },
+          },
+        },
+        command: [
+          "sh",
+          "-c",
+          "echo got $CAESIUM_OUTPUT_TRANSFORM_CLEAN; echo '##caesium::output {\"sent\": \"yes\"}'",
+        ],
+        dependsOn: ["transform"],
       },
     ],
   };

--- a/ui/e2e/lineage.spec.ts
+++ b/ui/e2e/lineage.spec.ts
@@ -1,0 +1,251 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+
+type E2EJob = {
+  id: string;
+  alias: string;
+};
+
+type E2ERun = {
+  id: string;
+  status: string;
+};
+
+type LineageImpactResult = {
+  root_namespace: string;
+  root_name: string;
+  downstream: Array<{
+    dataset_namespace: string;
+    dataset_name: string;
+    direction: string;
+    producing_step?: string;
+    job_id: string;
+    job_alias: string;
+    last_seen: string;
+    depth: number;
+  }>;
+};
+
+type LineageFixture = {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    alias: string;
+  };
+  trigger: {
+    type: string;
+    configuration: {
+      cron: string;
+      timezone: string;
+    };
+  };
+  steps: Array<{
+    name: string;
+    engine: string;
+    image: string;
+    command: string[];
+    outputSchema?: Record<string, unknown>;
+    inputSchema?: Record<string, Record<string, unknown>>;
+    next?: string[];
+    dependsOn?: string[];
+  }>;
+};
+
+const shellImage = "debian:12-slim";
+
+test("operator can inspect a dataset-keyed downstream lineage graph", async ({ page, request }) => {
+  test.slow();
+
+  const alias = `lineage-e2e-${Date.now().toString(36)}`;
+  await applyDefinition(request, buildLineageDefinition(alias));
+  const job = await findJobByAlias(request, alias);
+
+  const run = await triggerRun(request, job.id);
+  await waitForRun(request, job.id, run.id);
+
+  const rootName = `${alias}.extract.output`;
+  const downstreamName = `${alias}.transform.output`;
+  const impact = await waitForImpact(request, "caesium", rootName, downstreamName);
+  const downstream = impact.downstream.find((node) => node.dataset_name === downstreamName);
+
+  expect(downstream?.job_id).toBe(job.id);
+  expect(downstream?.job_alias).toBe(alias);
+
+  await page.goto(`/lineage?namespace=caesium&name=${encodeURIComponent(rootName)}`);
+
+  await expect(page.getByTestId("lineage-container")).toBeVisible();
+  await expect(page.getByTestId("lineage-namespace-input")).toHaveValue("caesium");
+  await expect(page.getByTestId("lineage-name-input")).toHaveValue(rootName);
+
+  await expect(page.getByTestId("lineage-root-node")).toBeVisible();
+  await expect(page.getByTestId("lineage-root-node")).toContainText(rootName);
+  await expect(page.getByTestId("lineage-root-node")).toContainText("caesium");
+
+  const impactNode = page.getByTestId(lineageImpactNodeTestId("caesium", downstreamName, job.id));
+  await expect(impactNode).toBeVisible();
+  await expect(impactNode).toContainText(downstreamName);
+  await expect(impactNode).toContainText(alias);
+  await expect(page.getByTestId("lineage-edge").first()).toContainText("downstream");
+
+  await impactNode.click();
+  await page.waitForURL(new RegExp(`/jobs/${job.id}$`));
+  await expect(page.getByRole("heading", { name: alias, exact: true })).toBeVisible();
+
+  await page.goto(`/lineage?namespace=caesium&name=${encodeURIComponent(`${alias}.empty.output`)}`);
+  await expect(page.getByTestId("lineage-empty-state")).toBeVisible();
+  await expect(page.getByTestId("lineage-empty-state")).toContainText(
+    "no downstream impact recorded yet (lineage datasets populate as jobs declare/consume outputs)",
+  );
+});
+
+function lineageImpactNodeTestId(namespace: string, name: string, jobId: string): string {
+  return `lineage-impact-node:${namespace}:${name}:${jobId}`;
+}
+
+function buildLineageDefinition(alias: string): LineageFixture {
+  return {
+    apiVersion: "v1",
+    kind: "Job",
+    metadata: {
+      alias,
+    },
+    trigger: {
+      type: "cron",
+      configuration: {
+        cron: "0 2 * * *",
+        timezone: "UTC",
+      },
+    },
+    steps: [
+      {
+        name: "extract",
+        engine: "docker",
+        image: shellImage,
+        outputSchema: {
+          type: "object",
+          properties: {
+            rows: { type: "string" },
+          },
+        },
+        command: ["sh", "-c", "echo '##caesium::output {\"rows\": \"1\"}'"],
+        next: ["transform"],
+      },
+      {
+        name: "transform",
+        engine: "docker",
+        image: shellImage,
+        inputSchema: {
+          extract: {
+            required: ["rows"],
+            properties: {
+              rows: { type: "string" },
+            },
+          },
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            clean: { type: "string" },
+          },
+        },
+        command: [
+          "sh",
+          "-c",
+          "echo got $CAESIUM_OUTPUT_EXTRACT_ROWS; echo '##caesium::output {\"clean\": \"yes\"}'",
+        ],
+        dependsOn: ["extract"],
+      },
+    ],
+  };
+}
+
+async function applyDefinition(request: APIRequestContext, definition: LineageFixture): Promise<void> {
+  const response = await request.post("/v1/jobdefs/apply", {
+    data: { definitions: [definition] },
+  });
+  if (!response.ok()) {
+    throw new Error(`failed to apply fixture: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function findJobByAlias(request: APIRequestContext, alias: string): Promise<E2EJob> {
+  let foundJob: E2EJob | undefined;
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get("/v1/jobs");
+        if (!response.ok()) {
+          throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+        }
+        const jobs = (await response.json()) as E2EJob[];
+        foundJob = jobs.find((candidate) => candidate.alias === alias);
+        return foundJob?.alias ?? "";
+      },
+      {
+        timeout: 10_000,
+        intervals: [250, 500, 1_000],
+      },
+    )
+    .toBe(alias);
+
+  return foundJob!;
+}
+
+async function triggerRun(request: APIRequestContext, jobId: string): Promise<E2ERun> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`);
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run: ${response.status()} ${await response.text()}`);
+  }
+
+  return (await response.json()) as E2ERun;
+}
+
+async function waitForRun(request: APIRequestContext, jobId: string, runId: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+        if (!response.ok()) {
+          throw new Error(`failed to load run ${runId}: ${response.status()} ${await response.text()}`);
+        }
+        const run = (await response.json()) as E2ERun;
+        return run.status;
+      },
+      {
+        timeout: 120_000,
+        intervals: [1_000, 2_000, 5_000],
+      },
+    )
+    .toBe("succeeded");
+}
+
+async function waitForImpact(
+  request: APIRequestContext,
+  namespace: string,
+  name: string,
+  downstreamName: string,
+): Promise<LineageImpactResult> {
+  let latest: LineageImpactResult | undefined;
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(
+          `/v1/lineage/impact?namespace=${encodeURIComponent(namespace)}&name=${encodeURIComponent(name)}`,
+        );
+        if (!response.ok()) {
+          return "";
+        }
+        latest = (await response.json()) as LineageImpactResult;
+        return latest.downstream.map((node) => node.dataset_name).join("\n");
+      },
+      {
+        timeout: 30_000,
+        intervals: [500, 1_000, 2_000],
+      },
+    )
+    .toContain(downstreamName);
+
+  if (!latest) {
+    throw new Error("lineage impact endpoint did not return a result");
+  }
+  return latest;
+}

--- a/ui/src/features/jobs/LineageGraph.tsx
+++ b/ui/src/features/jobs/LineageGraph.tsx
@@ -1,0 +1,579 @@
+import { type FormEvent, memo, useCallback, useMemo, useState } from "react";
+import { Link, getRouteApi, useNavigate } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import ReactFlow, {
+  Background,
+  BaseEdge,
+  Controls,
+  EdgeLabelRenderer,
+  Handle,
+  MarkerType,
+  Position,
+  getSmoothStepPath,
+  type Edge,
+  type EdgeProps,
+  type Node,
+  type NodeProps,
+} from "reactflow";
+import "reactflow/dist/style.css";
+import dagre from "dagre";
+import { AlertTriangle, ArrowLeft, Database, GitBranch, Search, ShieldAlert } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { api, type ImpactNode } from "@/lib/api";
+import { usePrincipal } from "@/lib/auth";
+import { cn, shortId } from "@/lib/utils";
+
+const lineageRouteApi = getRouteApi("/lineage");
+const nodeWidth = 320;
+const nodeHeight = 150;
+
+type LineageSearch = {
+  namespace: string | undefined;
+  name: string | undefined;
+};
+
+type LineageNodeData = {
+  kind: "root" | "downstream";
+  namespace: string;
+  name: string;
+  jobId?: string;
+  jobAlias?: string;
+  producingStep?: string;
+  lastSeen?: string;
+  depth?: number;
+};
+
+export function LineageRoutePage() {
+  const search = lineageRouteApi.useSearch() as LineageSearch;
+  const initialNamespace = search.namespace ?? "";
+  const initialName = search.name ?? "";
+
+  return (
+    <LineageGraph
+      key={`${initialNamespace}:${initialName}`}
+      initialNamespace={initialNamespace}
+      initialName={initialName}
+    />
+  );
+}
+
+export function LineageGraph({
+  initialNamespace,
+  initialName,
+}: {
+  initialNamespace: string;
+  initialName: string;
+}) {
+  const navigate = useNavigate();
+  const principal = usePrincipal();
+  const namespace = cleanParam(initialNamespace) ?? "";
+  const name = cleanParam(initialName) ?? "";
+  const [namespaceInput, setNamespaceInput] = useState(namespace);
+  const [nameInput, setNameInput] = useState(name);
+  const hasDataset = namespace !== "" && name !== "";
+  const isScoped = principal.isScoped;
+
+  const impactQuery = useQuery({
+    queryKey: ["lineage", "impact", namespace, name],
+    queryFn: () => api.getLineageImpact({ namespace, name }),
+    enabled: hasDataset && !isScoped,
+  });
+
+  const graph = useMemo(() => {
+    if (!impactQuery.data) {
+      return { nodes: [] as Node<LineageNodeData>[], edges: [] as Edge[] };
+    }
+    return buildGraph(impactQuery.data.root_namespace, impactQuery.data.root_name, impactQuery.data.downstream ?? []);
+  }, [impactQuery.data]);
+
+  function applyDataset(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    void navigate({
+      to: "/lineage",
+      search: buildSearch(namespaceInput, nameInput),
+    });
+  }
+
+  const handleNodeClick = useCallback(
+    (_event: React.MouseEvent, node: Node<LineageNodeData>) => {
+      if (node.data.kind !== "downstream" || !node.data.jobId) {
+        return;
+      }
+      void navigate({
+        to: "/jobs/$jobId",
+        params: { jobId: node.data.jobId },
+      });
+    },
+    [navigate],
+  );
+
+  // Presently unreachable for scoped API keys: UI login calls GET /auth/whoami,
+  // which scoped keys receive as 403, and whoami does not expose a scope marker
+  // for already-authenticated principals. Keep this as the future scoped-session
+  // guard for the global lineage graph.
+  if (isScoped) {
+    return (
+      <div className="space-y-5" data-testid="lineage-container">
+        <LineageBreadcrumb />
+        <LineageHeader />
+        <DatasetForm
+          namespaceInput={namespaceInput}
+          nameInput={nameInput}
+          onNamespaceInput={setNamespaceInput}
+          onNameInput={setNameInput}
+          onSubmit={applyDataset}
+        />
+        <div data-testid="lineage-scoped-denied">
+          <EmptyState
+            title="cross-job lineage requires an unscoped key"
+            subtitle="Scoped API keys are limited to job-local routes and cannot query the global lineage-impact graph."
+            icon={<ShieldAlert className="h-12 w-12 text-warning" />}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5" data-testid="lineage-container">
+      <LineageBreadcrumb />
+      <LineageHeader />
+      <DatasetForm
+        namespaceInput={namespaceInput}
+        nameInput={nameInput}
+        onNamespaceInput={setNamespaceInput}
+        onNameInput={setNameInput}
+        onSubmit={applyDataset}
+      />
+
+      {!hasDataset ? (
+        <EmptyState
+          title="No dataset selected"
+          icon={<Database className="h-12 w-12 text-text-3" />}
+        />
+      ) : null}
+
+      {impactQuery.isLoading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-[240px]" />
+          <Skeleton className="h-[500px] w-full" />
+        </div>
+      ) : null}
+
+      {impactQuery.error ? (
+        <EmptyState
+          title="Lineage impact unavailable"
+          subtitle={impactQuery.error instanceof Error ? impactQuery.error.message : "The lineage-impact endpoint returned an error."}
+          icon={<AlertTriangle className="h-12 w-12 text-danger" />}
+        />
+      ) : null}
+
+      {impactQuery.data && impactQuery.data.downstream.length === 0 ? (
+        <div data-testid="lineage-empty-state">
+          <EmptyState
+            title="no downstream impact recorded yet (lineage datasets populate as jobs declare/consume outputs)"
+            icon={<GitBranch className="h-12 w-12 text-text-3" />}
+          />
+        </div>
+      ) : null}
+
+      {impactQuery.data && impactQuery.data.downstream.length > 0 ? (
+        <>
+          <div className="grid gap-3 md:grid-cols-3">
+            <MetadataCell label="Root Namespace" value={impactQuery.data.root_namespace} />
+            <MetadataCell label="Root Dataset" value={impactQuery.data.root_name} />
+            <MetadataCell label="Downstream Nodes" value={String(impactQuery.data.downstream.length)} />
+          </div>
+          <div className="relative h-[560px] min-h-[500px] w-full overflow-hidden rounded-lg bg-dag-bg" data-testid="lineage-graph">
+            <ReactFlow
+              nodes={graph.nodes}
+              edges={graph.edges}
+              nodeTypes={nodeTypes}
+              edgeTypes={edgeTypes}
+              onNodeClick={handleNodeClick}
+              fitView
+              fitViewOptions={{ padding: 0.2 }}
+              minZoom={0.1}
+              maxZoom={1.5}
+            >
+              <Background gap={20} />
+              <Controls />
+            </ReactFlow>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function lineageImpactNodeTestId(namespace: string, name: string, jobId?: string) {
+  return `lineage-impact-node:${namespace}:${name}:${jobId ?? "unknown-job"}`;
+}
+
+function LineageHeader() {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0">
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-text-3">
+          Lineage
+        </div>
+        <h1 className="text-xl font-semibold tracking-tight text-text-1">Lineage impact</h1>
+      </div>
+      <Badge variant="outline" className="text-[10px]">
+        Downstream only
+      </Badge>
+    </div>
+  );
+}
+
+function LineageBreadcrumb() {
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-text-3">
+      <Link
+        to="/jobs"
+        className="flex items-center gap-1 transition-colors hover:text-text-2"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        Jobs
+      </Link>
+      <span className="text-text-4">/</span>
+      <span>Lineage</span>
+    </div>
+  );
+}
+
+function DatasetForm({
+  namespaceInput,
+  nameInput,
+  onNamespaceInput,
+  onNameInput,
+  onSubmit,
+}: {
+  namespaceInput: string;
+  nameInput: string;
+  onNamespaceInput: (value: string) => void;
+  onNameInput: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Dataset</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form className="grid gap-3 md:grid-cols-[0.5fr_1fr_auto]" onSubmit={onSubmit}>
+          <LabeledInput
+            id="lineage-namespace"
+            label="Namespace"
+            value={namespaceInput}
+            placeholder="caesium"
+            testId="lineage-namespace-input"
+            onChange={onNamespaceInput}
+          />
+          <LabeledInput
+            id="lineage-name"
+            label="Name"
+            value={nameInput}
+            placeholder="job.extract.output"
+            testId="lineage-name-input"
+            onChange={onNameInput}
+          />
+          <div className="flex items-end">
+            <Button
+              type="submit"
+              size="sm"
+              className="h-9 w-full md:w-auto"
+              data-testid="lineage-submit"
+              disabled={namespaceInput.trim() === "" || nameInput.trim() === ""}
+            >
+              <Search className="h-3.5 w-3.5" />
+              Inspect
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LabeledInput({
+  id,
+  label,
+  value,
+  placeholder,
+  testId,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder: string;
+  testId: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <label htmlFor={id} className="space-y-1.5">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-text-3">
+        {label}
+      </span>
+      <input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        data-testid={testId}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-9 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-primary focus:ring-1 focus:ring-ring"
+      />
+    </label>
+  );
+}
+
+function MetadataCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border/60 bg-card px-3 py-2">
+      <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-text-3">
+        {label}
+      </div>
+      <div className="mt-1 truncate font-mono text-xs text-text-1" title={value}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactNode[]) {
+  const rootId = `root:${rootNamespace}:${rootName}`;
+  const initialNodes: Node<LineageNodeData>[] = [
+    {
+      id: rootId,
+      type: "lineage",
+      data: {
+        kind: "root",
+        namespace: rootNamespace,
+        name: rootName,
+      },
+      position: { x: 0, y: 0 },
+    },
+  ];
+
+  const initialEdges: Edge[] = [];
+  downstream.forEach((node, index) => {
+    const nodeId = `impact:${node.dataset_namespace}:${node.dataset_name}:${node.job_id}:${index}`;
+    initialNodes.push({
+      id: nodeId,
+      type: "lineage",
+      data: {
+        kind: "downstream",
+        namespace: node.dataset_namespace,
+        name: node.dataset_name,
+        jobId: node.job_id,
+        jobAlias: node.job_alias,
+        producingStep: node.producing_step,
+        lastSeen: node.last_seen,
+        depth: node.depth,
+      },
+      position: { x: 0, y: 0 },
+    });
+    initialEdges.push({
+      id: `lineage-edge-${index}`,
+      source: rootId,
+      target: nodeId,
+      type: "lineage",
+      data: {
+        depth: node.depth,
+      },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 20,
+        height: 20,
+        color: "hsl(var(--running))",
+      },
+      style: {
+        strokeWidth: 2,
+        stroke: "hsl(var(--running))",
+      },
+    });
+  });
+
+  return getLayoutedElements(initialNodes, initialEdges);
+}
+
+function getLayoutedElements(nodes: Node<LineageNodeData>[], edges: Edge[], direction = "LR") {
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({
+    rankdir: direction,
+    nodesep: 150,
+    ranksep: 200,
+    marginx: 50,
+    marginy: 50,
+    ranker: "network-simplex",
+  });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: nodeWidth, height: nodeHeight });
+  });
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  return {
+    nodes: nodes.map((node) => {
+      const layoutNode = dagreGraph.node(node.id);
+      return {
+        ...node,
+        targetPosition: direction === "LR" ? Position.Left : Position.Top,
+        sourcePosition: direction === "LR" ? Position.Right : Position.Bottom,
+        position: {
+          x: layoutNode.x - nodeWidth / 2,
+          y: layoutNode.y - nodeHeight / 2,
+        },
+      };
+    }),
+    edges,
+  };
+}
+
+const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
+  const isRoot = data.kind === "root";
+  const testId = isRoot ? "lineage-root-node" : lineageImpactNodeTestId(data.namespace, data.name, data.jobId);
+  const hop = typeof data.depth === "number" ? data.depth + 1 : undefined;
+
+  return (
+    <div
+      data-testid={testId}
+      data-lineage-node-kind={isRoot ? "root" : "impact"}
+      data-dataset-namespace={data.namespace}
+      data-dataset-name={data.name}
+      data-job-id={data.jobId}
+      data-job-alias={data.jobAlias}
+      className={cn(
+        "relative h-[150px] w-[320px] overflow-hidden rounded-lg border-2 px-4 py-3 shadow-sm transition-colors",
+        isRoot
+          ? "border-gold/50 bg-[linear-gradient(155deg,hsl(var(--gold)/0.18),hsl(var(--node-surface)/0.95)_60%)]"
+          : "cursor-pointer border-caesium-cyan/45 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.18),hsl(var(--node-surface)/0.95)_60%)] hover:border-caesium-cyan/80",
+      )}
+      title={isRoot ? `${data.namespace}/${data.name}` : `Open job ${data.jobAlias ?? data.jobId}`}
+    >
+      {!isRoot ? (
+        <Handle type="target" position={Position.Left} className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan" />
+      ) : null}
+      <Handle type="source" position={Position.Right} className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan" />
+
+      <div className="flex h-full flex-col justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Database className={cn("h-4 w-4 shrink-0", isRoot ? "text-gold" : "text-running")} />
+            <Badge variant="outline" className="text-[10px]">
+              {isRoot ? "Root dataset" : "Downstream output"}
+            </Badge>
+            {hop ? (
+              <span className="rounded border border-running/30 bg-running/10 px-1.5 py-0.5 text-[10px] font-semibold text-running">
+                Hop {hop}
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-3 truncate font-mono text-sm font-semibold text-text-1" title={data.name}>
+            {data.name}
+          </div>
+          <div className="mt-1 truncate font-mono text-[11px] text-text-3" title={data.namespace}>
+            {data.namespace}
+          </div>
+        </div>
+
+        {isRoot ? (
+          <div className="text-xs text-text-3">Impact root</div>
+        ) : (
+          <div className="space-y-1 text-xs text-text-3">
+            <div className="truncate">
+              Job <span className="font-mono text-text-1">{data.jobAlias ?? shortId(data.jobId)}</span>
+            </div>
+            {data.producingStep ? (
+              <div className="truncate">
+                Step <span className="font-mono text-text-1">{data.producingStep}</span>
+              </div>
+            ) : null}
+            {data.lastSeen ? (
+              <div className="truncate font-mono text-[10px]" title={data.lastSeen}>
+                {new Date(data.lastSeen).toLocaleString()}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+
+LineageDatasetNode.displayName = "LineageDatasetNode";
+
+const LineageImpactEdge = memo(({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  data,
+}: EdgeProps) => {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: 16,
+  });
+  const depth = typeof data?.depth === "number" ? data.depth : 0;
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} style={style} markerEnd={markerEnd} />
+      <EdgeLabelRenderer>
+        <div
+          data-testid="lineage-edge"
+          data-edge-id={id}
+          className="nodrag nopan rounded-full border border-running/35 bg-card/95 px-2 py-1 text-[10px] font-semibold text-running shadow-sm"
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+          }}
+        >
+          {depth === 0 ? "downstream" : `depth ${depth + 1}`}
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+});
+
+LineageImpactEdge.displayName = "LineageImpactEdge";
+
+const nodeTypes = {
+  lineage: LineageDatasetNode,
+};
+
+const edgeTypes = {
+  lineage: LineageImpactEdge,
+};
+
+function buildSearch(namespace: string, name: string) {
+  return {
+    namespace: cleanParam(namespace),
+    name: cleanParam(name),
+  };
+}
+
+function cleanParam(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}

--- a/ui/src/features/jobs/LineageGraph.tsx
+++ b/ui/src/features/jobs/LineageGraph.tsx
@@ -47,6 +47,19 @@ type LineageNodeData = {
   depth?: number;
 };
 
+type LineageEdgeData = {
+  depth: number;
+  testId: string;
+  sourceName: string;
+  targetName: string;
+};
+
+type GraphNodeRef = {
+  id: string;
+  name: string;
+  depth: number;
+};
+
 export function LineageRoutePage() {
   const search = lineageRouteApi.useSearch() as LineageSearch;
   const initialNamespace = search.namespace ?? "";
@@ -214,6 +227,10 @@ function lineageImpactNodeTestId(namespace: string, name: string, jobId?: string
   return `lineage-impact-node:${namespace}:${name}:${jobId ?? "unknown-job"}`;
 }
 
+function lineageImpactEdgeTestId(sourceName: string, targetName: string, index: number) {
+  return `lineage-edge:${sourceName}:${targetName}:${index}`;
+}
+
 function LineageHeader() {
   return (
     <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
@@ -347,6 +364,7 @@ function MetadataCell({ label, value }: { label: string; value: string }) {
 
 function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactNode[]) {
   const rootId = `root:${rootNamespace}:${rootName}`;
+  const rootRef: GraphNodeRef = { id: rootId, name: rootName, depth: -1 };
   const initialNodes: Node<LineageNodeData>[] = [
     {
       id: rootId,
@@ -360,9 +378,17 @@ function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactN
     },
   ];
 
-  const initialEdges: Edge[] = [];
+  const initialEdges: Edge<LineageEdgeData>[] = [];
+  const nodesByDepth = new Map<number, GraphNodeRef[]>();
+  const impactRefs: GraphNodeRef[] = [];
+
   downstream.forEach((node, index) => {
     const nodeId = `impact:${node.dataset_namespace}:${node.dataset_name}:${node.job_id}:${index}`;
+    const nodeRef = {
+      id: nodeId,
+      name: node.dataset_name,
+      depth: node.depth,
+    };
     initialNodes.push({
       id: nodeId,
       type: "lineage",
@@ -378,31 +404,52 @@ function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactN
       },
       position: { x: 0, y: 0 },
     });
-    initialEdges.push({
-      id: `lineage-edge-${index}`,
-      source: rootId,
-      target: nodeId,
-      type: "lineage",
-      data: {
-        depth: node.depth,
-      },
-      markerEnd: {
-        type: MarkerType.ArrowClosed,
-        width: 20,
-        height: 20,
-        color: "hsl(var(--running))",
-      },
-      style: {
-        strokeWidth: 2,
-        stroke: "hsl(var(--running))",
-      },
+
+    impactRefs.push(nodeRef);
+    const depthNodes = nodesByDepth.get(node.depth) ?? [];
+    depthNodes.push(nodeRef);
+    nodesByDepth.set(node.depth, depthNodes);
+  });
+
+  let edgeIndex = 0;
+  impactRefs.forEach((nodeRef) => {
+    // The impact endpoint returns BFS depth but no concrete parent edge. Direct
+    // consumers attach to the root; deeper nodes attach to the prior BFS frontier
+    // so multi-hop chains render by hop instead of every node falsely pointing at root.
+    const sourceRefs = nodeRef.depth === 0 ? [rootRef] : nodesByDepth.get(nodeRef.depth - 1) ?? [rootRef];
+
+    sourceRefs.forEach((sourceRef) => {
+      const index = edgeIndex;
+      edgeIndex += 1;
+      initialEdges.push({
+        id: `lineage-edge-${index}`,
+        source: sourceRef.id,
+        target: nodeRef.id,
+        type: "lineage",
+        data: {
+          depth: nodeRef.depth,
+          sourceName: sourceRef.name,
+          targetName: nodeRef.name,
+          testId: lineageImpactEdgeTestId(sourceRef.name, nodeRef.name, index),
+        },
+        markerEnd: {
+          type: MarkerType.ArrowClosed,
+          width: 20,
+          height: 20,
+          color: "hsl(var(--running))",
+        },
+        style: {
+          strokeWidth: 2,
+          stroke: "hsl(var(--running))",
+        },
+      });
     });
   });
 
   return getLayoutedElements(initialNodes, initialEdges);
 }
 
-function getLayoutedElements(nodes: Node<LineageNodeData>[], edges: Edge[], direction = "LR") {
+function getLayoutedElements(nodes: Node<LineageNodeData>[], edges: Edge<LineageEdgeData>[], direction = "LR") {
   const dagreGraph = new dagre.graphlib.Graph();
   dagreGraph.setDefaultEdgeLabel(() => ({}));
   dagreGraph.setGraph({
@@ -440,10 +487,22 @@ function getLayoutedElements(nodes: Node<LineageNodeData>[], edges: Edge[], dire
   };
 }
 
+function jobLabel(jobAlias?: string, jobId?: string) {
+  if (jobAlias) {
+    return jobAlias;
+  }
+  if (jobId) {
+    return shortId(jobId);
+  }
+  return "unknown job";
+}
+
 const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
   const isRoot = data.kind === "root";
   const testId = isRoot ? "lineage-root-node" : lineageImpactNodeTestId(data.namespace, data.name, data.jobId);
   const hop = typeof data.depth === "number" ? data.depth + 1 : undefined;
+  const displayJob = jobLabel(data.jobAlias, data.jobId);
+  const jobTitle = data.jobId ? `Open job ${displayJob}` : displayJob;
 
   return (
     <div
@@ -459,7 +518,7 @@ const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
           ? "border-gold/50 bg-[linear-gradient(155deg,hsl(var(--gold)/0.18),hsl(var(--node-surface)/0.95)_60%)]"
           : "cursor-pointer border-caesium-cyan/45 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.18),hsl(var(--node-surface)/0.95)_60%)] hover:border-caesium-cyan/80",
       )}
-      title={isRoot ? `${data.namespace}/${data.name}` : `Open job ${data.jobAlias ?? data.jobId}`}
+      title={isRoot ? `${data.namespace}/${data.name}` : jobTitle}
     >
       {!isRoot ? (
         <Handle type="target" position={Position.Left} className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan" />
@@ -492,7 +551,7 @@ const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
         ) : (
           <div className="space-y-1 text-xs text-text-3">
             <div className="truncate">
-              Job <span className="font-mono text-text-1">{data.jobAlias ?? shortId(data.jobId)}</span>
+              Job <span className="font-mono text-text-1">{displayJob}</span>
             </div>
             {data.producingStep ? (
               <div className="truncate">
@@ -524,7 +583,7 @@ const LineageImpactEdge = memo(({
   style,
   markerEnd,
   data,
-}: EdgeProps) => {
+}: EdgeProps<LineageEdgeData>) => {
   const [edgePath, labelX, labelY] = getSmoothStepPath({
     sourceX,
     sourceY,
@@ -535,14 +594,17 @@ const LineageImpactEdge = memo(({
     borderRadius: 16,
   });
   const depth = typeof data?.depth === "number" ? data.depth : 0;
+  const testId = data?.testId ?? `lineage-edge:${id}`;
 
   return (
     <>
       <BaseEdge id={id} path={edgePath} style={style} markerEnd={markerEnd} />
       <EdgeLabelRenderer>
         <div
-          data-testid="lineage-edge"
+          data-testid={testId}
           data-edge-id={id}
+          data-edge-source={data?.sourceName}
+          data-edge-target={data?.targetName}
           className="nodrag nopan rounded-full border border-running/35 bg-card/95 px-2 py-1 text-[10px] font-semibold text-running shadow-sm"
           style={{
             position: "absolute",

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -7,6 +7,7 @@ import { JobDefsPage } from "./features/jobdefs/JobDefsPage";
 import { BlameRoutePage } from "./features/jobs/BlameView";
 import { JobsPage } from "./features/jobs/JobsPage";
 import { JobDetailPage } from "./features/jobs/JobDetailPage";
+import { LineageRoutePage } from "./features/jobs/LineageGraph";
 import { RunDetailPage } from "./features/jobs/RunDetailPage";
 import { RunDiffRoutePage } from "./features/jobs/RunDiffView";
 import { StatsPage } from "./features/stats/StatsPage";
@@ -59,6 +60,16 @@ const runDiffRoute = createRoute({
     to: typeof search.to === "string" ? search.to : undefined,
   }),
   component: RunDiffRoutePage,
+});
+
+const lineageRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "lineage",
+  validateSearch: (search: Record<string, unknown>) => ({
+    namespace: typeof search.namespace === "string" ? search.namespace : undefined,
+    name: typeof search.name === "string" ? search.name : undefined,
+  }),
+  component: LineageRoutePage,
 });
 
 const statsRoute = createRoute({
@@ -116,6 +127,7 @@ const routeTree = rootRoute.addChildren([
   blameRoute,
   runDiffRoute,
   runDetailRoute,
+  lineageRoute,
   statsRoute,
   triggersRoute,
   atomsRoute,


### PR DESCRIPTION
## F1+F2+F3 — dataset-keyed lineage-impact graph + e2e (Wave 4)

A `LineageGraph` (route `/lineage?namespace=&name=`) rendering the **dataset-keyed downstream** impact via `getLineageImpact` — a ReactFlow graph (reusing JobDAG's dagre) with job-level click-through (`ImpactNode` has no run_id), an explicit namespace/name input, and an honest empty state. F2 enables `CAESIUM_OPEN_LINEAGE_ENABLED` on the ui-e2e backend. e2e drives a real downstream dataset graph; the scoped-denied check is **API-level** (a scoped key can't UI-login — H-3 finding). **Frontend-only.**

**Opus review:** 1 blocker → **backend follow-up** recorded (not fixed here, per frontend-only): `producing_step` is always empty because `persistTaskDatasets` writes the facet flat but `stepNameFromFacet` reads it nested. Descoped `producing_step` (rendered gracefully; e2e asserts the working downstream graph instead). should-fix: commented the unreachable scoped guard. `ui-lint`+`ui-test` green; e2e in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BvA6zFvnhXRHHHVccZy1em