### PR TITLE
Add trigger chaining + cycle detection (event-trigger-routing W2-β)

### DIFF
--- a/api/rest/controller/jobdef/apply.go
+++ b/api/rest/controller/jobdef/apply.go
@@ -37,6 +37,9 @@ func Apply(c *echo.Context) error {
 		Force:      req.Force,
 		Provenance: prov,
 	}
+	if err := importer.ValidateBatch(ctx, req.Definitions); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
 
 	for i := range req.Definitions {
 		def := &req.Definitions[i]

--- a/api/rest/controller/jobdef/lint.go
+++ b/api/rest/controller/jobdef/lint.go
@@ -1,11 +1,13 @@
 package jobdef
 
 import (
+	"fmt"
 	"net/http"
 	"sort"
 	"strings"
-	"fmt"
 
+	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
+	"github.com/caesium-cloud/caesium/pkg/db"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/labstack/echo/v5"
 )
@@ -50,6 +52,11 @@ func Lint(c *echo.Context) error {
 
 	for _, def := range req.Definitions {
 		if err := def.Validate(); err != nil {
+			resp.Errors = append(resp.Errors, LintMessage{Message: err.Error()})
+		}
+	}
+	if len(resp.Errors) == 0 {
+		if err := internaljobdef.ValidateTriggerChains(c.Request().Context(), db.Connection(), req.Definitions); err != nil {
 			resp.Errors = append(resp.Errors, LintMessage{Message: err.Error()})
 		}
 	}

--- a/cmd/job/lint.go
+++ b/cmd/job/lint.go
@@ -63,6 +63,9 @@ var lintCmd = &cobra.Command{
 					}
 				}
 			}
+			if err := writeLintTriggerScopeNote(cmd); err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -84,6 +87,9 @@ var lintCmd = &cobra.Command{
 		if err := writeCmdOut(cmd, "Validated %d job definition(s) with secrets\n", len(defs)); err != nil {
 			return err
 		}
+		if err := writeLintTriggerScopeNote(cmd); err != nil {
+			return err
+		}
 		return nil
 	},
 }
@@ -101,6 +107,10 @@ func init() {
 	lintCmd.Flags().BoolVar(&lintVaultSkipVerify, "vault-skip-verify", envBool("VAULT_SKIP_VERIFY", false), "Disable TLS verification when connecting to Vault")
 
 	Cmd.AddCommand(lintCmd)
+}
+
+func writeLintTriggerScopeNote(cmd *cobra.Command) error {
+	return writeCmdOut(cmd, "Note: trigger-cycle lint is file-scoped; cross-job cycles against persisted triggers are validated at apply.\n")
 }
 
 func buildLintResolver() (*secret.MultiResolver, error) {

--- a/cmd/job/lint.go
+++ b/cmd/job/lint.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
 	lintpkg "github.com/caesium-cloud/caesium/internal/jobdef/lint"
 	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/pkg/jobdef"
@@ -46,6 +47,9 @@ var lintCmd = &cobra.Command{
 			if err := def.Validate(); err != nil {
 				return fmt.Errorf("definition %s: %w", def.Metadata.Alias, err)
 			}
+		}
+		if err := internaljobdef.ValidateTriggerChains(cmd.Context(), nil, defs); err != nil {
+			return err
 		}
 
 		if !lintCheckSecrets {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -422,13 +422,6 @@ func start(cmd *cobra.Command, args []string) error {
 		})
 	}
 
-	runAsync(func() {
-		log.Info("launching event bus dispatcher")
-		if err := event.NewBusDispatcher(event.NewStore(db.Connection()), bus).Start(ctx); err != nil && ctx.Err() == nil {
-			log.Error("event bus dispatcher exited", "error", err)
-		}
-	})
-
 	importer := jobdef.NewImporter(db.Connection())
 	resolver, err := runtime.BuildSecretResolver(vars)
 	if err != nil {
@@ -439,6 +432,22 @@ func start(cmd *cobra.Command, args []string) error {
 	if err := eventRouter.Reload(ctx); err != nil {
 		log.Fatal("event trigger router initial load failure", "error", err)
 	}
+	lifecycleEvents, err := eventRouter.SubscribeLifecycleBridge(ctx, bus)
+	if err != nil {
+		log.Fatal("event trigger lifecycle bridge subscription failure", "error", err)
+	}
+	runAsync(func() {
+		log.Info("launching event trigger lifecycle bridge")
+		if err := eventRouter.RunLifecycleBridge(ctx, lifecycleEvents); err != nil && ctx.Err() == nil {
+			log.Error("event trigger lifecycle bridge exited", "error", err)
+		}
+	})
+	runAsync(func() {
+		log.Info("launching event bus dispatcher")
+		if err := event.NewBusDispatcher(event.NewStore(db.Connection()), bus).Start(ctx); err != nil && ctx.Err() == nil {
+			log.Error("event bus dispatcher exited", "error", err)
+		}
+	})
 	reloadEventRouter := func(reloadCtx context.Context) error {
 		return eventRouter.Reload(reloadCtx)
 	}

--- a/docs/exec-plans/active/event-trigger-routing.md
+++ b/docs/exec-plans/active/event-trigger-routing.md
@@ -280,7 +280,7 @@ Chaining is WS2 with the event source being the internal lifecycle bus
 persists via `internal/event/store.go`). Builds directly on Stream A's router —
 **same file (`router.go`), so it sequences after A**.
 
-- [ ] C1. Bridge internal lifecycle events into the router: subscribe to
+- [x] C1. Bridge internal lifecycle events into the router: subscribe to
       `TypeRunCompleted`/`TypeRunFailed`/`TypeRunTerminal`, convert each to an
       `IngestedEvent{Source:"caesium"}`, enrich with `job_alias` (so triggers can
       `filter: {job_alias: …}`), and `Route` it. Raise the subscriber buffer and
@@ -288,7 +288,11 @@ persists via `internal/event/store.go`). Builds directly on Stream A's router �
       silently lose completions).
       Files: `internal/trigger/event/router.go`, `internal/event/` (bus subscribe).
       Depends on: A4.
-- [ ] C2. Cycle detection — **static (BATCH-level)**: build the trigger-dependency
+      - W2-β: Added the startup lifecycle bridge on the singleton router using
+        `TypeRunCompleted`/`TypeRunFailed`/`TypeRunTerminal` (`run_completed`,
+        `run_failed`, `run_terminal`), `Source:"caesium"` ingested events,
+        `job_alias` enrichment, and raised/logged/metered bus drops.
+- [x] C2. Cycle detection — **static (BATCH-level)**: build the trigger-dependency
       graph across **all definitions being applied PLUS the existing DB triggers**
       and reject cycles (A→B→A) **before any definition is persisted**. This must live
       in the **batch validation path** (`internal/jobdef/` collect/validate), NOT the
@@ -305,6 +309,10 @@ persists via `internal/event/store.go`). Builds directly on Stream A's router �
       `cmd/job/lint.go`, `pkg/env/env.go`, `internal/metrics/metrics.go`.
       Depends on: C1.
       Test: a cyclic batch is rejected with **no partial persistence**.
+      - W2-β: Added `internal/jobdef` batch trigger-chain cycle validation and wired it
+        into CLI lint, REST lint/apply pre-write, and git sync pre-apply. Runtime
+        `_trigger_depth` now increments in the event trigger fire path and rejects past
+        `CAESIUM_MAX_TRIGGER_DEPTH` with chain depth/rejection metrics.
 
 ### Stream D — Webhook event log + trigger CLI (WS2/WS3 observability)
 

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -6,8 +6,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
 )
+
+const defaultSubscriberBuffer = 1000
 
 // EventType represents the type of event.
 type Type string
@@ -87,14 +91,20 @@ func (b *bus) Publish(e Event) {
 			select {
 			case ch <- e:
 			default:
-				// Drop event if channel is full to prevent blocking
+				metrics.EventBusDroppedTotal.WithLabelValues(string(e.Type)).Inc()
+				log.Warn("event bus subscriber buffer full; dropping event",
+					"type", e.Type,
+					"sequence", e.Sequence,
+					"job_id", e.JobID,
+					"run_id", e.RunID,
+				)
 			}
 		}
 	}
 }
 
 func (b *bus) Subscribe(ctx context.Context, filter Filter) (<-chan Event, error) {
-	ch := make(chan Event, 100)
+	ch := make(chan Event, defaultSubscriberBuffer)
 
 	b.mu.Lock()
 	b.subscribers[ch] = filter

--- a/internal/event/bus_test.go
+++ b/internal/event/bus_test.go
@@ -221,8 +221,9 @@ func TestEventDropWhenBufferFull(t *testing.T) {
 	ch, err := b.Subscribe(ctx, Filter{})
 	require.NoError(t, err)
 
-	// Publish 101 events without reading - should not deadlock or panic
-	for i := 0; i < 101; i++ {
+	// Publish more events than the subscriber buffer can hold without reading;
+	// this should not deadlock or panic.
+	for i := 0; i < defaultSubscriberBuffer+1; i++ {
 		b.Publish(Event{Type: TypeLogChunk, Timestamp: time.Now()})
 	}
 
@@ -237,7 +238,7 @@ func TestEventDropWhenBufferFull(t *testing.T) {
 		}
 	}
 done:
-	assert.Equal(t, 100, count)
+	assert.Equal(t, defaultSubscriberBuffer, count)
 }
 
 func TestContextCancellationCleansUp(t *testing.T) {
@@ -307,7 +308,7 @@ func TestConcurrentPublishSafety(t *testing.T) {
 
 	wg.Wait()
 	count := <-received
-	// Channel buffer is 100, total published is 10000.
+	// Channel buffer is bounded, total published is 10000.
 	// Some will be dropped but we should receive many.
 	assert.Greater(t, count, 0)
 }

--- a/internal/jobdef/git/git_sync.go
+++ b/internal/jobdef/git/git_sync.go
@@ -80,6 +80,11 @@ type WatchOptions struct {
 	Once     bool
 }
 
+type applyFilePlan struct {
+	def  *schema.Definition
+	opts *jobdef.ApplyOptions
+}
+
 // Watch performs an initial sync and optionally continues on an interval until ctx is cancelled.
 func Watch(ctx context.Context, importer *jobdef.Importer, opts WatchOptions) error {
 	if importer == nil {
@@ -244,6 +249,8 @@ func (s *Source) applyDir(ctx context.Context, importer *jobdef.Importer, dir st
 
 	slices.Sort(files)
 
+	plans := make([]applyFilePlan, 0)
+	defs := make([]schema.Definition, 0)
 	desiredAliases := make([]string, 0)
 	for _, path := range files {
 		relToRepo, err := filepath.Rel(dir, path)
@@ -259,11 +266,26 @@ func (s *Source) applyDir(ctx context.Context, importer *jobdef.Importer, dir st
 		}
 
 		opts := &jobdef.ApplyOptions{Provenance: prov}
-		aliases, err := applyFile(ctx, importer, path, opts)
+		fileDefs, err := collectFileDefinitions(path)
 		if err != nil {
 			return err
 		}
-		desiredAliases = append(desiredAliases, aliases...)
+		for _, def := range fileDefs {
+			def := def
+			desiredAliases = append(desiredAliases, def.Metadata.Alias)
+			defs = append(defs, def)
+			plans = append(plans, applyFilePlan{def: &def, opts: opts})
+		}
+	}
+
+	if err := importer.ValidateBatch(ctx, defs); err != nil {
+		return err
+	}
+
+	for _, plan := range plans {
+		if _, err := importer.ApplyWithOptions(ctx, plan.def, plan.opts); err != nil {
+			return err
+		}
 	}
 
 	if strings.TrimSpace(s.SourceID) != "" {
@@ -273,6 +295,26 @@ func (s *Source) applyDir(ctx context.Context, importer *jobdef.Importer, dir st
 	}
 
 	return nil
+}
+
+func collectFileDefinitions(path string) ([]schema.Definition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	dec := yamlNewDecoder(data)
+	defs := make([]schema.Definition, 0)
+	for {
+		def, err := dec()
+		if errors.Is(err, errEOF) {
+			return defs, nil
+		}
+		if err != nil {
+			return nil, err
+		}
+		defs = append(defs, *def)
+	}
 }
 
 func (s *Source) cloneOptions(ctx context.Context) (*git.CloneOptions, func(), error) {
@@ -621,30 +663,6 @@ func (s *Source) shouldInclude(fullPath, relative string) bool {
 		}
 	}
 	return false
-}
-
-func applyFile(ctx context.Context, importer *jobdef.Importer, path string, opts *jobdef.ApplyOptions) ([]string, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	dec := yamlNewDecoder(data)
-	aliases := make([]string, 0)
-	for {
-		def, err := dec()
-		if errors.Is(err, errEOF) {
-			return aliases, nil
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if _, err := importer.ApplyWithOptions(ctx, def, opts); err != nil {
-			return nil, err
-		}
-		aliases = append(aliases, def.Metadata.Alias)
-	}
 }
 
 var errEOF = errors.New("eof")

--- a/internal/jobdef/trigger_cycle.go
+++ b/internal/jobdef/trigger_cycle.go
@@ -55,6 +55,7 @@ func ValidateTriggerChains(ctx context.Context, conn *gorm.DB, defs []schema.Def
 func triggerChainNodes(ctx context.Context, conn *gorm.DB, defs []schema.Definition) ([]triggerChainNode, error) {
 	nodes := make([]triggerChainNode, 0, len(defs))
 	incomingAliases := make(map[string]struct{}, len(defs))
+	incomingAliasIndexes := make(map[string]int, len(defs))
 	for idx := range defs {
 		alias := strings.TrimSpace(defs[idx].Metadata.Alias)
 		if alias == "" {
@@ -64,6 +65,7 @@ func triggerChainNodes(ctx context.Context, conn *gorm.DB, defs []schema.Definit
 			return nil, fmt.Errorf("%w: %s", ErrDuplicateJob, alias)
 		}
 		incomingAliases[alias] = struct{}{}
+		incomingAliasIndexes[alias] = len(nodes)
 		nodes = append(nodes, triggerChainNode{
 			alias:         alias,
 			triggerType:   strings.TrimSpace(defs[idx].Trigger.Type),
@@ -71,7 +73,22 @@ func triggerChainNodes(ctx context.Context, conn *gorm.DB, defs []schema.Definit
 		})
 	}
 
-	existing, err := existingTriggerChainNodes(ctx, conn, incomingAliases)
+	incomingJobIDs, err := existingJobIDsByAlias(ctx, conn, incomingAliases)
+	if err != nil {
+		return nil, err
+	}
+	for alias, id := range incomingJobIDs {
+		if idx, ok := incomingAliasIndexes[alias]; ok {
+			nodes[idx].id = id
+		}
+	}
+
+	incomingJobIDSet := make(map[uuid.UUID]struct{}, len(incomingJobIDs))
+	for _, id := range incomingJobIDs {
+		incomingJobIDSet[id] = struct{}{}
+	}
+
+	existing, err := existingTriggerChainNodes(ctx, conn, incomingAliases, incomingJobIDSet)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +96,45 @@ func triggerChainNodes(ctx context.Context, conn *gorm.DB, defs []schema.Definit
 	return nodes, nil
 }
 
-func existingTriggerChainNodes(ctx context.Context, conn *gorm.DB, incomingAliases map[string]struct{}) ([]triggerChainNode, error) {
+func existingJobIDsByAlias(ctx context.Context, conn *gorm.DB, incomingAliases map[string]struct{}) (map[string]uuid.UUID, error) {
+	if conn == nil || len(incomingAliases) == 0 {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	aliases := make([]string, 0, len(incomingAliases))
+	for alias := range incomingAliases {
+		aliases = append(aliases, alias)
+	}
+
+	var rows []struct {
+		ID    uuid.UUID
+		Alias string
+	}
+	err := conn.WithContext(ctx).
+		Table("jobs").
+		Select("id, alias").
+		Where("deleted_at IS NULL").
+		Where("alias IN ?", aliases).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make(map[string]uuid.UUID, len(rows))
+	for _, row := range rows {
+		alias := strings.TrimSpace(row.Alias)
+		if alias == "" || row.ID == uuid.Nil {
+			continue
+		}
+		ids[alias] = row.ID
+	}
+	return ids, nil
+}
+
+func existingTriggerChainNodes(ctx context.Context, conn *gorm.DB, incomingAliases map[string]struct{}, incomingJobIDs map[uuid.UUID]struct{}) ([]triggerChainNode, error) {
 	if conn == nil {
 		return nil, nil
 	}
@@ -110,6 +165,9 @@ func existingTriggerChainNodes(ctx context.Context, conn *gorm.DB, incomingAlias
 			continue
 		}
 		if _, replaced := incomingAliases[alias]; replaced {
+			continue
+		}
+		if _, replaced := incomingJobIDs[row.ID]; replaced {
 			continue
 		}
 		cfg := make(map[string]any)

--- a/internal/jobdef/trigger_cycle.go
+++ b/internal/jobdef/trigger_cycle.go
@@ -1,0 +1,332 @@
+package jobdef
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var ErrTriggerChainCycle = errors.New("trigger chain cycle detected")
+
+type triggerChainNode struct {
+	id            uuid.UUID
+	alias         string
+	triggerType   string
+	configuration map[string]any
+}
+
+type triggerChainPattern struct {
+	eventType string
+	source    string
+	filter    map[string]string
+}
+
+func (i *Importer) ValidateBatch(ctx context.Context, defs []schema.Definition) error {
+	for idx := range defs {
+		if err := defs[idx].Validate(); err != nil {
+			return fmt.Errorf("definition %s: %w", defs[idx].Metadata.Alias, err)
+		}
+	}
+	return ValidateTriggerChains(ctx, i.db, defs)
+}
+
+func ValidateTriggerChains(ctx context.Context, conn *gorm.DB, defs []schema.Definition) error {
+	nodes, err := triggerChainNodes(ctx, conn, defs)
+	if err != nil {
+		return err
+	}
+	graph, err := triggerChainGraph(nodes)
+	if err != nil {
+		return err
+	}
+	return rejectTriggerChainCycle(graph)
+}
+
+func triggerChainNodes(ctx context.Context, conn *gorm.DB, defs []schema.Definition) ([]triggerChainNode, error) {
+	nodes := make([]triggerChainNode, 0, len(defs))
+	incomingAliases := make(map[string]struct{}, len(defs))
+	for idx := range defs {
+		alias := strings.TrimSpace(defs[idx].Metadata.Alias)
+		if alias == "" {
+			return nil, fmt.Errorf("definition %d: metadata.alias is required", idx)
+		}
+		if _, ok := incomingAliases[alias]; ok {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateJob, alias)
+		}
+		incomingAliases[alias] = struct{}{}
+		nodes = append(nodes, triggerChainNode{
+			alias:         alias,
+			triggerType:   strings.TrimSpace(defs[idx].Trigger.Type),
+			configuration: cloneAnyMap(defs[idx].Trigger.Configuration),
+		})
+	}
+
+	existing, err := existingTriggerChainNodes(ctx, conn, incomingAliases)
+	if err != nil {
+		return nil, err
+	}
+	nodes = append(nodes, existing...)
+	return nodes, nil
+}
+
+func existingTriggerChainNodes(ctx context.Context, conn *gorm.DB, incomingAliases map[string]struct{}) ([]triggerChainNode, error) {
+	if conn == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var rows []struct {
+		ID            uuid.UUID
+		Alias         string
+		TriggerType   string
+		Configuration string
+	}
+	err := conn.WithContext(ctx).
+		Table("jobs").
+		Select("jobs.id, jobs.alias, triggers.type AS trigger_type, triggers.configuration").
+		Joins("JOIN triggers ON triggers.id = jobs.trigger_id AND triggers.deleted_at IS NULL").
+		Where("jobs.deleted_at IS NULL").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	nodes := make([]triggerChainNode, 0, len(rows))
+	for _, row := range rows {
+		alias := strings.TrimSpace(row.Alias)
+		if alias == "" {
+			continue
+		}
+		if _, replaced := incomingAliases[alias]; replaced {
+			continue
+		}
+		cfg := make(map[string]any)
+		if strings.TrimSpace(row.Configuration) != "" {
+			if err := json.Unmarshal([]byte(row.Configuration), &cfg); err != nil {
+				return nil, fmt.Errorf("existing trigger %s configuration: %w", alias, err)
+			}
+		}
+		nodes = append(nodes, triggerChainNode{
+			id:            row.ID,
+			alias:         alias,
+			triggerType:   strings.TrimSpace(row.TriggerType),
+			configuration: cfg,
+		})
+	}
+	return nodes, nil
+}
+
+func triggerChainGraph(nodes []triggerChainNode) (map[string][]string, error) {
+	graph := make(map[string][]string, len(nodes))
+	knownAliases := make([]string, 0, len(nodes))
+	knownSet := make(map[string]struct{}, len(nodes))
+	aliasByJobID := make(map[string]string, len(nodes))
+	for _, node := range nodes {
+		if node.alias == "" {
+			continue
+		}
+		if node.id != uuid.Nil {
+			aliasByJobID[node.id.String()] = node.alias
+		}
+		if _, ok := graph[node.alias]; !ok {
+			graph[node.alias] = nil
+		}
+		if _, ok := knownSet[node.alias]; !ok {
+			knownSet[node.alias] = struct{}{}
+			knownAliases = append(knownAliases, node.alias)
+		}
+	}
+	sort.Strings(knownAliases)
+
+	for _, node := range nodes {
+		if node.triggerType != schema.TriggerEvent && node.triggerType != string(models.TriggerTypeEvent) {
+			continue
+		}
+		patterns, err := triggerChainPatterns(node.configuration)
+		if err != nil {
+			return nil, fmt.Errorf("definition %s: %w", node.alias, err)
+		}
+		for _, pattern := range patterns {
+			if !patternCanMatchCaesiumLifecycle(pattern) {
+				continue
+			}
+			sourceAlias, scoped := triggerChainPatternSourceAlias(pattern, aliasByJobID)
+			if scoped {
+				addTriggerChainEdge(graph, sourceAlias, node.alias)
+				continue
+			}
+			for _, alias := range knownAliases {
+				addTriggerChainEdge(graph, alias, node.alias)
+			}
+		}
+	}
+	return graph, nil
+}
+
+func triggerChainPatternSourceAlias(pattern triggerChainPattern, aliasByJobID map[string]string) (string, bool) {
+	sourceAlias := strings.TrimSpace(pattern.filter["job_alias"])
+	sourceJobID := strings.TrimSpace(pattern.filter["job_id"])
+
+	if sourceAlias == "" && sourceJobID == "" {
+		return "", false
+	}
+
+	if sourceJobID == "" {
+		return sourceAlias, true
+	}
+
+	resolvedAlias := aliasByJobID[sourceJobID]
+	if sourceAlias == "" {
+		return resolvedAlias, true
+	}
+	if resolvedAlias != "" && resolvedAlias != sourceAlias {
+		return "", true
+	}
+	return sourceAlias, true
+}
+
+func triggerChainPatterns(cfg map[string]any) ([]triggerChainPattern, error) {
+	rawEvents, ok := cfg["events"]
+	if !ok || rawEvents == nil {
+		return nil, nil
+	}
+	events, ok := rawEvents.([]any)
+	if !ok {
+		return nil, fmt.Errorf("trigger.configuration.events must be a list")
+	}
+
+	patterns := make([]triggerChainPattern, 0, len(events))
+	for idx, rawEvent := range events {
+		eventMap, ok := rawEvent.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("trigger.configuration.events[%d] must be an object", idx)
+		}
+		pattern := triggerChainPattern{filter: map[string]string{}}
+		pattern.eventType, _ = eventMap["type"].(string)
+		pattern.source, _ = eventMap["source"].(string)
+		if rawFilter, ok := eventMap["filter"]; ok && rawFilter != nil {
+			filter, ok := rawFilter.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("trigger.configuration.events[%d].filter must be an object", idx)
+			}
+			for key, value := range filter {
+				if stringValue, ok := value.(string); ok {
+					pattern.filter[key] = stringValue
+				}
+			}
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns, nil
+}
+
+func patternCanMatchCaesiumLifecycle(pattern triggerChainPattern) bool {
+	source := strings.TrimSpace(pattern.source)
+	if source != "" && source != "caesium" {
+		return false
+	}
+	for _, lifecycleType := range []event.Type{event.TypeRunCompleted, event.TypeRunFailed, event.TypeRunTerminal} {
+		if matchesTriggerChainEventType(pattern.eventType, string(lifecycleType)) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesTriggerChainEventType(patternValue, eventType string) bool {
+	patternValue = strings.TrimSpace(patternValue)
+	eventType = strings.TrimSpace(eventType)
+	if patternValue == "" || eventType == "" {
+		return false
+	}
+	if !strings.ContainsAny(patternValue, "*?[") {
+		return patternValue == eventType
+	}
+	matched, err := path.Match(patternValue, eventType)
+	return err == nil && matched
+}
+
+func addTriggerChainEdge(graph map[string][]string, from, to string) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if from == "" || to == "" {
+		return
+	}
+	if _, ok := graph[from]; !ok {
+		graph[from] = nil
+	}
+	for _, existing := range graph[from] {
+		if existing == to {
+			return
+		}
+	}
+	graph[from] = append(graph[from], to)
+}
+
+func rejectTriggerChainCycle(graph map[string][]string) error {
+	for node := range graph {
+		sort.Strings(graph[node])
+	}
+
+	nodes := make([]string, 0, len(graph))
+	for node := range graph {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	state := make(map[string]int, len(graph))
+	stack := make([]string, 0, len(graph))
+	var visit func(string) []string
+	visit = func(node string) []string {
+		state[node] = 1
+		stack = append(stack, node)
+		for _, next := range graph[node] {
+			switch state[next] {
+			case 0:
+				if cycle := visit(next); len(cycle) > 0 {
+					return cycle
+				}
+			case 1:
+				return triggerChainCyclePath(stack, next)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[node] = 2
+		return nil
+	}
+
+	for _, node := range nodes {
+		if state[node] != 0 {
+			continue
+		}
+		if cycle := visit(node); len(cycle) > 0 {
+			return fmt.Errorf("%w: %s", ErrTriggerChainCycle, strings.Join(cycle, " -> "))
+		}
+	}
+	return nil
+}
+
+func triggerChainCyclePath(stack []string, repeated string) []string {
+	start := 0
+	for idx, node := range stack {
+		if node == repeated {
+			start = idx
+			break
+		}
+	}
+	cycle := append([]string{}, stack[start:]...)
+	cycle = append(cycle, repeated)
+	return cycle
+}

--- a/internal/jobdef/trigger_cycle_test.go
+++ b/internal/jobdef/trigger_cycle_test.go
@@ -57,6 +57,63 @@ func TestValidateTriggerChainsRejectsJobIDScopedCycle(t *testing.T) {
 	require.Contains(t, err.Error(), "chain-a -> chain-b -> chain-a")
 }
 
+func TestValidateTriggerChainsUpdateSupersedesPersistedTriggerByJobID(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects cycle introduced by update", func(t *testing.T) {
+		t.Parallel()
+
+		db := openTriggerCycleTestDB(t)
+		staleBTrigger := triggerCycleCronModel(t, "job-b")
+		require.NoError(t, db.Create(staleBTrigger).Error)
+		jobBID := createTriggerCycleJob(t, db, "job-b", staleBTrigger.ID)
+
+		jobATrigger := triggerCycleModelWithConfig(t, "job-a", map[string]any{
+			"events": []any{
+				map[string]any{
+					"type":   "run_completed",
+					"source": "caesium",
+					"filter": map[string]any{"job_id": jobBID.String()},
+				},
+			},
+		})
+		require.NoError(t, db.Create(jobATrigger).Error)
+		createTriggerCycleJob(t, db, "job-a", jobATrigger.ID)
+
+		err := ValidateTriggerChains(context.Background(), db, []schema.Definition{
+			triggerChainDefinition("job-b", "job-a"),
+		})
+		require.ErrorIs(t, err, ErrTriggerChainCycle)
+		require.Contains(t, err.Error(), "job-a -> job-b -> job-a")
+	})
+
+	t.Run("allows non-cyclic update without stale persisted edge", func(t *testing.T) {
+		t.Parallel()
+
+		db := openTriggerCycleTestDB(t)
+		staleBTrigger := triggerCycleModel(t, "job-b", "job-a")
+		require.NoError(t, db.Create(staleBTrigger).Error)
+		jobBID := createTriggerCycleJob(t, db, "job-b", staleBTrigger.ID)
+
+		jobATrigger := triggerCycleModelWithConfig(t, "job-a", map[string]any{
+			"events": []any{
+				map[string]any{
+					"type":   "run_completed",
+					"source": "caesium",
+					"filter": map[string]any{"job_id": jobBID.String()},
+				},
+			},
+		})
+		require.NoError(t, db.Create(jobATrigger).Error)
+		createTriggerCycleJob(t, db, "job-a", jobATrigger.ID)
+
+		err := ValidateTriggerChains(context.Background(), db, []schema.Definition{
+			triggerChainCronDefinition("job-b"),
+		})
+		require.NoError(t, err)
+	})
+}
+
 func TestValidateTriggerChainsAllowsJobIDScopedNonCycle(t *testing.T) {
 	t.Parallel()
 
@@ -104,6 +161,15 @@ func triggerChainDefinition(alias, upstream string) schema.Definition {
 	return triggerChainDefinitionWithFilter(alias, filter)
 }
 
+func triggerChainCronDefinition(alias string) schema.Definition {
+	def := triggerChainDefinitionWithFilter(alias, nil)
+	def.Trigger = schema.Trigger{
+		Type:          schema.TriggerCron,
+		Configuration: map[string]any{},
+	}
+	return def
+}
+
 func triggerChainDefinitionWithFilter(alias string, filter map[string]any) schema.Definition {
 	pattern := map[string]any{
 		"type":   "run_completed",
@@ -149,6 +215,20 @@ func triggerCycleModelWithConfig(t *testing.T, alias string, configuration map[s
 		Alias:         alias,
 		Type:          models.TriggerTypeEvent,
 		Configuration: string(cfg),
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, trigger.ApplyDerivedFields())
+	return trigger
+}
+
+func triggerCycleCronModel(t *testing.T, alias string) *models.Trigger {
+	t.Helper()
+	trigger := &models.Trigger{
+		ID:            uuid.New(),
+		Alias:         alias,
+		Type:          models.TriggerTypeCron,
+		Configuration: `{}`,
 		CreatedAt:     time.Now().UTC(),
 		UpdatedAt:     time.Now().UTC(),
 	}

--- a/internal/jobdef/trigger_cycle_test.go
+++ b/internal/jobdef/trigger_cycle_test.go
@@ -1,0 +1,181 @@
+package jobdef
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestValidateTriggerChainsRejectsBatchCycle(t *testing.T) {
+	t.Parallel()
+
+	defs := []schema.Definition{
+		triggerChainDefinition("chain-a", "chain-b"),
+		triggerChainDefinition("chain-b", "chain-a"),
+	}
+
+	err := ValidateTriggerChains(context.Background(), nil, defs)
+	require.ErrorIs(t, err, ErrTriggerChainCycle)
+	require.Contains(t, err.Error(), "chain-a -> chain-b -> chain-a")
+}
+
+func TestValidateTriggerChainsIncludesExistingDBTriggers(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	existingTrigger := triggerCycleModel(t, "chain-a", "chain-b")
+	require.NoError(t, db.Create(existingTrigger).Error)
+	createTriggerCycleJob(t, db, "chain-a", existingTrigger.ID)
+
+	err := ValidateTriggerChains(context.Background(), db, []schema.Definition{
+		triggerChainDefinition("chain-b", "chain-a"),
+	})
+	require.ErrorIs(t, err, ErrTriggerChainCycle)
+	require.Contains(t, err.Error(), "chain-a -> chain-b -> chain-a")
+}
+
+func TestValidateTriggerChainsRejectsJobIDScopedCycle(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	existingTrigger := triggerCycleModel(t, "chain-a", "chain-b")
+	require.NoError(t, db.Create(existingTrigger).Error)
+	upstreamID := createTriggerCycleJob(t, db, "chain-a", existingTrigger.ID)
+
+	err := ValidateTriggerChains(context.Background(), db, []schema.Definition{
+		triggerChainDefinitionWithFilter("chain-b", map[string]any{"job_id": upstreamID.String()}),
+	})
+	require.ErrorIs(t, err, ErrTriggerChainCycle)
+	require.Contains(t, err.Error(), "chain-a -> chain-b -> chain-a")
+}
+
+func TestValidateTriggerChainsAllowsJobIDScopedNonCycle(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	upstreamTrigger := triggerCycleModelWithConfig(t, "chain-a", map[string]any{
+		"events": []any{
+			map[string]any{
+				"type":   "webhook.*",
+				"source": "github",
+			},
+		},
+	})
+	require.NoError(t, db.Create(upstreamTrigger).Error)
+	upstreamID := createTriggerCycleJob(t, db, "chain-a", upstreamTrigger.ID)
+
+	err := ValidateTriggerChains(context.Background(), db, []schema.Definition{
+		triggerChainDefinitionWithFilter("chain-b", map[string]any{"job_id": upstreamID.String()}),
+	})
+	require.NoError(t, err)
+}
+
+func TestValidateTriggerChainsRejectsUnfilteredLifecycleSelfCycle(t *testing.T) {
+	t.Parallel()
+
+	def := triggerChainDefinition("chain-self", "")
+	def.Trigger.Configuration = map[string]any{
+		"events": []any{
+			map[string]any{
+				"type":   "run_*",
+				"source": "caesium",
+			},
+		},
+	}
+
+	err := ValidateTriggerChains(context.Background(), nil, []schema.Definition{def})
+	require.ErrorIs(t, err, ErrTriggerChainCycle)
+	require.Contains(t, err.Error(), "chain-self -> chain-self")
+}
+
+func triggerChainDefinition(alias, upstream string) schema.Definition {
+	filter := map[string]any(nil)
+	if upstream != "" {
+		filter = map[string]any{"job_alias": upstream}
+	}
+	return triggerChainDefinitionWithFilter(alias, filter)
+}
+
+func triggerChainDefinitionWithFilter(alias string, filter map[string]any) schema.Definition {
+	pattern := map[string]any{
+		"type":   "run_completed",
+		"source": "caesium",
+	}
+	if len(filter) > 0 {
+		pattern["filter"] = filter
+	}
+	return schema.Definition{
+		APIVersion: schema.APIVersionV1,
+		Kind:       schema.KindJob,
+		Metadata:   schema.Metadata{Alias: alias},
+		Trigger: schema.Trigger{
+			Type:          schema.TriggerEvent,
+			Configuration: map[string]any{"events": []any{pattern}},
+		},
+		Steps: []schema.Step{{
+			Name:    "run",
+			Image:   "alpine:3.23",
+			Command: []string{"sh", "-c", "echo ok"},
+		}},
+	}
+}
+
+func triggerCycleModel(t *testing.T, alias, upstream string) *models.Trigger {
+	return triggerCycleModelWithConfig(t, alias, map[string]any{
+		"events": []any{
+			map[string]any{
+				"type":   "run_completed",
+				"source": "caesium",
+				"filter": map[string]any{"job_alias": upstream},
+			},
+		},
+	})
+}
+
+func triggerCycleModelWithConfig(t *testing.T, alias string, configuration map[string]any) *models.Trigger {
+	t.Helper()
+	cfg, err := json.Marshal(configuration)
+	require.NoError(t, err)
+	trigger := &models.Trigger{
+		ID:            uuid.New(),
+		Alias:         alias,
+		Type:          models.TriggerTypeEvent,
+		Configuration: string(cfg),
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+	}
+	require.NoError(t, trigger.ApplyDerivedFields())
+	return trigger
+}
+
+func createTriggerCycleJob(t *testing.T, db *gorm.DB, alias string, triggerID uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	require.NoError(t, db.Create(&models.Job{
+		ID:        id,
+		Alias:     alias,
+		TriggerID: triggerID,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}).Error)
+	return id
+}
+
+func openTriggerCycleTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(models.All...))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return db
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -259,6 +259,29 @@ var (
 		[]string{"trigger_id", "event_type"},
 	)
 
+	EventBusDroppedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_event_bus_dropped_total",
+			Help: "Total events dropped because an event bus subscriber buffer was full.",
+		},
+		[]string{"event_type"},
+	)
+
+	TriggerChainDepth = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "caesium_trigger_chain_depth",
+			Help:    "Observed trigger chain depth for lifecycle-event-triggered job runs.",
+			Buckets: []float64{1, 2, 3, 4, 5, 10, 20, 50},
+		},
+	)
+
+	TriggerChainRejectedTotal = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "caesium_trigger_chain_rejected_total",
+			Help: "Total event trigger fires rejected because trigger chain depth exceeded the configured maximum.",
+		},
+	)
+
 	// DBWritesTotal counts durable database writes by category, measured in
 	// rows touched (so a batched UPDATE/INSERT increments by the row count, not
 	// by one). Use this for capacity-planning and "how much work is the DB
@@ -425,6 +448,9 @@ func Register() {
 			SSOLogoutsTotal,
 			WebhookAuthFailuresTotal,
 			EventTriggerMatchesTotal,
+			EventBusDroppedTotal,
+			TriggerChainDepth,
+			TriggerChainRejectedTotal,
 			DBWritesTotal,
 			DBStatementsTotal,
 			CompleteRejectedTotal,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -36,6 +36,9 @@ func (s *MetricsSuite) SetupTest() {
 		WorkerLeaseExpirationsTotal,
 		TaskRetriesTotal,
 		WebhookAuthFailuresTotal,
+		EventBusDroppedTotal,
+		TriggerChainDepth,
+		TriggerChainRejectedTotal,
 		SSOLoginsTotal,
 		SSOLoginDurationSeconds,
 		SSOLogoutsTotal,
@@ -113,6 +116,26 @@ func (s *MetricsSuite) TestTaskRegisterBatchSizeObserves() {
 	s.Require().NoError(TaskRegisterBatchSize.Write(&after))
 	s.Equal(before.GetHistogram().GetSampleCount()+1, after.GetHistogram().GetSampleCount())
 	s.InDelta(before.GetHistogram().GetSampleSum()+12, after.GetHistogram().GetSampleSum(), 0.000001)
+}
+
+func (s *MetricsSuite) TestTriggerChainMetricsObserveAndIncrement() {
+	beforeDrop := metrictestutil.CounterValue(s.T(), EventBusDroppedTotal, "run_completed")
+	EventBusDroppedTotal.WithLabelValues("run_completed").Inc()
+	s.GreaterOrEqual(metrictestutil.CounterValue(s.T(), EventBusDroppedTotal, "run_completed"), beforeDrop+1)
+
+	var beforeDepth dto.Metric
+	s.Require().NoError(TriggerChainDepth.Write(&beforeDepth))
+	TriggerChainDepth.Observe(3)
+	var afterDepth dto.Metric
+	s.Require().NoError(TriggerChainDepth.Write(&afterDepth))
+	s.Equal(beforeDepth.GetHistogram().GetSampleCount()+1, afterDepth.GetHistogram().GetSampleCount())
+
+	var beforeRejected dto.Metric
+	s.Require().NoError(TriggerChainRejectedTotal.Write(&beforeRejected))
+	TriggerChainRejectedTotal.Inc()
+	var afterRejected dto.Metric
+	s.Require().NoError(TriggerChainRejectedTotal.Write(&afterRejected))
+	s.GreaterOrEqual(afterRejected.GetCounter().GetValue(), beforeRejected.GetCounter().GetValue()+1)
 }
 
 func (s *MetricsSuite) TestJobsActiveGauge() {

--- a/internal/trigger/event/event.go
+++ b/internal/trigger/event/event.go
@@ -196,20 +196,20 @@ func (t *EventTrigger) applyTriggerDepth(params map[string]string) error {
 
 	depth, err := strconv.Atoi(strings.TrimSpace(rawDepth))
 	if err != nil || depth < 0 {
-		metrics.TriggerChainRejectedTotal.Inc()
-		return fmt.Errorf("%w: invalid %s %q", ErrTriggerChainDepthExceeded, TriggerDepthParam, rawDepth)
+		depth = 0
 	}
 
-	nextDepth := depth + 1
 	maxDepth := t.maxTriggerDepth
 	if maxDepth <= 0 {
 		maxDepth = defaultMaxTriggerDepth
 	}
-	metrics.TriggerChainDepth.Observe(float64(nextDepth))
-	if nextDepth > maxDepth {
+	if depth >= maxDepth {
 		metrics.TriggerChainRejectedTotal.Inc()
-		return fmt.Errorf("%w: depth %d exceeds max %d", ErrTriggerChainDepthExceeded, nextDepth, maxDepth)
+		return fmt.Errorf("%w: depth %d exceeds max %d", ErrTriggerChainDepthExceeded, depth+1, maxDepth)
 	}
+
+	nextDepth := depth + 1
+	metrics.TriggerChainDepth.Observe(float64(nextDepth))
 
 	params[TriggerDepthParam] = strconv.Itoa(nextDepth)
 	return nil

--- a/internal/trigger/event/event.go
+++ b/internal/trigger/event/event.go
@@ -4,20 +4,30 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	"github.com/caesium-cloud/caesium/internal/job"
+	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	runstorage "github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/internal/trigger"
+	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
 )
 
 var _ trigger.Trigger = (*EventTrigger)(nil)
+
+const (
+	TriggerDepthParam      = "_trigger_depth"
+	defaultMaxTriggerDepth = 10
+)
+
+var ErrTriggerChainDepthExceeded = errors.New("trigger chain depth exceeded")
 
 type Config struct {
 	Events        []EventPattern    `json:"events,omitempty"`
@@ -33,6 +43,7 @@ type EventTrigger struct {
 	runStoreFactory func() *runstorage.Store
 	runJob          func(context.Context, *models.Job, map[string]string) error
 	deferLaunch     bool
+	maxTriggerDepth int
 }
 
 type Option func(*EventTrigger)
@@ -71,6 +82,12 @@ func WithRunJob(fn func(context.Context, *models.Job, map[string]string) error) 
 	}
 }
 
+func WithMaxTriggerDepth(max int) Option {
+	return func(t *EventTrigger) {
+		t.maxTriggerDepth = max
+	}
+}
+
 func withDeferredLaunch() Option {
 	return func(t *EventTrigger) {
 		t.deferLaunch = true
@@ -93,6 +110,7 @@ func New(t *models.Trigger, opts ...Option) (*EventTrigger, error) {
 		listJobs:        defaultListJobs,
 		runStoreFactory: runstorage.Default,
 		runJob:          defaultRunJob,
+		maxTriggerDepth: configuredMaxTriggerDepth(),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -115,6 +133,11 @@ func (t *EventTrigger) Fire(ctx context.Context) error {
 func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]string) ([]FireOutcome, error) {
 	log.Info("trigger firing", "id", t.id, "type", models.TriggerTypeEvent)
 
+	mergedParams := t.config.mergedParams(params)
+	if err := t.applyTriggerDepth(mergedParams); err != nil {
+		return nil, err
+	}
+
 	jobs, err := t.listJobs(ctx, t.id.String())
 	if err != nil {
 		return nil, err
@@ -123,7 +146,6 @@ func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]str
 		return []FireOutcome{{Skipped: true, SkipReason: "no jobs registered for trigger"}}, nil
 	}
 
-	mergedParams := t.config.mergedParams(params)
 	outcomes := make([]FireOutcome, 0, len(jobs))
 	for _, j := range jobs {
 		jobModel := j
@@ -164,6 +186,33 @@ func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]str
 	}
 
 	return outcomes, nil
+}
+
+func (t *EventTrigger) applyTriggerDepth(params map[string]string) error {
+	rawDepth, ok := params[TriggerDepthParam]
+	if !ok {
+		return nil
+	}
+
+	depth, err := strconv.Atoi(strings.TrimSpace(rawDepth))
+	if err != nil || depth < 0 {
+		metrics.TriggerChainRejectedTotal.Inc()
+		return fmt.Errorf("%w: invalid %s %q", ErrTriggerChainDepthExceeded, TriggerDepthParam, rawDepth)
+	}
+
+	nextDepth := depth + 1
+	maxDepth := t.maxTriggerDepth
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxTriggerDepth
+	}
+	metrics.TriggerChainDepth.Observe(float64(nextDepth))
+	if nextDepth > maxDepth {
+		metrics.TriggerChainRejectedTotal.Inc()
+		return fmt.Errorf("%w: depth %d exceeds max %d", ErrTriggerChainDepthExceeded, nextDepth, maxDepth)
+	}
+
+	params[TriggerDepthParam] = strconv.Itoa(nextDepth)
+	return nil
 }
 
 func (t *EventTrigger) ID() uuid.UUID {
@@ -215,6 +264,14 @@ var (
 		return job.New(j, job.WithParams(params)).Run(ctx)
 	}
 )
+
+func configuredMaxTriggerDepth() int {
+	maxDepth := env.Variables().MaxTriggerDepth
+	if maxDepth <= 0 {
+		return defaultMaxTriggerDepth
+	}
+	return maxDepth
+}
 
 func parseConfig(raw string) (Config, error) {
 	cfg := Config{}

--- a/internal/trigger/event/event_test.go
+++ b/internal/trigger/event/event_test.go
@@ -79,6 +79,30 @@ func TestFireWithParamsSkipAndErrorOutcomes(t *testing.T) {
 		require.NotEmpty(t, outcomes[0].Error)
 		require.Equal(t, uuid.Nil, outcomes[0].RunID)
 	})
+
+	t.Run("malformed trigger depth starts new chain", func(t *testing.T) {
+		for _, rawDepth := range []string{"not-a-number", "-1"} {
+			rawDepth := rawDepth
+			t.Run(rawDepth, func(t *testing.T) {
+				listJobsCalled := false
+				trig, err := New(triggerModel,
+					WithMaxTriggerDepth(1),
+					WithListJobs(func(context.Context, string) (models.Jobs, error) {
+						listJobsCalled = true
+						return nil, nil
+					}),
+				)
+				require.NoError(t, err)
+
+				outcomes, err := trig.FireWithParams(context.Background(), map[string]string{TriggerDepthParam: rawDepth})
+				require.NoError(t, err)
+				require.True(t, listJobsCalled)
+				require.Len(t, outcomes, 1)
+				require.True(t, outcomes[0].Skipped)
+				require.Equal(t, "no jobs registered for trigger", outcomes[0].SkipReason)
+			})
+		}
+	})
 }
 
 func TestExtractParamsJSONPath(t *testing.T) {

--- a/internal/trigger/event/event_test.go
+++ b/internal/trigger/event/event_test.go
@@ -58,6 +58,7 @@ func TestFireWithParamsSkipAndErrorOutcomes(t *testing.T) {
 		require.NoError(t, err)
 		sqlDB, err := db.DB()
 		require.NoError(t, err)
+		sqlDB.SetMaxOpenConns(1)
 		t.Cleanup(func() { _ = sqlDB.Close() })
 
 		job := &models.Job{ID: uuid.New(), TriggerID: triggerID}

--- a/internal/trigger/event/router.go
+++ b/internal/trigger/event/router.go
@@ -1,11 +1,13 @@
 package event
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
@@ -52,6 +54,12 @@ var (
 	defaultRouter     *Router
 	defaultRouterOnce sync.Once
 )
+
+var lifecycleEventTypes = []eventstore.Type{
+	eventstore.TypeRunCompleted,
+	eventstore.TypeRunFailed,
+	eventstore.TypeRunTerminal,
+}
 
 func NewRouter(conn *gorm.DB, opts ...RouterOption) *Router {
 	if conn == nil {
@@ -189,6 +197,7 @@ func (r *Router) Route(ctx context.Context, evt *models.IngestedEvent) (*RouteRe
 		matchRows := make([]*models.EventTriggerMatch, 0, len(matches))
 		for _, trigger := range matches {
 			params := trigger.ExtractEventParams(evt)
+			params = withLifecycleTriggerDepth(evt, params)
 			txTrigger := trigger.cloneWithOptions(
 				WithListJobs(func(jobCtx context.Context, triggerID string) (models.Jobs, error) {
 					req := &jsvc.ListRequest{TriggerID: triggerID}
@@ -230,6 +239,200 @@ func (r *Router) Route(ctx context.Context, evt *models.IngestedEvent) (*RouteRe
 	}
 
 	return result, nil
+}
+
+func (r *Router) StartLifecycleBridge(ctx context.Context, bus eventstore.Bus) error {
+	events, err := r.SubscribeLifecycleBridge(ctx, bus)
+	if err != nil {
+		return err
+	}
+	return r.RunLifecycleBridge(ctx, events)
+}
+
+func (r *Router) SubscribeLifecycleBridge(ctx context.Context, bus eventstore.Bus) (<-chan eventstore.Event, error) {
+	if r == nil {
+		return nil, errors.New("event trigger router is nil")
+	}
+	if bus == nil {
+		return nil, errors.New("event trigger lifecycle bridge requires bus")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	return bus.Subscribe(ctx, eventstore.Filter{Types: lifecycleEventTypes})
+}
+
+func (r *Router) RunLifecycleBridge(ctx context.Context, events <-chan eventstore.Event) error {
+	if r == nil {
+		return errors.New("event trigger router is nil")
+	}
+	if events == nil {
+		return errors.New("event trigger lifecycle bridge requires event subscription")
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt, ok := <-events:
+			if !ok {
+				return nil
+			}
+			r.routeLifecycleEvent(ctx, evt)
+		}
+	}
+}
+
+func (r *Router) routeLifecycleEvent(ctx context.Context, evt eventstore.Event) {
+	ingested, err := r.lifecycleIngestedEvent(ctx, evt)
+	if err != nil {
+		log.Error("event trigger lifecycle bridge conversion failed", "type", evt.Type, "run_id", evt.RunID, "job_id", evt.JobID, "error", err)
+		return
+	}
+	if _, err := r.Route(ctx, ingested); err != nil {
+		log.Error("event trigger lifecycle bridge routing failed", "type", evt.Type, "run_id", evt.RunID, "job_id", evt.JobID, "error", err)
+	}
+}
+
+func (r *Router) lifecycleIngestedEvent(ctx context.Context, evt eventstore.Event) (*models.IngestedEvent, error) {
+	data, err := lifecycleEventData(evt)
+	if err != nil {
+		return nil, err
+	}
+
+	jobAlias := stringValue(data["job_alias"])
+	if jobAlias == "" && evt.JobID != uuid.Nil {
+		jobAlias, err = r.lookupJobAlias(ctx, evt.JobID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if jobAlias != "" {
+		data["job_alias"] = jobAlias
+	}
+
+	if depth := lifecycleTriggerDepth(data); depth != "" {
+		data[TriggerDepthParam] = depth
+	}
+
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return &models.IngestedEvent{
+		Type:   string(evt.Type),
+		Source: "caesium",
+		Data:   datatypes.JSON(raw),
+	}, nil
+}
+
+func (r *Router) lookupJobAlias(ctx context.Context, jobID uuid.UUID) (string, error) {
+	r.mu.RLock()
+	conn := r.db
+	r.mu.RUnlock()
+	if conn == nil {
+		return "", errors.New("event trigger router has no database")
+	}
+
+	var jobModel models.Job
+	err := conn.WithContext(ctx).Select("alias").First(&jobModel, "id = ?", jobID).Error
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return "", nil
+	case err != nil:
+		return "", err
+	default:
+		return jobModel.Alias, nil
+	}
+}
+
+func lifecycleEventData(evt eventstore.Event) (map[string]any, error) {
+	data := make(map[string]any)
+	if len(evt.Payload) > 0 {
+		decoder := json.NewDecoder(bytes.NewReader(evt.Payload))
+		decoder.UseNumber()
+		var payload any
+		if err := decoder.Decode(&payload); err != nil {
+			return nil, fmt.Errorf("decode lifecycle payload: %w", err)
+		}
+		if payloadMap, ok := payload.(map[string]any); ok {
+			data = payloadMap
+		} else {
+			data["payload"] = payload
+		}
+	}
+
+	data["event_type"] = string(evt.Type)
+	if evt.Sequence != 0 {
+		data["sequence"] = evt.Sequence
+	}
+	if evt.JobID != uuid.Nil {
+		data["job_id"] = evt.JobID.String()
+	}
+	if evt.RunID != uuid.Nil {
+		data["run_id"] = evt.RunID.String()
+	}
+	if evt.TaskID != uuid.Nil {
+		data["task_id"] = evt.TaskID.String()
+	}
+	if !evt.Timestamp.IsZero() {
+		data["timestamp"] = evt.Timestamp.UTC().Format(time.RFC3339Nano)
+	}
+	return data, nil
+}
+
+func withLifecycleTriggerDepth(evt *models.IngestedEvent, params map[string]string) map[string]string {
+	if !isCaesiumLifecycleEvent(evt) {
+		return params
+	}
+	if params == nil {
+		params = map[string]string{}
+	}
+	depth := "0"
+	if extracted := lifecycleTriggerDepthJSON(evt.Data); extracted != "" {
+		depth = extracted
+	}
+	params[TriggerDepthParam] = depth
+	return params
+}
+
+func isCaesiumLifecycleEvent(evt *models.IngestedEvent) bool {
+	if evt == nil || evt.Source != "caesium" {
+		return false
+	}
+	for _, typ := range lifecycleEventTypes {
+		if evt.Type == string(typ) {
+			return true
+		}
+	}
+	return false
+}
+
+func lifecycleTriggerDepth(data map[string]any) string {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return ""
+	}
+	return lifecycleTriggerDepthJSON(raw)
+}
+
+func lifecycleTriggerDepthJSON(data []byte) string {
+	if depth, ok := extractField(data, TriggerDepthParam); ok {
+		return depth
+	}
+	if depth, ok := extractField(data, "params."+TriggerDepthParam); ok {
+		return depth
+	}
+	return ""
+}
+
+func stringValue(v any) string {
+	s, _ := v.(string)
+	return s
 }
 
 func (r *Router) adoptStartedRuns(result *RouteResult) {

--- a/internal/trigger/event/router_test.go
+++ b/internal/trigger/event/router_test.go
@@ -2,10 +2,12 @@ package event
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
+	eventstore "github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -152,6 +154,113 @@ func TestRouterRouteAfterSharedTriggerJobDeleteFiresSibling(t *testing.T) {
 	require.True(t, storedTrigger.DeletedAt.Valid)
 }
 
+func TestLifecycleBridgeRoutesRunCompletedWithJobAliasAndDepth(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db := openEventRouterTestDB(t)
+	upstreamTrigger := &models.Trigger{
+		ID:            uuid.New(),
+		Alias:         "upstream-cron",
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"expression":"* * * * *"}`,
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
+	}
+	downstreamTrigger := eventRouterTestTriggerConfig(t, "downstream-event", `{
+		"events":[{"type":"run_completed","source":"caesium","filter":{"job_alias":"upstream-job"}}]
+	}`)
+	require.NoError(t, db.Create([]*models.Trigger{upstreamTrigger, downstreamTrigger}).Error)
+
+	upstreamJob := &models.Job{
+		ID:        uuid.New(),
+		Alias:     "upstream-job",
+		TriggerID: upstreamTrigger.ID,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	downstreamJob := &models.Job{
+		ID:        uuid.New(),
+		Alias:     "downstream-job",
+		TriggerID: downstreamTrigger.ID,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+	require.NoError(t, db.Create([]*models.Job{upstreamJob, downstreamJob}).Error)
+
+	router := NewRouter(db,
+		WithEventTriggerOptions(
+			WithRunJob(func(context.Context, *models.Job, map[string]string) error {
+				return nil
+			}),
+			WithMaxTriggerDepth(3),
+		),
+		withStartedRunAdopter(func(uuid.UUID) {}),
+	)
+	require.NoError(t, router.Reload(ctx))
+
+	bus := eventstore.New()
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- router.StartLifecycleBridge(ctx, bus)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		require.NoError(t, <-errCh)
+	})
+
+	runID := uuid.New()
+	require.Eventually(t, func() bool {
+		bus.Publish(eventstore.Event{
+			Type:    eventstore.TypeRunCompleted,
+			JobID:   upstreamJob.ID,
+			RunID:   runID,
+			Payload: []byte(`{"params":{"_trigger_depth":"1"}}`),
+		})
+
+		var count int64
+		if err := db.Model(&models.JobRun{}).Where("job_id = ?", downstreamJob.ID).Count(&count).Error; err != nil {
+			return false
+		}
+		return count > 0
+	}, time.Second, 10*time.Millisecond)
+
+	var run models.JobRun
+	require.NoError(t, db.First(&run, "job_id = ?", downstreamJob.ID).Error)
+	require.JSONEq(t, `{"_trigger_depth":"2"}`, string(run.Params))
+
+	var ingested models.IngestedEvent
+	require.NoError(t, db.First(&ingested, "type = ? AND source = ?", string(eventstore.TypeRunCompleted), "caesium").Error)
+	require.JSONEq(t, `{
+		"event_type":"run_completed",
+		"job_alias":"upstream-job",
+		"job_id":"`+upstreamJob.ID.String()+`",
+		"run_id":"`+runID.String()+`",
+		"_trigger_depth":"1",
+		"params":{"_trigger_depth":"1"}
+	}`, string(ingested.Data))
+}
+
+func TestEventTriggerFireRejectsDepthExceeded(t *testing.T) {
+	t.Parallel()
+
+	triggerModel := eventRouterTestTrigger(t, "depth")
+	trigger, err := New(triggerModel,
+		WithMaxTriggerDepth(1),
+		WithListJobs(func(context.Context, string) (models.Jobs, error) {
+			t.Fatal("list jobs should not be called after depth rejection")
+			return nil, nil
+		}),
+	)
+	require.NoError(t, err)
+
+	_, err = trigger.FireWithParams(context.Background(), map[string]string{TriggerDepthParam: "1"})
+	require.ErrorIs(t, err, ErrTriggerChainDepthExceeded)
+	require.True(t, errors.Is(err, ErrTriggerChainDepthExceeded))
+}
+
 func openEventRouterTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
@@ -159,22 +268,32 @@ func openEventRouterTestDB(t *testing.T) *gorm.DB {
 	require.NoError(t, db.AutoMigrate(models.All...))
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
+	// Serialize all access through a single connection: the lifecycle-bridge test
+	// writes (Route) concurrently with the test's reads on this cache=shared in-mem
+	// DB, and concurrent shared-cache access deadlocks (and via the process-wide
+	// shared-cache lock hangs sibling tests' gorm.Open). One connection serializes
+	// it without contention.
+	sqlDB.SetMaxOpenConns(1)
 	t.Cleanup(func() { _ = sqlDB.Close() })
 	return db
 }
 
 func eventRouterTestTrigger(t *testing.T, alias string) *models.Trigger {
+	return eventRouterTestTriggerConfig(t, alias, `{
+		"events":[{"type":"webhook.*","source":"github"}],
+		"paramMapping":{"branch":"$.ref"}
+	}`)
+}
+
+func eventRouterTestTriggerConfig(t *testing.T, alias string, configuration string) *models.Trigger {
 	t.Helper()
 	trigger := &models.Trigger{
-		ID:    uuid.New(),
-		Alias: alias,
-		Type:  models.TriggerTypeEvent,
-		Configuration: `{
-			"events":[{"type":"webhook.*","source":"github"}],
-			"paramMapping":{"branch":"$.ref"}
-		}`,
-		CreatedAt: time.Now().UTC(),
-		UpdatedAt: time.Now().UTC(),
+		ID:            uuid.New(),
+		Alias:         alias,
+		Type:          models.TriggerTypeEvent,
+		Configuration: configuration,
+		CreatedAt:     time.Now().UTC(),
+		UpdatedAt:     time.Now().UTC(),
 	}
 	require.NoError(t, trigger.ApplyDerivedFields())
 	return trigger

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -151,6 +151,7 @@ type Environment struct {
 	WebhookRateLimitPerMinute int           `envconfig:"WEBHOOK_RATE_LIMIT_PER_MINUTE" default:"120"`
 	WebhookRateLimitBurst     int           `envconfig:"WEBHOOK_RATE_LIMIT_BURST" default:"20"`
 	EventRetention            time.Duration `envconfig:"EVENT_RETENTION" default:"168h"`
+	MaxTriggerDepth           int           `envconfig:"MAX_TRIGGER_DEPTH" default:"10"`
 
 	// Notification Watcher
 	NotificationWatcherInterval time.Duration `envconfig:"NOTIFICATION_WATCHER_INTERVAL" default:"15s"`

--- a/test/trigger_chain_test.go
+++ b/test/trigger_chain_test.go
@@ -1,0 +1,168 @@
+//go:build integration
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestTriggerChainLifecycleBridgeFiresDownstreamJob() {
+	suffix := time.Now().UnixNano()
+	upstream := fmt.Sprintf("integration-chain-a-%d", suffix)
+	downstream := fmt.Sprintf("integration-chain-b-%d", suffix)
+
+	dir := s.writeTriggerChainManifests(map[string]string{
+		upstream:   triggerChainCronManifest(upstream),
+		downstream: triggerChainEventManifest(downstream, upstream),
+	})
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	upstreamJob := s.requireJobByAlias(upstream)
+	downstreamJob := s.requireJobByAlias(downstream)
+
+	beforeDownstream := len(s.fetchRuns(downstreamJob.ID))
+	upstreamRunID := s.triggerRun(upstreamJob.ID)
+	s.Require().Equal("succeeded", s.awaitRun(upstreamJob.ID, upstreamRunID, runTimeout).Status)
+
+	downstreamRun := s.awaitNewRun(downstreamJob.ID, beforeDownstream, 60*time.Second)
+	completedDownstream := s.awaitRun(downstreamJob.ID, downstreamRun.ID, runTimeout)
+	s.Require().Equal("succeeded", completedDownstream.Status)
+	s.Equal("1", completedDownstream.Params["_trigger_depth"])
+}
+
+func (s *IntegrationTestSuite) TestTriggerChainCycleRejectedBeforePersistence() {
+	suffix := time.Now().UnixNano()
+	a := fmt.Sprintf("integration-chain-cycle-a-%d", suffix)
+	b := fmt.Sprintf("integration-chain-cycle-b-%d", suffix)
+
+	dir := s.writeTriggerChainManifests(map[string]string{
+		a: triggerChainEventManifest(a, b),
+		b: triggerChainEventManifest(b, a),
+	})
+	defer os.RemoveAll(dir)
+
+	stdout, stderr, err := s.runCLISeparate("job", "lint", "--path", dir)
+	s.Require().Error(err)
+	s.Contains(stdout+stderr, "trigger chain cycle detected")
+
+	output, err := s.runCLIExpectError("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	s.Require().Error(err)
+	s.Contains(output, "trigger chain cycle detected")
+	s.False(s.jobExists(a))
+	s.False(s.jobExists(b))
+}
+
+func (s *IntegrationTestSuite) TestTriggerChainDepthLimitRejectsNextHop() {
+	suffix := time.Now().UnixNano()
+	a := fmt.Sprintf("integration-chain-depth-a-%d", suffix)
+	b := fmt.Sprintf("integration-chain-depth-b-%d", suffix)
+
+	dir := s.writeTriggerChainManifests(map[string]string{
+		a: triggerChainCronManifest(a),
+		b: triggerChainEventManifest(b, a),
+	})
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	jobA := s.requireJobByAlias(a)
+	jobB := s.requireJobByAlias(b)
+
+	runA := s.triggerRunWithParams(jobA.ID, map[string]string{"_trigger_depth": "1000000"})
+	s.Require().Equal("succeeded", s.awaitRun(jobA.ID, runA, runTimeout).Status)
+
+	s.assertNoRuns(jobB.ID, 5*time.Second)
+}
+
+func (s *IntegrationTestSuite) writeTriggerChainManifests(files map[string]string) string {
+	s.T().Helper()
+
+	dir, err := os.MkdirTemp("", "caesium-trigger-chain-*")
+	s.Require().NoError(err)
+	for name, contents := range files {
+		path := filepath.Join(dir, name+".job.yaml")
+		s.Require().NoError(os.WriteFile(path, []byte(strings.TrimSpace(s.injectEngine(contents))), 0o644))
+	}
+	return dir
+}
+
+func (s *IntegrationTestSuite) awaitNewRun(jobID string, previousCount int, timeout time.Duration) runResponse {
+	s.T().Helper()
+
+	var run runResponse
+	s.Require().Eventually(func() bool {
+		runs, err := s.tryFetchRuns(jobID)
+		if err != nil {
+			return false
+		}
+		if len(runs) <= previousCount {
+			return false
+		}
+		run = runs[len(runs)-1]
+		return run.ID != ""
+	}, timeout, 500*time.Millisecond)
+	return run
+}
+
+func (s *IntegrationTestSuite) tryFetchRuns(jobID string) ([]runResponse, error) {
+	s.T().Helper()
+
+	var runs []runResponse
+	if err := s.tryGetJSON(fmt.Sprintf("/v1/jobs/%s/runs", jobID), &runs); err != nil {
+		return nil, err
+	}
+	return runs, nil
+}
+
+func (s *IntegrationTestSuite) assertNoRuns(jobID string, duration time.Duration) {
+	s.T().Helper()
+
+	deadline := time.Now().Add(duration)
+	for time.Now().Before(deadline) {
+		runs := s.fetchRuns(jobID)
+		if len(runs) > 0 {
+			s.T().Fatalf("expected no runs for job %s, got %d", jobID, len(runs))
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func triggerChainCronManifest(alias string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger:
+  type: cron
+  configuration:
+    cron: "0 0 1 1 *"
+steps:
+  - name: run
+    image: alpine:3.23
+    command: ["sh", "-c", "echo %s"]
+`, alias, alias)
+}
+
+func triggerChainEventManifest(alias, upstream string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger:
+  type: event
+  configuration:
+    events:
+      - type: run_completed
+        source: caesium
+        filter:
+          job_alias: %s
+steps:
+  - name: run
+    image: alpine:3.23
+    command: ["sh", "-c", "echo %s"]
+`, alias, upstream, alias)
+}


### PR DESCRIPTION
## Summary

Wave 2, Stream C of event-trigger-routing — trigger chaining (WS3) via the internal lifecycle bus, with cycle guards.

- **C1** — the lifecycle bridge: subscribes to `run_completed`/`run_failed`/`run_terminal`, converts each to an `IngestedEvent{source:"caesium"}` enriched with `job_alias` (+ `job_id`), and routes it through A's `Router.Route`. Subscriber buffer raised; dropped events logged + metered. Subscribe is registered before the dispatcher starts (no startup-race lost completions).
- **C2** — cycle detection: a **batch** static validator (`ValidateTriggerChains`) run **pre-write** on REST apply, git-sync, and lint (recognizing both `job_alias` and `job_id` filter edges, across applied defs + existing DB triggers); plus the runtime `_trigger_depth` guard rejecting past `CAESIUM_MAX_TRIGGER_DEPTH`.
- Integration tests: an A→B chain (assert B's run fires) + cyclic-apply rejection (no partial persistence) + depth-limit rejection.

## Review
Opus 3-lens + fixes: the startup-race (Subscribe before dispatch), the cycle-graph `job_id` gap (specific edge, not a fan-out), and a test deadlock (single-connection in-mem DB to avoid shared-cache lock contention). `just lint`+`unit-test` green (engine pkg 79%).

## Test plan
- [x] just lint + just unit-test (orchestrator)
- [ ] just integration-test — Phase 6.5 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)