### PR TITLE
Add the webhook event log + event/trigger CLI (event-trigger-routing W3-α)

### DIFF
--- a/api/rest/controller/webhook/webhook.go
+++ b/api/rest/controller/webhook/webhook.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
@@ -42,6 +43,8 @@ type acceptedHTTPTrigger struct {
 	params      map[string]string
 	jobs        models.Jobs
 }
+
+const webhookReceiptRecordTimeout = 10 * time.Second
 
 // triggerFailure captures a per-trigger auth failure during the matching loop.
 type triggerFailure struct {
@@ -142,12 +145,13 @@ func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobListe
 		metrics.EventsIngestedTotal.WithLabelValues("webhook").Inc()
 	}
 
-	receipt := acceptedWebhookReceipt(path, ingested.Source, accepted, result, err)
-	recordWebhookReceiptAsync(c.Request().Context(), path, receipt)
-
+	httpRunsStarted := 0
 	for _, acceptedTrigger := range accepted {
-		launchHTTPTriggerJobs(c.Request().Context(), acceptedTrigger, runner)
+		httpRunsStarted += launchHTTPTriggerJobs(c.Request().Context(), acceptedTrigger, runner)
 	}
+
+	receipt := acceptedWebhookReceipt(path, ingested.Source, accepted, httpRunsStarted, result, err)
+	recordWebhookReceiptAsync(c.Request().Context(), path, receipt)
 
 	return c.JSON(http.StatusAccepted, webhookReceiptResponse(receipt))
 }
@@ -199,17 +203,18 @@ func listTriggerJobs(ctx context.Context, jobSvc JobLister, trig *models.Trigger
 	return jobs, nil
 }
 
-func launchHTTPTriggerJobs(ctx context.Context, accepted acceptedHTTPTrigger, runner Runner) {
+func launchHTTPTriggerJobs(ctx context.Context, accepted acceptedHTTPTrigger, runner Runner) int {
 	if runner == nil {
 		runner = DefaultRunner
 	}
 	if accepted.httpTrigger == nil || accepted.trigger == nil {
 		log.Warn("skipping malformed accepted webhook trigger")
-		return
+		return 0
 	}
 
 	log.Info("running jobs", "count", len(accepted.jobs), "trigger_id", accepted.trigger.ID)
 
+	started := 0
 	for _, j := range accepted.jobs {
 		if j == nil {
 			log.Warn("skipping nil job", "trigger_id", accepted.trigger.ID)
@@ -222,6 +227,7 @@ func launchHTTPTriggerJobs(ctx context.Context, accepted acceptedHTTPTrigger, ru
 
 		capturedJob := j
 		capturedParams := cloneStringMap(accepted.httpTrigger.MergeParams(accepted.params))
+		started++
 		go func() {
 			runCtx := context.WithoutCancel(ctx)
 			if err := runner(runCtx, capturedJob, capturedParams); err != nil {
@@ -229,6 +235,7 @@ func launchHTTPTriggerJobs(ctx context.Context, accepted acceptedHTTPTrigger, ru
 			}
 		}()
 	}
+	return started
 }
 
 func DefaultRunner(ctx context.Context, j *models.Job, params map[string]string) error {
@@ -276,14 +283,14 @@ func webhookEventData(c *echo.Context, path string, body []byte) datatypes.JSON 
 	return datatypes.JSON(data)
 }
 
-func acceptedWebhookReceipt(path, source string, accepted []acceptedHTTPTrigger, result *triggerevent.RouteResult, routeErr error) *models.WebhookEvent {
+func acceptedWebhookReceipt(path, source string, accepted []acceptedHTTPTrigger, httpRunsStarted int, result *triggerevent.RouteResult, routeErr error) *models.WebhookEvent {
 	receipt := &models.WebhookEvent{
 		ID:                   uuid.New(),
 		Path:                 path,
 		Source:               source,
 		Status:               "accepted",
 		HTTPTriggersAccepted: len(accepted),
-		HTTPRunsStarted:      launchableWebhookJobCount(accepted),
+		HTTPRunsStarted:      httpRunsStarted,
 		HTTPTriggerIDs:       stringJSONList(acceptedWebhookTriggerIDs(accepted)),
 		HTTPJobIDs:           stringJSONList(acceptedWebhookJobIDs(accepted)),
 	}
@@ -309,7 +316,8 @@ func recordWebhookReceiptAsync(ctx context.Context, path string, receipt *models
 	// goroutine races the test's Cleanup (the -race detector flags it).
 	recorder := recordWebhookReceipt
 	go func() {
-		recordCtx := context.WithoutCancel(ctx)
+		recordCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), webhookReceiptRecordTimeout)
+		defer cancel()
 		if recordErr := recorder(recordCtx, &captured); recordErr != nil {
 			log.Warn("webhook receipt log failed", "path", path, "error", recordErr)
 		}
@@ -358,18 +366,6 @@ func acceptedWebhookJobIDs(accepted []acceptedHTTPTrigger) []string {
 		}
 	}
 	return ids
-}
-
-func launchableWebhookJobCount(accepted []acceptedHTTPTrigger) int {
-	var count int
-	for _, item := range accepted {
-		for _, j := range item.jobs {
-			if j != nil && !j.Paused {
-				count++
-			}
-		}
-	}
-	return count
 }
 
 func webhookEventRunsStarted(result *triggerevent.RouteResult) int {

--- a/api/rest/controller/webhook/webhook.go
+++ b/api/rest/controller/webhook/webhook.go
@@ -12,13 +12,16 @@ import (
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
 	triggersvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
 	"github.com/caesium-cloud/caesium/internal/auth"
+	eventstore "github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/job"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	triggerevent "github.com/caesium-cloud/caesium/internal/trigger/event"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
+	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"gorm.io/datatypes"
 )
@@ -48,6 +51,10 @@ type triggerFailure struct {
 
 var routeWebhookEvent = func(ctx context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
 	return triggerevent.DefaultRouter().Route(ctx, evt)
+}
+
+var recordWebhookReceipt = func(ctx context.Context, receipt *models.WebhookEvent) error {
+	return eventstore.NewWebhookEventStore(db.Connection()).Create(ctx, receipt)
 }
 
 // ReceiveWith returns a handler that uses the given auditor for failure logging.
@@ -122,7 +129,8 @@ func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobListe
 	// before HTTP jobs are launched when possible, and both trigger families may
 	// start runs. The event bridge is at-least-once: retrying the same delivery
 	// can route another event-trigger run.
-	result, err := routeWebhookEvent(c.Request().Context(), webhookIngestedEvent(c, path, body))
+	ingested := webhookIngestedEvent(c, path, body)
+	result, err := routeWebhookEvent(c.Request().Context(), ingested)
 	switch {
 	case err != nil:
 		log.Warn("webhook event bridge failed", "path", path, "error", err)
@@ -134,11 +142,14 @@ func ReceiveWithServices(c *echo.Context, trigSvc TriggerLister, jobSvc JobListe
 		metrics.EventsIngestedTotal.WithLabelValues("webhook").Inc()
 	}
 
+	receipt := acceptedWebhookReceipt(path, ingested.Source, accepted, result, err)
+	recordWebhookReceiptAsync(c.Request().Context(), path, receipt)
+
 	for _, acceptedTrigger := range accepted {
 		launchHTTPTriggerJobs(c.Request().Context(), acceptedTrigger, runner)
 	}
 
-	return c.JSON(http.StatusAccepted, nil)
+	return c.JSON(http.StatusAccepted, webhookReceiptResponse(receipt))
 }
 
 func FireHTTPTrigger(ctx context.Context, jobSvc JobLister, trig *models.Trigger, params map[string]string, runner Runner) error {
@@ -263,6 +274,124 @@ func webhookEventData(c *echo.Context, path string, body []byte) datatypes.JSON 
 		return datatypes.JSON(`{}`)
 	}
 	return datatypes.JSON(data)
+}
+
+func acceptedWebhookReceipt(path, source string, accepted []acceptedHTTPTrigger, result *triggerevent.RouteResult, routeErr error) *models.WebhookEvent {
+	receipt := &models.WebhookEvent{
+		ID:                   uuid.New(),
+		Path:                 path,
+		Source:               source,
+		Status:               "accepted",
+		HTTPTriggersAccepted: len(accepted),
+		HTTPRunsStarted:      launchableWebhookJobCount(accepted),
+		HTTPTriggerIDs:       stringJSONList(acceptedWebhookTriggerIDs(accepted)),
+		HTTPJobIDs:           stringJSONList(acceptedWebhookJobIDs(accepted)),
+	}
+	if result != nil {
+		receipt.EventID = result.EventID
+		receipt.EventMatchedTriggers = len(result.MatchedTriggers)
+		receipt.EventRunsStarted = webhookEventRunsStarted(result)
+	}
+	if routeErr != nil {
+		receipt.Error = routeErr.Error()
+	}
+	return receipt
+}
+
+func recordWebhookReceiptAsync(ctx context.Context, path string, receipt *models.WebhookEvent) {
+	if receipt == nil {
+		return
+	}
+
+	captured := *receipt
+	// Capture the recorder synchronously before launching the goroutine: it's a
+	// package-level var that tests stub + restore, so reading it inside the
+	// goroutine races the test's Cleanup (the -race detector flags it).
+	recorder := recordWebhookReceipt
+	go func() {
+		recordCtx := context.WithoutCancel(ctx)
+		if recordErr := recorder(recordCtx, &captured); recordErr != nil {
+			log.Warn("webhook receipt log failed", "path", path, "error", recordErr)
+		}
+	}()
+}
+
+func webhookReceiptResponse(receipt *models.WebhookEvent) map[string]any {
+	if receipt == nil {
+		return map[string]any{}
+	}
+	resp := map[string]any{
+		"receipt_id":             receipt.ID,
+		"path":                   receipt.Path,
+		"source":                 receipt.Source,
+		"event_matched_triggers": receipt.EventMatchedTriggers,
+		"event_runs_started":     receipt.EventRunsStarted,
+		"http_triggers_accepted": receipt.HTTPTriggersAccepted,
+		"http_runs_started":      receipt.HTTPRunsStarted,
+	}
+	if receipt.EventID != uuid.Nil {
+		resp["event_id"] = receipt.EventID
+	}
+	if receipt.Error != "" {
+		resp["error"] = receipt.Error
+	}
+	return resp
+}
+
+func acceptedWebhookTriggerIDs(accepted []acceptedHTTPTrigger) []string {
+	ids := make([]string, 0, len(accepted))
+	for _, item := range accepted {
+		if item.trigger != nil && item.trigger.ID != uuid.Nil {
+			ids = append(ids, item.trigger.ID.String())
+		}
+	}
+	return ids
+}
+
+func acceptedWebhookJobIDs(accepted []acceptedHTTPTrigger) []string {
+	ids := make([]string, 0)
+	for _, item := range accepted {
+		for _, j := range item.jobs {
+			if j != nil && !j.Paused && j.ID != uuid.Nil {
+				ids = append(ids, j.ID.String())
+			}
+		}
+	}
+	return ids
+}
+
+func launchableWebhookJobCount(accepted []acceptedHTTPTrigger) int {
+	var count int
+	for _, item := range accepted {
+		for _, j := range item.jobs {
+			if j != nil && !j.Paused {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func webhookEventRunsStarted(result *triggerevent.RouteResult) int {
+	if result == nil {
+		return 0
+	}
+	var total int
+	for _, match := range result.MatchedTriggers {
+		total += len(match.RunsStarted)
+	}
+	return total
+}
+
+func stringJSONList(values []string) datatypes.JSON {
+	if len(values) == 0 {
+		return nil
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return nil
+	}
+	return datatypes.JSON(raw)
 }
 
 var errRequestTooLarge = errors.New("request body too large")

--- a/api/rest/controller/webhook/webhook_test.go
+++ b/api/rest/controller/webhook/webhook_test.go
@@ -47,8 +47,20 @@ func (s stubJobLister) List(*jsvc.ListRequest) (models.Jobs, error) {
 func stubWebhookRouter(t *testing.T, fn func(context.Context, *models.IngestedEvent) (*triggerevent.RouteResult, error)) {
 	t.Helper()
 	original := routeWebhookEvent
+	originalRecorder := recordWebhookReceipt
 	routeWebhookEvent = fn
-	t.Cleanup(func() { routeWebhookEvent = original })
+	recordWebhookReceipt = func(context.Context, *models.WebhookEvent) error { return nil }
+	t.Cleanup(func() {
+		routeWebhookEvent = original
+		recordWebhookReceipt = originalRecorder
+	})
+}
+
+func stubWebhookReceiptRecorder(t *testing.T, fn func(context.Context, *models.WebhookEvent) error) {
+	t.Helper()
+	original := recordWebhookReceipt
+	recordWebhookReceipt = fn
+	t.Cleanup(func() { recordWebhookReceipt = original })
 }
 
 func TestReceiveWithServicesFiresWebhookTrigger(t *testing.T) {
@@ -118,6 +130,79 @@ func TestReceiveWithServicesFiresWebhookTrigger(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for webhook-triggered job")
 	}
+}
+
+func TestReceiveWithServicesRecordsWebhookReceipt(t *testing.T) {
+	require.NoError(t, env.Process())
+	eventID := uuid.New()
+	runID := uuid.New()
+	stubWebhookRouter(t, func(_ context.Context, evt *models.IngestedEvent) (*triggerevent.RouteResult, error) {
+		return &triggerevent.RouteResult{
+			EventID:   eventID,
+			EventType: evt.Type,
+			Source:    evt.Source,
+			MatchedTriggers: []triggerevent.TriggerRouteResult{
+				{TriggerID: uuid.New(), RunsStarted: []uuid.UUID{runID}},
+			},
+		}, nil
+	})
+
+	recorded := make(chan *models.WebhookEvent, 1)
+	stubWebhookReceiptRecorder(t, func(_ context.Context, receipt *models.WebhookEvent) error {
+		receipt.ID = uuid.New()
+		recorded <- receipt
+		return nil
+	})
+
+	triggerID := uuid.New()
+	jobID := uuid.New()
+	req := httptest.NewRequest(http.MethodPost, "/v1/hooks/github/push", strings.NewReader(`{"ref":"refs/heads/main"}`))
+	req.Header.Set("Authorization", "Bearer top-secret")
+	req.Header.Set("X-Caesium-Event-Source", "github")
+	rec := httptest.NewRecorder()
+
+	e := echo.New()
+	c := e.NewContext(req, rec)
+	c.SetPathValues(echo.PathValues{{Name: "*", Value: "github/push"}})
+
+	err := ReceiveWithServices(
+		c,
+		stubTriggerLister{
+			triggers: models.Triggers{
+				&models.Trigger{
+					ID:   triggerID,
+					Type: models.TriggerTypeHTTP,
+					Configuration: `{
+						"path":"github/push",
+						"secret":"top-secret",
+						"signatureScheme":"bearer"
+					}`,
+				},
+			},
+		},
+		stubJobLister{jobs: models.Jobs{&models.Job{ID: jobID, Alias: "deploy"}}},
+		nil,
+		func(context.Context, *models.Job, map[string]string) error { return nil },
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusAccepted, rec.Code)
+
+	var receipt *models.WebhookEvent
+	select {
+	case receipt = <-recorded:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for webhook receipt")
+	}
+	require.Equal(t, "github/push", receipt.Path)
+	require.Equal(t, "github", receipt.Source)
+	require.Equal(t, "accepted", receipt.Status)
+	require.Equal(t, eventID, receipt.EventID)
+	require.Equal(t, 1, receipt.EventMatchedTriggers)
+	require.Equal(t, 1, receipt.EventRunsStarted)
+	require.Equal(t, 1, receipt.HTTPTriggersAccepted)
+	require.Equal(t, 1, receipt.HTTPRunsStarted)
+	require.JSONEq(t, fmt.Sprintf(`["%s"]`, triggerID), string(receipt.HTTPTriggerIDs))
+	require.JSONEq(t, fmt.Sprintf(`["%s"]`, jobID), string(receipt.HTTPJobIDs))
 }
 
 func TestReceiveWithServicesContinuesWhenWebhookBridgeFails(t *testing.T) {

--- a/cmd/cliutil/auth.go
+++ b/cmd/cliutil/auth.go
@@ -1,0 +1,25 @@
+package cliutil
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const APIKeyEnvVar = "CAESIUM_API_KEY"
+
+func ResolveAPIKey(cmd *cobra.Command, flagValue, preferredEnvVar string, fallbackEnvVars ...string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: --api-key is visible in process listings; prefer %s\n", preferredEnvVar)
+		return strings.TrimSpace(flagValue)
+	}
+
+	for _, envVar := range append([]string{preferredEnvVar}, fallbackEnvVars...) {
+		if value := strings.TrimSpace(os.Getenv(envVar)); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/cmd/cliutil/http.go
+++ b/cmd/cliutil/http.go
@@ -1,0 +1,5 @@
+package cliutil
+
+import "time"
+
+const DefaultHTTPTimeout = 30 * time.Second

--- a/cmd/cliutil/json.go
+++ b/cmd/cliutil/json.go
@@ -1,0 +1,22 @@
+package cliutil
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func WritePrettyJSON(cmd *cobra.Command, body []byte, label string) error {
+	var out any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("%s was not valid JSON: %w", label, err)
+	}
+	pretty, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("re-encoding %s: %w", label, err)
+	}
+	_, _ = cmd.OutOrStdout().Write(pretty)
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	return nil
+}

--- a/cmd/event/event.go
+++ b/cmd/event/event.go
@@ -1,0 +1,12 @@
+package event
+
+import "github.com/spf13/cobra"
+
+var Cmd = &cobra.Command{
+	Use:   "event",
+	Short: "Push and inspect event-trigger events",
+}
+
+func init() {
+	Cmd.AddCommand(pushCmd)
+}

--- a/cmd/event/push.go
+++ b/cmd/event/push.go
@@ -6,16 +6,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
 	"github.com/spf13/cobra"
 )
 
-const (
-	eventIngestAPIKeyEnvVar = "CAESIUM_EVENT_INGEST_API_KEY"
-	apiKeyEnvVar            = "CAESIUM_API_KEY"
-)
+const eventIngestAPIKeyEnvVar = "CAESIUM_EVENT_INGEST_API_KEY"
 
 var (
 	pushType   string
@@ -23,6 +20,8 @@ var (
 	pushData   string
 	pushServer string
 	pushAPIKey string
+
+	pushHTTPClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
 )
 
 type pushRequest struct {
@@ -63,7 +62,7 @@ var pushCmd = &cobra.Command{
 			req.Header.Set("Authorization", "Bearer "+apiKey)
 		}
 
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := pushHTTPClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -77,7 +76,7 @@ var pushCmd = &cobra.Command{
 			return fmt.Errorf("event push failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
 		}
 
-		return writePrettyJSON(cmd, body, "event push response")
+		return cliutil.WritePrettyJSON(cmd, body, "event push response")
 	},
 }
 
@@ -94,28 +93,7 @@ func parseEventData(raw string) (json.RawMessage, error) {
 }
 
 func resolveEventAPIKey(cmd *cobra.Command, flagValue string) string {
-	if strings.TrimSpace(flagValue) != "" {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: --api-key is visible in process listings; prefer %s\n", eventIngestAPIKeyEnvVar)
-		return strings.TrimSpace(flagValue)
-	}
-	if value := strings.TrimSpace(os.Getenv(eventIngestAPIKeyEnvVar)); value != "" {
-		return value
-	}
-	return strings.TrimSpace(os.Getenv(apiKeyEnvVar))
-}
-
-func writePrettyJSON(cmd *cobra.Command, body []byte, label string) error {
-	var out any
-	if err := json.Unmarshal(body, &out); err != nil {
-		return fmt.Errorf("%s was not valid JSON: %w", label, err)
-	}
-	pretty, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return fmt.Errorf("re-encoding %s: %w", label, err)
-	}
-	_, _ = cmd.OutOrStdout().Write(pretty)
-	_, _ = fmt.Fprintln(cmd.OutOrStdout())
-	return nil
+	return cliutil.ResolveAPIKey(cmd, flagValue, eventIngestAPIKeyEnvVar, cliutil.APIKeyEnvVar)
 }
 
 func init() {

--- a/cmd/event/push.go
+++ b/cmd/event/push.go
@@ -1,0 +1,127 @@
+package event
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	eventIngestAPIKeyEnvVar = "CAESIUM_EVENT_INGEST_API_KEY"
+	apiKeyEnvVar            = "CAESIUM_API_KEY"
+)
+
+var (
+	pushType   string
+	pushSource string
+	pushData   string
+	pushServer string
+	pushAPIKey string
+)
+
+type pushRequest struct {
+	Type   string          `json:"type"`
+	Source string          `json:"source,omitempty"`
+	Data   json.RawMessage `json:"data"`
+}
+
+var pushCmd = &cobra.Command{
+	Use:   "push --type <type> [--source <source>] --data '{}'",
+	Short: "Push an event into the event-trigger router",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		eventType := strings.TrimSpace(pushType)
+		if eventType == "" {
+			return fmt.Errorf("--type is required")
+		}
+		data, err := parseEventData(pushData)
+		if err != nil {
+			return err
+		}
+
+		payload, err := json.Marshal(pushRequest{
+			Type:   eventType,
+			Source: strings.TrimSpace(pushSource),
+			Data:   data,
+		})
+		if err != nil {
+			return err
+		}
+
+		server := strings.TrimSuffix(pushServer, "/")
+		req, err := http.NewRequestWithContext(cmd.Context(), http.MethodPost, server+"/v1/events", bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if apiKey := resolveEventAPIKey(cmd, pushAPIKey); apiKey != "" {
+			req.Header.Set("Authorization", "Bearer "+apiKey)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = resp.Body.Close() }()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("reading event push response: %w", err)
+		}
+		if resp.StatusCode != http.StatusAccepted {
+			return fmt.Errorf("event push failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		return writePrettyJSON(cmd, body, "event push response")
+	},
+}
+
+func parseEventData(raw string) (json.RawMessage, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		raw = "{}"
+	}
+	data := json.RawMessage(raw)
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("--data must be valid JSON")
+	}
+	return data, nil
+}
+
+func resolveEventAPIKey(cmd *cobra.Command, flagValue string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: --api-key is visible in process listings; prefer %s\n", eventIngestAPIKeyEnvVar)
+		return strings.TrimSpace(flagValue)
+	}
+	if value := strings.TrimSpace(os.Getenv(eventIngestAPIKeyEnvVar)); value != "" {
+		return value
+	}
+	return strings.TrimSpace(os.Getenv(apiKeyEnvVar))
+}
+
+func writePrettyJSON(cmd *cobra.Command, body []byte, label string) error {
+	var out any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("%s was not valid JSON: %w", label, err)
+	}
+	pretty, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("re-encoding %s: %w", label, err)
+	}
+	_, _ = cmd.OutOrStdout().Write(pretty)
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	return nil
+}
+
+func init() {
+	pushCmd.Flags().StringVar(&pushType, "type", "", "Event type to ingest (required)")
+	pushCmd.Flags().StringVar(&pushSource, "source", "", "Event source")
+	pushCmd.Flags().StringVar(&pushData, "data", "{}", "JSON event payload")
+	pushCmd.Flags().StringVar(&pushServer, "server", "http://localhost:8080", "Caesium server base URL")
+	pushCmd.Flags().StringVar(&pushAPIKey, "api-key", "", "Event ingest API key for authentication (prefer "+eventIngestAPIKeyEnvVar+"; --api-key is visible in process listings)")
+}

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -6,11 +6,13 @@ import (
 	"github.com/caesium-cloud/caesium/cmd/blame"
 	"github.com/caesium-cloud/caesium/cmd/cache"
 	"github.com/caesium-cloud/caesium/cmd/dev"
+	"github.com/caesium-cloud/caesium/cmd/event"
 	"github.com/caesium-cloud/caesium/cmd/job"
 	"github.com/caesium-cloud/caesium/cmd/receipt"
 	"github.com/caesium-cloud/caesium/cmd/run"
 	"github.com/caesium-cloud/caesium/cmd/start"
 	"github.com/caesium-cloud/caesium/cmd/test"
+	"github.com/caesium-cloud/caesium/cmd/trigger"
 	"github.com/caesium-cloud/caesium/cmd/verify"
 	"github.com/caesium-cloud/caesium/cmd/why"
 	"github.com/spf13/cobra"
@@ -22,11 +24,13 @@ var cmds = []*cobra.Command{
 	blame.Cmd,
 	cache.Cmd,
 	dev.Cmd,
+	event.Cmd,
 	job.Cmd,
 	receipt.Cmd,
 	run.Cmd,
 	start.Cmd,
 	test.Cmd,
+	trigger.Cmd,
 	verify.Cmd,
 	why.Cmd,
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -158,6 +158,7 @@ func start(cmd *cobra.Command, args []string) error {
 		log.Fatal("database migration failure", "error", err)
 	}
 	event.StartIngestRetentionPruner(ctx, event.NewIngestStore(db.Connection()), vars.EventRetention)
+	event.StartWebhookEventRetentionPruner(ctx, event.NewWebhookEventStore(db.Connection()), vars.WebhookEventRetention)
 
 	bus := event.New()
 	runStore := run.Default()

--- a/cmd/trigger/events.go
+++ b/cmd/trigger/events.go
@@ -1,0 +1,151 @@
+package trigger
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+const apiKeyEnvVar = "CAESIUM_API_KEY"
+
+var (
+	eventsServer string
+	eventsAPIKey string
+	eventsType   string
+	eventsSource string
+	eventsLimit  uint64
+	eventsOffset uint64
+)
+
+type jobSummary struct {
+	ID        string `json:"id"`
+	Alias     string `json:"alias"`
+	TriggerID string `json:"trigger_id"`
+}
+
+var eventsCmd = &cobra.Command{
+	Use:   "events <alias>",
+	Short: "List durable events matched by a trigger",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		server := strings.TrimSuffix(eventsServer, "/")
+		triggerID, err := resolveTriggerID(cmd, server, strings.TrimSpace(args[0]))
+		if err != nil {
+			return err
+		}
+
+		params := url.Values{}
+		if eventsType != "" {
+			params.Set("type", eventsType)
+		}
+		if eventsSource != "" {
+			params.Set("source", eventsSource)
+		}
+		if eventsLimit > 0 {
+			params.Set("limit", fmt.Sprintf("%d", eventsLimit))
+		}
+		if eventsOffset > 0 {
+			params.Set("offset", fmt.Sprintf("%d", eventsOffset))
+		}
+
+		reqURL := fmt.Sprintf("%s/v1/triggers/%s/events", server, url.PathEscape(triggerID))
+		if encoded := params.Encode(); encoded != "" {
+			reqURL += "?" + encoded
+		}
+		body, err := get(cmd, reqURL, "trigger events")
+		if err != nil {
+			return err
+		}
+		return writePrettyJSON(cmd, body, "trigger events response")
+	},
+}
+
+func resolveTriggerID(cmd *cobra.Command, server, alias string) (string, error) {
+	if alias == "" {
+		return "", fmt.Errorf("trigger alias is required")
+	}
+	if _, err := uuid.Parse(alias); err == nil {
+		return alias, nil
+	}
+
+	body, err := get(cmd, server+"/v1/jobs", "job lookup")
+	if err != nil {
+		return "", err
+	}
+	var jobs []jobSummary
+	if err := json.Unmarshal(body, &jobs); err != nil {
+		return "", fmt.Errorf("job lookup returned invalid JSON: %w", err)
+	}
+	for _, job := range jobs {
+		if job.Alias == alias {
+			if strings.TrimSpace(job.TriggerID) == "" {
+				return "", fmt.Errorf("job alias %q has no trigger_id", alias)
+			}
+			return job.TriggerID, nil
+		}
+	}
+	return "", fmt.Errorf("job alias %q not found", alias)
+}
+
+func get(cmd *cobra.Command, reqURL, label string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := resolveAPIKey(cmd, eventsAPIKey); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s response: %w", label, err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("%s failed (%d): %s", label, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	return body, nil
+}
+
+func resolveAPIKey(cmd *cobra.Command, flagValue string) string {
+	if strings.TrimSpace(flagValue) != "" {
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: --api-key is visible in process listings; prefer %s\n", apiKeyEnvVar)
+		return strings.TrimSpace(flagValue)
+	}
+	return strings.TrimSpace(os.Getenv(apiKeyEnvVar))
+}
+
+func writePrettyJSON(cmd *cobra.Command, body []byte, label string) error {
+	var out any
+	if err := json.Unmarshal(body, &out); err != nil {
+		return fmt.Errorf("%s was not valid JSON: %w", label, err)
+	}
+	pretty, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("re-encoding %s: %w", label, err)
+	}
+	_, _ = cmd.OutOrStdout().Write(pretty)
+	_, _ = fmt.Fprintln(cmd.OutOrStdout())
+	return nil
+}
+
+func init() {
+	eventsCmd.Flags().StringVar(&eventsServer, "server", "http://localhost:8080", "Caesium server base URL")
+	eventsCmd.Flags().StringVar(&eventsAPIKey, "api-key", "", "API key for authentication (prefer "+apiKeyEnvVar+"; --api-key is visible in process listings)")
+	eventsCmd.Flags().StringVar(&eventsType, "type", "", "Filter by event type")
+	eventsCmd.Flags().StringVar(&eventsSource, "source", "", "Filter by event source")
+	eventsCmd.Flags().Uint64Var(&eventsLimit, "limit", 0, "Maximum number of events to return")
+	eventsCmd.Flags().Uint64Var(&eventsOffset, "offset", 0, "Number of events to skip")
+}

--- a/cmd/trigger/events.go
+++ b/cmd/trigger/events.go
@@ -6,14 +6,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
 	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 )
-
-const apiKeyEnvVar = "CAESIUM_API_KEY"
 
 var (
 	eventsServer string
@@ -22,6 +20,8 @@ var (
 	eventsSource string
 	eventsLimit  uint64
 	eventsOffset uint64
+
+	eventsHTTPClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
 )
 
 type jobSummary struct {
@@ -63,7 +63,7 @@ var eventsCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		return writePrettyJSON(cmd, body, "trigger events response")
+		return cliutil.WritePrettyJSON(cmd, body, "trigger events response")
 	},
 }
 
@@ -103,7 +103,7 @@ func get(cmd *cobra.Command, reqURL, label string) ([]byte, error) {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := eventsHTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -120,30 +120,12 @@ func get(cmd *cobra.Command, reqURL, label string) ([]byte, error) {
 }
 
 func resolveAPIKey(cmd *cobra.Command, flagValue string) string {
-	if strings.TrimSpace(flagValue) != "" {
-		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "warning: --api-key is visible in process listings; prefer %s\n", apiKeyEnvVar)
-		return strings.TrimSpace(flagValue)
-	}
-	return strings.TrimSpace(os.Getenv(apiKeyEnvVar))
-}
-
-func writePrettyJSON(cmd *cobra.Command, body []byte, label string) error {
-	var out any
-	if err := json.Unmarshal(body, &out); err != nil {
-		return fmt.Errorf("%s was not valid JSON: %w", label, err)
-	}
-	pretty, err := json.MarshalIndent(out, "", "  ")
-	if err != nil {
-		return fmt.Errorf("re-encoding %s: %w", label, err)
-	}
-	_, _ = cmd.OutOrStdout().Write(pretty)
-	_, _ = fmt.Fprintln(cmd.OutOrStdout())
-	return nil
+	return cliutil.ResolveAPIKey(cmd, flagValue, cliutil.APIKeyEnvVar)
 }
 
 func init() {
 	eventsCmd.Flags().StringVar(&eventsServer, "server", "http://localhost:8080", "Caesium server base URL")
-	eventsCmd.Flags().StringVar(&eventsAPIKey, "api-key", "", "API key for authentication (prefer "+apiKeyEnvVar+"; --api-key is visible in process listings)")
+	eventsCmd.Flags().StringVar(&eventsAPIKey, "api-key", "", "API key for authentication (prefer "+cliutil.APIKeyEnvVar+"; --api-key is visible in process listings)")
 	eventsCmd.Flags().StringVar(&eventsType, "type", "", "Filter by event type")
 	eventsCmd.Flags().StringVar(&eventsSource, "source", "", "Filter by event source")
 	eventsCmd.Flags().Uint64Var(&eventsLimit, "limit", 0, "Maximum number of events to return")

--- a/cmd/trigger/trigger.go
+++ b/cmd/trigger/trigger.go
@@ -1,0 +1,12 @@
+package trigger
+
+import "github.com/spf13/cobra"
+
+var Cmd = &cobra.Command{
+	Use:   "trigger",
+	Short: "Inspect and operate on triggers",
+}
+
+func init() {
+	Cmd.AddCommand(eventsCmd)
+}

--- a/docs/exec-plans/active/event-trigger-routing.md
+++ b/docs/exec-plans/active/event-trigger-routing.md
@@ -355,19 +355,26 @@ functionally independent of the engine, but it **shares files** with A1
 (`models.go`/`start.go`) and B3 (`webhook.go`), so it lands in **W3** (after those),
 NOT the first wave; D2 calls the Stream B endpoints.
 
-- [ ] D1. Add the durable `webhook_events` log: model + `All` registration + an
+- [x] D1. Add the durable `webhook_events` log: model + `All` registration + an
       env-gated pruner with `CAESIUM_WEBHOOK_EVENT_RETENTION` (default `7d`);
       record each webhook receipt in the receiver.
       Files: new `internal/models/webhook_event.go`, `internal/models/models.go`,
       `pkg/env/env.go`, `cmd/start/start.go`, `api/rest/controller/webhook/webhook.go`.
       Depends on: A1 + B3 (shared `models.go`/`start.go` and `webhook.go` — sequence
       after them per the collision matrix; not a functional dependency).
-- [ ] D2. Add the trigger/event CLI: `caesium event push --type --source --data '{}'`
+      - W3-α: Added catalog `webhook_events`, `CAESIUM_WEBHOOK_EVENT_RETENTION`
+        (default `7d`), a mirrored retention pruner, and webhook receipt recording
+        from the live receiver with receipt counts surfaced in the accepted response.
+- [x] D2. Add the trigger/event CLI: `caesium event push --type --source --data '{}'`
       (`POST /v1/events`) and `caesium trigger events <alias>`
       (`GET /v1/triggers/:id/events`), as new top-level Cobra command groups
       appended to the `cmds` slice in `cmd/execute.go`.
       Files: new `cmd/event/`, new `cmd/trigger/`, `cmd/execute.go`.
       Depends on: B1 + B2.
+      - W3-α: Added `caesium event push` and `caesium trigger events <alias>`;
+        both use `--server`, bearer API-key headers, and `cmd.OutOrStdout()` for
+        clean JSON stdout. Integration coverage drives the real CLI binary with
+        split stdout/stderr capture.
 
 #### Deferred — Event-trigger UI (design Phase 4 item 15)
 

--- a/internal/event/webhook_store.go
+++ b/internal/event/webhook_store.go
@@ -1,0 +1,127 @@
+package event
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const defaultWebhookEventStatus = "accepted"
+
+type WebhookEventStore struct {
+	db  *gorm.DB
+	now func() time.Time
+}
+
+func NewWebhookEventStore(db *gorm.DB) *WebhookEventStore {
+	if db == nil {
+		panic("webhook event store requires database connection")
+	}
+	return &WebhookEventStore{
+		db:  db,
+		now: func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (s *WebhookEventStore) Create(ctx context.Context, evt *models.WebhookEvent) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		return s.CreateTx(tx, evt)
+	})
+}
+
+func (s *WebhookEventStore) CreateTx(tx *gorm.DB, evt *models.WebhookEvent) error {
+	if tx == nil {
+		return errors.New("webhook event: create requires transaction")
+	}
+	if evt == nil {
+		return errors.New("webhook event: create requires event")
+	}
+
+	evt.Path = strings.TrimSpace(evt.Path)
+	evt.Source = strings.TrimSpace(evt.Source)
+	evt.Status = strings.TrimSpace(evt.Status)
+	if evt.Path == "" {
+		return errors.New("webhook event: path is required")
+	}
+	if evt.Status == "" {
+		evt.Status = defaultWebhookEventStatus
+	}
+	if evt.ID == uuid.Nil {
+		evt.ID = uuid.New()
+	}
+	if evt.ReceivedAt.IsZero() {
+		evt.ReceivedAt = s.now()
+	}
+	if err := validateJSONField("http_trigger_ids", evt.HTTPTriggerIDs); err != nil {
+		return err
+	}
+	if err := validateJSONField("http_job_ids", evt.HTTPJobIDs); err != nil {
+		return err
+	}
+	if err := validateJSONField("auth_failures", evt.AuthFailures); err != nil {
+		return err
+	}
+
+	return tx.Create(evt).Error
+}
+
+func (s *WebhookEventStore) Prune(ctx context.Context, retention time.Duration) (int, error) {
+	if retention <= 0 {
+		return 0, nil
+	}
+	cutoff := s.now().Add(-retention)
+
+	result := s.db.WithContext(ctx).Where("received_at <= ?", cutoff).Delete(&models.WebhookEvent{})
+	return int(result.RowsAffected), result.Error
+}
+
+func StartWebhookEventRetentionPruner(ctx context.Context, store *WebhookEventStore, retention time.Duration) {
+	if store == nil || retention <= 0 {
+		return
+	}
+
+	interval := defaultIngestRetentionPruneInterval
+	if retention < interval {
+		interval = retention
+	}
+	if interval < minIngestRetentionPruneInterval {
+		interval = minIngestRetentionPruneInterval
+	}
+	ticker := time.NewTicker(interval)
+	go func() {
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				count, err := store.Prune(ctx, retention)
+				if err != nil {
+					log.Error("webhook event retention pruner failed", "error", err)
+					continue
+				}
+				if count > 0 {
+					log.Info("webhook event retention pruner removed old rows", "count", count)
+				}
+			}
+		}
+	}()
+}
+
+func validateJSONField(name string, data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if !json.Valid(data) {
+		return fmt.Errorf("webhook event: %s must be valid JSON", name)
+	}
+	return nil
+}

--- a/internal/event/webhook_store_test.go
+++ b/internal/event/webhook_store_test.go
@@ -1,0 +1,105 @@
+package event
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestWebhookEventStoreCreateTxValidatesAndDefaults(t *testing.T) {
+	t.Parallel()
+
+	db := openWebhookEventStoreTestDB(t)
+	now := time.Date(2026, 6, 27, 13, 0, 0, 0, time.UTC)
+	store := NewWebhookEventStore(db)
+	store.now = func() time.Time { return now }
+
+	require.Error(t, db.Transaction(func(tx *gorm.DB) error {
+		return store.CreateTx(tx, &models.WebhookEvent{})
+	}))
+
+	require.Error(t, db.Transaction(func(tx *gorm.DB) error {
+		return store.CreateTx(tx, &models.WebhookEvent{
+			Path:           "github/push",
+			HTTPTriggerIDs: datatypes.JSON(`{`),
+		})
+	}))
+
+	evt := &models.WebhookEvent{
+		Path:                 " github/push ",
+		Source:               " github ",
+		EventMatchedTriggers: 1,
+		HTTPTriggersAccepted: 1,
+		HTTPTriggerIDs:       datatypes.JSON(`["` + uuid.NewString() + `"]`),
+	}
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return store.CreateTx(tx, evt)
+	}))
+	require.NotEqual(t, uuid.Nil, evt.ID)
+	require.Equal(t, now, evt.ReceivedAt)
+	require.Equal(t, "github/push", evt.Path)
+	require.Equal(t, "github", evt.Source)
+	require.Equal(t, defaultWebhookEventStatus, evt.Status)
+
+	var stored models.WebhookEvent
+	require.NoError(t, db.First(&stored, "id = ?", evt.ID).Error)
+	require.Equal(t, evt.ID, stored.ID)
+	require.Equal(t, evt.EventMatchedTriggers, stored.EventMatchedTriggers)
+}
+
+func TestWebhookEventStorePrune(t *testing.T) {
+	t.Parallel()
+
+	db := openWebhookEventStoreTestDB(t)
+	now := time.Date(2026, 6, 27, 14, 0, 0, 0, time.UTC)
+	store := NewWebhookEventStore(db)
+	store.now = func() time.Time { return now }
+
+	old := &models.WebhookEvent{Path: "old", ReceivedAt: now.Add(-8 * 24 * time.Hour)}
+	fresh := &models.WebhookEvent{Path: "fresh", ReceivedAt: now.Add(-6 * 24 * time.Hour)}
+	require.NoError(t, store.Create(context.Background(), old))
+	require.NoError(t, store.Create(context.Background(), fresh))
+
+	count, err := store.Prune(context.Background(), 7*24*time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+
+	var remaining []models.WebhookEvent
+	require.NoError(t, db.Find(&remaining).Error)
+	require.Len(t, remaining, 1)
+	require.Equal(t, "fresh", remaining[0].Path)
+}
+
+func TestWebhookEventStorePruneDisabled(t *testing.T) {
+	t.Parallel()
+
+	db := openWebhookEventStoreTestDB(t)
+	store := NewWebhookEventStore(db)
+	require.NoError(t, store.Create(context.Background(), &models.WebhookEvent{Path: "keep"}))
+
+	count, err := store.Prune(context.Background(), 0)
+	require.NoError(t, err)
+	require.Equal(t, 0, count)
+
+	var rows int64
+	require.NoError(t, db.Model(&models.WebhookEvent{}).Count(&rows).Error)
+	require.EqualValues(t, 1, rows)
+}
+
+func openWebhookEventStoreTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.WebhookEvent{}))
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	return db
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -8,6 +8,7 @@ var All = []interface{}{
 	&Trigger{},
 	&Job{},
 	&IngestedEvent{},
+	&WebhookEvent{},
 	&Task{},
 	&TaskEdge{},
 	&Callback{},

--- a/internal/models/webhook_event.go
+++ b/internal/models/webhook_event.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+type WebhookEvent struct {
+	ID                   uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	Path                 string         `gorm:"type:text;index;not null" json:"path"`
+	Source               string         `gorm:"type:text;index" json:"source,omitempty"`
+	ReceivedAt           time.Time      `gorm:"not null;index" json:"received_at"`
+	Status               string         `gorm:"type:text;index;not null" json:"status"`
+	EventID              uuid.UUID      `gorm:"type:uuid;index" json:"event_id,omitempty"`
+	EventMatchedTriggers int            `gorm:"not null;default:0" json:"event_matched_triggers"`
+	EventRunsStarted     int            `gorm:"not null;default:0" json:"event_runs_started"`
+	HTTPTriggersAccepted int            `gorm:"not null;default:0" json:"http_triggers_accepted"`
+	HTTPRunsStarted      int            `gorm:"not null;default:0" json:"http_runs_started"`
+	HTTPTriggerIDs       datatypes.JSON `gorm:"type:json" json:"http_trigger_ids,omitempty"`
+	HTTPJobIDs           datatypes.JSON `gorm:"type:json" json:"http_job_ids,omitempty"`
+	AuthFailures         datatypes.JSON `gorm:"type:json" json:"auth_failures,omitempty"`
+	Error                string         `gorm:"type:text" json:"error,omitempty"`
+}

--- a/internal/models/webhook_event_test.go
+++ b/internal/models/webhook_event_test.go
@@ -1,0 +1,16 @@
+package models
+
+import "testing"
+
+func TestWebhookEventInAllSlice(t *testing.T) {
+	found := false
+	for _, m := range All {
+		if _, ok := m.(*WebhookEvent); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("WebhookEvent not found in models.All; AutoMigrate will not create the table")
+	}
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -152,6 +152,7 @@ type Environment struct {
 	WebhookRateLimitPerMinute int           `envconfig:"WEBHOOK_RATE_LIMIT_PER_MINUTE" default:"120"`
 	WebhookRateLimitBurst     int           `envconfig:"WEBHOOK_RATE_LIMIT_BURST" default:"20"`
 	EventRetention            time.Duration `envconfig:"EVENT_RETENTION" default:"168h"`
+	WebhookEventRetention     time.Duration `envconfig:"WEBHOOK_EVENT_RETENTION" default:"168h"`
 	MaxTriggerDepth           int           `envconfig:"MAX_TRIGGER_DEPTH" default:"10"`
 
 	// Notification Watcher

--- a/test/event_cli_test.go
+++ b/test/event_cli_test.go
@@ -1,0 +1,229 @@
+//go:build integration
+
+package test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	dqliteclient "github.com/canonical/go-dqlite/v3/client"
+	dqlitedriver "github.com/canonical/go-dqlite/v3/driver"
+)
+
+type webhookReceiptResponse struct {
+	ReceiptID            string `json:"receipt_id"`
+	Path                 string `json:"path"`
+	Source               string `json:"source"`
+	EventMatchedTriggers int    `json:"event_matched_triggers"`
+	EventRunsStarted     int    `json:"event_runs_started"`
+	HTTPTriggersAccepted int    `json:"http_triggers_accepted"`
+	HTTPRunsStarted      int    `json:"http_runs_started"`
+}
+
+type persistedWebhookEvent struct {
+	ReceiptID            string
+	Path                 string
+	Source               string
+	Status               string
+	EventMatchedTriggers int
+	EventRunsStarted     int
+	HTTPTriggersAccepted int
+	HTTPRunsStarted      int
+}
+
+func (s *IntegrationTestSuite) TestEventAndTriggerCLIWithWebhookReceiptLog() {
+	suffix := time.Now().UnixNano()
+	alias := fmt.Sprintf("integration-event-cli-%d", suffix)
+	eventType := fmt.Sprintf("cli.created.%d", suffix)
+	source := fmt.Sprintf("cli-source-%d", suffix)
+	dir := s.writeJobManifest(eventCLIManifest(alias, eventType, source))
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	payload := fmt.Sprintf(`{"env":"w3-alpha","item":{"id":"item-%d"}}`, suffix)
+	stdout, stderr, err := s.runCLISeparate(
+		"event", "push",
+		"--type", eventType,
+		"--source", source,
+		"--data", payload,
+		"--server", s.caesiumURL,
+		"--api-key", s.eventIngestAPIKey,
+	)
+	s.Require().NoError(err, "caesium event push failed:\nstdout=%s\nstderr=%s", stdout, stderr)
+	s.Require().True(json.Valid([]byte(stdout)), "caesium event push stdout was not clean JSON:\n%s", stdout)
+	s.NotContains(stdout, "warning:", "operator warnings must stay off stdout")
+	s.Contains(strings.ToLower(stderr), "warning", "--api-key secrecy warning should land on stderr")
+
+	var pushed eventIngestResponse
+	s.Require().NoError(json.Unmarshal([]byte(stdout), &pushed))
+	s.Require().NotEmpty(pushed.EventID)
+	s.Equal(1, pushed.MatchedTriggers)
+	s.Equal(1, pushed.RunsStarted)
+
+	var runID string
+	var lastListOut string
+	var lastListErrOut string
+	s.Require().Eventually(func() bool {
+		listOut, listErrOut, listErr := s.runCLISeparate(
+			"trigger", "events", alias,
+			"--type", eventType,
+			"--source", source,
+			"--server", s.caesiumURL,
+			"--api-key", s.manualTriggerAPIKey,
+		)
+		lastListOut = listOut
+		lastListErrOut = listErrOut
+		if listErr != nil || !json.Valid([]byte(listOut)) {
+			return false
+		}
+
+		var events []triggerEventResponse
+		if err := json.Unmarshal([]byte(listOut), &events); err != nil {
+			return false
+		}
+		for _, evt := range events {
+			if evt.EventID == pushed.EventID && evt.TriggerID != "" && len(evt.RunsStarted) == 1 {
+				runID = evt.RunsStarted[0]
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 500*time.Millisecond, "trigger events CLI should list the matched event")
+	s.Require().True(json.Valid([]byte(lastListOut)), "caesium trigger events stdout was not clean JSON:\n%s", lastListOut)
+	s.NotContains(lastListOut, "warning:", "operator warnings must stay off stdout")
+	s.Contains(strings.ToLower(lastListErrOut), "warning", "--api-key secrecy warning should land on stderr")
+
+	run := s.awaitRun(job.ID, runID, runTimeout)
+	s.Equal("succeeded", run.Status)
+	s.Equal(fmt.Sprintf("item-%d", suffix), run.Params["item_id"])
+
+	webhookAlias := fmt.Sprintf("integration-webhook-log-%d", suffix)
+	hookPath := fmt.Sprintf("/receipt-log/%d", suffix)
+	webhookJob := s.createJobWithTriggerConfig(
+		webhookAlias,
+		nil,
+		models.TriggerTypeHTTP,
+		map[string]any{"path": hookPath},
+	)
+	s.Require().NotNil(webhookJob)
+
+	req, err := http.NewRequestWithContext(
+		s.T().Context(),
+		http.MethodPost,
+		fmt.Sprintf("%v/v1/hooks%s", s.caesiumURL, hookPath),
+		bytes.NewBufferString(`{"delivery":"receipt-log"}`),
+	)
+	s.Require().NoError(err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Caesium-Event-Source", "integration-webhook-log")
+
+	resp, err := http.DefaultClient.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusAccepted, resp.StatusCode, string(body))
+	s.Require().True(json.Valid(body), "webhook receipt response was not clean JSON:\n%s", body)
+
+	var receipt webhookReceiptResponse
+	s.Require().NoError(json.Unmarshal(body, &receipt))
+	s.Require().NotEmpty(receipt.ReceiptID)
+	s.Equal(strings.Trim(hookPath, "/"), receipt.Path)
+	s.Equal("integration-webhook-log", receipt.Source)
+	s.Equal(1, receipt.HTTPTriggersAccepted)
+	s.Equal(1, receipt.HTTPRunsStarted)
+
+	catalogDB := s.openIntegrationCatalogDB()
+	defer func() { s.Require().NoError(catalogDB.Close()) }()
+
+	var persisted persistedWebhookEvent
+	var readErr error
+	// webhook_events has no read surface yet, so this verifies persistence at the DB level.
+	s.Require().Eventually(func() bool {
+		persisted, readErr = readPersistedWebhookEvent(s.T().Context(), catalogDB, receipt.ReceiptID)
+		return readErr == nil
+	}, 30*time.Second, 500*time.Millisecond, "webhook_events should persist the receipt row")
+	s.Require().NoError(readErr)
+	s.Equal(receipt.ReceiptID, persisted.ReceiptID)
+	s.Equal(receipt.Path, persisted.Path)
+	s.Equal(receipt.Source, persisted.Source)
+	s.Equal("accepted", persisted.Status)
+	s.Equal(receipt.EventMatchedTriggers, persisted.EventMatchedTriggers)
+	s.Equal(receipt.EventRunsStarted, persisted.EventRunsStarted)
+	s.Equal(receipt.HTTPTriggersAccepted, persisted.HTTPTriggersAccepted)
+	s.Equal(receipt.HTTPRunsStarted, persisted.HTTPRunsStarted)
+}
+
+func (s *IntegrationTestSuite) openIntegrationCatalogDB() *sql.DB {
+	nodeAddress := strings.TrimSpace(os.Getenv("CAESIUM_NODE_ADDRESS"))
+	if nodeAddress == "" {
+		nodeAddress = "127.0.0.1:9001"
+	}
+
+	store := dqliteclient.NewInmemNodeStore()
+	s.Require().NoError(store.Set(s.T().Context(), []dqliteclient.NodeInfo{{
+		ID:      1,
+		Address: nodeAddress,
+		Role:    dqliteclient.Voter,
+	}}))
+	drv, err := dqlitedriver.New(store)
+	s.Require().NoError(err)
+	connector, err := drv.OpenConnector("caesium")
+	s.Require().NoError(err)
+
+	return sql.OpenDB(connector)
+}
+
+func readPersistedWebhookEvent(ctx context.Context, db *sql.DB, receiptID string) (persistedWebhookEvent, error) {
+	var evt persistedWebhookEvent
+	err := db.QueryRowContext(ctx, `
+SELECT id, path, source, status, event_matched_triggers, event_runs_started, http_triggers_accepted, http_runs_started
+FROM webhook_events
+WHERE id = ?
+`, receiptID).Scan(
+		&evt.ReceiptID,
+		&evt.Path,
+		&evt.Source,
+		&evt.Status,
+		&evt.EventMatchedTriggers,
+		&evt.EventRunsStarted,
+		&evt.HTTPTriggersAccepted,
+		&evt.HTTPRunsStarted,
+	)
+	return evt, err
+}
+
+func eventCLIManifest(alias, eventType, source string) string {
+	return fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger:
+  type: event
+  configuration:
+    events:
+      - type: %s
+        source: %s
+        filter:
+          env: w3-alpha
+    paramMapping:
+      item_id: $.item.id
+steps:
+  - name: record
+    image: debian:12-slim
+    command: ["sh", "-c", "echo event-cli"]
+`, alias, eventType, source)
+}


### PR DESCRIPTION
## Summary

Wave 3, Stream D — the durable webhook log + the operator CLI, completing the event-trigger observability tail.

- **D1** — `webhook_events` model + store + an env-gated retention pruner (`CAESIUM_WEBHOOK_EVENT_RETENTION`, mirrors the `ingested_events` pruner); each webhook receipt is recorded **off the hot path** (best-effort goroutine, doesn't block the 202).
- **D2** — `caesium event push --type --source --data` (POST /v1/events) + `caesium trigger events <alias>` (GET /v1/triggers/:id/events). Clean stdout via `runCLISeparate`; the api-key secrecy warning goes to stderr; auth mirrors existing commands.
- Integration test drives the **real CLI binary** against the live server (apply event trigger → `caesium event push` → assert the run fires) + reads the persisted `webhook_events` row back.

## Review
Opus review: CLI/stdout hygiene **clean** (passes the CLAUDE.md gate). Fixes: the webhook-log persistence assertion (DB read-back instead of the in-memory 202), the receipt write moved off the hot path, and a `-race` fix (capture the recorder fn before the goroutine). `just lint`+`unit-test` green (webhook pkg 69%).

## Test plan
- [x] just lint + just unit-test (orchestrator, -race)
- [ ] just integration-test — Phase 6.5 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)