### PR TITLE
Add resource rate limiting — durable sliding-window limiter + pruner (concurrency-priority-queues W2-δ)

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -30,6 +30,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/lineage"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/internal/notification"
+	"github.com/caesium-cloud/caesium/internal/ratelimit"
 	"github.com/caesium-cloud/caesium/internal/run"
 	triggerevent "github.com/caesium-cloud/caesium/internal/trigger/event"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
@@ -159,6 +160,12 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 	event.StartIngestRetentionPruner(ctx, event.NewIngestStore(db.Connection()), vars.EventRetention)
 	event.StartWebhookEventRetentionPruner(ctx, event.NewWebhookEventStore(db.Connection()), vars.WebhookEventRetention)
+	if vars.RateLimitPrunerEnabled {
+		runAsync(func() {
+			log.Info("launching rate limit token pruner", "interval", vars.RateLimitPruneInterval)
+			ratelimit.NewPruner(db.Connection()).Run(ctx, vars.RateLimitPruneInterval)
+		})
+	}
 
 	bus := event.New()
 	runStore := run.Default()
@@ -324,6 +331,8 @@ func start(cmd *cobra.Command, args []string) error {
 			LeaseTTL:     vars.RunLeaseTTL,
 			LeaseStore:   leaseStore,
 			Store:        runStore,
+			RateLimitDB:  db.Connection(),
+			RateLimiter:  ratelimit.NewLimiter(db.Connection()),
 			Peers:        dqliteDispatchPeerResolver(),
 			OwnerManager: ownerManager,
 		})
@@ -501,7 +510,8 @@ func start(cmd *cobra.Command, args []string) error {
 			vars.WorkerLeaseTTL,
 		)
 
-		claimer := worker.NewClaimer(vars.NodeAddress, runStore, vars.WorkerLeaseTTL, worker.ParseNodeLabels(vars.NodeLabels))
+		claimer := worker.NewClaimer(vars.NodeAddress, runStore, vars.WorkerLeaseTTL, worker.ParseNodeLabels(vars.NodeLabels)).
+			WithRateLimiter(ratelimit.NewLimiter(db.Connection()))
 		executorFn := worker.NewRuntimeExecutor(runStore, vars.TaskTimeout, vars.TaskFailurePolicy, resolver)
 		wakeups := worker.SubscribeWakeups(ctx, bus, wakeupSignaler.C())
 		distributedWorker = worker.NewWorker(claimer, worker.NewPool(poolSize), vars.WorkerPollInterval, executorFn).

--- a/docs/exec-plans/active/concurrency-priority-queues.md
+++ b/docs/exec-plans/active/concurrency-priority-queues.md
@@ -368,7 +368,7 @@ A durable sliding-window counter that throttles tasks against a named shared res
 a single atomic statement, re-queuing (not blocking) over-limit tasks. Independent of B/C
 except the shared schema (A).
 
-- [ ] D1. Build the durable resource limiter + model. New `RateLimitToken` catalog model
+- [x] D1. Build the durable resource limiter + model. New `RateLimitToken` catalog model
       (composite PK `(resource, window_key)`, `consumed`/`limit_val`/`expires_at`; in
       `models.All` catalog section, **not** hot-sharded); new
       `internal/ratelimit.Limiter.Acquire(resource, units, limit, window) (bool, error)`
@@ -382,7 +382,9 @@ except the shared schema (A).
       Files: `new internal/models/rate_limit_token.go`, `internal/models/models.go`,
       `new internal/ratelimit/limiter.go`, `internal/metrics/metrics.go`.
       Depends on: A1.
-- [ ] D2. Integrate the limiter into task dispatch + add the pruner. Read the persisted
+      Done (W2-delta): added the catalog `RateLimitToken`, raw guarded `tx.Exec`
+      upsert limiter, bounded-resource metrics, and limiter/pruner unit tests.
+- [x] D2. Integrate the limiter into task dispatch + add the pruner. Read the persisted
       per-task `RateLimitResource`/`RateLimitUnits` (A3) before dispatch; on rejection,
       re-queue the task `pending` with a retry-after delay (don't hold the slot) and count
       `caesium_run_skipped_total{reason="rate_limit"}`; a `CAESIUM_RATE_LIMIT_*`-gated
@@ -391,6 +393,10 @@ except the shared schema (A).
       `new internal/ratelimit/pruner.go`, `cmd/start/start.go`, `pkg/env/env.go`,
       `test/rate_limit_test.go` (enforcement + window rollover + multi-task contention).
       Depends on: D1 + A3.
+      Done (W2-delta): local, owner-push, and pull-worker dispatch gates acquire tokens
+      before worker submission; rejects stamp `rate_limit_retry_after`, increment
+      `caesium_run_skipped_total` with reason `rate_limit`, and the env-gated
+      token pruner is wired via `runAsync`.
 
 ### Stream E — Observability surfaces (P2)
 

--- a/internal/dispatch/loop.go
+++ b/internal/dispatch/loop.go
@@ -31,9 +31,11 @@ import (
 
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/ratelimit"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
+	"gorm.io/gorm"
 )
 
 // DispatchRejectionReason labels for caesium_dispatch_rejected_total.
@@ -87,6 +89,15 @@ type TaskPendingReader interface {
 	PendingTasksForDispatch(ctx context.Context, runID uuid.UUID, limit int) ([]models.TaskRun, error)
 }
 
+// RateLimiter consumes durable resource tokens before a task is dispatched.
+type RateLimiter interface {
+	Acquire(ctx context.Context, resource string, units, limit int, window time.Duration) (bool, error)
+}
+
+type rateLimitTaskUpdater interface {
+	RateLimitTask(ctx context.Context, runID, taskID uuid.UUID, retryAfter time.Time) error
+}
+
 // DispatchLoopConfig holds all parameters for the dispatch loop goroutine.
 type DispatchLoopConfig struct {
 	// NodeID is this node's canonical address (CAESIUM_NODE_ADDRESS).  Used
@@ -117,6 +128,11 @@ type DispatchLoopConfig struct {
 	LeaseStore OwnerReader
 	// Store provides pending-task queries.
 	Store TaskPendingReader
+	// RateLimitDB is the catalog DB used to resolve persisted task/job
+	// rate-limit metadata. Nil disables rate limiting for tests.
+	RateLimitDB *gorm.DB
+	// RateLimiter enforces declared resource limits before worker dispatch.
+	RateLimiter RateLimiter
 	// Peers resolves the current peer list.
 	Peers PeerLister
 	// PeerBaseURL maps a raw peer node address (host:dqlitePort) to the HTTP
@@ -154,6 +170,11 @@ type DispatchLoop struct {
 	// alive and merely declined.
 	benchMu      sync.Mutex
 	benchedPeers map[string]time.Time
+
+	// In-memory owner mode does not poll PendingTasksForDispatch, so it needs a
+	// local mirror of rate-limit retry-after times to avoid re-dispatch spin.
+	rateLimitDelayMu sync.Mutex
+	rateLimitDelays  map[uuid.UUID]map[uuid.UUID]time.Time
 }
 
 // peerBenchCooldown is how long a peer stays benched after a network-error
@@ -176,7 +197,11 @@ func NewDispatchLoop(cfg DispatchLoopConfig) *DispatchLoop {
 	if cfg.APIPort <= 0 {
 		cfg.APIPort = 8080
 	}
-	l := &DispatchLoop{cfg: cfg, benchedPeers: make(map[string]time.Time)}
+	l := &DispatchLoop{
+		cfg:             cfg,
+		benchedPeers:    make(map[string]time.Time),
+		rateLimitDelays: make(map[uuid.UUID]map[uuid.UUID]time.Time),
+	}
 	// Reuse the same nodeAddr→baseURL logic the peer list uses so the owner's
 	// own base URL is built identically (and honors the PeerBaseURL test hook).
 	l.ownerBaseURL = l.nodeAddrToBaseURL(cfg.NodeID)
@@ -334,6 +359,9 @@ func (l *DispatchLoop) dispatchRun(ctx context.Context, runID uuid.UUID, generat
 		go func(p peer, req DispatchRequest) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			if ok := l.acquireRateLimit(ctx, runID, req.TaskID); !ok {
+				return
+			}
 			l.postOne(ctx, runID, p, req, task.Quarantine)
 		}(p, req)
 	}
@@ -357,6 +385,18 @@ func (l *DispatchLoop) dispatchRunInMemory(ctx context.Context, runID uuid.UUID,
 	}
 
 	ready := mgr.ReadyForDispatch(runID)
+	if len(ready) == 0 {
+		return
+	}
+	now := time.Now().UTC()
+	filtered := ready[:0]
+	for _, dt := range ready {
+		if l.rateLimitDelayed(runID, dt.TaskID, now) {
+			continue
+		}
+		filtered = append(filtered, dt)
+	}
+	ready = filtered
 	if len(ready) == 0 {
 		return
 	}
@@ -392,10 +432,94 @@ func (l *DispatchLoop) dispatchRunInMemory(ctx context.Context, runID uuid.UUID,
 		go func(p peer, req DispatchRequest) {
 			defer wg.Done()
 			defer func() { <-sem }()
+			if ok := l.acquireRateLimit(ctx, runID, req.TaskID); !ok {
+				return
+			}
 			l.postOne(ctx, runID, p, req, false)
 		}(p, req)
 	}
 	wg.Wait()
+}
+
+func (l *DispatchLoop) acquireRateLimit(ctx context.Context, runID, taskID uuid.UUID) bool {
+	if l.cfg.RateLimiter == nil || l.cfg.RateLimitDB == nil {
+		return true
+	}
+	rule, ok, err := ratelimit.RuleForTask(ctx, l.cfg.RateLimitDB, runID, taskID)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Warn("dispatch loop: rate limit lookup failed", "run_id", runID, "task_id", taskID, "error", err)
+		}
+		return false
+	}
+	if !ok {
+		return true
+	}
+	acquired, err := l.cfg.RateLimiter.Acquire(ctx, rule.Resource, rule.Units, rule.Limit, rule.Window)
+	if err != nil {
+		if ctx.Err() == nil {
+			log.Warn("dispatch loop: rate limit acquire failed", "run_id", runID, "task_id", taskID, "resource", rule.Resource, "error", err)
+		}
+		return false
+	}
+	if acquired {
+		return true
+	}
+
+	updater, ok := l.cfg.Store.(rateLimitTaskUpdater)
+	if !ok {
+		log.Warn("dispatch loop: rate limit rejected task but store cannot requeue", "run_id", runID, "task_id", taskID, "resource", rule.Resource)
+		return false
+	}
+	now := time.Now().UTC()
+	retryAfter := now.Add(ratelimit.RetryAfter(now, rule.Window))
+	if err := updater.RateLimitTask(ctx, runID, taskID, retryAfter); err != nil {
+		if ctx.Err() == nil {
+			log.Warn("dispatch loop: rate limit requeue failed", "run_id", runID, "task_id", taskID, "resource", rule.Resource, "error", err)
+		}
+		return false
+	}
+	if l.cfg.OwnerManager != nil {
+		l.rememberRateLimitDelay(runID, taskID, retryAfter)
+	}
+	metrics.RunSkippedTotal.WithLabelValues(rule.JobAlias, "rate_limit").Inc()
+	log.Info("dispatch loop: task delayed by rate limit", "run_id", runID, "task_id", taskID, "resource", rule.Resource, "retry_after", retryAfter)
+	return false
+}
+
+func (l *DispatchLoop) rememberRateLimitDelay(runID, taskID uuid.UUID, retryAfter time.Time) {
+	if retryAfter.IsZero() {
+		return
+	}
+	l.rateLimitDelayMu.Lock()
+	defer l.rateLimitDelayMu.Unlock()
+	tasks := l.rateLimitDelays[runID]
+	if tasks == nil {
+		tasks = make(map[uuid.UUID]time.Time)
+		l.rateLimitDelays[runID] = tasks
+	}
+	tasks[taskID] = retryAfter.UTC()
+}
+
+func (l *DispatchLoop) rateLimitDelayed(runID, taskID uuid.UUID, now time.Time) bool {
+	l.rateLimitDelayMu.Lock()
+	defer l.rateLimitDelayMu.Unlock()
+	tasks := l.rateLimitDelays[runID]
+	if tasks == nil {
+		return false
+	}
+	retryAfter, ok := tasks[taskID]
+	if !ok {
+		return false
+	}
+	if retryAfter.After(now.UTC()) {
+		return true
+	}
+	delete(tasks, taskID)
+	if len(tasks) == 0 {
+		delete(l.rateLimitDelays, runID)
+	}
+	return false
 }
 
 // postOne does the actual HTTP call + metric/log accounting for one dispatch.

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -28,6 +28,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/ratelimit"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/internal/worker"
 	"github.com/caesium-cloud/caesium/pkg/container"
@@ -1158,8 +1159,69 @@ func (j *job) Run(ctx context.Context) error {
 	results := make(chan taskResult)
 	active := 0
 	halt := false
+	deferred := make(map[uuid.UUID]time.Time)
+	rateLimiter := ratelimit.NewLimiter(store.DB())
+
+	acquireTaskRateLimit := func(taskID uuid.UUID) (bool, time.Time, error) {
+		rule, ok, err := ratelimit.RuleForTask(ctx, store.DB(), runID, taskID)
+		if err != nil {
+			return false, time.Time{}, err
+		}
+		if !ok {
+			return true, time.Time{}, nil
+		}
+		acquired, err := rateLimiter.Acquire(ctx, rule.Resource, rule.Units, rule.Limit, rule.Window)
+		if err != nil {
+			return false, time.Time{}, err
+		}
+		if acquired {
+			return true, time.Time{}, nil
+		}
+
+		now := time.Now().UTC()
+		retryAfter := now.Add(ratelimit.RetryAfter(now, rule.Window))
+		if err := store.RateLimitTask(ctx, runID, taskID, retryAfter); err != nil {
+			return false, time.Time{}, err
+		}
+		metrics.RunSkippedTotal.WithLabelValues(j.alias, "rate_limit").Inc()
+		log.Info("task delayed by rate limit", "job_id", j.id, "run_id", runID, "task_id", taskID, "resource", rule.Resource, "retry_after", retryAfter)
+		return false, retryAfter, nil
+	}
+
+	moveDueDeferred := func() bool {
+		now := time.Now().UTC()
+		moved := false
+		for taskID, retryAfter := range deferred {
+			if retryAfter.After(now) {
+				continue
+			}
+			delete(deferred, taskID)
+			push(taskID)
+			moved = true
+		}
+		return moved
+	}
+
+	nextDeferredAt := func() (time.Time, bool) {
+		var next time.Time
+		for _, retryAfter := range deferred {
+			if next.IsZero() || retryAfter.Before(next) {
+				next = retryAfter
+			}
+		}
+		return next, !next.IsZero()
+	}
 
 	dispatch := func(taskID uuid.UUID) error {
+		acquired, retryAfter, err := acquireTaskRateLimit(taskID)
+		if err != nil {
+			return err
+		}
+		if !acquired {
+			deferred[taskID] = retryAfter
+			return nil
+		}
+
 		active++
 		if err := taskPool.Submit(ctx, func() {
 			skipped, err := runTask(taskID)
@@ -1171,7 +1233,11 @@ func (j *job) Run(ctx context.Context) error {
 		return nil
 	}
 
-	for len(queue) > 0 || active > 0 {
+	for (!halt && (len(queue) > 0 || len(deferred) > 0)) || active > 0 {
+		if moveDueDeferred() {
+			continue
+		}
+
 		for !halt && active < maxParallel && len(queue) > 0 {
 			taskID := queue[0]
 			queue = queue[1:]
@@ -1191,12 +1257,56 @@ func (j *job) Run(ctx context.Context) error {
 			}
 		}
 
-		if active == 0 {
-			break
+		var result taskResult
+		gotResult := false
+		if len(queue) == 0 && len(deferred) > 0 {
+			next, ok := nextDeferredAt()
+			if !ok {
+				continue
+			}
+			wait := time.Until(next)
+			if wait <= 0 {
+				continue
+			}
+			timer := time.NewTimer(wait)
+			if active == 0 {
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					runErr = ctx.Err()
+					halt = true
+					continue
+				case <-timer.C:
+					continue
+				}
+			}
+			select {
+			case result = <-results:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				active--
+				gotResult = true
+			case <-ctx.Done():
+				timer.Stop()
+				runErr = ctx.Err()
+				halt = true
+				continue
+			case <-timer.C:
+				continue
+			}
 		}
 
-		result := <-results
-		active--
+		if !gotResult {
+			if active == 0 {
+				break
+			}
+			result = <-results
+			active--
+		}
 
 		if processed[result.id] {
 			continue

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -57,6 +57,14 @@ var runStartReadBackoffs = []time.Duration{
 	320 * time.Millisecond,
 }
 
+const haltedDispatchWaitInterval = 50 * time.Millisecond
+
+type taskResult struct {
+	id              uuid.UUID
+	err             error
+	skippedByBranch []uuid.UUID
+}
+
 // ErrLocalQuarantinedReplayUnsupported is returned when a quarantined replay
 // reaches the in-process executor, which is not descriptor-aware.
 var ErrLocalQuarantinedReplayUnsupported = errors.New("replay requires the descriptor-aware executor")
@@ -91,6 +99,22 @@ func retryOnContention(ctx context.Context, fn func() error) error {
 			return ctx.Err()
 		case <-timer.C:
 		}
+	}
+}
+
+func waitForHaltedDispatchResult(results <-chan taskResult, wait time.Duration) (taskResult, bool) {
+	if wait <= 0 {
+		wait = haltedDispatchWaitInterval
+	}
+
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case result := <-results:
+		return result, true
+	case <-timer.C:
+		return taskResult{}, false
 	}
 }
 
@@ -716,12 +740,6 @@ func (j *job) Run(ctx context.Context) error {
 		return runErr
 	}
 
-	type taskResult struct {
-		id              uuid.UUID
-		err             error
-		skippedByBranch []uuid.UUID
-	}
-
 	paramEnv := buildParamEnv(snapshot.ID, j.alias, snapshot.Params)
 
 	// executeAtom creates, monitors, and stops a container for one execution attempt.
@@ -1234,7 +1252,7 @@ func (j *job) Run(ctx context.Context) error {
 	}
 
 	for (!halt && (len(queue) > 0 || len(deferred) > 0)) || active > 0 {
-		if moveDueDeferred() {
+		if !halt && moveDueDeferred() {
 			continue
 		}
 
@@ -1259,7 +1277,18 @@ func (j *job) Run(ctx context.Context) error {
 
 		var result taskResult
 		gotResult := false
-		if len(queue) == 0 && len(deferred) > 0 {
+		if halt && len(queue) == 0 && len(deferred) > 0 {
+			if active == 0 {
+				break
+			}
+			var ok bool
+			result, ok = waitForHaltedDispatchResult(results, haltedDispatchWaitInterval)
+			if !ok {
+				continue
+			}
+			active--
+			gotResult = true
+		} else if len(queue) == 0 && len(deferred) > 0 {
 			next, ok := nextDeferredAt()
 			if !ok {
 				continue

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -66,6 +66,32 @@ func TestUnmarshalSchedulingMetadataLogsInvalidJSON(t *testing.T) {
 	})
 }
 
+func TestHaltedDispatchWaitDoesNotBusySpin(t *testing.T) {
+	t.Run("blocks until bounded timer", func(t *testing.T) {
+		results := make(chan taskResult)
+		wait := 25 * time.Millisecond
+
+		started := time.Now()
+		_, gotResult := waitForHaltedDispatchResult(results, wait)
+
+		require.False(t, gotResult)
+		require.GreaterOrEqual(t, time.Since(started), wait-2*time.Millisecond)
+	})
+
+	t.Run("returns on task completion", func(t *testing.T) {
+		results := make(chan taskResult, 1)
+		want := taskResult{id: uuid.New()}
+		results <- want
+
+		started := time.Now()
+		got, gotResult := waitForHaltedDispatchResult(results, time.Second)
+
+		require.True(t, gotResult)
+		require.Equal(t, want.id, got.id)
+		require.Less(t, time.Since(started), 100*time.Millisecond)
+	})
+}
+
 func captureJobLogs(t *testing.T, fn func()) string {
 	t.Helper()
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -184,6 +184,34 @@ var (
 		},
 	)
 
+	// The resource label is bounded by declared metadata.rateLimits resources,
+	// not per-request free-form input.
+	RateLimitAcquiredTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_rate_limit_acquired_total",
+			Help: "Total rate-limit token acquisitions by declared resource.",
+		},
+		[]string{"resource"},
+	)
+
+	// The resource label is bounded by declared metadata.rateLimits resources,
+	// not per-request free-form input.
+	RateLimitRejectedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_rate_limit_rejected_total",
+			Help: "Total rate-limit token rejections by declared resource.",
+		},
+		[]string{"resource"},
+	)
+
+	RunSkippedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_run_skipped_total",
+			Help: "Total runs or run tasks skipped by scheduler control, by job and reason.",
+		},
+		[]string{"job_alias", "reason"},
+	)
+
 	// Auth metrics
 
 	AuthRequestsTotal = prometheus.NewCounterVec(
@@ -455,6 +483,9 @@ func Register() {
 			TaskCacheMissesTotal,
 			TaskCacheShortCircuitsTotal,
 			TaskCacheEntries,
+			RateLimitAcquiredTotal,
+			RateLimitRejectedTotal,
+			RunSkippedTotal,
 			AuthRequestsTotal,
 			AuthFailuresTotal,
 			AuthKeyAgeSeconds,

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -27,6 +27,7 @@ var All = []interface{}{
 	&SAMLAssertionReplay{},
 	&NotificationChannel{},
 	&NotificationPolicy{},
+	&RateLimitToken{},
 	// Phase 2 run-owner coordination tables (catalog DB, cross-run, low-volume).
 	&RunLease{},
 	&InternalCAGeneration{},

--- a/internal/models/rate_limit_token.go
+++ b/internal/models/rate_limit_token.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+// RateLimitToken stores consumed units for one resource/window pair. This is a
+// catalog table: resources are declared on jobs and remain low-cardinality.
+type RateLimitToken struct {
+	Resource  string    `gorm:"type:text;primaryKey;column:resource" json:"resource"`
+	WindowKey string    `gorm:"type:text;primaryKey;column:window_key" json:"window_key"`
+	Consumed  int       `gorm:"not null;default:0" json:"consumed"`
+	LimitVal  int       `gorm:"column:limit_val;not null" json:"limit_val"`
+	ExpiresAt time.Time `gorm:"not null;index" json:"expires_at"`
+}
+
+func (RateLimitToken) TableName() string {
+	return "rate_limit_tokens"
+}

--- a/internal/models/run.go
+++ b/internal/models/run.go
@@ -37,23 +37,26 @@ type JobRun struct {
 }
 
 type TaskRun struct {
-	ID             uuid.UUID         `gorm:"type:uuid;primaryKey" json:"id"`
-	JobRunID       uuid.UUID         `gorm:"type:uuid;index:idx_taskrun_jobrun_task;index;index:idx_taskrun_terminal_seq,priority:1;not null" json:"job_run_id"`
-	JobRun         JobRun            `gorm:"constraint:OnDelete:CASCADE" json:"-"`
-	TaskID         uuid.UUID         `gorm:"type:uuid;index:idx_taskrun_jobrun_task;index;not null" json:"task_id"`
-	Task           Task              `gorm:"constraint:OnDelete:CASCADE" json:"-"`
-	AtomID         uuid.UUID         `gorm:"type:uuid;index;not null" json:"atom_id"`
-	Engine         AtomEngine        `gorm:"type:text;not null" json:"engine"`
-	Image          string            `gorm:"not null" json:"image"`
-	Command        string            `gorm:"not null" json:"command"`
-	Status         string            `gorm:"type:text;index;not null" json:"status"`
-	ClaimedBy      string            `gorm:"type:text;index;not null;default:''" json:"claimed_by"`
-	ClaimExpiresAt *time.Time        `gorm:"index" json:"claim_expires_at,omitempty"`
-	ClaimAttempt   int               `gorm:"not null;default:0" json:"claim_attempt"`
-	Attempt        int               `gorm:"not null;default:1" json:"attempt"`
-	MaxAttempts    int               `gorm:"not null;default:1" json:"max_attempts"`
-	NodeSelector   datatypes.JSONMap `gorm:"type:json" json:"node_selector,omitempty"`
-	Hash           string            `gorm:"type:text;index" json:"-"`
+	ID             uuid.UUID  `gorm:"type:uuid;primaryKey" json:"id"`
+	JobRunID       uuid.UUID  `gorm:"type:uuid;index:idx_taskrun_jobrun_task;index;index:idx_taskrun_terminal_seq,priority:1;not null" json:"job_run_id"`
+	JobRun         JobRun     `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	TaskID         uuid.UUID  `gorm:"type:uuid;index:idx_taskrun_jobrun_task;index;not null" json:"task_id"`
+	Task           Task       `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	AtomID         uuid.UUID  `gorm:"type:uuid;index;not null" json:"atom_id"`
+	Engine         AtomEngine `gorm:"type:text;not null" json:"engine"`
+	Image          string     `gorm:"not null" json:"image"`
+	Command        string     `gorm:"not null" json:"command"`
+	Status         string     `gorm:"type:text;index;not null" json:"status"`
+	ClaimedBy      string     `gorm:"type:text;index;not null;default:''" json:"claimed_by"`
+	ClaimExpiresAt *time.Time `gorm:"index" json:"claim_expires_at,omitempty"`
+	ClaimAttempt   int        `gorm:"not null;default:0" json:"claim_attempt"`
+	// RateLimitRetryAfter keeps over-limit tasks pending without letting worker
+	// claims or owner dispatch pick them back up before the current window rolls.
+	RateLimitRetryAfter *time.Time        `gorm:"index" json:"rate_limit_retry_after,omitempty"`
+	Attempt             int               `gorm:"not null;default:1" json:"attempt"`
+	MaxAttempts         int               `gorm:"not null;default:1" json:"max_attempts"`
+	NodeSelector        datatypes.JSONMap `gorm:"type:json" json:"node_selector,omitempty"`
+	Hash                string            `gorm:"type:text;index" json:"-"`
 	// EffectiveHash is the identity this task presents to its DOWNSTREAM
 	// consumers when a value-verified short-circuit was proven (design Component
 	// 5 / D2). Nullable: empty means "use Hash" — the common case. When this

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -1,0 +1,210 @@
+package ratelimit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+const minWindow = time.Minute
+
+type clockFunc func() time.Time
+
+// Limiter atomically consumes resource units from durable fixed windows.
+type Limiter struct {
+	db  *gorm.DB
+	now clockFunc
+}
+
+// Option configures a Limiter.
+type Option func(*Limiter)
+
+// WithClock overrides the limiter clock for tests.
+func WithClock(now clockFunc) Option {
+	return func(l *Limiter) {
+		if now != nil {
+			l.now = now
+		}
+	}
+}
+
+// NewLimiter creates a database-backed limiter.
+func NewLimiter(db *gorm.DB, opts ...Option) *Limiter {
+	if db == nil {
+		panic("rate limit limiter requires database connection")
+	}
+	l := &Limiter{db: db, now: func() time.Time { return time.Now().UTC() }}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(l)
+		}
+	}
+	return l
+}
+
+// Acquire consumes units for resource if the current fixed window has capacity.
+// It is intentionally one guarded raw upsert; GORM's clause.OnConflict cannot
+// express the WHERE guard needed for atomic cross-node rejection.
+func (l *Limiter) Acquire(ctx context.Context, resource string, units, limit int, window time.Duration) (bool, error) {
+	resource = strings.TrimSpace(resource)
+	if resource == "" {
+		return false, errors.New("rate limit resource is required")
+	}
+	if units <= 0 {
+		return false, fmt.Errorf("rate limit units must be > 0 for resource %q", resource)
+	}
+	if limit <= 0 {
+		return false, fmt.Errorf("rate limit limit must be > 0 for resource %q", resource)
+	}
+	if units > limit {
+		return false, nil
+	}
+	normalizedWindow := NormalizeWindow(window)
+
+	now := l.now().UTC()
+	windowStart := now.Truncate(normalizedWindow)
+	windowKey := windowStart.Format(time.RFC3339Nano)
+	expiresAt := windowStart.Add(normalizedWindow)
+
+	var acquired bool
+	err := l.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		result := tx.Exec(`
+INSERT INTO rate_limit_tokens (resource, window_key, consumed, limit_val, expires_at)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(resource, window_key) DO UPDATE SET
+	consumed = consumed + ?
+WHERE consumed + ? <= limit_val`,
+			resource, windowKey, units, limit, expiresAt, units, units,
+		)
+		if result.Error != nil {
+			return result.Error
+		}
+		acquired = result.RowsAffected == 1
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if acquired {
+		metrics.RateLimitAcquiredTotal.WithLabelValues(resource).Inc()
+	} else {
+		metrics.RateLimitRejectedTotal.WithLabelValues(resource).Inc()
+	}
+	return acquired, nil
+}
+
+// NormalizeWindow enforces the minimum one-minute bucket granularity.
+func NormalizeWindow(window time.Duration) time.Duration {
+	if window < minWindow {
+		return minWindow
+	}
+	return window
+}
+
+// RetryAfter returns the remaining duration before the current window rolls.
+func RetryAfter(now time.Time, window time.Duration) time.Duration {
+	window = NormalizeWindow(window)
+	now = now.UTC()
+	next := now.Truncate(window).Add(window)
+	if !next.After(now) {
+		return 0
+	}
+	return next.Sub(now)
+}
+
+// Rule is the resolved rate-limit contract for one task.
+type Rule struct {
+	Resource string
+	Units    int
+	Limit    int
+	Window   time.Duration
+	JobAlias string
+}
+
+// RuleForTask resolves the persisted task-level rate-limit fields and owning
+// job-level declaration for a task run.
+func RuleForTask(ctx context.Context, db *gorm.DB, runID, taskID uuid.UUID) (*Rule, bool, error) {
+	if db == nil {
+		return nil, false, errors.New("rate limit rule lookup requires database connection")
+	}
+
+	var row struct {
+		Resource   string         `gorm:"column:resource"`
+		Units      int            `gorm:"column:units"`
+		RateLimits datatypes.JSON `gorm:"column:rate_limits"`
+		JobAlias   string         `gorm:"column:job_alias"`
+	}
+	err := db.WithContext(ctx).
+		Table("task_runs AS tr").
+		Select("t.rate_limit_resource AS resource, t.rate_limit_units AS units, j.rate_limits AS rate_limits, j.alias AS job_alias").
+		Joins("JOIN tasks AS t ON t.id = tr.task_id").
+		Joins("JOIN job_runs AS jr ON jr.id = tr.job_run_id").
+		Joins("JOIN jobs AS j ON j.id = jr.job_id").
+		Where("tr.job_run_id = ? AND tr.task_id = ?", runID, taskID).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if strings.TrimSpace(row.Resource) == "" {
+		return nil, false, nil
+	}
+
+	return RuleFromDeclarations(row.JobAlias, row.RateLimits, row.Resource, row.Units)
+}
+
+// RuleFromDeclarations resolves a task resource/units pair against serialized
+// job-level metadata.rateLimits declarations.
+func RuleFromDeclarations(jobAlias string, raw datatypes.JSON, resource string, units int) (*Rule, bool, error) {
+	resource = strings.TrimSpace(resource)
+	if resource == "" || units <= 0 {
+		return nil, false, nil
+	}
+	if len(raw) == 0 {
+		return nil, false, fmt.Errorf("rate limit resource %q has no job-level declarations", resource)
+	}
+
+	var declarations []jobdefschema.RateLimit
+	if err := json.Unmarshal(raw, &declarations); err != nil {
+		return nil, false, fmt.Errorf("decode job rate limits: %w", err)
+	}
+	return RuleFromRateLimits(jobAlias, declarations, resource, units)
+}
+
+// RuleFromRateLimits resolves a task resource/units pair against parsed
+// job-level metadata.rateLimits declarations.
+func RuleFromRateLimits(jobAlias string, declarations []jobdefschema.RateLimit, resource string, units int) (*Rule, bool, error) {
+	resource = strings.TrimSpace(resource)
+	if resource == "" || units <= 0 {
+		return nil, false, nil
+	}
+	for _, declaration := range declarations {
+		if strings.TrimSpace(declaration.Resource) != resource {
+			continue
+		}
+		window, err := time.ParseDuration(declaration.Window)
+		if err != nil {
+			return nil, false, fmt.Errorf("parse rate limit window for %q: %w", resource, err)
+		}
+		return &Rule{
+			Resource: resource,
+			Units:    units,
+			Limit:    declaration.Limit,
+			Window:   window,
+			JobAlias: jobAlias,
+		}, true, nil
+	}
+	return nil, false, fmt.Errorf("rate limit resource %q is not declared on job", resource)
+}

--- a/internal/ratelimit/limiter.go
+++ b/internal/ratelimit/limiter.go
@@ -77,13 +77,17 @@ func (l *Limiter) Acquire(ctx context.Context, resource string, units, limit int
 
 	var acquired bool
 	err := l.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// A resource's limit should be consistent across jobs. Within a window,
+		// every guard uses the caller's limit, and successful conflict updates
+		// persist that most-recent caller's limit.
 		result := tx.Exec(`
-INSERT INTO rate_limit_tokens (resource, window_key, consumed, limit_val, expires_at)
-VALUES (?, ?, ?, ?, ?)
-ON CONFLICT(resource, window_key) DO UPDATE SET
-	consumed = consumed + ?
-WHERE consumed + ? <= limit_val`,
-			resource, windowKey, units, limit, expiresAt, units, units,
+	INSERT INTO rate_limit_tokens (resource, window_key, consumed, limit_val, expires_at)
+	VALUES (?, ?, ?, ?, ?)
+	ON CONFLICT(resource, window_key) DO UPDATE SET
+		consumed = consumed + ?,
+		limit_val = ?
+	WHERE consumed + ? <= ?`,
+			resource, windowKey, units, limit, expiresAt, units, limit, units, limit,
 		)
 		if result.Error != nil {
 			return result.Error

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -1,0 +1,152 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimiterAcquireConditionalUpsertRowsAffected(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	metrics.RateLimitAcquiredTotal.Reset()
+	metrics.RateLimitRejectedTotal.Reset()
+
+	now := time.Date(2026, 6, 29, 12, 0, 15, 0, time.UTC)
+	limiter := NewLimiter(db, WithClock(func() time.Time { return now }))
+
+	acquired, err := limiter.Acquire(context.Background(), "database", 1, 2, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired, "first insert should affect one row")
+
+	acquired, err = limiter.Acquire(context.Background(), "database", 1, 2, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired, "guarded update within the limit should affect one row")
+
+	acquired, err = limiter.Acquire(context.Background(), "database", 1, 2, time.Minute)
+	require.NoError(t, err)
+	require.False(t, acquired, "guarded update over the limit should affect zero rows")
+
+	var token models.RateLimitToken
+	require.NoError(t, db.First(&token, "resource = ? AND window_key = ?", "database", now.Truncate(time.Minute).Format(time.RFC3339Nano)).Error)
+	require.Equal(t, 2, token.Consumed, "rejected acquire must not increment consumed")
+	require.Equal(t, 2, token.LimitVal)
+
+	now = now.Add(time.Minute)
+	acquired, err = limiter.Acquire(context.Background(), "database", 1, 2, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired, "new window should insert a fresh token")
+}
+
+func TestLimiterRejectsSingleAcquireOverLimitOnFreshWindow(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	now := time.Date(2026, 6, 29, 12, 0, 15, 0, time.UTC)
+	limiter := NewLimiter(db, WithClock(func() time.Time { return now }))
+
+	acquired, err := limiter.Acquire(context.Background(), "database", 3, 2, time.Minute)
+	require.NoError(t, err)
+	require.False(t, acquired)
+
+	var count int64
+	require.NoError(t, db.Model(&models.RateLimitToken{}).Where("resource = ?", "database").Count(&count).Error)
+	require.Zero(t, count)
+}
+
+func TestLimiterNormalizesSubMinuteWindows(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	limiter := NewLimiter(db, WithClock(func() time.Time { return now }))
+
+	acquired, err := limiter.Acquire(context.Background(), "api", 1, 1, time.Second)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	now = now.Add(30 * time.Second)
+	acquired, err = limiter.Acquire(context.Background(), "api", 1, 1, time.Second)
+	require.NoError(t, err)
+	require.False(t, acquired, "sub-minute windows should share the same one-minute bucket")
+}
+
+func TestRuleForTaskTreatsMissingOrEmptyResourceAsNoRule(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	rule, ok, err := RuleForTask(context.Background(), db, uuid.New(), uuid.New())
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, rule)
+
+	now := time.Date(2026, 6, 29, 12, 0, 15, 0, time.UTC)
+	triggerID := uuid.New()
+	jobID := uuid.New()
+	atomID := uuid.New()
+	taskID := uuid.New()
+	runID := uuid.New()
+
+	require.NoError(t, db.Create(&models.Trigger{
+		ID:        triggerID,
+		Type:      models.TriggerTypeCron,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Job{
+		ID:        jobID,
+		Alias:     "unlimited-job",
+		TriggerID: triggerID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Atom{
+		ID:        atomID,
+		Engine:    models.AtomEngineDocker,
+		Image:     "alpine:3.23",
+		Command:   `["sh","-c","true"]`,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Task{
+		ID:        taskID,
+		JobID:     jobID,
+		AtomID:    atomID,
+		Name:      "unlimited-step",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:          runID,
+		JobID:       jobID,
+		TriggerID:   triggerID,
+		TriggerType: string(models.TriggerTypeCron),
+		Status:      "running",
+		StartedAt:   now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}).Error)
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID:        uuid.New(),
+		JobRunID:  runID,
+		TaskID:    taskID,
+		AtomID:    atomID,
+		Engine:    models.AtomEngineDocker,
+		Image:     "alpine:3.23",
+		Command:   `["sh","-c","true"]`,
+		Status:    "pending",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+
+	rule, ok, err = RuleForTask(context.Background(), db, runID, taskID)
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Nil(t, rule)
+}

--- a/internal/ratelimit/limiter_test.go
+++ b/internal/ratelimit/limiter_test.go
@@ -44,6 +44,31 @@ func TestLimiterAcquireConditionalUpsertRowsAffected(t *testing.T) {
 	require.True(t, acquired, "new window should insert a fresh token")
 }
 
+func TestLimiterAcquireConflictUsesCurrentCallerLimit(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	now := time.Date(2026, 6, 29, 12, 0, 15, 0, time.UTC)
+	limiter := NewLimiter(db, WithClock(func() time.Time { return now }))
+
+	acquired, err := limiter.Acquire(context.Background(), "database", 1, 5, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired)
+
+	acquired, err = limiter.Acquire(context.Background(), "database", 2, 2, time.Minute)
+	require.NoError(t, err)
+	require.False(t, acquired, "conflict guard must use the second caller's lower limit")
+
+	acquired, err = limiter.Acquire(context.Background(), "database", 1, 2, time.Minute)
+	require.NoError(t, err)
+	require.True(t, acquired, "one more unit should fit under the second caller's limit")
+
+	var token models.RateLimitToken
+	require.NoError(t, db.First(&token, "resource = ? AND window_key = ?", "database", now.Truncate(time.Minute).Format(time.RFC3339Nano)).Error)
+	require.Equal(t, 2, token.Consumed)
+	require.Equal(t, 2, token.LimitVal)
+}
+
 func TestLimiterRejectsSingleAcquireOverLimitOnFreshWindow(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })

--- a/internal/ratelimit/pruner.go
+++ b/internal/ratelimit/pruner.go
@@ -1,0 +1,66 @@
+package ratelimit
+
+import (
+	"context"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"gorm.io/gorm"
+)
+
+// Pruner deletes expired rate-limit windows.
+type Pruner struct {
+	db  *gorm.DB
+	now clockFunc
+}
+
+// NewPruner creates a rate-limit token pruner.
+func NewPruner(db *gorm.DB, opts ...Option) *Pruner {
+	if db == nil {
+		panic("rate limit pruner requires database connection")
+	}
+	p := &Pruner{db: db, now: func() time.Time { return time.Now().UTC() }}
+	l := &Limiter{db: db, now: p.now}
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		opt(l)
+	}
+	p.now = l.now
+	return p
+}
+
+// Prune removes expired windows and returns the number of deleted rows.
+func (p *Pruner) Prune(ctx context.Context) (int, error) {
+	result := p.db.WithContext(ctx).
+		Where("expires_at <= ?", p.now().UTC()).
+		Delete(&models.RateLimitToken{})
+	return int(result.RowsAffected), result.Error
+}
+
+// Run starts the pruning loop and returns when ctx is cancelled.
+func (p *Pruner) Run(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			count, err := p.Prune(ctx)
+			if err != nil {
+				log.Error("rate limit token pruner failed", "error", err)
+				continue
+			}
+			if count > 0 {
+				log.Info("rate limit token pruner removed expired rows", "count", count)
+			}
+		}
+	}
+}

--- a/internal/ratelimit/pruner_test.go
+++ b/internal/ratelimit/pruner_test.go
@@ -1,0 +1,42 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrunerDeletesExpiredWindows(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	now := time.Date(2026, 6, 29, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Create(&models.RateLimitToken{
+		Resource:  "api",
+		WindowKey: "expired",
+		Consumed:  1,
+		LimitVal:  1,
+		ExpiresAt: now.Add(-time.Second),
+	}).Error)
+	require.NoError(t, db.Create(&models.RateLimitToken{
+		Resource:  "api",
+		WindowKey: "live",
+		Consumed:  1,
+		LimitVal:  1,
+		ExpiresAt: now.Add(time.Minute),
+	}).Error)
+
+	pruner := NewPruner(db, WithClock(func() time.Time { return now }))
+	deleted, err := pruner.Prune(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, deleted)
+
+	var tokens []models.RateLimitToken
+	require.NoError(t, db.Order("window_key ASC").Find(&tokens).Error)
+	require.Len(t, tokens, 1)
+	require.Equal(t, "live", tokens[0].WindowKey)
+}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1267,9 +1267,10 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 			if err := tx.Model(&models.TaskRun{}).
 				Where("job_run_id = ? AND task_id = ?", runID, taskID).
 				Updates(map[string]interface{}{
-					"status":     string(TaskStatusRunning),
-					"runtime_id": runtimeID,
-					"started_at": now,
+					"status":                 string(TaskStatusRunning),
+					"runtime_id":             runtimeID,
+					"started_at":             now,
+					"rate_limit_retry_after": nil,
 				}).Error; err != nil {
 				return err
 			}
@@ -1331,19 +1332,20 @@ func (s *Store) ClaimTaskForDispatch(runID, taskID uuid.UUID, workerNode string,
 			// in memory and did NOT decrement the DB counter, so the dispatched
 			// successor still shows outstanding>0 here — trustOwnerReadiness drops
 			// the predecessor check so the claim reflects the owner's decision.
-			where := "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0 AND owner_generation <= ?"
+			where := "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0 AND owner_generation <= ? AND (rate_limit_retry_after IS NULL OR rate_limit_retry_after <= ?)"
 			if trustOwnerReadiness {
-				where = "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND owner_generation <= ?"
+				where = "job_run_id = ? AND task_id = ? AND status = ? AND claimed_by = '' AND owner_generation <= ? AND (rate_limit_retry_after IS NULL OR rate_limit_retry_after <= ?)"
 			}
 			result := tx.Model(&models.TaskRun{}).
-				Where(where, runID, taskID, string(TaskStatusPending), ownerGeneration).
+				Where(where, runID, taskID, string(TaskStatusPending), ownerGeneration, now).
 				Updates(map[string]interface{}{
-					"status":           string(TaskStatusRunning),
-					"claimed_by":       workerNode,
-					"claim_expires_at": leaseExpiry,
-					"claim_attempt":    gorm.Expr("claim_attempt + 1"),
-					"started_at":       now,
-					"owner_generation": ownerGeneration,
+					"status":                 string(TaskStatusRunning),
+					"claimed_by":             workerNode,
+					"claim_expires_at":       leaseExpiry,
+					"claim_attempt":          gorm.Expr("claim_attempt + 1"),
+					"started_at":             now,
+					"owner_generation":       ownerGeneration,
+					"rate_limit_retry_after": nil,
 				})
 			if result.Error != nil {
 				return result.Error
@@ -1388,8 +1390,8 @@ func (s *Store) PendingTasksForDispatch(ctx context.Context, runID uuid.UUID, li
 	}
 	var tasks []models.TaskRun
 	err := s.db.WithContext(ctx).
-		Where("job_run_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0",
-			runID, string(TaskStatusPending)).
+		Where("job_run_id = ? AND status = ? AND claimed_by = '' AND outstanding_predecessors = 0 AND (rate_limit_retry_after IS NULL OR rate_limit_retry_after <= ?)",
+			runID, string(TaskStatusPending), time.Now().UTC()).
 		Order("created_at ASC").
 		Limit(limit).
 		Find(&tasks).Error
@@ -1455,6 +1457,36 @@ func (s *Store) ReleaseTaskClaim(runID, taskID uuid.UUID, claimedBy string, owne
 	})
 }
 
+// RateLimitTask leaves a task pending until retryAfter so rate-limit rejections
+// do not hold worker capacity or spin through immediate reclaims.
+func (s *Store) RateLimitTask(ctx context.Context, runID, taskID uuid.UUID, retryAfter time.Time) error {
+	if retryAfter.IsZero() {
+		retryAfter = time.Now().UTC()
+	}
+	retryAfter = retryAfter.UTC()
+
+	return withStoreBusyRetry(func() error {
+		result := s.db.WithContext(ctx).Model(&models.TaskRun{}).
+			Where("job_run_id = ? AND task_id = ? AND status IN ?", runID, taskID, []string{string(TaskStatusPending), string(TaskStatusRunning)}).
+			Updates(map[string]interface{}{
+				"status":                 string(TaskStatusPending),
+				"claimed_by":             "",
+				"claim_expires_at":       nil,
+				"runtime_id":             "",
+				"started_at":             nil,
+				"rate_limit_retry_after": retryAfter,
+			})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected > 0 {
+			metrics.DBWritesTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Add(float64(result.RowsAffected))
+			metrics.DBStatementsTotal.WithLabelValues(metrics.DBWriteCategoryTaskRunStatus).Inc()
+		}
+		return nil
+	})
+}
+
 func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy string) error {
 	var pendingEvents []event.Event
 	var counts dbWriteCounts
@@ -1466,8 +1498,9 @@ func (s *Store) StartTaskClaimed(runID, taskID uuid.UUID, runtimeID, claimedBy s
 			result := tx.Model(&models.TaskRun{}).
 				Where("job_run_id = ? AND task_id = ? AND claimed_by = ? AND status = ?", runID, taskID, claimedBy, string(TaskStatusRunning)).
 				Updates(map[string]interface{}{
-					"runtime_id": runtimeID,
-					"started_at": now,
+					"runtime_id":             runtimeID,
+					"started_at":             now,
+					"rate_limit_retry_after": nil,
 				})
 			if result.Error != nil {
 				return result.Error
@@ -2861,21 +2894,22 @@ func (s *Store) retryTask(runID, taskID uuid.UUID, attempt int, claimedBy string
 		}
 		resultUpdate := updateQuery.
 			Updates(map[string]interface{}{
-				"status":              string(TaskStatusPending),
-				"attempt":             attempt,
-				"runtime_id":          "",
-				"started_at":          nil,
-				"completed_at":        nil,
-				"result":              "",
-				"output":              nil,
-				"branch_selections":   nil,
-				"log_text":            "",
-				"log_truncated":       false,
-				"error":               "",
-				"cache_hit":           false,
-				"cache_origin_run_id": nil,
-				"cache_created_at":    nil,
-				"cache_expires_at":    nil,
+				"status":                 string(TaskStatusPending),
+				"attempt":                attempt,
+				"runtime_id":             "",
+				"started_at":             nil,
+				"completed_at":           nil,
+				"result":                 "",
+				"output":                 nil,
+				"branch_selections":      nil,
+				"log_text":               "",
+				"log_truncated":          false,
+				"error":                  "",
+				"rate_limit_retry_after": nil,
+				"cache_hit":              false,
+				"cache_origin_run_id":    nil,
+				"cache_created_at":       nil,
+				"cache_expires_at":       nil,
 			})
 		if resultUpdate.Error != nil {
 			return resultUpdate.Error
@@ -3132,14 +3166,15 @@ func (s *Store) ResetInFlightTasks(runID uuid.UUID) error {
 			// Clear the claim too, so a new owner taking over a run can re-claim
 			// these rows (ClaimTaskForDispatch requires claimed_by = '').  The old
 			// owner's worker that held the claim is gone (its lease expired).
-			"claimed_by":          "",
-			"claim_expires_at":    nil,
-			"runtime_id":          "",
-			"started_at":          nil,
-			"cache_hit":           false,
-			"cache_origin_run_id": nil,
-			"cache_created_at":    nil,
-			"cache_expires_at":    nil,
+			"claimed_by":             "",
+			"claim_expires_at":       nil,
+			"runtime_id":             "",
+			"started_at":             nil,
+			"rate_limit_retry_after": nil,
+			"cache_hit":              false,
+			"cache_origin_run_id":    nil,
+			"cache_created_at":       nil,
+			"cache_expires_at":       nil,
 		}).Error
 }
 

--- a/internal/worker/claimer.go
+++ b/internal/worker/claimer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/internal/ratelimit"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/pkg/dqlite"
 	"github.com/google/uuid"
@@ -70,6 +71,11 @@ type Claimer struct {
 	store             *run.Store
 	leaseTTL          time.Duration
 	busyRetryBackoffs []time.Duration
+	rateLimiter       resourceLimiter
+}
+
+type resourceLimiter interface {
+	Acquire(ctx context.Context, resource string, units, limit int, window time.Duration) (bool, error)
 }
 
 func NewClaimer(nodeID string, store *run.Store, leaseTTL time.Duration, nodeLabels ...map[string]string) *Claimer {
@@ -98,6 +104,12 @@ func NewClaimer(nodeID string, store *run.Store, leaseTTL time.Duration, nodeLab
 		leaseTTL:          leaseTTL,
 		busyRetryBackoffs: defaultBusyRetryBackoffSchedule(),
 	}
+}
+
+// WithRateLimiter gates claimed tasks before they enter the worker pool.
+func (c *Claimer) WithRateLimiter(l resourceLimiter) *Claimer {
+	c.rateLimiter = l
+	return c
 }
 
 func defaultBusyRetryBackoffSchedule() []time.Duration {
@@ -150,6 +162,21 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	if claimed != nil {
+		acquired, jobAlias, retryAfter, err := c.acquireRateLimit(ctx, claimed)
+		if err != nil {
+			return nil, err
+		}
+		if !acquired {
+			counts.commit()
+			if err := c.store.RateLimitTask(ctx, claimed.JobRunID, claimed.TaskID, retryAfter); err != nil {
+				return nil, err
+			}
+			metrics.RunSkippedTotal.WithLabelValues(jobAlias, "rate_limit").Inc()
+			return nil, nil
+		}
+	}
 	if claimed != nil {
 		if !claimed.Quarantine {
 			metrics.WorkerClaimsTotal.WithLabelValues(c.nodeID).Inc()
@@ -161,6 +188,28 @@ func (c *Claimer) ClaimNext(ctx context.Context) (*models.TaskRun, error) {
 	c.store.PublishEvents(pendingEvents...)
 
 	return claimed, nil
+}
+
+func (c *Claimer) acquireRateLimit(ctx context.Context, task *models.TaskRun) (bool, string, time.Time, error) {
+	if c.rateLimiter == nil || task == nil {
+		return true, "", time.Time{}, nil
+	}
+	rule, ok, err := ratelimit.RuleForTask(ctx, c.store.DB(), task.JobRunID, task.TaskID)
+	if err != nil {
+		return false, "", time.Time{}, err
+	}
+	if !ok {
+		return true, "", time.Time{}, nil
+	}
+	acquired, err := c.rateLimiter.Acquire(ctx, rule.Resource, rule.Units, rule.Limit, rule.Window)
+	if err != nil {
+		return false, rule.JobAlias, time.Time{}, err
+	}
+	if acquired {
+		return true, rule.JobAlias, time.Time{}, nil
+	}
+	now := time.Now().UTC()
+	return false, rule.JobAlias, now.Add(ratelimit.RetryAfter(now, rule.Window)), nil
 }
 
 func (c *Claimer) claimNextTx(tx *gorm.DB, now, leaseExpiry time.Time, counts *dbWriteCounts) (*models.TaskRun, *event.Event, error) {
@@ -197,7 +246,7 @@ func (c *Claimer) claimNextSingleStatementTx(tx *gorm.DB, now, leaseExpiry time.
 
 	sql := `
 UPDATE task_runs
-SET claimed_by = ?, claim_expires_at = ?, claim_attempt = claim_attempt + 1, status = ?, updated_at = ?
+SET claimed_by = ?, claim_expires_at = ?, claim_attempt = claim_attempt + 1, status = ?, updated_at = ?, rate_limit_retry_after = NULL
 WHERE id = (
 	SELECT tr.id
 	FROM task_runs AS tr
@@ -206,6 +255,7 @@ WHERE id = (
 		AND tr.status = ?
 		AND tr.outstanding_predecessors = ?
 		AND (tr.claimed_by = '' OR tr.claim_expires_at IS NULL OR tr.claim_expires_at < ?)
+		AND (tr.rate_limit_retry_after IS NULL OR tr.rate_limit_retry_after <= ?)
 		AND ` + selectorSQL + `
 		AND ` + liveLeaseGuard + `
 	ORDER BY tr.created_at ASC
@@ -214,6 +264,7 @@ WHERE id = (
 AND status = ?
 AND outstanding_predecessors = ?
 AND (claimed_by = '' OR claim_expires_at IS NULL OR claim_expires_at < ?)
+AND (rate_limit_retry_after IS NULL OR rate_limit_retry_after <= ?)
 AND job_run_id IN (SELECT id FROM job_runs WHERE status = ?)
 RETURNING *, (SELECT job_id FROM job_runs WHERE id = task_runs.job_run_id) AS claim_job_id`
 
@@ -226,11 +277,12 @@ RETURNING *, (SELECT job_id FROM job_runs WHERE id = task_runs.job_run_id) AS cl
 		string(run.TaskStatusPending),
 		0,
 		now,
+		now,
 	}
 	args = append(args, selectorArgs...)
 	// liveLeaseGuard binds one parameter: now (the live-lease expiry cutoff).
 	args = append(args, now)
-	args = append(args, string(run.TaskStatusPending), 0, now, string(run.StatusRunning))
+	args = append(args, string(run.TaskStatusPending), 0, now, now, string(run.StatusRunning))
 
 	var claimed claimedTaskRunRow
 	result := tx.Raw(sql, args...).Scan(&claimed)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -154,6 +154,8 @@ type Environment struct {
 	EventRetention            time.Duration `envconfig:"EVENT_RETENTION" default:"168h"`
 	WebhookEventRetention     time.Duration `envconfig:"WEBHOOK_EVENT_RETENTION" default:"168h"`
 	MaxTriggerDepth           int           `envconfig:"MAX_TRIGGER_DEPTH" default:"10"`
+	RateLimitPrunerEnabled    bool          `envconfig:"RATE_LIMIT_PRUNER_ENABLED" default:"false"`
+	RateLimitPruneInterval    time.Duration `envconfig:"RATE_LIMIT_PRUNE_INTERVAL" default:"1m"`
 
 	// Notification Watcher
 	NotificationWatcherInterval time.Duration `envconfig:"NOTIFICATION_WATCHER_INTERVAL" default:"15s"`

--- a/test/rate_limit_test.go
+++ b/test/rate_limit_test.go
@@ -1,0 +1,127 @@
+//go:build integration
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestRateLimitRequeuesUntilWindowRollover() {
+	alias := fmt.Sprintf("integration-rate-limit-%d", time.Now().UnixNano())
+	resource := fmt.Sprintf("shared-api-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  maxParallelTasks: 2
+  rateLimits:
+    - resource: %s
+      limit: 1
+      window: 1m
+trigger:
+  type: cron
+  configuration:
+    expression: "0 0 31 2 *"
+steps:
+  - name: fanout
+    image: alpine:3.23
+    command: ["sh", "-c", "echo fanout"]
+    next: [limited-a, limited-b]
+  - name: limited-a
+    image: alpine:3.23
+    command: ["sh", "-c", "echo limited-a"]
+    dependsOn: fanout
+    rateLimit:
+      resource: %s
+      units: 1
+  - name: limited-b
+    image: alpine:3.23
+    command: ["sh", "-c", "echo limited-b"]
+    dependsOn: fanout
+    rateLimit:
+      resource: %s
+      units: 1
+`, alias, resource, resource, resource)
+
+	dir := s.writeJobManifest(manifest)
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+
+	nameByID := s.taskNameMap(job.ID)
+	s.waitForRateLimitWindowHeadroom(20 * time.Second)
+	runID := s.triggerRun(job.ID)
+
+	s.Require().Eventually(func() bool {
+		var run runResponse
+		if err := s.tryGetJSON(fmt.Sprintf("/v1/jobs/%s/runs/%s", job.ID, runID), &run); err != nil {
+			return false
+		}
+		statuses := statusesByName(nameByID, &run)
+		if statuses["fanout"] != "succeeded" {
+			return false
+		}
+		succeeded := 0
+		pending := 0
+		for _, name := range []string{"limited-a", "limited-b"} {
+			switch statuses[name] {
+			case "succeeded":
+				succeeded++
+			case "pending":
+				pending++
+			}
+		}
+		return run.Status == "running" && succeeded == 1 && pending == 1
+	}, 30*time.Second, 500*time.Millisecond, "one contending task should be requeued as pending in the first window")
+
+	run := s.awaitRun(job.ID, runID, runTimeout)
+	s.Equal("succeeded", run.Status)
+	statuses := statusesByName(nameByID, run)
+	s.Equal("succeeded", statuses["limited-a"])
+	s.Equal("succeeded", statuses["limited-b"])
+}
+
+func (s *IntegrationTestSuite) taskNameMap(jobID string) map[string]string {
+	s.T().Helper()
+
+	var tasks []struct {
+		ID   string `json:"ID"`
+		Name string `json:"Name"`
+	}
+	s.getJSON(fmt.Sprintf("/v1/jobs/%s/tasks", jobID), &tasks)
+
+	nameByID := make(map[string]string, len(tasks))
+	for _, task := range tasks {
+		nameByID[task.ID] = task.Name
+	}
+	return nameByID
+}
+
+func statusesByName(nameByID map[string]string, run *runResponse) map[string]string {
+	statuses := make(map[string]string, len(run.Tasks))
+	for _, task := range run.Tasks {
+		name := nameByID[task.ID]
+		if name == "" {
+			name = task.ID
+		}
+		statuses[name] = task.Status
+	}
+	return statuses
+}
+
+func (s *IntegrationTestSuite) waitForRateLimitWindowHeadroom(headroom time.Duration) {
+	s.T().Helper()
+
+	for {
+		now := time.Now().UTC()
+		remaining := now.Truncate(time.Minute).Add(time.Minute).Sub(now)
+		if remaining >= headroom {
+			return
+		}
+		time.Sleep(remaining + time.Second)
+	}
+}


### PR DESCRIPTION
## Summary
**Wave 2, Stream D** — resource rate limiting (roadmap §1.3). A durable sliding-window counter throttles tasks against a named shared resource; over-limit tasks are re-queued (not blocked).

- **D1** — a `RateLimitToken` **catalog** model (composite PK) + `Limiter.Acquire` as a **single atomic guarded upsert** (raw SQL — `clause.OnConflict` can't express the WHERE-guard), sub-minute windows normalized to 1-minute buckets, `acquired` from `RowsAffected`. Metrics both sites.
- **D2** — dispatch-path enforcement reading the persisted per-task `rateLimit` (re-queue with retry-after, no slot held) + a `CAESIUM_RATE_LIMIT_*`-gated expired-window pruner.

## Review
Opus review + fixes: unused-import build break, the `units > limit` fresh-window admission gap, a `record-not-found` graceful no-op (was breaking all local dispatch), the window-normalization bug. `just unit-test` green.

## Test plan
- [x] just unit-test (orchestrator)
- [ ] just integration-test — Phase 6.5 gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)