### PR TITLE
Add event ingestion + webhook bridge (event-trigger-routing W2-α)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Build release image (amd64)
         run: just tag=${{ env.IMAGE_TAG }}-amd64 build
       - name: Integration tests (amd64)
-        run: just tag=${{ env.IMAGE_TAG }}-amd64 integration-test
+        run: CAESIUM_EVENT_INGEST_API_KEY=integration-test-key just tag=${{ env.IMAGE_TAG }}-amd64 integration-test
       - name: Save release image
         run: |
           docker save caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 \
@@ -180,7 +180,7 @@ jobs:
       - name: Build release image (arm64)
         run: just tag=${{ env.IMAGE_TAG }}-arm64 build
       - name: Integration tests (arm64)
-        run: just tag=${{ env.IMAGE_TAG }}-arm64 integration-test
+        run: CAESIUM_EVENT_INGEST_API_KEY=integration-test-key just tag=${{ env.IMAGE_TAG }}-arm64 integration-test
       - name: Save release image
         run: |
           docker save caesiumcloud/caesium:${{ env.IMAGE_TAG }}-arm64 \

--- a/api/middleware/ip_rate_limit.go
+++ b/api/middleware/ip_rate_limit.go
@@ -1,0 +1,70 @@
+package middleware
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// IPRateLimitConfig returns the per-minute rate and burst limit.
+type IPRateLimitConfig func() (perMinute int, burst int)
+
+// IPRateLimiters tracks token buckets by source IP.
+type IPRateLimiters struct {
+	mu       sync.Mutex
+	clients  map[string]*ipClientLimiter
+	staleAge time.Duration
+	config   IPRateLimitConfig
+}
+
+type ipClientLimiter struct {
+	limiter    *rate.Limiter
+	lastSeen   time.Time
+	perMinute  int
+	burstLimit int
+}
+
+func NewIPRateLimiters(staleAge time.Duration, config IPRateLimitConfig) *IPRateLimiters {
+	return &IPRateLimiters{
+		clients:  map[string]*ipClientLimiter{},
+		staleAge: staleAge,
+		config:   config,
+	}
+}
+
+func (l *IPRateLimiters) Allow(ip string) bool {
+	if l == nil {
+		return true
+	}
+	perMinute, burst := 0, 0
+	if l.config != nil {
+		perMinute, burst = l.config()
+	}
+	if perMinute <= 0 || burst <= 0 {
+		return true
+	}
+
+	now := time.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for key, client := range l.clients {
+		if now.Sub(client.lastSeen) > l.staleAge {
+			delete(l.clients, key)
+		}
+	}
+
+	client, ok := l.clients[ip]
+	if !ok || client.perMinute != perMinute || client.burstLimit != burst {
+		limit := rate.Every(time.Minute / time.Duration(perMinute))
+		client = &ipClientLimiter{
+			limiter:    rate.NewLimiter(limit, burst),
+			perMinute:  perMinute,
+			burstLimit: burst,
+		}
+		l.clients[ip] = client
+	}
+	client.lastSeen = now
+	return client.limiter.Allow()
+}

--- a/api/middleware/ip_rate_limit.go
+++ b/api/middleware/ip_rate_limit.go
@@ -7,6 +7,8 @@ import (
 	"golang.org/x/time/rate"
 )
 
+const ipRateLimitMaxCleanupInterval = time.Minute
+
 // IPRateLimitConfig returns the per-minute rate and burst limit.
 type IPRateLimitConfig func() (perMinute int, burst int)
 
@@ -26,11 +28,13 @@ type ipClientLimiter struct {
 }
 
 func NewIPRateLimiters(staleAge time.Duration, config IPRateLimitConfig) *IPRateLimiters {
-	return &IPRateLimiters{
+	limiters := &IPRateLimiters{
 		clients:  map[string]*ipClientLimiter{},
 		staleAge: staleAge,
 		config:   config,
 	}
+	go limiters.cleanupLoop(cleanupInterval(staleAge))
+	return limiters
 }
 
 func (l *IPRateLimiters) Allow(ip string) bool {
@@ -49,13 +53,11 @@ func (l *IPRateLimiters) Allow(ip string) bool {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	for key, client := range l.clients {
-		if now.Sub(client.lastSeen) > l.staleAge {
-			delete(l.clients, key)
-		}
-	}
-
 	client, ok := l.clients[ip]
+	if ok && l.isStale(now, client) {
+		delete(l.clients, ip)
+		ok = false
+	}
 	if !ok || client.perMinute != perMinute || client.burstLimit != burst {
 		limit := rate.Every(time.Minute / time.Duration(perMinute))
 		client = &ipClientLimiter{
@@ -67,4 +69,42 @@ func (l *IPRateLimiters) Allow(ip string) bool {
 	}
 	client.lastSeen = now
 	return client.limiter.Allow()
+}
+
+func (l *IPRateLimiters) cleanupLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for now := range ticker.C {
+		l.cleanupStale(now)
+	}
+}
+
+func (l *IPRateLimiters) cleanupStale(now time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for key, client := range l.clients {
+		if l.isStale(now, client) {
+			delete(l.clients, key)
+		}
+	}
+}
+
+func (l *IPRateLimiters) isStale(now time.Time, client *ipClientLimiter) bool {
+	return now.Sub(client.lastSeen) > l.staleAge
+}
+
+func cleanupInterval(staleAge time.Duration) time.Duration {
+	if staleAge <= 0 {
+		return time.Second
+	}
+	interval := staleAge / 2
+	if interval <= 0 {
+		return time.Second
+	}
+	if interval > ipRateLimitMaxCleanupInterval {
+		return ipRateLimitMaxCleanupInterval
+	}
+	return interval
 }

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -58,6 +58,8 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 	{
 		ctrl := event.New(bus)
 		g.GET("/events", ctrl.Stream)
+		g.POST("/events", ctrl.Ingest)
+		g.GET("/events/ingested", ctrl.ListIngested)
 	}
 
 	// atoms
@@ -128,6 +130,7 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 	{
 		g.GET("/triggers", trigger.List)
 		g.POST("/triggers", trigger.Post)
+		g.GET("/triggers/:id/events", trigger.Events)
 		g.GET("/triggers/:id", trigger.Get)
 		g.PATCH("/triggers/:id", trigger.Patch)
 		g.POST("/triggers/:id/fire", trigger.Fire)

--- a/api/rest/controller/event/ingest.go
+++ b/api/rest/controller/event/ingest.go
@@ -1,0 +1,167 @@
+package event
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	eventsvc "github.com/caesium-cloud/caesium/api/rest/service/event"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	triggerevent "github.com/caesium-cloud/caesium/internal/trigger/event"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/datatypes"
+)
+
+type ingestRequest struct {
+	Type   string          `json:"type"`
+	Source string          `json:"source"`
+	Data   json.RawMessage `json:"data"`
+}
+
+type ingestResponse struct {
+	// EventID is unique per accepted request. Event ingestion is at-least-once:
+	// retrying the same payload can create another event and route another run.
+	EventID         uuid.UUID `json:"event_id"`
+	MatchedTriggers int       `json:"matched_triggers"`
+	RunsStarted     int       `json:"runs_started"`
+}
+
+var routeEvent = func(ctx context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+	return triggerevent.DefaultRouter().Route(ctx, evt)
+}
+
+var eventIngestRateLimiters = authmw.NewIPRateLimiters(15*time.Minute, eventIngestRateLimitConfig)
+
+// Ingest accepts client-supplied events using at-least-once semantics. A
+// successful response means this request was persisted and routed; repeating an
+// identical request may create another event and start another run.
+func (ctrl *Controller) Ingest(c *echo.Context) error {
+	if !eventIngestRateLimiters.Allow(c.RealIP()) {
+		return echo.NewHTTPError(http.StatusTooManyRequests, "rate limit exceeded")
+	}
+	if err := requireEventIngestAPIKey(c); err != nil {
+		return err
+	}
+
+	body, err := readIngestBody(c.Request().Body)
+	switch {
+	case errors.Is(err, errIngestRequestTooLarge):
+		return echo.NewHTTPError(http.StatusRequestEntityTooLarge, "request body too large")
+	case err != nil:
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	req := &ingestRequest{}
+	if err := json.Unmarshal(body, req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	data := req.Data
+	if len(data) == 0 {
+		data = json.RawMessage(`{}`)
+	}
+	if !json.Valid(data) {
+		return echo.NewHTTPError(http.StatusBadRequest, "data must be valid json")
+	}
+
+	evt := &models.IngestedEvent{
+		Type:   strings.TrimSpace(req.Type),
+		Source: strings.TrimSpace(req.Source),
+		Data:   datatypes.JSON(data),
+	}
+	if evt.Type == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "type is required")
+	}
+
+	result, err := routeEvent(c.Request().Context(), evt)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	if result == nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error")
+	}
+	metrics.EventsIngestedTotal.WithLabelValues("ingest").Inc()
+
+	return c.JSON(http.StatusAccepted, ingestResponse{
+		EventID:         result.EventID,
+		MatchedTriggers: len(result.MatchedTriggers),
+		RunsStarted:     runsStarted(result),
+	})
+}
+
+func (ctrl *Controller) ListIngested(c *echo.Context) error {
+	req, err := eventsvc.ListRequestFromValues(c.QueryParams())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	events, err := eventsvc.New(c.Request().Context()).ListIngested(req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, events)
+}
+
+func eventIngestRateLimitConfig() (int, int) {
+	vars := env.Variables()
+	return vars.WebhookRateLimitPerMinute, vars.WebhookRateLimitBurst
+}
+
+var errIngestRequestTooLarge = errors.New("ingest request body too large")
+
+func readIngestBody(body io.Reader) ([]byte, error) {
+	maxBytes := env.Variables().WebhookMaxBodySize.Int64()
+	if maxBytes <= 0 {
+		return io.ReadAll(body)
+	}
+
+	limited := io.LimitReader(body, maxBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, errIngestRequestTooLarge
+	}
+	return data, nil
+}
+
+func requireEventIngestAPIKey(c *echo.Context) error {
+	expected := strings.TrimSpace(env.Variables().EventIngestAPIKey)
+	if expected == "" {
+		return echo.NewHTTPError(http.StatusServiceUnavailable, "event ingest is disabled")
+	}
+
+	provided := strings.TrimSpace(c.Request().Header.Get("X-Caesium-API-Key"))
+	if provided == "" {
+		auth := strings.TrimSpace(c.Request().Header.Get("Authorization"))
+		if strings.HasPrefix(strings.ToLower(auth), "bearer ") {
+			provided = strings.TrimSpace(auth[7:])
+		}
+	}
+
+	if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid api key")
+	}
+	return nil
+}
+
+func runsStarted(result *triggerevent.RouteResult) int {
+	if result == nil {
+		return 0
+	}
+	var total int
+	for _, match := range result.MatchedTriggers {
+		total += len(match.RunsStarted)
+	}
+	return total
+}

--- a/api/rest/controller/event/ingest.go
+++ b/api/rest/controller/event/ingest.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -149,7 +150,9 @@ func requireEventIngestAPIKey(c *echo.Context) error {
 		}
 	}
 
-	if subtle.ConstantTimeCompare([]byte(provided), []byte(expected)) != 1 {
+	providedHash := sha256.Sum256([]byte(provided))
+	expectedHash := sha256.Sum256([]byte(expected))
+	if subtle.ConstantTimeCompare(providedHash[:], expectedHash[:]) != 1 {
 		return echo.NewHTTPError(http.StatusUnauthorized, "invalid api key")
 	}
 	return nil

--- a/api/rest/controller/event/ingest_test.go
+++ b/api/rest/controller/event/ingest_test.go
@@ -1,0 +1,70 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	triggerevent "github.com/caesium-cloud/caesium/internal/trigger/event"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIngestRoutesEventWithAPIKey(t *testing.T) {
+	t.Setenv("CAESIUM_EVENT_INGEST_API_KEY", "test-key")
+	require.NoError(t, env.Process())
+
+	original := routeEvent
+	routeEvent = func(_ context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+		require.Equal(t, "order.created", evt.Type)
+		require.Equal(t, "integration", evt.Source)
+		require.JSONEq(t, `{"id":"ord-1"}`, string(evt.Data))
+		return &triggerevent.RouteResult{
+			EventID:   uuid.New(),
+			EventType: evt.Type,
+			Source:    evt.Source,
+			MatchedTriggers: []triggerevent.TriggerRouteResult{
+				{TriggerID: uuid.New(), RunsStarted: []uuid.UUID{uuid.New(), uuid.New()}},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { routeEvent = original })
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", strings.NewReader(`{
+		"type":"order.created",
+		"source":"integration",
+		"data":{"id":"ord-1"}
+	}`))
+	req.Header.Set("X-Caesium-API-Key", "test-key")
+	rec := httptest.NewRecorder()
+
+	err := New(nil).Ingest(echo.New().NewContext(req, rec))
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var resp ingestResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	require.NotEqual(t, uuid.Nil, resp.EventID)
+	require.Equal(t, 1, resp.MatchedTriggers)
+	require.Equal(t, 2, resp.RunsStarted)
+}
+
+func TestIngestRejectsMissingAPIKey(t *testing.T) {
+	t.Setenv("CAESIUM_EVENT_INGEST_API_KEY", "test-key")
+	require.NoError(t, env.Process())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/events", strings.NewReader(`{"type":"order.created","data":{}}`))
+	rec := httptest.NewRecorder()
+
+	err := New(nil).Ingest(echo.New().NewContext(req, rec))
+	require.Error(t, err)
+	httpErr, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusUnauthorized, httpErr.Code)
+}

--- a/api/rest/controller/trigger/events.go
+++ b/api/rest/controller/trigger/events.go
@@ -1,0 +1,27 @@
+package trigger
+
+import (
+	"net/http"
+
+	eventsvc "github.com/caesium-cloud/caesium/api/rest/service/event"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+func Events(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	req, err := eventsvc.ListRequestFromValues(c.QueryParams())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	events, err := eventsvc.New(c.Request().Context()).ListTriggerEvents(id, req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, events)
+}

--- a/api/rest/controller/webhook/limits.go
+++ b/api/rest/controller/webhook/limits.go
@@ -1,58 +1,15 @@
 package webhook
 
 import (
-	"sync"
 	"time"
 
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	"github.com/caesium-cloud/caesium/pkg/env"
-	"golang.org/x/time/rate"
 )
 
-type ipRateLimiters struct {
-	mu       sync.Mutex
-	clients  map[string]*clientLimiter
-	staleAge time.Duration
-}
+var webhookRateLimiters = authmw.NewIPRateLimiters(15*time.Minute, webhookRateLimitConfig)
 
-type clientLimiter struct {
-	limiter    *rate.Limiter
-	lastSeen   time.Time
-	perMinute  int
-	burstLimit int
-}
-
-var webhookRateLimiters = &ipRateLimiters{
-	clients:  map[string]*clientLimiter{},
-	staleAge: 15 * time.Minute,
-}
-
-func (l *ipRateLimiters) Allow(ip string) bool {
-	perMinute := env.Variables().WebhookRateLimitPerMinute
-	burst := env.Variables().WebhookRateLimitBurst
-	if perMinute <= 0 || burst <= 0 {
-		return true
-	}
-
-	now := time.Now()
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	for key, client := range l.clients {
-		if now.Sub(client.lastSeen) > l.staleAge {
-			delete(l.clients, key)
-		}
-	}
-
-	client, ok := l.clients[ip]
-	if !ok || client.perMinute != perMinute || client.burstLimit != burst {
-		limit := rate.Every(time.Minute / time.Duration(perMinute))
-		client = &clientLimiter{
-			limiter:    rate.NewLimiter(limit, burst),
-			perMinute:  perMinute,
-			burstLimit: burst,
-		}
-		l.clients[ip] = client
-	}
-	client.lastSeen = now
-	return client.limiter.Allow()
+func webhookRateLimitConfig() (int, int) {
+	vars := env.Variables()
+	return vars.WebhookRateLimitPerMinute, vars.WebhookRateLimitBurst
 }

--- a/api/rest/controller/webhook/webhook.go
+++ b/api/rest/controller/webhook/webhook.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,10 +15,12 @@ import (
 	"github.com/caesium-cloud/caesium/internal/job"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	triggerevent "github.com/caesium-cloud/caesium/internal/trigger/event"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/labstack/echo/v5"
+	"gorm.io/datatypes"
 )
 
 type Runner func(context.Context, *models.Job, map[string]string) error
@@ -30,10 +33,21 @@ type TriggerLister interface {
 	ListByPath(string) (models.Triggers, error)
 }
 
+type acceptedHTTPTrigger struct {
+	trigger     *models.Trigger
+	httpTrigger *triggerhttp.HTTP
+	params      map[string]string
+	jobs        models.Jobs
+}
+
 // triggerFailure captures a per-trigger auth failure during the matching loop.
 type triggerFailure struct {
 	triggerID string
 	reason    string
+}
+
+var routeWebhookEvent = func(ctx context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+	return triggerevent.DefaultRouter().Route(ctx, evt)
 }
 
 // ReceiveWith returns a handler that uses the given auditor for failure logging.
@@ -66,7 +80,7 @@ func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobListe
 		return echo.NewHTTPError(http.StatusNotFound, "no trigger registered for path")
 	}
 
-	var accepted int
+	accepted := make([]acceptedHTTPTrigger, 0, len(triggers))
 	var failures []triggerFailure
 	for _, trig := range triggers {
 		httpTrigger, err := triggerhttp.New(trig, opts...)
@@ -86,51 +100,117 @@ func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobListe
 			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 		}
 
-		if err := FireHTTPTrigger(c.Request().Context(), jobSvc, trig, params, runner); err != nil {
+		jobs, err := listTriggerJobs(c.Request().Context(), jobSvc, trig)
+		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 		}
-		accepted++
+		accepted = append(accepted, acceptedHTTPTrigger{
+			trigger:     trig,
+			httpTrigger: httpTrigger,
+			params:      params,
+			jobs:        jobs,
+		})
 	}
 
-	if accepted == 0 {
+	if len(accepted) == 0 {
 		recordWebhookAuthFailures(path, c.RealIP(), failures, auditor)
 		return echo.NewHTTPError(http.StatusUnauthorized, "invalid signature")
+	}
+
+	// A webhook may satisfy both an HTTP trigger and one or more event triggers.
+	// That is an explicit fan-out contract: the event bridge is persisted/routed
+	// before HTTP jobs are launched when possible, and both trigger families may
+	// start runs. The event bridge is at-least-once: retrying the same delivery
+	// can route another event-trigger run.
+	result, err := routeWebhookEvent(c.Request().Context(), webhookIngestedEvent(c, path, body))
+	switch {
+	case err != nil:
+		log.Warn("webhook event bridge failed", "path", path, "error", err)
+		metrics.EventBridgeFailuresTotal.WithLabelValues("webhook").Inc()
+	case result == nil:
+		log.Warn("webhook event bridge returned nil result", "path", path)
+		metrics.EventBridgeFailuresTotal.WithLabelValues("webhook").Inc()
+	default:
+		metrics.EventsIngestedTotal.WithLabelValues("webhook").Inc()
+	}
+
+	for _, acceptedTrigger := range accepted {
+		launchHTTPTriggerJobs(c.Request().Context(), acceptedTrigger, runner)
 	}
 
 	return c.JSON(http.StatusAccepted, nil)
 }
 
 func FireHTTPTrigger(ctx context.Context, jobSvc JobLister, trig *models.Trigger, params map[string]string, runner Runner) error {
+	httpTrigger, err := newHTTPTrigger(trig)
+	if err != nil {
+		return err
+	}
+	jobs, err := listTriggerJobs(ctx, jobSvc, trig)
+	if err != nil {
+		return err
+	}
+	launchHTTPTriggerJobs(ctx, acceptedHTTPTrigger{
+		trigger:     trig,
+		httpTrigger: httpTrigger,
+		params:      params,
+		jobs:        jobs,
+	}, runner)
+	return nil
+}
+
+func newHTTPTrigger(trig *models.Trigger) (*triggerhttp.HTTP, error) {
 	if trig == nil {
-		return fmt.Errorf("trigger is required")
+		return nil, fmt.Errorf("trigger is required")
 	}
 	if trig.Type != models.TriggerTypeHTTP {
-		return fmt.Errorf("trigger %v is not http", trig.ID)
-	}
-	if runner == nil {
-		runner = DefaultRunner
+		return nil, fmt.Errorf("trigger %v is not http", trig.ID)
 	}
 	httpTrigger, err := triggerhttp.New(trig)
 	if err != nil {
-		return err
+		return nil, err
 	}
+	return httpTrigger, nil
+}
 
+func listTriggerJobs(ctx context.Context, jobSvc JobLister, trig *models.Trigger) (models.Jobs, error) {
+	if trig == nil {
+		return nil, fmt.Errorf("trigger is required")
+	}
+	if trig.Type != models.TriggerTypeHTTP {
+		return nil, fmt.Errorf("trigger %v is not http", trig.ID)
+	}
 	req := &jsvc.ListRequest{TriggerID: trig.ID.String()}
 	jobs, err := jobSvc.List(req)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	return jobs, nil
+}
+
+func launchHTTPTriggerJobs(ctx context.Context, accepted acceptedHTTPTrigger, runner Runner) {
+	if runner == nil {
+		runner = DefaultRunner
+	}
+	if accepted.httpTrigger == nil || accepted.trigger == nil {
+		log.Warn("skipping malformed accepted webhook trigger")
+		return
 	}
 
-	log.Info("running jobs", "count", len(jobs), "trigger_id", trig.ID)
+	log.Info("running jobs", "count", len(accepted.jobs), "trigger_id", accepted.trigger.ID)
 
-	for _, j := range jobs {
+	for _, j := range accepted.jobs {
+		if j == nil {
+			log.Warn("skipping nil job", "trigger_id", accepted.trigger.ID)
+			continue
+		}
 		if j.Paused {
 			log.Info("skipping paused job", "id", j.ID)
 			continue
 		}
 
 		capturedJob := j
-		capturedParams := cloneStringMap(httpTrigger.MergeParams(params))
+		capturedParams := cloneStringMap(accepted.httpTrigger.MergeParams(accepted.params))
 		go func() {
 			runCtx := context.WithoutCancel(ctx)
 			if err := runner(runCtx, capturedJob, capturedParams); err != nil {
@@ -138,8 +218,6 @@ func FireHTTPTrigger(ctx context.Context, jobSvc JobLister, trig *models.Trigger
 			}
 		}()
 	}
-
-	return nil
 }
 
 func DefaultRunner(ctx context.Context, j *models.Job, params map[string]string) error {
@@ -148,6 +226,43 @@ func DefaultRunner(ctx context.Context, j *models.Job, params map[string]string)
 
 func normalizeHookPath(path string) string {
 	return models.NormalizedTriggerPath(strings.TrimSpace(path))
+}
+
+func AllowRateLimit(ip string) bool {
+	return webhookRateLimiters.Allow(ip)
+}
+
+func webhookIngestedEvent(c *echo.Context, path string, body []byte) *models.IngestedEvent {
+	return &models.IngestedEvent{
+		Type:   "webhook",
+		Source: webhookEventSource(c, path),
+		Data:   webhookEventData(c, path, body),
+	}
+}
+
+func webhookEventSource(c *echo.Context, path string) string {
+	for _, header := range []string{"X-Caesium-Event-Source", "X-Webhook-Source"} {
+		if value := strings.TrimSpace(c.Request().Header.Get(header)); value != "" {
+			return value
+		}
+	}
+	return path
+}
+
+func webhookEventData(c *echo.Context, path string, body []byte) datatypes.JSON {
+	if len(body) > 0 && json.Valid(body) {
+		return datatypes.JSON(body)
+	}
+	payload := map[string]string{
+		"hook_path":    path,
+		"content_type": c.Request().Header.Get(echo.HeaderContentType),
+		"raw_body":     string(body),
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return datatypes.JSON(`{}`)
+	}
+	return datatypes.JSON(data)
 }
 
 var errRequestTooLarge = errors.New("request body too large")

--- a/api/rest/controller/webhook/webhook_test.go
+++ b/api/rest/controller/webhook/webhook_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,10 +13,12 @@ import (
 	"testing"
 	"time"
 
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	metrictestutil "github.com/caesium-cloud/caesium/internal/metrics/testutil"
 	"github.com/caesium-cloud/caesium/internal/models"
+	triggerevent "github.com/caesium-cloud/caesium/internal/trigger/event"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/google/uuid"
@@ -41,8 +44,21 @@ func (s stubJobLister) List(*jsvc.ListRequest) (models.Jobs, error) {
 	return s.jobs, s.err
 }
 
+func stubWebhookRouter(t *testing.T, fn func(context.Context, *models.IngestedEvent) (*triggerevent.RouteResult, error)) {
+	t.Helper()
+	original := routeWebhookEvent
+	routeWebhookEvent = fn
+	t.Cleanup(func() { routeWebhookEvent = original })
+}
+
 func TestReceiveWithServicesFiresWebhookTrigger(t *testing.T) {
 	require.NoError(t, env.Process())
+	stubWebhookRouter(t, func(_ context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+		require.Equal(t, "webhook", evt.Type)
+		require.Equal(t, "github/push", evt.Source)
+		require.JSONEq(t, `{"ref":"refs/heads/main"}`, string(evt.Data))
+		return &triggerevent.RouteResult{EventID: uuid.New(), EventType: evt.Type, Source: evt.Source}, nil
+	})
 
 	triggerID := uuid.New()
 	jobID := uuid.New()
@@ -99,6 +115,118 @@ func TestReceiveWithServicesFiresWebhookTrigger(t *testing.T) {
 			"environment": "staging",
 			"branch":      "refs/heads/main",
 		}, params)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook-triggered job")
+	}
+}
+
+func TestReceiveWithServicesContinuesWhenWebhookBridgeFails(t *testing.T) {
+	require.NoError(t, env.Process())
+	metrics.Register()
+
+	stubWebhookRouter(t, func(_ context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+		require.Equal(t, "webhook", evt.Type)
+		return nil, errors.New("route failed")
+	})
+
+	runs := make(chan struct{}, 1)
+	before := metrictestutil.CounterValue(t, metrics.EventBridgeFailuresTotal, "webhook")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/issues", strings.NewReader(`{"action":"opened"}`))
+	req.Header.Set("Authorization", "Bearer top-secret")
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "*", Value: "github/issues"}})
+
+	err := ReceiveWithServices(
+		c,
+		stubTriggerLister{
+			triggers: models.Triggers{
+				&models.Trigger{
+					ID:   uuid.New(),
+					Type: models.TriggerTypeHTTP,
+					Configuration: `{
+						"path":"github/issues",
+						"secret":"top-secret",
+						"signatureScheme":"bearer"
+					}`,
+				},
+			},
+		},
+		stubJobLister{jobs: models.Jobs{&models.Job{ID: uuid.New(), Alias: "deploy"}}},
+		nil,
+		func(context.Context, *models.Job, map[string]string) error {
+			runs <- struct{}{}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	select {
+	case <-runs:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook-triggered job")
+	}
+
+	after := metrictestutil.CounterValue(t, metrics.EventBridgeFailuresTotal, "webhook")
+	require.Greater(t, after, before)
+}
+
+func TestReceiveWithServicesRoutesWebhookBeforeHTTPJobs(t *testing.T) {
+	require.NoError(t, env.Process())
+
+	runs := make(chan struct{}, 1)
+	stubWebhookRouter(t, func(_ context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+		require.Equal(t, "webhook", evt.Type)
+		require.Equal(t, "github", evt.Source)
+		require.JSONEq(t, `{"action":"opened"}`, string(evt.Data))
+		select {
+		case <-runs:
+			t.Fatal("HTTP job launched before webhook event route completed")
+		default:
+		}
+		return &triggerevent.RouteResult{EventID: uuid.New(), EventType: evt.Type, Source: evt.Source}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/issues", strings.NewReader(`{"action":"opened"}`))
+	req.Header.Set("Authorization", "Bearer top-secret")
+	req.Header.Set("X-Caesium-Event-Source", "github")
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "*", Value: "github/issues"}})
+
+	err := ReceiveWithServices(
+		c,
+		stubTriggerLister{
+			triggers: models.Triggers{
+				&models.Trigger{
+					ID:   uuid.New(),
+					Type: models.TriggerTypeHTTP,
+					Configuration: `{
+						"path":"github/issues",
+						"secret":"top-secret",
+						"signatureScheme":"bearer"
+					}`,
+				},
+			},
+		},
+		stubJobLister{jobs: models.Jobs{&models.Job{ID: uuid.New(), Alias: "deploy"}}},
+		nil,
+		func(context.Context, *models.Job, map[string]string) error {
+			runs <- struct{}{}
+			return nil
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	select {
+	case <-runs:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for webhook-triggered job")
 	}
@@ -172,10 +300,10 @@ func TestReceiveWithServicesRateLimitsByIP(t *testing.T) {
 	t.Setenv("CAESIUM_WEBHOOK_RATE_LIMIT_PER_MINUTE", "1")
 	t.Setenv("CAESIUM_WEBHOOK_RATE_LIMIT_BURST", "1")
 	require.NoError(t, env.Process())
-	webhookRateLimiters = &ipRateLimiters{
-		clients:  map[string]*clientLimiter{},
-		staleAge: 15 * time.Minute,
-	}
+	stubWebhookRouter(t, func(_ context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+		return &triggerevent.RouteResult{EventID: uuid.New(), EventType: evt.Type, Source: evt.Source}, nil
+	})
+	webhookRateLimiters = authmw.NewIPRateLimiters(15*time.Minute, webhookRateLimitConfig)
 
 	newContext := func() *echo.Context {
 		req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{"ref":"refs/heads/main"}`))
@@ -307,6 +435,9 @@ func TestReceiveWithServicesRecordsMetricOnReplayedRequest(t *testing.T) {
 func TestReceiveWithServicesNoMetricWhenOneTriggerAccepts(t *testing.T) {
 	require.NoError(t, env.Process())
 	metrics.Register()
+	stubWebhookRouter(t, func(_ context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+		return &triggerevent.RouteResult{EventID: uuid.New(), EventType: evt.Type, Source: evt.Source}, nil
+	})
 
 	before := metrictestutil.CounterValue(t, metrics.WebhookAuthFailuresTotal, "multi/path", "invalid_signature")
 

--- a/api/rest/service/event/event.go
+++ b/api/rest/service/event/event.go
@@ -1,0 +1,253 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+const (
+	defaultListLimit uint64 = 100
+	maxListLimit     uint64 = 500
+)
+
+type Service interface {
+	ListIngested(*ListRequest) ([]models.IngestedEvent, error)
+	ListTriggerEvents(uuid.UUID, *ListRequest) ([]TriggerEvent, error)
+}
+
+type service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+type ListRequest struct {
+	Type          string
+	Source        string
+	CreatedAfter  *time.Time
+	CreatedBefore *time.Time
+	Limit         uint64
+	Offset        uint64
+}
+
+type TriggerEvent struct {
+	MatchID     uuid.UUID      `json:"match_id"`
+	EventID     uuid.UUID      `json:"event_id"`
+	TriggerID   uuid.UUID      `json:"trigger_id"`
+	Type        string         `json:"type"`
+	Source      string         `json:"source,omitempty"`
+	Data        datatypes.JSON `json:"data,omitempty"`
+	CreatedAt   time.Time      `json:"created_at"`
+	MatchedAt   time.Time      `json:"matched_at"`
+	RunsStarted []uuid.UUID    `json:"runs_started,omitempty"`
+	Skipped     bool           `json:"skipped"`
+	SkipReason  string         `json:"skip_reason,omitempty"`
+	Error       string         `json:"error,omitempty"`
+}
+
+func New(ctx context.Context) Service {
+	return NewWithDatabase(ctx, db.Connection())
+}
+
+func NewWithDatabase(ctx context.Context, conn *gorm.DB) Service {
+	return &service{
+		ctx: ctx,
+		db:  conn,
+	}
+}
+
+func ListRequestFromValues(values url.Values) (*ListRequest, error) {
+	req := &ListRequest{
+		Type:   strings.TrimSpace(values.Get("type")),
+		Source: strings.TrimSpace(values.Get("source")),
+	}
+
+	if raw := strings.TrimSpace(values.Get("limit")); raw != "" {
+		limit, err := parseUint(raw, "limit")
+		if err != nil {
+			return nil, err
+		}
+		req.Limit = limit
+	}
+	if raw := strings.TrimSpace(values.Get("offset")); raw != "" {
+		offset, err := parseUint(raw, "offset")
+		if err != nil {
+			return nil, err
+		}
+		req.Offset = offset
+	}
+
+	var err error
+	req.CreatedAfter, err = parseTimeValue(values, "created_after", "after", "from", "start")
+	if err != nil {
+		return nil, err
+	}
+	req.CreatedBefore, err = parseTimeValue(values, "created_before", "before", "to", "end")
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+func (s *service) ListIngested(req *ListRequest) ([]models.IngestedEvent, error) {
+	req = normalizeListRequest(req)
+
+	events := make([]models.IngestedEvent, 0, req.Limit)
+	q := s.applyEventFilters(s.db.WithContext(s.ctx).Model(&models.IngestedEvent{}), req).
+		Order("created_at desc").
+		Order("id desc").
+		Limit(int(req.Limit))
+	if req.Offset > 0 {
+		q = q.Offset(int(req.Offset))
+	}
+
+	return events, q.Find(&events).Error
+}
+
+func (s *service) ListTriggerEvents(triggerID uuid.UUID, req *ListRequest) ([]TriggerEvent, error) {
+	req = normalizeListRequest(req)
+
+	rows := make([]models.EventTriggerMatch, 0, req.Limit)
+	q := s.db.WithContext(s.ctx).
+		Model(&models.EventTriggerMatch{}).
+		Joins("JOIN ingested_events ON ingested_events.id = event_trigger_matches.event_id").
+		Preload("Event").
+		Where("event_trigger_matches.trigger_id = ?", triggerID)
+	q = s.applyJoinedEventFilters(q, req).
+		Order("event_trigger_matches.matched_at desc").
+		Order("event_trigger_matches.id desc").
+		Limit(int(req.Limit))
+	if req.Offset > 0 {
+		q = q.Offset(int(req.Offset))
+	}
+	if err := q.Find(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	out := make([]TriggerEvent, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, triggerEventFromMatch(row))
+	}
+	return out, nil
+}
+
+func (s *service) applyEventFilters(q *gorm.DB, req *ListRequest) *gorm.DB {
+	if req.Type != "" {
+		q = q.Where("type = ?", req.Type)
+	}
+	if req.Source != "" {
+		q = q.Where("source = ?", req.Source)
+	}
+	if req.CreatedAfter != nil {
+		q = q.Where("created_at >= ?", *req.CreatedAfter)
+	}
+	if req.CreatedBefore != nil {
+		q = q.Where("created_at <= ?", *req.CreatedBefore)
+	}
+	return q
+}
+
+func (s *service) applyJoinedEventFilters(q *gorm.DB, req *ListRequest) *gorm.DB {
+	if req.Type != "" {
+		q = q.Where("ingested_events.type = ?", req.Type)
+	}
+	if req.Source != "" {
+		q = q.Where("ingested_events.source = ?", req.Source)
+	}
+	if req.CreatedAfter != nil {
+		q = q.Where("ingested_events.created_at >= ?", *req.CreatedAfter)
+	}
+	if req.CreatedBefore != nil {
+		q = q.Where("ingested_events.created_at <= ?", *req.CreatedBefore)
+	}
+	return q
+}
+
+func normalizeListRequest(req *ListRequest) *ListRequest {
+	if req == nil {
+		req = &ListRequest{}
+	}
+	normalized := *req
+	normalized.Type = strings.TrimSpace(normalized.Type)
+	normalized.Source = strings.TrimSpace(normalized.Source)
+	if normalized.Limit == 0 {
+		normalized.Limit = defaultListLimit
+	}
+	if normalized.Limit > maxListLimit {
+		normalized.Limit = maxListLimit
+	}
+	return &normalized
+}
+
+func triggerEventFromMatch(row models.EventTriggerMatch) TriggerEvent {
+	return TriggerEvent{
+		MatchID:     row.ID,
+		EventID:     row.EventID,
+		TriggerID:   row.TriggerID,
+		Type:        row.Event.Type,
+		Source:      row.Event.Source,
+		Data:        row.Event.Data,
+		CreatedAt:   row.Event.CreatedAt,
+		MatchedAt:   row.MatchedAt,
+		RunsStarted: decodeRunIDs(row.RunsStarted),
+		Skipped:     row.Skipped,
+		SkipReason:  row.SkipReason,
+		Error:       row.Error,
+	}
+}
+
+func decodeRunIDs(data datatypes.JSON) []uuid.UUID {
+	if len(data) == 0 {
+		return nil
+	}
+	var raw []string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	out := make([]uuid.UUID, 0, len(raw))
+	for _, value := range raw {
+		id, err := uuid.Parse(value)
+		if err == nil && id != uuid.Nil {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+func parseUint(raw, name string) (uint64, error) {
+	value, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be a non-negative integer", name)
+	}
+	return value, nil
+}
+
+func parseTimeValue(values url.Values, names ...string) (*time.Time, error) {
+	for _, name := range names {
+		raw := strings.TrimSpace(values.Get(name))
+		if raw == "" {
+			continue
+		}
+		parsed, err := time.Parse(time.RFC3339Nano, raw)
+		if err != nil {
+			parsed, err = time.Parse(time.RFC3339, raw)
+			if err != nil {
+				return nil, fmt.Errorf("%s must be RFC3339", name)
+			}
+		}
+		utc := parsed.UTC()
+		return &utc, nil
+	}
+	return nil, nil
+}

--- a/docs/exec-plans/active/event-trigger-routing.md
+++ b/docs/exec-plans/active/event-trigger-routing.md
@@ -231,7 +231,7 @@ path. There is already an `api/rest/controller/event/` package (SSE) and an
 `api/rest/controller/trigger/` package (List/Post/Get/Patch/Fire bound in
 `api/rest/bind/bind.go` lines ~127-133) — extend those, don't fork them.
 
-- [ ] B1. Add `POST /v1/events` (`{type, source, data}`): **authenticate via a
+- [x] B1. Add `POST /v1/events` (`{type, source, data}`): **authenticate via a
       dedicated `CAESIUM_EVENT_INGEST_API_KEY`** (mirroring the shipped
       `CAESIUM_MANUAL_TRIGGER_API_KEY` gate on `POST /v1/triggers/:id/fire` — the
       webhook signature auth is *per-path/per-trigger* and does NOT fit a path-less
@@ -245,7 +245,13 @@ path. There is already an `api/rest/controller/event/` package (SSE) and an
       Files: new `api/rest/controller/event/ingest.go`, `api/rest/service/event/`,
       `api/rest/bind/bind.go`, `pkg/env/env.go`, `internal/metrics/metrics.go`.
       Depends on: A4.
-- [ ] B2. Add the observability reads: `GET /v1/events/ingested` (filter by
+      - W2-α: Added keyed `POST /v1/events`, reusing the webhook per-IP
+        rate-limit and the manual-trigger API-key header convention. The handler
+        builds an `IngestedEvent`, calls the singleton `Router.Route`, maps the
+        `RouteResult` to `{event_id, matched_triggers, runs_started}`, and
+        increments `caesium_events_ingested_total{type,source}`; Stream A's router
+        remains the persist-and-fire boundary for events and match rows.
+- [x] B2. Add the observability reads: `GET /v1/events/ingested` (filter by
       `type`/`source`/time window, bounded+paginated) and `GET /v1/triggers/:id/events`
       (read the `event_trigger_matches` table joined to `ingested_events` — the
       durable match record, **NOT** a re-evaluation of the current patterns, which
@@ -253,7 +259,12 @@ path. There is already an `api/rest/controller/event/` package (SSE) and an
       Files: `api/rest/controller/event/`, `api/rest/controller/trigger/`,
       `api/rest/service/event/`, `api/rest/bind/bind.go`.
       Depends on: A1 (both models) + B1 (which writes the match rows).
-- [ ] B3. **Bridge the webhook receiver into the event router** — without this,
+      - W2-α: Added bounded `GET /v1/events/ingested` and durable
+        `GET /v1/triggers/:id/events` reads through `api/rest/service/event`,
+        with type/source/time filters plus limit/offset pagination. Trigger-event
+        reads join `event_trigger_matches` to `ingested_events` and return the
+        stored match/run outcome.
+- [x] B3. **Bridge the webhook receiver into the event router** — without this,
       content-based routing never reaches the shipped `/v1/hooks/*` traffic and the
       P0 problem stays half-solved (the design exposes the router to *both* the
       ingestion API AND the webhook controller). After the receiver's auth/rate-limit,
@@ -272,6 +283,11 @@ path. There is already an `api/rest/controller/event/` package (SSE) and an
       Files: `api/rest/controller/webhook/webhook.go` (reorder around the existing
       `FireHTTPTrigger`; routes through the shared persist-and-fire boundary from A4).
       Depends on: A4.
+      - W2-α: The webhook receiver now validates matching HTTP triggers and lists
+        their jobs first, routes a single `type:"webhook"` event through
+        `Router.Route` before launching HTTP jobs, then starts the prepared HTTP
+        work. The code documents the intentional double-fire contract: one webhook
+        can fire both HTTP-trigger jobs and event-trigger jobs.
 
 ### Stream C — Trigger chaining (WS3)
 
@@ -339,7 +355,7 @@ plan against the Stream B endpoints.
 
 ## Harness Strengthening
 
-- [ ] H-1. Ensure the integration server exercises the real event path: set
+- [x] H-1. Ensure the integration server exercises the real event path: set
       `CAESIUM_EVENT_INGEST_API_KEY` (so the Stream A/B/C scenarios can authenticate
       `POST /v1/events`) and a low `CAESIUM_MAX_TRIGGER_DEPTH` if the chain tests need
       a tight bound, on the `just integration-up` / `just integration-test` server,
@@ -347,6 +363,11 @@ plan against the Stream B endpoints.
       triggers land behind an enable flag, set it here (mirror the lineage
       `CAESIUM_OPEN_LINEAGE_ENABLED` precedent the `CLAUDE.md` gate calls out).
       Files: `justfile`, `.github/workflows/ci.yml`, `test/` harness helpers.
+      - W2-α: `just integration-up` now injects
+        `CAESIUM_EVENT_INGEST_API_KEY`, CI passes the same key into the integration
+        job, the test harness carries it, and `test/event_trigger_test.go` drives
+        apply → authenticated `/v1/events` ingest → durable trigger-event read →
+        run completion through the live server.
 
 ## Navigational / Organizational Improvements
 

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -53,12 +53,14 @@ var endpointPolicy = map[string]models.Role{
 	"GET /v1/jobs/:id/backfills":                models.RoleViewer,
 	"GET /v1/jobs/:id/backfills/:id":            models.RoleViewer,
 	"GET /v1/events":                            models.RoleViewer,
+	"GET /v1/events/ingested":                   models.RoleViewer,
 	"GET /v1/stats":                             models.RoleViewer,
 	"GET /v1/stats/summary":                     models.RoleViewer,
 	"GET /v1/system/features":                   models.RoleViewer,
 	"GET /v1/system/nodes":                      models.RoleViewer,
 	"GET /v1/triggers":                          models.RoleViewer,
 	"GET /v1/triggers/:id":                      models.RoleViewer,
+	"GET /v1/triggers/:id/events":               models.RoleViewer,
 	"GET /v1/atoms":                             models.RoleViewer,
 	"GET /v1/atoms/:id":                         models.RoleViewer,
 	"GET /v1/nodes/:id/workers":                 models.RoleViewer,
@@ -76,6 +78,7 @@ var endpointPolicy = map[string]models.Role{
 	"POST /v1/jobs/:id/runs/:id/retry":           models.RoleRunner,
 	"POST /v1/jobs/:id/runs/:id/callbacks/retry": models.RoleRunner,
 	"POST /v1/jobs/:id/backfill":                 models.RoleRunner,
+	"POST /v1/events":                            models.RoleRunner,
 	"POST /v1/triggers/:id/fire":                 models.RoleRunner,
 
 	// Operator

--- a/internal/harness/runner.go
+++ b/internal/harness/runner.go
@@ -526,7 +526,7 @@ var harnessMetricSpecs = map[string]metricSpec{
 		read:       readCounter(metrics.DBBusyRetriesTotal),
 	},
 	"caesium_event_trigger_matches_total": {
-		labelNames: []string{"trigger_id", "event_type"},
+		labelNames: []string{"trigger_id"},
 		read:       readCounterVec(metrics.EventTriggerMatchesTotal),
 	},
 	"caesium_job_runs_total": {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -254,9 +254,25 @@ var (
 	EventTriggerMatchesTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "caesium_event_trigger_matches_total",
-			Help: "Total event trigger matches by trigger and event type.",
+			Help: "Total event trigger matches by configured trigger.",
 		},
-		[]string{"trigger_id", "event_type"},
+		[]string{"trigger_id"},
+	)
+
+	EventsIngestedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_events_ingested_total",
+			Help: "Total events ingested by low-cardinality origin.",
+		},
+		[]string{"origin"},
+	)
+
+	EventBridgeFailuresTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_event_bridge_failures_total",
+			Help: "Total event bridge routing failures by low-cardinality origin.",
+		},
+		[]string{"origin"},
 	)
 
 	// DBWritesTotal counts durable database writes by category, measured in
@@ -425,6 +441,8 @@ func Register() {
 			SSOLogoutsTotal,
 			WebhookAuthFailuresTotal,
 			EventTriggerMatchesTotal,
+			EventsIngestedTotal,
+			EventBridgeFailuresTotal,
 			DBWritesTotal,
 			DBStatementsTotal,
 			CompleteRejectedTotal,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -36,6 +36,9 @@ func (s *MetricsSuite) SetupTest() {
 		WorkerLeaseExpirationsTotal,
 		TaskRetriesTotal,
 		WebhookAuthFailuresTotal,
+		EventTriggerMatchesTotal,
+		EventsIngestedTotal,
+		EventBridgeFailuresTotal,
 		SSOLoginsTotal,
 		SSOLoginDurationSeconds,
 		SSOLogoutsTotal,
@@ -199,6 +202,29 @@ func (s *MetricsSuite) TestWebhookAuthFailuresTotalIncrements() {
 
 	val = metrictestutil.CounterValue(s.T(), WebhookAuthFailuresTotal, "github/push", "replayed_request")
 	s.GreaterOrEqual(val, float64(2))
+}
+
+func (s *MetricsSuite) TestEventsIngestedTotalIncrements() {
+	EventsIngestedTotal.WithLabelValues("ingest").Inc()
+	EventsIngestedTotal.WithLabelValues("ingest").Inc()
+
+	val := metrictestutil.CounterValue(s.T(), EventsIngestedTotal, "ingest")
+	s.GreaterOrEqual(val, float64(2))
+}
+
+func (s *MetricsSuite) TestEventTriggerMatchesTotalIncrements() {
+	EventTriggerMatchesTotal.WithLabelValues("trigger-1").Inc()
+	EventTriggerMatchesTotal.WithLabelValues("trigger-1").Inc()
+
+	val := metrictestutil.CounterValue(s.T(), EventTriggerMatchesTotal, "trigger-1")
+	s.GreaterOrEqual(val, float64(2))
+}
+
+func (s *MetricsSuite) TestEventBridgeFailuresTotalIncrements() {
+	EventBridgeFailuresTotal.WithLabelValues("webhook").Inc()
+
+	val := metrictestutil.CounterValue(s.T(), EventBridgeFailuresTotal, "webhook")
+	s.GreaterOrEqual(val, float64(1))
 }
 
 func (s *MetricsSuite) TestSSOLoginsTotalIncrements() {

--- a/internal/trigger/event/router.go
+++ b/internal/trigger/event/router.go
@@ -226,7 +226,7 @@ func (r *Router) Route(ctx context.Context, evt *models.IngestedEvent) (*RouteRe
 		}
 	}
 	for _, match := range metricMatches {
-		metrics.EventTriggerMatchesTotal.WithLabelValues(match.TriggerID.String(), result.EventType).Inc()
+		metrics.EventTriggerMatchesTotal.WithLabelValues(match.TriggerID.String()).Inc()
 	}
 
 	return result, nil

--- a/justfile
+++ b/justfile
@@ -29,6 +29,7 @@ publish_builder_ref := repo + "/" + builder_image
 sock := env("CAESIUM_SOCK", default_sock)
 port := env("CAESIUM_PORT", "8080")
 auth_mode := env("CAESIUM_AUTH_MODE", "none")
+event_ingest_api_key := env("CAESIUM_EVENT_INGEST_API_KEY", "integration-test-key")
 
 # Local Docker registry used by `just k8s-distributed` to push freshly-built
 # images into the cluster's containerd. Port 5050 sidesteps the macOS
@@ -158,6 +159,7 @@ integration-test:
         -v {{ repo_dir }}:{{ bld_dir }} \
         -v {{ sock }}:/var/run/docker.sock \
         -e CAESIUM_CLI_PATH={{ bld_dir }}/.tmp/caesium-cli/caesium \
+        -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
         -e DOCKER_HOST=unix:///var/run/docker.sock \
         --network=container:{{ it_container }} \
         -w {{ bld_dir }} \
@@ -189,12 +191,14 @@ integration-test-podman: build
         -v "${PODMAN_SOCK}:/run/podman/podman.sock" \
         -e CAESIUM_PODMAN_URI=unix:///run/podman/podman.sock \
         -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
+        -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
         -e CAESIUM_LOG_LEVEL=debug \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
     if docker run --rm --platform {{ platform }} \
         -v {{ repo_dir }}:{{ bld_dir }} \
         -e CAESIUM_TEST_ENGINE=podman \
+        -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
         --network=host \
         -w {{ bld_dir }} \
         {{ repo }}/{{ builder_image }}:{{ tag }}-full \
@@ -224,6 +228,7 @@ integration-up: build-test
         -e DOCKER_HOST=unix:///var/run/docker.sock \
         --user 0:0 \
         -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
+        -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
         -e CAESIUM_LOG_LEVEL=debug \
         -e CAESIUM_DATABASE_SHARDS=4 \
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -88,6 +88,7 @@ type Environment struct {
 	DatabaseStandbys               int           `default:"3" split_words:"true"`
 	DatabaseConsoleEnabled         bool          `default:"false" split_words:"true"`
 	ManualTriggerAPIKey            string        `envconfig:"MANUAL_TRIGGER_API_KEY" default:""`
+	EventIngestAPIKey              string        `envconfig:"EVENT_INGEST_API_KEY" default:""`
 	MaxParallelTasks               int           `split_words:"true"`
 	TaskFailurePolicy              string        `default:"halt" split_words:"true"`
 	TaskTimeout                    time.Duration `default:"0" split_words:"true"`

--- a/test/event_trigger_test.go
+++ b/test/event_trigger_test.go
@@ -1,0 +1,290 @@
+//go:build integration
+
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+type eventIngestResponse struct {
+	EventID         string `json:"event_id"`
+	MatchedTriggers int    `json:"matched_triggers"`
+	RunsStarted     int    `json:"runs_started"`
+}
+
+type triggerEventResponse struct {
+	EventID     string   `json:"event_id"`
+	TriggerID   string   `json:"trigger_id"`
+	Type        string   `json:"type"`
+	Source      string   `json:"source"`
+	RunsStarted []string `json:"runs_started"`
+}
+
+type ingestedEventResponse struct {
+	ID     string          `json:"id"`
+	Type   string          `json:"type"`
+	Source string          `json:"source"`
+	Data   json.RawMessage `json:"data"`
+}
+
+func (s *IntegrationTestSuite) TestEventIngestRoutesEventTriggerJob() {
+	alias := fmt.Sprintf("integration-event-trigger-%d", time.Now().UnixNano())
+	dir := s.writeJobManifest(eventTriggerManifest(alias))
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	triggerID := stringFromMap(s.jobDetailByAlias(alias), "trigger_id")
+	s.Require().NotEmpty(triggerID)
+
+	matching := s.postEvent(`{
+		"type":"order.created",
+		"source":"integration",
+		"data":{"env":"w2-alpha","order":{"id":"ord-123"}}
+	}`)
+	s.Equal(1, matching.MatchedTriggers)
+	s.Equal(1, matching.RunsStarted)
+
+	runID := s.requireTriggerEventRun(triggerID, matching.EventID)
+	run := s.awaitRun(job.ID, runID, runTimeout)
+	s.Equal("succeeded", run.Status)
+	s.Equal("ord-123", run.Params["order_id"])
+
+	beforeRuns := len(s.fetchRuns(job.ID))
+	nonMatching := s.postEvent(`{
+		"type":"order.updated",
+		"source":"integration",
+		"data":{"env":"w2-alpha","order":{"id":"ord-456"}}
+	}`)
+	s.NotEmpty(nonMatching.EventID)
+	s.Equal(0, nonMatching.MatchedTriggers)
+	s.Equal(0, nonMatching.RunsStarted)
+
+	time.Sleep(2 * time.Second)
+	s.Equal(beforeRuns, len(s.fetchRuns(job.ID)), "non-matching event should not start a run")
+}
+
+func (s *IntegrationTestSuite) TestEventIngestRequiresAPIKey() {
+	payload := `{"type":"auth.probe","source":"integration","data":{}}`
+
+	s.requireEventIngestStatus(payload, "wrong-key", true, http.StatusUnauthorized)
+	s.requireEventIngestStatus(payload, "", false, http.StatusUnauthorized)
+}
+
+func (s *IntegrationTestSuite) TestListIngestedEventsFiltersAndBoundsPagination() {
+	suffix := time.Now().UnixNano()
+	eventType := fmt.Sprintf("audit.created.%d", suffix)
+	source := fmt.Sprintf("integration-list-%d", suffix)
+
+	first := s.postEvent(fmt.Sprintf(`{"type":%q,"source":%q,"data":{"seq":1}}`, eventType, source))
+	second := s.postEvent(fmt.Sprintf(`{"type":%q,"source":%q,"data":{"seq":2}}`, eventType, source))
+
+	events := s.listIngestedEvents(eventType, source, 100)
+	s.Require().Len(events, 2)
+	s.Contains(eventIDs(events), first.EventID)
+	s.Contains(eventIDs(events), second.EventID)
+	for _, evt := range events {
+		s.Equal(eventType, evt.Type)
+		s.Equal(source, evt.Source)
+	}
+
+	limited := s.listIngestedEvents(eventType, source, 1)
+	s.Require().Len(limited, 1)
+
+	overMax := s.listIngestedEvents(eventType, source, 9999)
+	s.Require().Len(overMax, 2)
+}
+
+func (s *IntegrationTestSuite) TestWebhookPathFiresHTTPAndEventTriggers() {
+	suffix := time.Now().UnixNano()
+	path := fmt.Sprintf("/double-match/%d", suffix)
+	source := fmt.Sprintf("webhook-double-%d", suffix)
+
+	httpJob := s.createJobWithTriggerConfig(
+		fmt.Sprintf("integration-webhook-http-%d", suffix),
+		nil,
+		models.TriggerTypeHTTP,
+		map[string]any{"path": path},
+	)
+	s.Require().NotNil(httpJob)
+
+	eventAlias := fmt.Sprintf("integration-webhook-event-%d", suffix)
+	dir := s.writeJobManifest(webhookEventTriggerManifest(eventAlias, source))
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	eventJob := s.requireJobByAlias(eventAlias)
+	s.Require().NotNil(eventJob)
+
+	req, err := http.NewRequestWithContext(
+		s.T().Context(),
+		http.MethodPost,
+		fmt.Sprintf("%v/v1/hooks%s", s.caesiumURL, path),
+		bytes.NewBufferString(`{"payload":"double-match"}`),
+	)
+	s.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Caesium-Event-Source", source)
+
+	resp, err := http.DefaultClient.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusAccepted, resp.StatusCode, string(body))
+
+	s.Require().Eventually(func() bool {
+		return len(s.fetchRuns(httpJob.ID.String())) > 0
+	}, 30*time.Second, 500*time.Millisecond, "HTTP trigger run should start")
+	s.Require().Eventually(func() bool {
+		return len(s.fetchRuns(eventJob.ID)) > 0
+	}, 30*time.Second, 500*time.Millisecond, "event trigger run should start")
+}
+
+func (s *IntegrationTestSuite) postEvent(payload string) eventIngestResponse {
+	s.T().Helper()
+
+	resp, err := s.doEventIngestRequest(http.MethodPost, fmt.Sprintf("%v/v1/events", s.caesiumURL), bytes.NewBufferString(payload))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusAccepted, resp.StatusCode, string(body))
+
+	var result eventIngestResponse
+	s.Require().NoError(json.Unmarshal(body, &result))
+	s.Require().NotEmpty(result.EventID)
+	return result
+}
+
+func (s *IntegrationTestSuite) requireEventIngestStatus(payload, apiKey string, setAPIKey bool, status int) {
+	s.T().Helper()
+
+	resp, err := s.doEventIngestRequestWithKey(
+		http.MethodPost,
+		fmt.Sprintf("%v/v1/events", s.caesiumURL),
+		bytes.NewBufferString(payload),
+		apiKey,
+		setAPIKey,
+	)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(status, resp.StatusCode, string(body))
+}
+
+func (s *IntegrationTestSuite) doEventIngestRequestWithKey(method, target string, body io.Reader, apiKey string, setAPIKey bool) (*http.Response, error) {
+	s.T().Helper()
+
+	req, err := http.NewRequestWithContext(s.T().Context(), method, target, body)
+	if err != nil {
+		return nil, err
+	}
+	if setAPIKey {
+		req.Header.Set("X-Caesium-API-Key", apiKey)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return http.DefaultClient.Do(req)
+}
+
+func (s *IntegrationTestSuite) listIngestedEvents(eventType, source string, limit int) []ingestedEventResponse {
+	s.T().Helper()
+
+	query := url.Values{}
+	query.Set("type", eventType)
+	query.Set("source", source)
+	query.Set("limit", fmt.Sprintf("%d", limit))
+
+	var events []ingestedEventResponse
+	s.getJSON("/v1/events/ingested?"+query.Encode(), &events)
+	return events
+}
+
+func eventIDs(events []ingestedEventResponse) []string {
+	ids := make([]string, 0, len(events))
+	for _, evt := range events {
+		ids = append(ids, evt.ID)
+	}
+	return ids
+}
+
+func (s *IntegrationTestSuite) requireTriggerEventRun(triggerID, eventID string) string {
+	s.T().Helper()
+
+	var runID string
+	s.Require().Eventually(func() bool {
+		var events []triggerEventResponse
+		if err := s.tryGetJSON(fmt.Sprintf("/v1/triggers/%s/events?type=order.created&source=integration", triggerID), &events); err != nil {
+			return false
+		}
+		for _, evt := range events {
+			if evt.EventID != eventID {
+				continue
+			}
+			if evt.TriggerID != triggerID || evt.Type != "order.created" || evt.Source != "integration" || len(evt.RunsStarted) != 1 {
+				return false
+			}
+			runID = evt.RunsStarted[0]
+			return runID != ""
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond)
+	return runID
+}
+
+func eventTriggerManifest(alias string) string {
+	return fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger:
+  type: event
+  configuration:
+    events:
+      - type: order.created
+        source: integration
+        filter:
+          env: w2-alpha
+    paramMapping:
+      order_id: $.order.id
+steps:
+  - name: record
+    image: debian:12-slim
+    command: ["sh", "-c", "echo event-trigger"]
+`, alias)
+}
+
+func webhookEventTriggerManifest(alias, source string) string {
+	return fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger:
+  type: event
+  configuration:
+    events:
+      - type: webhook
+        source: %s
+steps:
+  - name: record
+    image: debian:12-slim
+    command: ["sh", "-c", "echo webhook-event-trigger"]
+`, alias, source)
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -34,6 +34,7 @@ type IntegrationTestSuite struct {
 	projectRoot         string
 	engineType          string // "docker", "podman", or "kubernetes"
 	manualTriggerAPIKey string
+	eventIngestAPIKey   string
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -67,6 +68,10 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.manualTriggerAPIKey = os.Getenv("CAESIUM_MANUAL_TRIGGER_API_KEY")
 	if s.manualTriggerAPIKey == "" {
 		s.manualTriggerAPIKey = "integration-test-key"
+	}
+	s.eventIngestAPIKey = os.Getenv("CAESIUM_EVENT_INGEST_API_KEY")
+	if s.eventIngestAPIKey == "" {
+		s.eventIngestAPIKey = "integration-test-key"
 	}
 
 	client := &http.Client{Timeout: 2 * time.Second}
@@ -357,5 +362,15 @@ func (s *IntegrationTestSuite) doManualTriggerRequest(method, target string, bod
 		return nil, err
 	}
 	req.Header.Set("X-Caesium-API-Key", s.manualTriggerAPIKey)
+	return http.DefaultClient.Do(req)
+}
+
+func (s *IntegrationTestSuite) doEventIngestRequest(method, target string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(s.T().Context(), method, target, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Caesium-API-Key", s.eventIngestAPIKey)
+	req.Header.Set("Content-Type", "application/json")
 	return http.DefaultClient.Do(req)
 }


### PR DESCRIPTION
## Summary

Wave 2, Stream B of event-trigger-routing — the REST surface over A's engine. Builds on the merged W1 router (which already does the persist-and-fire boundary).

- **B1** — `POST /v1/events` keyed by `CAESIUM_EVENT_INGEST_API_KEY` (constant-time compare, fail-closed 503 when unset, `RoleRunner` RBAC, per-IP rate-limit); builds the `IngestedEvent` and calls `Router.Route`, returning truthful `{event_id, matched_triggers, runs_started}`.
- **B2** — `GET /v1/events/ingested` (paginated) + `GET /v1/triggers/:id/events` reading the durable `event_trigger_matches` table (viewer RBAC).
- **B3** — the webhook→event bridge: content-routes `/v1/hooks/*` traffic through the router; degrades gracefully on a bridge `Route` failure (logs + meters, doesn't 500 the HTTP webhook); at-least-once documented.
- **H-1** — `CAESIUM_EVENT_INGEST_API_KEY` on the integration server + the apply→ingest→run integration test (plus auth-rejection + the ingested-list + the hooks double-match cases).

## Review
Opus 4-lens (incl. a security pass: auth verified constant-time/fail-closed/correct RBAC — no forgery hole) + fixes: a metric-cardinality DoS (dropped attacker-controlled `type`/`source` labels), the three integration-test gaps, graceful bridge-error handling, body-size limit. `just lint`+`unit-test` green; integration gate runs as the Phase 6.5 check.

## Test plan
- [x] just lint + just unit-test (orchestrator)
- [ ] just integration-test — Phase 6.5 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)