### PR TITLE
Add run concurrency strategies — atomic admission + cancellation + leader-gated queue (concurrency-priority-queues W3-γ)

### DIFF
--- a/api/rest/controller/job/run/post.go
+++ b/api/rest/controller/job/run/post.go
@@ -59,7 +59,16 @@ func Post(c *echo.Context) error {
 		if errors.Is(err, runstorage.ErrInvalidPriority) {
 			return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
 		}
+		if errors.Is(err, runstorage.ErrMaxConcurrentRunsReached) {
+			return echo.NewHTTPError(http.StatusConflict, "max concurrent runs reached").Wrap(err)
+		}
+		if errors.Is(err, runstorage.ErrRunSkipped) || errors.Is(err, runstorage.ErrRunQueued) {
+			return c.NoContent(http.StatusAccepted)
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	if r == nil {
+		return c.NoContent(http.StatusAccepted)
 	}
 
 	go func() {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -32,6 +32,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/notification"
 	"github.com/caesium-cloud/caesium/internal/ratelimit"
 	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/internal/runqueue"
 	triggerevent "github.com/caesium-cloud/caesium/internal/trigger/event"
 	triggerhttp "github.com/caesium-cloud/caesium/internal/trigger/http"
 	"github.com/caesium-cloud/caesium/internal/worker"
@@ -172,6 +173,20 @@ func start(cmd *cobra.Command, args []string) error {
 	runStore.SetBus(bus)
 	jsvc.Service(ctx).SetBus(bus)
 	runsvc.New(ctx).SetBus(bus)
+	if vars.RunQueueDequeuerEnabled {
+		dequeuer := runqueue.NewDequeuer(runqueue.Config{
+			DB:                  db.Connection(),
+			Store:               runStore,
+			NodeID:              vars.NodeAddress,
+			Interval:            vars.RunQueueDequeueInterval,
+			StaleClaimThreshold: vars.RunQueueClaimStaleAfter,
+			LeaderCheck:         dqlite.IsLocalLeader,
+		})
+		runAsync(func() {
+			log.Info("launching run queue dequeuer", "interval", vars.RunQueueDequeueInterval, "stale_claim_after", vars.RunQueueClaimStaleAfter, "max_depth", vars.RunQueueMaxDepth)
+			dequeuer.Run(ctx)
+		})
+	}
 
 	distributedMode := strings.EqualFold(strings.TrimSpace(vars.ExecutionMode), "distributed")
 	wakeupSignaler := worker.NewWakeupSignaler()

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -173,7 +173,7 @@ func start(cmd *cobra.Command, args []string) error {
 	runStore.SetBus(bus)
 	jsvc.Service(ctx).SetBus(bus)
 	runsvc.New(ctx).SetBus(bus)
-	if vars.RunQueueDequeuerEnabled {
+	if vars.RunQueueEnabled || vars.RunQueueDequeuerEnabled {
 		dequeuer := runqueue.NewDequeuer(runqueue.Config{
 			DB:                  db.Connection(),
 			Store:               runStore,

--- a/docs/exec-plans/active/concurrency-priority-queues.md
+++ b/docs/exec-plans/active/concurrency-priority-queues.md
@@ -346,7 +346,7 @@ Gates a *new run* when the job is already at `maxRuns`. The gate lives in `run.S
 — the one place REST, cron, and HTTP-trigger all create runs — and is **atomic** so it
 holds across nodes.
 
-- [ ] C1. Atomic admission + the simple strategies. Add `run.Store.CountActive(jobID)` and
+- [x] C1. Atomic admission + the simple strategies. Add `run.Store.CountActive(jobID)` and
       an `admit(tx, jobID, strategy, maxRuns)` helper (correction #4) invoked from
       `store.Start`, `resolveRun` (before the `FindRunning` attach), and `StartForBackfill`
       (or backfill excluded from the count). `admit` loads the job's `maxRuns`/`strategy`
@@ -368,7 +368,12 @@ holds across nodes.
       `api/rest/controller/job/run/post.go`, `internal/trigger/event/event.go`,
       `internal/job/job.go` (the `resolveRun` admit call), `internal/metrics/metrics.go`.
       Depends on: A3.
-- [ ] C2. The `replace` strategy + the cancellation primitive it needs (correction #9).
+      Done (W3-gamma): shared admission now runs through `Store.Start`, `AdmitRun`
+      from `resolveRun`, and `StartForBackfill`; ordinary active counts explicitly
+      exclude backfills with `backfill_id IS NULL`. Admission uses a single raw
+      conditional `INSERT ... SELECT ... WHERE` with client-generated UUIDs and no
+      `RETURNING`, and REST/event callers surface skip/fail outcomes with nil-run guards.
+- [x] C2. The `replace` strategy + the cancellation primitive it needs (correction #9).
       Add a `StatusCancelled` terminal status (+ its `ExecutionEvent` type) and a
       `run.Store.CancelRun` that **atomically** transitions the target `JobRun` AND its
       non-terminal `task_runs` **AND expires its `run_leases` row** in one transaction. The
@@ -389,7 +394,12 @@ holds across nodes.
       `internal/models/run.go` (status const), `internal/models/execution_event.go`
       (event type), `internal/job/job.go`, `internal/metrics/metrics.go`.
       Depends on: C1.
-- [ ] C3. The durable run queue + **leader-gated** dequeuer for `queue`. New `RunQueue`
+      Done (W3-gamma): cancelled run/task statuses and events are wired through
+      terminal handling; `CancelRun` updates the run, non-terminal task runs, and
+      run lease inside one transaction. `replace` cancels the oldest active run,
+      inserts the replacement under the same admission decision, records the
+      replacement metric, and `waitForRunCompletion` treats cancellation as terminal.
+- [x] C3. The durable run queue + **leader-gated** dequeuer for `queue`. New `RunQueue`
       catalog model (`uuid.UUID` PK, `JobID` FK→Job, `Params datatypes.JSON`,
       `Priority int`, `ClaimedBy string`, composite index `(job_id, priority DESC,
       created_at ASC)` via GORM tags — not raw SQL); register in `models.All` after `Job`;
@@ -407,6 +417,12 @@ holds across nodes.
       `pkg/env/env.go`, `internal/metrics/metrics.go`,
       `test/run_concurrency_test.go` (skip/fail/replace/queue integration scenarios).
       Depends on: C1 + C2 + B1 (the queue orders by B's `priority`).
+      Done (W3-gamma): `RunQueue` is registered after `Job` and not in hot routing
+      tables; queue admission persists rows with max-depth eviction, dequeue claims
+      rows with an optimistic update, and the `CAESIUM_RUN_QUEUE_*` dequeuer is
+      `runAsync` wired with `dqlite.IsLocalLeader`, launches the created run, and
+      is enabled in `integration-up`. Queue depth/wait metrics and unit/integration
+      coverage were added for the real admission surfaces.
 
 ### Stream D — Resource rate limiting (roadmap §1.3, P2)
 

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -22,6 +22,7 @@ const (
 	TypeRunStarted        Type = "run_started"
 	TypeRunCompleted      Type = "run_completed"
 	TypeRunFailed         Type = "run_failed"
+	TypeRunCancelled      Type = "run_cancelled"
 	TypeRunTerminal       Type = "run_terminal"
 	TypeTaskStarted       Type = "task_started"
 	TypeTaskSucceeded     Type = "task_succeeded"

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -434,6 +434,10 @@ func (j *job) Run(ctx context.Context) error {
 			return existing, nil
 		}
 
+		if admitted, handled, err := store.AdmitRun(j.id, j.triggerID, startOpts...); handled || err != nil {
+			return admitted, err
+		}
+
 		running, err := store.FindRunning(j.id)
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, err
@@ -459,7 +463,13 @@ func (j *job) Run(ctx context.Context) error {
 		snapshot, e = resolveRun()
 		return e
 	}); err != nil {
+		if errors.Is(err, run.ErrRunSkipped) || errors.Is(err, run.ErrRunQueued) {
+			return nil
+		}
 		return err
+	}
+	if snapshot == nil {
+		return nil
 	}
 
 	runID := snapshot.ID
@@ -1572,7 +1582,7 @@ func waitForRunCompletion(ctx context.Context, store *run.Store, runID uuid.UUID
 	if bus := store.Bus(); bus != nil {
 		events, err := bus.Subscribe(ctx, event.Filter{
 			RunID: runID,
-			Types: []event.Type{event.TypeRunTerminal, event.TypeRunCompleted, event.TypeRunFailed},
+			Types: []event.Type{event.TypeRunTerminal, event.TypeRunCompleted, event.TypeRunFailed, event.TypeRunCancelled},
 		})
 		if err == nil {
 			ch = events
@@ -1588,10 +1598,16 @@ func waitForRunCompletion(ctx context.Context, store *run.Store, runID uuid.UUID
 				ch = nil
 				continue
 			}
-			if evt.Type == event.TypeRunFailed {
+			if evt.Type == event.TypeRunFailed || evt.Type == event.TypeRunCancelled {
 				snapshot, err := store.Get(runID)
 				if err != nil {
 					return err
+				}
+				if snapshot.Status == run.StatusCancelled {
+					if snapshot.Error != "" {
+						return errors.New(snapshot.Error)
+					}
+					return fmt.Errorf("run %s cancelled", runID)
 				}
 				if snapshot.Error != "" {
 					return errors.New(snapshot.Error)
@@ -1609,6 +1625,12 @@ func waitForRunCompletion(ctx context.Context, store *run.Store, runID uuid.UUID
 					}
 					return fmt.Errorf("run %s failed", runID)
 				}
+				if snapshot.Status == run.StatusCancelled {
+					if snapshot.Error != "" {
+						return errors.New(snapshot.Error)
+					}
+					return fmt.Errorf("run %s cancelled", runID)
+				}
 				return nil
 			}
 		case <-ticker.C:
@@ -1622,6 +1644,7 @@ func waitForRunCompletion(ctx context.Context, store *run.Store, runID uuid.UUID
 			succeeded := 0
 			skipped := 0
 			cached := 0
+			cancelled := 0
 
 			for _, taskState := range snapshot.Tasks {
 				switch taskState.Status {
@@ -1635,11 +1658,23 @@ func waitForRunCompletion(ctx context.Context, store *run.Store, runID uuid.UUID
 					skipped++
 				case run.TaskStatusCached:
 					cached++
+				case run.TaskStatusCancelled:
+					cancelled++
 				}
 			}
 
-			terminal := failed + succeeded + skipped + cached
+			if snapshot.Status == run.StatusCancelled {
+				if snapshot.Error != "" {
+					return errors.New(snapshot.Error)
+				}
+				return fmt.Errorf("run %s cancelled", runID)
+			}
+
+			terminal := failed + succeeded + skipped + cached + cancelled
 			if terminal == taskCount {
+				if cancelled > 0 {
+					return fmt.Errorf("run %s cancelled", runID)
+				}
 				if failed > 0 {
 					return fmt.Errorf("run %s completed with %d failed task(s)", runID, failed)
 				}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -419,8 +419,12 @@ func (j *job) Run(ctx context.Context) error {
 
 	resolveRun := func() (*run.JobRun, error) {
 		startOpts := []run.StartOption{run.WithStartParams(j.params)}
-		if strings.TrimSpace(j.priorityOverride) != "" {
-			startOpts = append(startOpts, run.WithStartPriority(j.priorityOverride))
+		startPriority := strings.TrimSpace(j.priorityOverride)
+		if startPriority == "" {
+			startPriority = strings.TrimSpace(j.priority)
+		}
+		if startPriority != "" {
+			startOpts = append(startOpts, run.WithStartPriority(startPriority))
 		}
 
 		if id, ok := run.FromContext(ctx); ok {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -220,6 +220,31 @@ var (
 		[]string{"job_alias", "reason"},
 	)
 
+	RunReplacedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_run_replaced_total",
+			Help: "Total running job runs cancelled and replaced by the run concurrency policy.",
+		},
+		[]string{"job_alias"},
+	)
+
+	RunQueueDepth = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "caesium_run_queue_depth",
+			Help: "Current number of queued runs by job and priority.",
+		},
+		[]string{"job_alias", "priority"},
+	)
+
+	RunQueueWaitSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "caesium_run_queue_wait_seconds",
+			Help:    "Time a queued run waited before being launched.",
+			Buckets: []float64{0.5, 1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600},
+		},
+		[]string{"job_alias"},
+	)
+
 	// Auth metrics
 
 	AuthRequestsTotal = prometheus.NewCounterVec(
@@ -495,6 +520,9 @@ func Register() {
 			RateLimitAcquiredTotal,
 			RateLimitRejectedTotal,
 			RunSkippedTotal,
+			RunReplacedTotal,
+			RunQueueDepth,
+			RunQueueWaitSeconds,
 			AuthRequestsTotal,
 			AuthFailuresTotal,
 			AuthKeyAgeSeconds,

--- a/internal/models/execution_event.go
+++ b/internal/models/execution_event.go
@@ -6,6 +6,8 @@ import (
 	"github.com/google/uuid"
 )
 
+const ExecutionEventTypeRunCancelled = "run_cancelled"
+
 type ExecutionEvent struct {
 	Sequence           uint64     `gorm:"primaryKey;autoIncrement" json:"sequence"`
 	Type               string     `gorm:"type:text;index;not null" json:"type"`

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -7,6 +7,7 @@ var All = []interface{}{
 	&Atom{},
 	&Trigger{},
 	&Job{},
+	&RunQueue{},
 	&IngestedEvent{},
 	&WebhookEvent{},
 	&Task{},

--- a/internal/models/run.go
+++ b/internal/models/run.go
@@ -8,6 +8,11 @@ import (
 	"gorm.io/datatypes"
 )
 
+const (
+	JobRunStatusCancelled  = "cancelled"
+	TaskRunStatusCancelled = "cancelled"
+)
+
 type JobRun struct {
 	ID           uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
 	JobID        uuid.UUID      `gorm:"type:uuid;index;not null" json:"job_id"`

--- a/internal/models/run_queue.go
+++ b/internal/models/run_queue.go
@@ -1,0 +1,19 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+type RunQueue struct {
+	ID        uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
+	JobID     uuid.UUID      `gorm:"type:uuid;not null;index:idx_run_queue_job_priority_created,priority:1" json:"job_id"`
+	Job       Job            `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+	Params    datatypes.JSON `gorm:"type:json" json:"params,omitempty"`
+	Priority  int            `gorm:"not null;default:2;index:idx_run_queue_job_priority_created,priority:2,sort:desc" json:"priority"`
+	ClaimedBy string         `gorm:"type:text;not null;default:'';index" json:"claimed_by"`
+	ClaimedAt *time.Time     `gorm:"index" json:"claimed_at,omitempty"`
+	CreatedAt time.Time      `gorm:"not null;index:idx_run_queue_job_priority_created,priority:3,sort:asc" json:"created_at"`
+}

--- a/internal/models/run_queue.go
+++ b/internal/models/run_queue.go
@@ -7,6 +7,8 @@ import (
 	"gorm.io/datatypes"
 )
 
+func (RunQueue) TableName() string { return "run_queue" }
+
 type RunQueue struct {
 	ID        uuid.UUID      `gorm:"type:uuid;primaryKey" json:"id"`
 	JobID     uuid.UUID      `gorm:"type:uuid;not null;index:idx_run_queue_job_priority_created,priority:1" json:"job_id"`

--- a/internal/run/checkpoint_store.go
+++ b/internal/run/checkpoint_store.go
@@ -101,6 +101,7 @@ func (s *Store) TerminalTaskRunsSince(runID uuid.UUID, afterSeq int64) ([]models
 				string(TaskStatusFailed),
 				string(TaskStatusSkipped),
 				string(TaskStatusCached),
+				string(TaskStatusCancelled),
 			}).
 		Order("terminal_sequence ASC").
 		Find(&rows).Error

--- a/internal/run/concurrency_test.go
+++ b/internal/run/concurrency_test.go
@@ -1,0 +1,232 @@
+package run
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+func TestStartAdmissionConditionalInsertRowsAffected(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := NewStore(db)
+	job := createConcurrencyJob(t, db, "admit-rows", jobdef.ConcurrencyStrategyFail, 1)
+
+	first, err := store.Start(job.ID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+
+	second, err := store.Start(job.ID, nil)
+	require.ErrorIs(t, err, ErrMaxConcurrentRunsReached)
+	require.Nil(t, second)
+
+	var count int64
+	require.NoError(t, db.Model(&models.JobRun{}).Where("job_id = ?", job.ID).Count(&count).Error)
+	require.Equal(t, int64(1), count, "failed conditional insert must affect zero rows and create no run")
+
+	active, err := store.CountActive(job.ID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), active)
+}
+
+func TestCancelRunTransitionsRunTasksAndLease(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := NewStore(db)
+	now := time.Now().UTC()
+	job := createConcurrencyJob(t, db, "cancel-run", jobdef.ConcurrencyStrategyReplace, 1)
+	runID := uuid.New()
+	taskPending := uuid.New()
+	taskRunning := uuid.New()
+	taskSucceeded := uuid.New()
+	atomID := uuid.New()
+	require.NoError(t, db.Create(&models.Atom{
+		ID:        atomID,
+		Engine:    models.AtomEngineDocker,
+		Image:     "alpine:3.23",
+		Command:   `["true"]`,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	for name, taskID := range map[string]uuid.UUID{
+		"pending":   taskPending,
+		"running":   taskRunning,
+		"succeeded": taskSucceeded,
+	} {
+		require.NoError(t, db.Create(&models.Task{
+			ID:        taskID,
+			JobID:     job.ID,
+			AtomID:    atomID,
+			Name:      name,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}).Error)
+	}
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:        runID,
+		JobID:     job.ID,
+		Status:    string(StatusRunning),
+		StartedAt: now.Add(-time.Minute),
+		CreatedAt: now.Add(-time.Minute),
+		UpdatedAt: now.Add(-time.Minute),
+	}).Error)
+	for _, row := range []models.TaskRun{
+		{ID: uuid.New(), JobRunID: runID, TaskID: taskPending, AtomID: atomID, Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["true"]`, Status: string(TaskStatusPending), CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.New(), JobRunID: runID, TaskID: taskRunning, AtomID: atomID, Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["true"]`, Status: string(TaskStatusRunning), ClaimedBy: "node-a", CreatedAt: now, UpdatedAt: now},
+		{ID: uuid.New(), JobRunID: runID, TaskID: taskSucceeded, AtomID: atomID, Engine: models.AtomEngineDocker, Image: "alpine:3.23", Command: `["true"]`, Status: string(TaskStatusSucceeded), CreatedAt: now, UpdatedAt: now},
+	} {
+		require.NoError(t, db.Create(&row).Error)
+	}
+	require.NoError(t, db.Create(&models.RunLease{
+		RunID:          runID.String(),
+		OwnerNode:      "node-a",
+		AcquiredAt:     now,
+		LeaseExpiresAt: now.Add(time.Minute),
+		Generation:     1,
+	}).Error)
+
+	require.NoError(t, store.CancelRun(context.Background(), runID))
+
+	var runRow models.JobRun
+	require.NoError(t, db.First(&runRow, "id = ?", runID).Error)
+	require.Equal(t, string(StatusCancelled), runRow.Status)
+	require.NotNil(t, runRow.CompletedAt)
+
+	var taskRows []models.TaskRun
+	require.NoError(t, db.Order("task_id").Find(&taskRows, "job_run_id = ?", runID).Error)
+	statuses := map[uuid.UUID]string{}
+	for _, row := range taskRows {
+		statuses[row.TaskID] = row.Status
+		if row.TaskID == taskRunning {
+			require.Empty(t, row.ClaimedBy)
+			require.Nil(t, row.ClaimExpiresAt)
+		}
+	}
+	require.Equal(t, string(TaskStatusCancelled), statuses[taskPending])
+	require.Equal(t, string(TaskStatusCancelled), statuses[taskRunning])
+	require.Equal(t, string(TaskStatusSucceeded), statuses[taskSucceeded])
+
+	var leases int64
+	require.NoError(t, db.Model(&models.RunLease{}).Where("run_id = ?", runID.String()).Count(&leases).Error)
+	require.Zero(t, leases)
+}
+
+func TestDequeueNextRunClaimsOneRowByPriority(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := NewStore(db)
+	job := createConcurrencyJob(t, db, "queue-claim", jobdef.ConcurrencyStrategyQueue, 1)
+	now := time.Now().UTC()
+	lowID := uuid.New()
+	highID := uuid.New()
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        lowID,
+		JobID:     job.ID,
+		Priority:  PriorityLowValue,
+		CreatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        highID,
+		JobID:     job.ID,
+		Priority:  PriorityHighValue,
+		CreatedAt: now.Add(time.Second),
+	}).Error)
+
+	first, err := store.DequeueNextRun(context.Background(), job.ID, "claim-a")
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	require.Equal(t, highID, first.ID)
+
+	second, err := store.DequeueNextRun(context.Background(), job.ID, "claim-b")
+	require.NoError(t, err)
+	require.NotNil(t, second)
+	require.Equal(t, lowID, second.ID)
+
+	third, err := store.DequeueNextRun(context.Background(), job.ID, "claim-c")
+	require.NoError(t, err)
+	require.Nil(t, third)
+}
+
+func TestEnqueueRunEvictsOldestWhenDepthExceeded(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := NewStore(db)
+	job := createConcurrencyJob(t, db, "queue-depth", jobdef.ConcurrencyStrategyQueue, 1)
+	oldestID := uuid.New()
+	keptID := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        oldestID,
+		JobID:     job.ID,
+		Priority:  PriorityNormalValue,
+		CreatedAt: now.Add(-2 * time.Minute),
+	}).Error)
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        keptID,
+		JobID:     job.ID,
+		Priority:  PriorityNormalValue,
+		CreatedAt: now.Add(-time.Minute),
+	}).Error)
+
+	require.NoError(t, db.Transaction(func(tx *gorm.DB) error {
+		return store.enqueueRunTx(tx, job.ID, datatypes.JSON(`{"kind":"new"}`), PriorityNormalValue, 2)
+	}))
+
+	var rows []models.RunQueue
+	require.NoError(t, db.Order("created_at ASC").Find(&rows, "job_id = ?", job.ID).Error)
+	require.Len(t, rows, 2)
+	require.Equal(t, keptID, rows[0].ID)
+	require.NotEqual(t, oldestID, rows[1].ID)
+}
+
+func createConcurrencyJob(t *testing.T, db *gorm.DB, alias, strategy string, maxRuns int) *models.Job {
+	t.Helper()
+	now := time.Now().UTC()
+	trigger := &models.Trigger{
+		ID:            uuid.New(),
+		Alias:         alias + "-trigger",
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"cron":"0 * * * *","timezone":"UTC"}`,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	require.NoError(t, db.Create(trigger).Error)
+	raw, err := json.Marshal(&jobdef.Concurrency{MaxRuns: maxRuns, Strategy: strategy})
+	require.NoError(t, err)
+	job := &models.Job{
+		ID:          uuid.New(),
+		Alias:       alias,
+		TriggerID:   trigger.ID,
+		Concurrency: datatypes.JSON(raw),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	require.NoError(t, db.Create(job).Error)
+	return job
+}
+
+func TestStartSkipReturnsSentinel(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := NewStore(db)
+	job := createConcurrencyJob(t, db, "skip-sentinel", jobdef.ConcurrencyStrategySkip, 1)
+	_, err := store.Start(job.ID, nil)
+	require.NoError(t, err)
+	_, err = store.Start(job.ID, nil)
+	require.True(t, errors.Is(err, ErrRunSkipped))
+}

--- a/internal/run/lease.go
+++ b/internal/run/lease.go
@@ -23,6 +23,13 @@ func NewLeaseStore(db *gorm.DB) *LeaseStore {
 	return &LeaseStore{db: db}
 }
 
+func deleteRunLeaseTx(tx *gorm.DB, runID uuid.UUID) error {
+	if tx == nil || runID == uuid.Nil {
+		return nil
+	}
+	return tx.Delete(&models.RunLease{}, "run_id = ?", runID.String()).Error
+}
+
 // AcquireLease writes a run_leases row for the given run, recording the
 // owning node and expiry.  If a row already exists (e.g., from a previous
 // attempt), it is left unchanged — the initial write is treated as

--- a/internal/run/rundiff.go
+++ b/internal/run/rundiff.go
@@ -186,6 +186,7 @@ func terminalTaskStatuses() []string {
 		string(TaskStatusFailed),
 		string(TaskStatusSkipped),
 		string(TaskStatusCached),
+		string(TaskStatusCancelled),
 	}
 }
 

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -2498,9 +2498,7 @@ func satisfiesTriggerRule(rule string, predStatuses []TaskStatus) bool {
 		return true
 	}
 
-	isTerminal := func(s TaskStatus) bool {
-		return IsTerminal(s)
-	}
+	isTerminal := IsTerminal
 
 	switch rule {
 	case jobdefschema.TriggerRuleAllSuccess:

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -40,6 +40,7 @@ const (
 	StatusRunning   Status = "running"
 	StatusSucceeded Status = "succeeded"
 	StatusFailed    Status = "failed"
+	StatusCancelled Status = Status(models.JobRunStatusCancelled)
 )
 
 const (
@@ -49,6 +50,7 @@ const (
 	TaskStatusFailed    TaskStatus = "failed"
 	TaskStatusSkipped   TaskStatus = "skipped"
 	TaskStatusCached    TaskStatus = "cached"
+	TaskStatusCancelled TaskStatus = TaskStatus(models.TaskRunStatusCancelled)
 )
 
 // IsTerminalSuccess returns true for task statuses that represent successful completion.
@@ -62,7 +64,7 @@ func IsTerminalSuccess(status TaskStatus) bool {
 // scan, and archival so the set lives in exactly one place.
 func IsTerminal(status TaskStatus) bool {
 	switch status {
-	case TaskStatusSucceeded, TaskStatusFailed, TaskStatusSkipped, TaskStatusCached:
+	case TaskStatusSucceeded, TaskStatusFailed, TaskStatusSkipped, TaskStatusCached, TaskStatusCancelled:
 		return true
 	default:
 		return false
@@ -234,7 +236,50 @@ var (
 	defaultStoreOnce sync.Once
 )
 
-var ErrTaskClaimMismatch = errors.New("run: task claim mismatch")
+var (
+	ErrTaskClaimMismatch        = errors.New("run: task claim mismatch")
+	ErrRunSkipped               = errors.New("run: skipped by concurrency policy")
+	ErrRunQueued                = errors.New("run: queued by concurrency policy")
+	ErrMaxConcurrentRunsReached = errors.New("run: max concurrent runs reached")
+)
+
+type admissionDecision int
+
+const (
+	admissionNoPolicy admissionDecision = iota
+	admissionCreated
+	admissionSkipped
+	admissionFailed
+	admissionQueued
+)
+
+type cancelledRunInfo struct {
+	ID          uuid.UUID
+	JobID       uuid.UUID
+	JobAlias    string
+	StartedAt   time.Time
+	Quarantine  bool
+	CancelledAt time.Time
+}
+
+type admissionResult struct {
+	decision           admissionDecision
+	jobAlias           string
+	skipReason         string
+	replaced           bool
+	cancelledRun       *cancelledRunInfo
+	cancelledRunEvents []event.Event
+}
+
+type startRunRequest struct {
+	jobID            uuid.UUID
+	triggerID        *uuid.UUID
+	backfillID       *uuid.UUID
+	params           map[string]string
+	priorityOverride string
+	fromQueue        bool
+	policyOnly       bool
+}
 
 // storeBusyRetryBackoffs aliases the shared contention-retry schedule so
 // whole-transaction store ops back off on the same budget as the autocommit
@@ -555,6 +600,368 @@ func (s *Store) replayPredecessorRefsTx(tx *gorm.DB, runID, taskID uuid.UUID) ([
 	return descriptor.DAG.Predecessors, true, nil
 }
 
+func newStartRunModel(req startRunRequest) (*models.JobRun, error) {
+	now := time.Now().UTC()
+	model := &models.JobRun{
+		ID:        uuid.New(),
+		JobID:     req.jobID,
+		Status:    string(StatusRunning),
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if req.triggerID != nil {
+		model.TriggerID = *req.triggerID
+	}
+	if req.backfillID != nil {
+		model.BackfillID = req.backfillID
+	}
+	if len(req.params) > 0 {
+		encoded, err := json.Marshal(req.params)
+		if err != nil {
+			return nil, fmt.Errorf("run: failed to marshal params: %w", err)
+		}
+		model.Params = encoded
+	}
+	return model, nil
+}
+
+func (s *Store) appendRunStartedEventTx(tx *gorm.DB, model *models.JobRun) (*event.Event, error) {
+	if s.eventStore == nil || model == nil {
+		return nil, nil
+	}
+	payload, err := json.Marshal(&JobRun{
+		ID:        model.ID,
+		JobID:     model.JobID,
+		Status:    Status(model.Status),
+		Priority:  model.Priority,
+		StartedAt: model.StartedAt,
+		CreatedAt: model.CreatedAt,
+		UpdatedAt: model.UpdatedAt,
+		Tasks:     []*TaskRun{},
+	})
+	if err != nil {
+		return nil, err
+	}
+	evt := event.Event{
+		Type:       event.TypeRunStarted,
+		JobID:      model.JobID,
+		RunID:      model.ID,
+		Timestamp:  time.Now().UTC(),
+		Payload:    payload,
+		Quarantine: model.Quarantine,
+	}
+	if err := s.eventStore.AppendTx(tx, &evt); err != nil {
+		return nil, err
+	}
+	return &evt, nil
+}
+
+type concurrencyConfig struct {
+	jobAlias string
+	maxRuns  int
+	strategy string
+}
+
+func concurrencyFromJSON(raw []byte) (*jobdefschema.Concurrency, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var cfg *jobdefschema.Concurrency
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func (s *Store) concurrencyConfigTx(tx *gorm.DB, jobID uuid.UUID) (concurrencyConfig, bool, error) {
+	var row struct {
+		Alias       string
+		Concurrency datatypes.JSON
+	}
+	err := tx.Model(&models.Job{}).
+		Select("alias", "concurrency").
+		Where("id = ?", jobID).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return concurrencyConfig{}, false, nil
+		}
+		return concurrencyConfig{}, false, err
+	}
+	cfg, err := concurrencyFromJSON(row.Concurrency)
+	if err != nil {
+		return concurrencyConfig{}, false, fmt.Errorf("run: decode job concurrency metadata: %w", err)
+	}
+	if cfg == nil || cfg.MaxRuns <= 0 {
+		return concurrencyConfig{jobAlias: row.Alias}, false, nil
+	}
+	strategy := strings.ToLower(strings.TrimSpace(cfg.Strategy))
+	if strategy == "" {
+		strategy = jobdefschema.ConcurrencyStrategyQueue
+	}
+	return concurrencyConfig{
+		jobAlias: row.Alias,
+		maxRuns:  cfg.MaxRuns,
+		strategy: strategy,
+	}, true, nil
+}
+
+func (s *Store) admit(tx *gorm.DB, model *models.JobRun, req startRunRequest) (admissionResult, error) {
+	if model == nil {
+		return admissionResult{}, errors.New("run: admission requires a run model")
+	}
+	cfg, ok, err := s.concurrencyConfigTx(tx, model.JobID)
+	if err != nil {
+		return admissionResult{}, err
+	}
+	result := admissionResult{decision: admissionNoPolicy, jobAlias: cfg.jobAlias}
+	if !ok {
+		return result, nil
+	}
+	if model.BackfillID != nil {
+		// Backfills use their own MaxConcurrent semaphore and run_queue does not
+		// carry backfill_id, so ordinary run concurrency deliberately excludes
+		// backfill rows via backfill_id IS NULL in the active-count predicates.
+		return result, nil
+	}
+
+	inserted, err := s.insertRunIfSlotTx(tx, model, cfg.maxRuns)
+	if err != nil {
+		return result, err
+	}
+	if inserted {
+		result.decision = admissionCreated
+		return result, nil
+	}
+
+	switch cfg.strategy {
+	case jobdefschema.ConcurrencyStrategySkip:
+		result.decision = admissionSkipped
+		result.skipReason = "max_concurrency"
+		return result, nil
+	case jobdefschema.ConcurrencyStrategyFail:
+		result.decision = admissionFailed
+		return result, nil
+	case jobdefschema.ConcurrencyStrategyQueue:
+		if req.fromQueue {
+			result.decision = admissionFailed
+			return result, nil
+		}
+		if err := s.enqueueRunTx(tx, model.JobID, model.Params, model.Priority, env.Variables().RunQueueMaxDepth); err != nil {
+			return result, err
+		}
+		result.decision = admissionQueued
+		return result, nil
+	case jobdefschema.ConcurrencyStrategyReplace:
+		cancelled, cancelEvents, err := s.cancelOldestActiveRunTx(tx, model.JobID)
+		if err != nil {
+			return result, err
+		}
+		inserted, err := s.insertRunIfSlotTx(tx, model, cfg.maxRuns)
+		if err != nil {
+			return result, err
+		}
+		if !inserted {
+			result.decision = admissionFailed
+			return result, nil
+		}
+		result.decision = admissionCreated
+		result.replaced = cancelled != nil
+		result.cancelledRun = cancelled
+		result.cancelledRunEvents = cancelEvents
+		return result, nil
+	default:
+		return result, fmt.Errorf("run: unsupported concurrency strategy %q", cfg.strategy)
+	}
+}
+
+func (s *Store) insertRunIfSlotTx(tx *gorm.DB, model *models.JobRun, maxRuns int) (bool, error) {
+	if maxRuns <= 0 {
+		return true, tx.Create(model).Error
+	}
+	var backfillID any
+	if model.BackfillID != nil {
+		backfillID = *model.BackfillID
+	}
+	params := any(nil)
+	if len(model.Params) > 0 {
+		params = string(model.Params)
+	}
+	// This must remain one conditional INSERT statement: dqlite serializes the
+	// statement through Raft, so concurrent nodes derive admission from
+	// RowsAffected instead of racing through CountActive-then-Create. Backfill
+	// rows are intentionally excluded; they are governed by backfill maxConcurrent.
+	result := tx.Exec(`
+INSERT INTO job_runs (
+	id, job_id, backfill_id, trigger_id, status, priority, params, quarantine,
+	started_at, created_at, updated_at
+)
+SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+WHERE (
+	SELECT count(*)
+	FROM job_runs
+	WHERE job_id = ?
+		AND status = ?
+		AND quarantine <> true
+		AND backfill_id IS NULL
+) < ?`,
+		model.ID,
+		model.JobID,
+		backfillID,
+		model.TriggerID,
+		model.Status,
+		model.Priority,
+		params,
+		model.Quarantine,
+		model.StartedAt,
+		model.CreatedAt,
+		model.UpdatedAt,
+		model.JobID,
+		string(StatusRunning),
+		maxRuns,
+	)
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected == 1, nil
+}
+
+func metricJobAlias(jobID uuid.UUID, alias string) string {
+	if strings.TrimSpace(alias) != "" {
+		return alias
+	}
+	return jobID.String()
+}
+
+func (s *Store) startRun(req startRunRequest) (*JobRun, error) {
+	model, err := newStartRunModel(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var (
+		pendingEvents []event.Event
+		admission     admissionResult
+	)
+	if err := withStoreBusyRetry(func() error {
+		attemptEvents := make([]event.Event, 0, 3)
+		attemptAdmission := admissionResult{decision: admissionNoPolicy}
+		err := s.db.Transaction(func(tx *gorm.DB) error {
+			priority, err := startPriorityTx(tx, req.jobID, req.priorityOverride)
+			if err != nil {
+				return err
+			}
+			model.Priority = priority
+
+			result, err := s.admit(tx, model, req)
+			if err != nil {
+				return err
+			}
+			attemptAdmission = result
+
+			switch result.decision {
+			case admissionNoPolicy:
+				if req.policyOnly {
+					return nil
+				}
+				if err := tx.Create(model).Error; err != nil {
+					return err
+				}
+				attemptAdmission.decision = admissionCreated
+			case admissionCreated:
+			case admissionSkipped, admissionFailed, admissionQueued:
+				return nil
+			default:
+				return fmt.Errorf("run: unknown admission decision %d", result.decision)
+			}
+
+			evt, err := s.appendRunStartedEventTx(tx, model)
+			if err != nil {
+				return err
+			}
+			if evt != nil {
+				attemptEvents = append(attemptEvents, *evt)
+			}
+			if result.cancelledRun != nil && s.eventStore != nil {
+				// cancelRunTx appends its own events to the event store. They are
+				// returned here for bus publication after the surrounding run-start
+				// transaction commits.
+				attemptEvents = append(result.cancelledRunEvents, attemptEvents...)
+			}
+			return nil
+		})
+		if err == nil {
+			pendingEvents = attemptEvents
+			admission = attemptAdmission
+		}
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	switch admission.decision {
+	case admissionNoPolicy:
+		return nil, nil
+	case admissionSkipped:
+		reason := admission.skipReason
+		if reason == "" {
+			reason = "max_concurrency"
+		}
+		log.Info("run skipped by concurrency policy", "job_id", req.jobID, "job_alias", admission.jobAlias, "reason", reason)
+		metrics.RunSkippedTotal.WithLabelValues(metricJobAlias(req.jobID, admission.jobAlias), reason).Inc()
+		return nil, ErrRunSkipped
+	case admissionFailed:
+		return nil, ErrMaxConcurrentRunsReached
+	case admissionQueued:
+		log.Info("run queued by concurrency policy", "job_id", req.jobID, "job_alias", admission.jobAlias)
+		if err := s.observeRunQueueDepth(req.jobID); err != nil {
+			log.Warn("run queue: failed to observe depth", "job_id", req.jobID, "error", err)
+		}
+		return nil, ErrRunQueued
+	}
+
+	// Publish events immediately after commit, before loadRun, so that
+	// run_started reaches the bus before any task events that the executor
+	// may emit once Start returns.
+	s.publishEvents(pendingEvents...)
+
+	if admission.replaced {
+		metrics.RunReplacedTotal.WithLabelValues(metricJobAlias(req.jobID, admission.jobAlias)).Inc()
+	}
+	if admission.cancelledRun != nil {
+		s.recordCancelledRunMetrics(*admission.cancelledRun)
+	}
+
+	// Phase 2: write run_leases row when owner mode is enabled.
+	// This is done outside the run-creation transaction so that a lease write
+	// failure does not roll back the run itself — the ClaimNext recovery path
+	// still picks up the run if no lease is ever acquired.
+	if s.leaseStore != nil {
+		vars := env.Variables()
+		if _, leaseErr := s.leaseStore.AcquireLease(
+			context.Background(),
+			model.ID,
+			vars.NodeAddress,
+			vars.RunLeaseTTL,
+		); leaseErr != nil {
+			log.Warn("run owner: failed to acquire run lease; run will fall back to ClaimNext",
+				"run_id", model.ID,
+				"error", leaseErr,
+			)
+		}
+	}
+
+	if !model.Quarantine {
+		metrics.JobsActive.WithLabelValues(req.jobID.String()).Inc()
+		s.startedMu.Lock()
+		s.startedRuns[model.ID] = struct{}{}
+		s.startedMu.Unlock()
+	}
+
+	return s.loadRun(model.ID)
+}
+
 func (s *Store) mutateTaskExecutionDescriptor(runID, taskID uuid.UUID, mutate func(*models.TaskExecutionDescriptor)) error {
 	if mutate == nil {
 		return nil
@@ -625,211 +1032,53 @@ func mergeDescriptorSecretRefs(existing, updates []models.TaskExecutionSecretRef
 
 func (s *Store) Start(jobID uuid.UUID, triggerID *uuid.UUID, opts ...StartOption) (*JobRun, error) {
 	startOpts := startOptionsFrom(opts)
-	model := &models.JobRun{
-		ID:        uuid.New(),
-		JobID:     jobID,
-		Status:    string(StatusRunning),
-		StartedAt: time.Now().UTC(),
+	return s.startRun(startRunRequest{
+		jobID:            jobID,
+		triggerID:        triggerID,
+		params:           startOpts.Params,
+		priorityOverride: startOpts.Priority,
+	})
+}
+
+func (s *Store) AdmitRun(jobID uuid.UUID, triggerID *uuid.UUID, opts ...StartOption) (*JobRun, bool, error) {
+	startOpts := startOptionsFrom(opts)
+	r, err := s.startRun(startRunRequest{
+		jobID:            jobID,
+		triggerID:        triggerID,
+		params:           startOpts.Params,
+		priorityOverride: startOpts.Priority,
+		policyOnly:       true,
+	})
+	if r == nil && err == nil {
+		return nil, false, nil
 	}
-
-	if triggerID != nil {
-		model.TriggerID = *triggerID
-	}
-	if len(startOpts.Params) > 0 {
-		encoded, err := json.Marshal(startOpts.Params)
-		if err != nil {
-			return nil, fmt.Errorf("run: failed to marshal params: %w", err)
-		}
-		model.Params = encoded
-	}
-
-	var pendingEvents []event.Event
-	if err := withStoreBusyRetry(func() error {
-		attemptEvents := make([]event.Event, 0, 1)
-		err := s.db.Transaction(func(tx *gorm.DB) error {
-			priority, err := startPriorityTx(tx, jobID, startOpts.Priority)
-			if err != nil {
-				return err
-			}
-			model.Priority = priority
-
-			if err := tx.Create(model).Error; err != nil {
-				return err
-			}
-
-			if s.eventStore != nil {
-				payload, err := json.Marshal(&JobRun{
-					ID:        model.ID,
-					JobID:     model.JobID,
-					Status:    Status(model.Status),
-					Priority:  model.Priority,
-					StartedAt: model.StartedAt,
-					CreatedAt: model.CreatedAt,
-					UpdatedAt: model.UpdatedAt,
-					Tasks:     []*TaskRun{},
-				})
-				if err != nil {
-					return err
-				}
-
-				evt := event.Event{
-					Type:       event.TypeRunStarted,
-					JobID:      jobID,
-					RunID:      model.ID,
-					Timestamp:  time.Now().UTC(),
-					Payload:    payload,
-					Quarantine: model.Quarantine,
-				}
-				if err := s.eventStore.AppendTx(tx, &evt); err != nil {
-					return err
-				}
-				attemptEvents = append(attemptEvents, evt)
-			}
-
-			return nil
-		})
-		if err == nil {
-			pendingEvents = attemptEvents
-		}
-		return err
-	}); err != nil {
-		return nil, err
-	}
-
-	// Publish events immediately after commit, before loadRun, so that
-	// run_started reaches the bus before any task events that the executor
-	// may emit once Start returns.
-	s.publishEvents(pendingEvents...)
-
-	// Phase 2: write run_leases row when owner mode is enabled.
-	// This is done outside the run-creation transaction so that a lease write
-	// failure does not roll back the run itself — the ClaimNext recovery path
-	// still picks up the run if no lease is ever acquired.
-	if s.leaseStore != nil {
-		vars := env.Variables()
-		if _, leaseErr := s.leaseStore.AcquireLease(
-			context.Background(),
-			model.ID,
-			vars.NodeAddress,
-			vars.RunLeaseTTL,
-		); leaseErr != nil {
-			log.Warn("run owner: failed to acquire run lease; run will fall back to ClaimNext",
-				"run_id", model.ID,
-				"error", leaseErr,
-			)
-		}
-	}
-
-	if !model.Quarantine {
-		metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
-		s.startedMu.Lock()
-		s.startedRuns[model.ID] = struct{}{}
-		s.startedMu.Unlock()
-	}
-
-	run, err := s.loadRun(model.ID)
-	return run, err
+	return r, true, err
 }
 
 // StartForBackfill creates a JobRun pre-linked to a backfill ID. The caller
 // should then execute the job with run.WithContext(ctx, r.ID) so the executor
 // resumes from this pre-created record rather than creating a new one.
 func (s *Store) StartForBackfill(jobID, backfillID uuid.UUID, params map[string]string) (*JobRun, error) {
-	model := &models.JobRun{
-		ID:         uuid.New(),
-		JobID:      jobID,
-		BackfillID: &backfillID,
-		Status:     string(StatusRunning),
-		StartedAt:  time.Now().UTC(),
+	return s.startRun(startRunRequest{
+		jobID:      jobID,
+		backfillID: &backfillID,
+		params:     params,
+	})
+}
+
+// StartQueuedRun creates a fresh JobRun from an already-claimed run_queue row.
+// If a slot disappears between dequeue and insert, the caller should release the
+// queue row so a later drain can retry it.
+func (s *Store) StartQueuedRun(_ context.Context, queued *models.RunQueue) (*JobRun, error) {
+	if queued == nil {
+		return nil, errors.New("run: queued run is nil")
 	}
-
-	if len(params) > 0 {
-		encoded, err := json.Marshal(params)
-		if err != nil {
-			return nil, fmt.Errorf("run: failed to marshal params: %w", err)
-		}
-		model.Params = encoded
-	}
-
-	var pendingEvents []event.Event
-	if err := withStoreBusyRetry(func() error {
-		attemptEvents := make([]event.Event, 0, 1)
-		err := s.db.Transaction(func(tx *gorm.DB) error {
-			priority, err := startPriorityTx(tx, jobID, "")
-			if err != nil {
-				return err
-			}
-			model.Priority = priority
-
-			if err := tx.Create(model).Error; err != nil {
-				return err
-			}
-
-			if s.eventStore != nil {
-				payload, err := json.Marshal(&JobRun{
-					ID:        model.ID,
-					JobID:     model.JobID,
-					Status:    Status(model.Status),
-					Priority:  model.Priority,
-					StartedAt: model.StartedAt,
-					CreatedAt: model.CreatedAt,
-					UpdatedAt: model.UpdatedAt,
-					Tasks:     []*TaskRun{},
-				})
-				if err != nil {
-					return err
-				}
-
-				evt := event.Event{
-					Type:       event.TypeRunStarted,
-					JobID:      jobID,
-					RunID:      model.ID,
-					Timestamp:  time.Now().UTC(),
-					Payload:    payload,
-					Quarantine: model.Quarantine,
-				}
-				if err := s.eventStore.AppendTx(tx, &evt); err != nil {
-					return err
-				}
-				attemptEvents = append(attemptEvents, evt)
-			}
-
-			return nil
-		})
-		if err == nil {
-			pendingEvents = attemptEvents
-		}
-		return err
-	}); err != nil {
-		return nil, err
-	}
-
-	s.publishEvents(pendingEvents...)
-
-	// Phase 2: write run_leases row when owner mode is enabled.
-	if s.leaseStore != nil {
-		vars := env.Variables()
-		if _, leaseErr := s.leaseStore.AcquireLease(
-			context.Background(),
-			model.ID,
-			vars.NodeAddress,
-			vars.RunLeaseTTL,
-		); leaseErr != nil {
-			log.Warn("run owner: failed to acquire run lease (backfill); run will fall back to ClaimNext",
-				"run_id", model.ID,
-				"error", leaseErr,
-			)
-		}
-	}
-
-	if !model.Quarantine {
-		metrics.JobsActive.WithLabelValues(jobID.String()).Inc()
-		s.startedMu.Lock()
-		s.startedRuns[model.ID] = struct{}{}
-		s.startedMu.Unlock()
-	}
-
-	return s.loadRun(model.ID)
+	return s.startRun(startRunRequest{
+		jobID:            queued.JobID,
+		params:           decodeRunParams(queued.Params),
+		priorityOverride: PriorityLabel(queued.Priority),
+		fromQueue:        true,
+	})
 }
 
 func (s *Store) RegisterTask(runID uuid.UUID, task *models.Task, atom *models.Atom, outstanding int) error {
@@ -2250,7 +2499,7 @@ func satisfiesTriggerRule(rule string, predStatuses []TaskStatus) bool {
 	}
 
 	isTerminal := func(s TaskStatus) bool {
-		return s == TaskStatusSucceeded || s == TaskStatusCached || s == TaskStatusFailed || s == TaskStatusSkipped
+		return IsTerminal(s)
 	}
 
 	switch rule {
@@ -2758,6 +3007,7 @@ func terminalStatusStrings() []string {
 		string(TaskStatusFailed),
 		string(TaskStatusSkipped),
 		string(TaskStatusCached),
+		string(TaskStatusCancelled),
 	}
 }
 
@@ -3113,7 +3363,7 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 			// from the triggering node's waitForRunCompletion; this keeps the
 			// second call a no-op so run_completed/run_failed events fire once.
 			res := tx.Model(&models.JobRun{}).
-				Where("id = ? AND status NOT IN ?", runID, []string{string(StatusSucceeded), string(StatusFailed)}).
+				Where("id = ? AND status NOT IN ?", runID, []string{string(StatusSucceeded), string(StatusFailed), string(StatusCancelled)}).
 				Updates(map[string]interface{}{
 					"status":       string(status),
 					"completed_at": now,
@@ -3221,6 +3471,167 @@ func (s *Store) Complete(runID uuid.UUID, result error) error {
 	return nil
 }
 
+func (s *Store) CancelRun(ctx context.Context, runID uuid.UUID) error {
+	var (
+		pendingEvents []event.Event
+		cancelled     *cancelledRunInfo
+	)
+	if err := withStoreBusyRetry(func() error {
+		attemptEvents := make([]event.Event, 0, 2)
+		var attemptCancelled *cancelledRunInfo
+		err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			info, events, err := s.cancelRunTx(tx, runID, "cancelled by concurrency replacement")
+			if err != nil {
+				return err
+			}
+			attemptCancelled = info
+			attemptEvents = events
+			return nil
+		})
+		if err == nil {
+			pendingEvents = attemptEvents
+			cancelled = attemptCancelled
+		}
+		return err
+	}); err != nil {
+		return err
+	}
+	s.publishEvents(pendingEvents...)
+	if cancelled != nil {
+		s.recordCancelledRunMetrics(*cancelled)
+	}
+	return nil
+}
+
+func (s *Store) cancelOldestActiveRunTx(tx *gorm.DB, jobID uuid.UUID) (*cancelledRunInfo, []event.Event, error) {
+	var model models.JobRun
+	err := tx.
+		Where("job_id = ? AND status = ? AND quarantine <> true AND backfill_id IS NULL", jobID, string(StatusRunning)).
+		Order("started_at ASC").
+		Take(&model).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil, nil
+		}
+		return nil, nil, err
+	}
+	return s.cancelRunTx(tx, model.ID, "cancelled by concurrency replacement")
+}
+
+func (s *Store) cancelRunTx(tx *gorm.DB, runID uuid.UUID, reason string) (*cancelledRunInfo, []event.Event, error) {
+	now := time.Now().UTC()
+	if strings.TrimSpace(reason) == "" {
+		reason = "cancelled"
+	}
+	res := tx.Model(&models.JobRun{}).
+		Where("id = ? AND status = ?", runID, string(StatusRunning)).
+		Updates(map[string]interface{}{
+			"status":       string(StatusCancelled),
+			"completed_at": now,
+			"error":        reason,
+		})
+	if res.Error != nil {
+		return nil, nil, res.Error
+	}
+	if res.RowsAffected == 0 {
+		return nil, nil, nil
+	}
+
+	taskRes := tx.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND status NOT IN ?", runID, terminalTaskStatuses()).
+		Updates(map[string]interface{}{
+			"status":                 string(TaskStatusCancelled),
+			"completed_at":           now,
+			"error":                  reason,
+			"claimed_by":             "",
+			"claim_expires_at":       nil,
+			"runtime_id":             "",
+			"rate_limit_retry_after": nil,
+		})
+	if taskRes.Error != nil {
+		return nil, nil, taskRes.Error
+	}
+	if err := deleteRunLeaseTx(tx, runID); err != nil {
+		return nil, nil, err
+	}
+
+	var infoRow struct {
+		models.JobRun
+		JobAlias string
+	}
+	if err := tx.Table("job_runs").
+		Select("job_runs.*, jobs.alias as job_alias").
+		Joins("left join jobs on jobs.id = job_runs.job_id").
+		Where("job_runs.id = ?", runID).
+		Take(&infoRow).Error; err != nil {
+		return nil, nil, err
+	}
+
+	info := &cancelledRunInfo{
+		ID:          runID,
+		JobID:       infoRow.JobID,
+		JobAlias:    infoRow.JobAlias,
+		StartedAt:   infoRow.StartedAt,
+		Quarantine:  infoRow.Quarantine,
+		CancelledAt: now,
+	}
+
+	if s.eventStore == nil {
+		return info, nil, nil
+	}
+	loaded, err := s.loadRunWithDB(tx, runID)
+	if err != nil {
+		return nil, nil, err
+	}
+	payload, err := json.Marshal(loaded)
+	if err != nil {
+		return nil, nil, err
+	}
+	cancelledEvent := event.Event{
+		Type:       event.TypeRunCancelled,
+		JobID:      loaded.JobID,
+		RunID:      runID,
+		Timestamp:  now,
+		Payload:    payload,
+		Quarantine: loaded.Quarantine,
+	}
+	if err := s.eventStore.AppendTx(tx, &cancelledEvent); err != nil {
+		return nil, nil, err
+	}
+	terminalEvent := event.Event{
+		Type:       event.TypeRunTerminal,
+		JobID:      loaded.JobID,
+		RunID:      runID,
+		Timestamp:  now,
+		Payload:    payload,
+		Quarantine: loaded.Quarantine,
+	}
+	if err := s.eventStore.AppendTx(tx, &terminalEvent); err != nil {
+		return nil, nil, err
+	}
+	return info, []event.Event{cancelledEvent, terminalEvent}, nil
+}
+
+func (s *Store) recordCancelledRunMetrics(info cancelledRunInfo) {
+	if info.Quarantine {
+		return
+	}
+	jobLabel := info.JobID.String()
+	s.startedMu.Lock()
+	_, started := s.startedRuns[info.ID]
+	if started {
+		delete(s.startedRuns, info.ID)
+	}
+	s.startedMu.Unlock()
+	metrics.JobRunsTotal.WithLabelValues(jobLabel, string(StatusCancelled)).Inc()
+	if started {
+		metrics.JobsActive.WithLabelValues(jobLabel).Dec()
+	}
+	if !info.StartedAt.IsZero() {
+		metrics.JobRunDurationSeconds.WithLabelValues(jobLabel, string(StatusCancelled)).Observe(info.CancelledAt.Sub(info.StartedAt).Seconds())
+	}
+}
+
 func (s *Store) ResetInFlightTasks(runID uuid.UUID) error {
 	return s.db.Model(&models.TaskRun{}).
 		Where("job_run_id = ? AND status = ?", runID, string(TaskStatusRunning)).
@@ -3239,6 +3650,175 @@ func (s *Store) ResetInFlightTasks(runID uuid.UUID) error {
 			"cache_created_at":       nil,
 			"cache_expires_at":       nil,
 		}).Error
+}
+
+func (s *Store) CountActive(jobID uuid.UUID) (int64, error) {
+	var count int64
+	err := s.db.Model(&models.JobRun{}).
+		Where("job_id = ? AND status = ? AND quarantine <> true AND backfill_id IS NULL", jobID, string(StatusRunning)).
+		Count(&count).Error
+	return count, err
+}
+
+func (s *Store) enqueueRunTx(tx *gorm.DB, jobID uuid.UUID, params datatypes.JSON, priority, maxDepth int) error {
+	if priority <= 0 {
+		priority = PriorityNormalValue
+	}
+	if maxDepth <= 0 {
+		maxDepth = 100
+	}
+	now := time.Now().UTC()
+	row := &models.RunQueue{
+		ID:        uuid.New(),
+		JobID:     jobID,
+		Params:    append(datatypes.JSON(nil), params...),
+		Priority:  priority,
+		ClaimedBy: "",
+		CreatedAt: now,
+	}
+	if err := tx.Create(row).Error; err != nil {
+		return err
+	}
+	var depth int64
+	if err := tx.Model(&models.RunQueue{}).
+		Where("job_id = ? AND claimed_by = ''", jobID).
+		Count(&depth).Error; err != nil {
+		return err
+	}
+	if overflow := int(depth) - maxDepth; overflow > 0 {
+		if err := tx.Exec(`
+DELETE FROM run_queue
+WHERE id IN (
+	SELECT id
+	FROM run_queue
+	WHERE job_id = ? AND claimed_by = ''
+	ORDER BY created_at ASC
+	LIMIT ?
+)`, jobID, overflow).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) DequeueNextRun(ctx context.Context, jobID uuid.UUID, claimedBy string) (*models.RunQueue, error) {
+	claimedBy = strings.TrimSpace(claimedBy)
+	if claimedBy == "" {
+		claimedBy = uuid.NewString()
+	}
+	result := s.db.WithContext(ctx).Exec(`
+UPDATE run_queue
+SET claimed_by = ?, claimed_at = ?
+WHERE id = (
+	SELECT id
+	FROM run_queue
+	WHERE job_id = ? AND claimed_by = ''
+	ORDER BY priority DESC, created_at ASC
+	LIMIT 1
+)
+AND claimed_by = ''`, claimedBy, time.Now().UTC(), jobID)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	if result.RowsAffected == 0 {
+		return nil, nil
+	}
+	var queued models.RunQueue
+	if err := s.db.WithContext(ctx).
+		Where("job_id = ? AND claimed_by = ?", jobID, claimedBy).
+		Take(&queued).Error; err != nil {
+		return nil, err
+	}
+	if err := s.observeRunQueueDepth(jobID); err != nil {
+		log.Warn("run queue: failed to observe depth after dequeue", "job_id", jobID, "error", err)
+	}
+	return &queued, nil
+}
+
+func (s *Store) ReleaseQueuedRun(ctx context.Context, queueID uuid.UUID, claimedBy string) error {
+	result := s.db.WithContext(ctx).
+		Model(&models.RunQueue{}).
+		Where("id = ? AND claimed_by = ?", queueID, claimedBy).
+		Updates(map[string]any{
+			"claimed_by": "",
+			"claimed_at": nil,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	var queued models.RunQueue
+	if err := s.db.WithContext(ctx).Select("job_id").First(&queued, "id = ?", queueID).Error; err == nil {
+		if observeErr := s.observeRunQueueDepth(queued.JobID); observeErr != nil {
+			log.Warn("run queue: failed to observe depth after release", "job_id", queued.JobID, "error", observeErr)
+		}
+	}
+	return nil
+}
+
+func (s *Store) DeleteQueuedRun(ctx context.Context, queued *models.RunQueue) error {
+	if queued == nil {
+		return nil
+	}
+	result := s.db.WithContext(ctx).
+		Delete(&models.RunQueue{}, "id = ?", queued.ID)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 {
+		alias, err := s.jobAlias(queued.JobID)
+		if err != nil {
+			log.Warn("run queue: failed to load job alias for wait metric", "job_id", queued.JobID, "error", err)
+		} else {
+			metrics.RunQueueWaitSeconds.WithLabelValues(metricJobAlias(queued.JobID, alias)).Observe(time.Since(queued.CreatedAt).Seconds())
+		}
+	}
+	if err := s.observeRunQueueDepth(queued.JobID); err != nil {
+		log.Warn("run queue: failed to observe depth after delete", "job_id", queued.JobID, "error", err)
+	}
+	return nil
+}
+
+func (s *Store) jobAlias(jobID uuid.UUID) (string, error) {
+	var job models.Job
+	if err := s.db.Select("alias").First(&job, "id = ?", jobID).Error; err != nil {
+		return "", err
+	}
+	return job.Alias, nil
+}
+
+func (s *Store) observeRunQueueDepth(jobID uuid.UUID) error {
+	alias, err := s.jobAlias(jobID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			alias = jobID.String()
+		} else {
+			return err
+		}
+	}
+	rows := []struct {
+		Priority int
+		Depth    int64
+	}{}
+	if err := s.db.Model(&models.RunQueue{}).
+		Select("priority, count(*) as depth").
+		Where("job_id = ? AND claimed_by = ''", jobID).
+		Group("priority").
+		Scan(&rows).Error; err != nil {
+		return err
+	}
+	depths := map[int]int64{
+		PriorityLowValue:    0,
+		PriorityNormalValue: 0,
+		PriorityHighValue:   0,
+	}
+	for _, row := range rows {
+		depths[row.Priority] = row.Depth
+	}
+	jobLabel := metricJobAlias(jobID, alias)
+	for priority, depth := range depths {
+		metrics.RunQueueDepth.WithLabelValues(jobLabel, PriorityLabel(priority)).Set(float64(depth))
+	}
+	return nil
 }
 
 func (s *Store) FindRunning(jobID uuid.UUID) (*JobRun, error) {

--- a/internal/run/terminal_test.go
+++ b/internal/run/terminal_test.go
@@ -8,6 +8,7 @@ func TestIsTerminal(t *testing.T) {
 		TaskStatusFailed,
 		TaskStatusSkipped,
 		TaskStatusCached,
+		TaskStatusCancelled,
 	}
 	for _, s := range terminal {
 		if !IsTerminal(s) {

--- a/internal/run/trigger_rule.go
+++ b/internal/run/trigger_rule.go
@@ -37,10 +37,6 @@ func SatisfiesTriggerRule(rule string, predStatuses []TaskStatus) bool {
 		return true
 	}
 
-	isTerminal := func(s TaskStatus) bool {
-		return s == TaskStatusSucceeded || s == TaskStatusCached || s == TaskStatusFailed || s == TaskStatusSkipped
-	}
-
 	switch rule {
 	case jobdefschema.TriggerRuleAllSuccess:
 		for _, s := range predStatuses {
@@ -52,7 +48,7 @@ func SatisfiesTriggerRule(rule string, predStatuses []TaskStatus) bool {
 
 	case jobdefschema.TriggerRuleAllDone, jobdefschema.TriggerRuleAlways:
 		for _, s := range predStatuses {
-			if !isTerminal(s) {
+			if !IsTerminal(s) {
 				return false
 			}
 		}

--- a/internal/runqueue/dequeuer.go
+++ b/internal/runqueue/dequeuer.go
@@ -163,6 +163,15 @@ func (d *Dequeuer) drainJob(ctx context.Context, jobID uuid.UUID) error {
 		}
 		started, err := d.store.StartQueuedRun(ctx, queued)
 		if err != nil {
+			if errors.Is(err, runstorage.ErrRunSkipped) {
+				if err := d.store.DeleteQueuedRun(ctx, queued); err != nil {
+					if releaseErr := d.store.ReleaseQueuedRun(ctx, queued.ID, claim); releaseErr != nil {
+						log.Warn("run queue dequeuer failed to release skipped queued run", "queue_id", queued.ID, "error", releaseErr)
+					}
+					return err
+				}
+				continue
+			}
 			if releaseErr := d.store.ReleaseQueuedRun(ctx, queued.ID, claim); releaseErr != nil {
 				log.Warn("run queue dequeuer failed to release queued run", "queue_id", queued.ID, "error", releaseErr)
 			}

--- a/internal/runqueue/dequeuer.go
+++ b/internal/runqueue/dequeuer.go
@@ -1,0 +1,254 @@
+package runqueue
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	jobexec "github.com/caesium-cloud/caesium/internal/job"
+	"github.com/caesium-cloud/caesium/internal/models"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	jobdefschema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+type LeaderCheck func(context.Context) (bool, error)
+type LaunchFunc func(context.Context, *models.Job, *runstorage.JobRun)
+
+type Config struct {
+	DB                  *gorm.DB
+	Store               *runstorage.Store
+	NodeID              string
+	Interval            time.Duration
+	StaleClaimThreshold time.Duration
+	LeaderCheck         LeaderCheck
+	LaunchRun           LaunchFunc
+}
+
+type Dequeuer struct {
+	db                  *gorm.DB
+	store               *runstorage.Store
+	nodeID              string
+	interval            time.Duration
+	staleClaimThreshold time.Duration
+	leaderCheck         LeaderCheck
+	launchRun           LaunchFunc
+}
+
+func NewDequeuer(cfg Config) *Dequeuer {
+	if cfg.DB == nil {
+		panic("run queue dequeuer requires database connection")
+	}
+	store := cfg.Store
+	if store == nil {
+		store = runstorage.NewStore(cfg.DB)
+	}
+	nodeID := strings.TrimSpace(cfg.NodeID)
+	if nodeID == "" {
+		nodeID = "runqueue"
+	}
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = time.Second
+	}
+	staleClaimThreshold := cfg.StaleClaimThreshold
+	if staleClaimThreshold <= 0 {
+		staleClaimThreshold = 2 * time.Minute
+	}
+	return &Dequeuer{
+		db:                  cfg.DB,
+		store:               store,
+		nodeID:              nodeID,
+		interval:            interval,
+		staleClaimThreshold: staleClaimThreshold,
+		leaderCheck:         cfg.LeaderCheck,
+		launchRun:           cfg.LaunchRun,
+	}
+}
+
+func (d *Dequeuer) Run(ctx context.Context) {
+	if err := d.DrainOnce(ctx); err != nil && ctx.Err() == nil {
+		log.Error("run queue dequeuer drain failed", "error", err)
+	}
+
+	ticker := time.NewTicker(d.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := d.DrainOnce(ctx); err != nil && ctx.Err() == nil {
+				log.Error("run queue dequeuer drain failed", "error", err)
+			}
+		}
+	}
+}
+
+func (d *Dequeuer) DrainOnce(ctx context.Context) error {
+	if d.leaderCheck != nil {
+		leader, err := d.leaderCheck(ctx)
+		if err != nil {
+			return err
+		}
+		if !leader {
+			return nil
+		}
+	}
+
+	if err := d.reclaimStaleClaims(ctx); err != nil {
+		return err
+	}
+
+	var jobIDs []uuid.UUID
+	if err := d.db.WithContext(ctx).
+		Model(&models.RunQueue{}).
+		Where("claimed_by = ''").
+		Distinct("job_id").
+		Pluck("job_id", &jobIDs).Error; err != nil {
+		return err
+	}
+	for _, jobID := range jobIDs {
+		if err := d.drainJob(ctx, jobID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *Dequeuer) reclaimStaleClaims(ctx context.Context) error {
+	cutoff := time.Now().UTC().Add(-d.staleClaimThreshold)
+	result := d.db.WithContext(ctx).
+		Model(&models.RunQueue{}).
+		Where("claimed_by <> '' AND (claimed_at IS NULL OR claimed_at < ?)", cutoff).
+		Updates(map[string]any{
+			"claimed_by": "",
+			"claimed_at": nil,
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected > 0 {
+		log.Warn("run queue dequeuer reclaimed stale claims", "count", result.RowsAffected, "cutoff", cutoff)
+	}
+	return nil
+}
+
+func (d *Dequeuer) drainJob(ctx context.Context, jobID uuid.UUID) error {
+	cfg, ok, err := loadConcurrencyConfig(ctx, d.db, jobID)
+	if err != nil {
+		return err
+	}
+	if !ok || cfg.maxRuns <= 0 {
+		return nil
+	}
+	active, err := d.store.CountActive(jobID)
+	if err != nil {
+		return err
+	}
+	for active < int64(cfg.maxRuns) {
+		claim := fmt.Sprintf("%s/%s", d.nodeID, uuid.NewString())
+		queued, err := d.store.DequeueNextRun(ctx, jobID, claim)
+		if err != nil {
+			return err
+		}
+		if queued == nil {
+			return nil
+		}
+		started, err := d.store.StartQueuedRun(ctx, queued)
+		if err != nil {
+			if releaseErr := d.store.ReleaseQueuedRun(ctx, queued.ID, claim); releaseErr != nil {
+				log.Warn("run queue dequeuer failed to release queued run", "queue_id", queued.ID, "error", releaseErr)
+			}
+			if errors.Is(err, runstorage.ErrMaxConcurrentRunsReached) || errors.Is(err, runstorage.ErrRunQueued) {
+				return nil
+			}
+			return err
+		}
+		if started == nil {
+			if err := d.store.ReleaseQueuedRun(ctx, queued.ID, claim); err != nil {
+				return err
+			}
+			return nil
+		}
+		if err := d.store.DeleteQueuedRun(ctx, queued); err != nil {
+			return err
+		}
+		if err := d.launch(ctx, started); err != nil {
+			return err
+		}
+		active++
+	}
+	return nil
+}
+
+func (d *Dequeuer) launch(ctx context.Context, started *runstorage.JobRun) error {
+	if started == nil {
+		return nil
+	}
+	var jobModel models.Job
+	if err := d.db.WithContext(ctx).First(&jobModel, "id = ?", started.JobID).Error; err != nil {
+		return err
+	}
+	if d.launchRun != nil {
+		d.launchRun(ctx, &jobModel, started)
+		return nil
+	}
+	go func() {
+		runCtx := runstorage.WithContext(context.WithoutCancel(ctx), started.ID)
+		if err := jobexec.New(
+			&jobModel,
+			jobexec.WithRunStoreFactory(func() *runstorage.Store { return d.store }),
+			jobexec.WithParams(started.Params),
+		).Run(runCtx); err != nil {
+			log.Error("run queue dequeuer job run failure", "job_id", started.JobID, "run_id", started.ID, "error", err)
+		}
+	}()
+	return nil
+}
+
+type concurrencyConfig struct {
+	maxRuns  int
+	strategy string
+}
+
+func loadConcurrencyConfig(ctx context.Context, db *gorm.DB, jobID uuid.UUID) (concurrencyConfig, bool, error) {
+	var row struct {
+		Concurrency datatypes.JSON
+	}
+	err := db.WithContext(ctx).
+		Model(&models.Job{}).
+		Select("concurrency").
+		Where("id = ?", jobID).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return concurrencyConfig{}, false, nil
+		}
+		return concurrencyConfig{}, false, err
+	}
+	if len(row.Concurrency) == 0 {
+		return concurrencyConfig{}, false, nil
+	}
+	var cfg *jobdefschema.Concurrency
+	if err := json.Unmarshal(row.Concurrency, &cfg); err != nil {
+		return concurrencyConfig{}, false, err
+	}
+	if cfg == nil {
+		return concurrencyConfig{}, false, nil
+	}
+	strategy := strings.ToLower(strings.TrimSpace(cfg.Strategy))
+	if strategy == "" {
+		strategy = jobdefschema.ConcurrencyStrategyQueue
+	}
+	if strategy != jobdefschema.ConcurrencyStrategyQueue {
+		return concurrencyConfig{}, false, nil
+	}
+	return concurrencyConfig{maxRuns: cfg.MaxRuns, strategy: strategy}, true, nil
+}

--- a/internal/runqueue/dequeuer_test.go
+++ b/internal/runqueue/dequeuer_test.go
@@ -1,0 +1,111 @@
+package runqueue
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+func TestDequeuerLeaderGatedPriorityDrain(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	job := createQueuedJob(t, db)
+	now := time.Now().UTC()
+	lowID := uuid.New()
+	highID := uuid.New()
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        lowID,
+		JobID:     job.ID,
+		Priority:  runstorage.PriorityLowValue,
+		CreatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        highID,
+		JobID:     job.ID,
+		Priority:  runstorage.PriorityHighValue,
+		CreatedAt: now.Add(time.Second),
+	}).Error)
+
+	store := runstorage.NewStore(db)
+	var launchedRunID uuid.UUID
+	var launchedJobID uuid.UUID
+	dequeuer := NewDequeuer(Config{
+		DB:     db,
+		Store:  store,
+		NodeID: "node-a",
+		LeaderCheck: func(context.Context) (bool, error) {
+			return true, nil
+		},
+		LaunchRun: func(_ context.Context, jobModel *models.Job, started *runstorage.JobRun) {
+			launchedJobID = jobModel.ID
+			launchedRunID = started.ID
+		},
+	})
+	require.NoError(t, dequeuer.DrainOnce(context.Background()))
+
+	var runs []models.JobRun
+	require.NoError(t, db.Find(&runs, "job_id = ?", job.ID).Error)
+	require.Len(t, runs, 1)
+	require.Equal(t, runstorage.PriorityHighValue, runs[0].Priority)
+	require.Equal(t, job.ID, launchedJobID)
+	require.Equal(t, runs[0].ID, launchedRunID)
+
+	var remaining []models.RunQueue
+	require.NoError(t, db.Find(&remaining, "job_id = ?", job.ID).Error)
+	require.Len(t, remaining, 1)
+	require.Equal(t, lowID, remaining[0].ID)
+
+	follower := NewDequeuer(Config{
+		DB:     db,
+		Store:  store,
+		NodeID: "node-b",
+		LeaderCheck: func(context.Context) (bool, error) {
+			return false, nil
+		},
+	})
+	require.NoError(t, follower.DrainOnce(context.Background()))
+
+	var afterFollower int64
+	require.NoError(t, db.Model(&models.RunQueue{}).Where("job_id = ?", job.ID).Count(&afterFollower).Error)
+	require.Equal(t, int64(1), afterFollower)
+}
+
+func createQueuedJob(t *testing.T, db *gorm.DB) *models.Job {
+	t.Helper()
+	now := time.Now().UTC()
+	trigger := &models.Trigger{
+		ID:            uuid.New(),
+		Alias:         "queue-trigger",
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"cron":"0 * * * *","timezone":"UTC"}`,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	require.NoError(t, db.Create(trigger).Error)
+	raw, err := json.Marshal(&jobdef.Concurrency{
+		MaxRuns:  1,
+		Strategy: jobdef.ConcurrencyStrategyQueue,
+	})
+	require.NoError(t, err)
+	job := &models.Job{
+		ID:          uuid.New(),
+		Alias:       "queue-job",
+		TriggerID:   trigger.ID,
+		Concurrency: datatypes.JSON(raw),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	require.NoError(t, db.Create(job).Error)
+	return job
+}

--- a/internal/trigger/event/event.go
+++ b/internal/trigger/event/event.go
@@ -162,7 +162,19 @@ func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]str
 		runtimeParams := cloneParams(mergedParams)
 		runRecord, err := t.runStoreFactory().Start(jobModel.ID, &t.id, runstorage.WithStartParams(runtimeParams))
 		if err != nil {
+			if errors.Is(err, runstorage.ErrRunSkipped) {
+				outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Skipped: true, SkipReason: "max concurrency reached"})
+				continue
+			}
+			if errors.Is(err, runstorage.ErrRunQueued) {
+				outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Skipped: true, SkipReason: "queued"})
+				continue
+			}
 			outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Error: err.Error()})
+			continue
+		}
+		if runRecord == nil {
+			outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Skipped: true, SkipReason: "no run created"})
 			continue
 		}
 

--- a/internal/trigger/event/event.go
+++ b/internal/trigger/event/event.go
@@ -166,6 +166,10 @@ func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]str
 				outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Skipped: true, SkipReason: "max concurrency reached"})
 				continue
 			}
+			if errors.Is(err, runstorage.ErrMaxConcurrentRunsReached) {
+				outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Skipped: true, SkipReason: "max concurrency reached; run rejected"})
+				continue
+			}
 			if errors.Is(err, runstorage.ErrRunQueued) {
 				outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Skipped: true, SkipReason: "queued"})
 				continue

--- a/justfile
+++ b/justfile
@@ -234,6 +234,7 @@ integration-up: build-test
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
+        -e CAESIUM_RUN_QUEUE_ENABLED=true \
         -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
         -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
         {{ local_image_ref }}:{{ tag }}-test start

--- a/justfile
+++ b/justfile
@@ -234,6 +234,8 @@ integration-up: build-test
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
+        -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
+        -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
         {{ local_image_ref }}:{{ tag }}-test start
 
 lint: builder-full

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -156,6 +156,10 @@ type Environment struct {
 	MaxTriggerDepth           int           `envconfig:"MAX_TRIGGER_DEPTH" default:"10"`
 	RateLimitPrunerEnabled    bool          `envconfig:"RATE_LIMIT_PRUNER_ENABLED" default:"false"`
 	RateLimitPruneInterval    time.Duration `envconfig:"RATE_LIMIT_PRUNE_INTERVAL" default:"1m"`
+	RunQueueDequeuerEnabled   bool          `envconfig:"RUN_QUEUE_DEQUEUER_ENABLED" default:"false"`
+	RunQueueDequeueInterval   time.Duration `envconfig:"RUN_QUEUE_DEQUEUE_INTERVAL" default:"1s"`
+	RunQueueClaimStaleAfter   time.Duration `envconfig:"RUN_QUEUE_CLAIM_STALE_AFTER" default:"2m"`
+	RunQueueMaxDepth          int           `envconfig:"RUN_QUEUE_MAX_DEPTH" default:"100"`
 
 	// Notification Watcher
 	NotificationWatcherInterval time.Duration `envconfig:"NOTIFICATION_WATCHER_INTERVAL" default:"15s"`

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -156,6 +156,7 @@ type Environment struct {
 	MaxTriggerDepth           int           `envconfig:"MAX_TRIGGER_DEPTH" default:"10"`
 	RateLimitPrunerEnabled    bool          `envconfig:"RATE_LIMIT_PRUNER_ENABLED" default:"false"`
 	RateLimitPruneInterval    time.Duration `envconfig:"RATE_LIMIT_PRUNE_INTERVAL" default:"1m"`
+	RunQueueEnabled           bool          `envconfig:"RUN_QUEUE_ENABLED" default:"false"`
 	RunQueueDequeuerEnabled   bool          `envconfig:"RUN_QUEUE_DEQUEUER_ENABLED" default:"false"`
 	RunQueueDequeueInterval   time.Duration `envconfig:"RUN_QUEUE_DEQUEUE_INTERVAL" default:"1s"`
 	RunQueueClaimStaleAfter   time.Duration `envconfig:"RUN_QUEUE_CLAIM_STALE_AFTER" default:"2m"`

--- a/test/run_concurrency_test.go
+++ b/test/run_concurrency_test.go
@@ -1,0 +1,261 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestRunConcurrencyStrategies() {
+	s.Run("skip drops overlapping run", func() {
+		job := s.applyConcurrencyJob("skip", `sleep 6`)
+		firstStatus, firstRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, firstStatus)
+		s.NotEmpty(firstRunID)
+
+		secondStatus, secondRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, secondStatus)
+		s.Empty(secondRunID, "skipped run should return 202 with no created run")
+
+		s.Require().Eventually(func() bool {
+			return len(s.fetchRuns(job.ID)) == 1
+		}, 5*time.Second, 250*time.Millisecond)
+	})
+
+	s.Run("fail returns conflict", func() {
+		job := s.applyConcurrencyJob("fail", `sleep 6`)
+		firstStatus, firstRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, firstStatus)
+		s.NotEmpty(firstRunID)
+
+		secondStatus, secondRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusConflict, secondStatus)
+		s.Empty(secondRunID)
+	})
+
+	s.Run("replace cancels oldest and starts fresh", func() {
+		job := s.applyConcurrencyJob("replace", `sleep 8`)
+		firstStatus, firstRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, firstStatus)
+		s.NotEmpty(firstRunID)
+		s.awaitRunHasTasks(job.ID, firstRunID, 10*time.Second)
+
+		secondStatus, secondRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, secondStatus)
+		s.NotEmpty(secondRunID)
+		s.NotEqual(firstRunID, secondRunID)
+
+		cancelled := s.awaitRunStatus(job.ID, firstRunID, 10*time.Second, "cancelled")
+		s.Equal("cancelled", cancelled.Status)
+		for _, task := range cancelled.Tasks {
+			s.Equal("cancelled", task.Status, "cancelled run's tasks must be unclaimable")
+		}
+	})
+
+	s.Run("queue parks then dequeues", func() {
+		job := s.applyConcurrencyJob("queue", `sleep 3`)
+		firstStatus, firstRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, firstStatus)
+		s.NotEmpty(firstRunID)
+
+		secondStatus, secondRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, secondStatus)
+		s.Empty(secondRunID, "queued admission should not create a run synchronously")
+
+		s.Equal("succeeded", s.awaitRunStatus(job.ID, firstRunID, runTimeout, "succeeded").Status)
+		var queuedRunID string
+		s.Require().Eventually(func() bool {
+			for _, run := range s.fetchRuns(job.ID) {
+				if run.ID != firstRunID {
+					queuedRunID = run.ID
+					return true
+				}
+			}
+			return false
+		}, 30*time.Second, time.Second)
+		s.NotEmpty(queuedRunID)
+		s.Equal("succeeded", s.awaitRunStatus(job.ID, queuedRunID, runTimeout, "succeeded").Status)
+	})
+
+	s.Run("queue reclaims stale claim", func() {
+		job := s.applyConcurrencyJob("queue", `sleep 3`)
+		firstStatus, firstRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, firstStatus)
+		s.NotEmpty(firstRunID)
+
+		secondStatus, secondRunID := s.postConcurrencyRun(job.ID)
+		s.Equal(http.StatusAccepted, secondStatus)
+		s.Empty(secondRunID, "queued admission should not create a run synchronously")
+
+		s.staleClaimQueuedRun(job.ID)
+
+		s.Equal("succeeded", s.awaitRunStatus(job.ID, firstRunID, runTimeout, "succeeded").Status)
+		var reclaimedRunID string
+		s.Require().Eventually(func() bool {
+			for _, run := range s.fetchRuns(job.ID) {
+				if run.ID != firstRunID {
+					reclaimedRunID = run.ID
+					return true
+				}
+			}
+			return false
+		}, 30*time.Second, time.Second)
+		s.NotEmpty(reclaimedRunID)
+		s.Equal("succeeded", s.awaitRunStatus(job.ID, reclaimedRunID, runTimeout, "succeeded").Status)
+	})
+}
+
+func (s *IntegrationTestSuite) TestRunConcurrencyAtomicAdmissionTOCTOU() {
+	job := s.applyConcurrencyJob("fail", `sleep 6`)
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	type result struct {
+		status int
+		runID  string
+	}
+	results := make(chan result, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			status, runID := s.postConcurrencyRun(job.ID)
+			results <- result{status: status, runID: runID}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	admitted := 0
+	conflicts := 0
+	for got := range results {
+		switch got.status {
+		case http.StatusAccepted:
+			if got.runID != "" {
+				admitted++
+			}
+		case http.StatusConflict:
+			conflicts++
+		}
+	}
+	s.Equal(1, admitted, "two near-simultaneous maxRuns=1 admissions must create exactly one run")
+	s.Equal(1, conflicts)
+}
+
+func (s *IntegrationTestSuite) applyConcurrencyJob(strategy, command string) *jobSummary {
+	alias := fmt.Sprintf("e2e-concurrency-%s-%d", strategy, time.Now().UnixNano())
+	dir := s.writeJobManifest(concurrencyJobManifest(alias, strategy, command))
+	s.T().Cleanup(func() { _ = os.RemoveAll(dir) })
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	return s.requireJobByAlias(alias)
+}
+
+func (s *IntegrationTestSuite) postConcurrencyRun(jobID string) (int, string) {
+	s.T().Helper()
+	resp, err := s.doJSONRequest(http.MethodPost, fmt.Sprintf("%s/v1/jobs/%s/run", s.caesiumURL, jobID), nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	if len(body) == 0 {
+		return resp.StatusCode, ""
+	}
+	var run runResponse
+	if err := json.Unmarshal(body, &run); err != nil {
+		return resp.StatusCode, ""
+	}
+	return resp.StatusCode, run.ID
+}
+
+func (s *IntegrationTestSuite) staleClaimQueuedRun(jobID string) {
+	s.T().Helper()
+	catalogDB := s.openIntegrationCatalogDB()
+	defer func() { s.Require().NoError(catalogDB.Close()) }()
+
+	ctx := s.T().Context()
+	var queueID string
+	s.Require().Eventually(func() bool {
+		err := catalogDB.QueryRowContext(ctx, `
+SELECT id
+FROM run_queue
+WHERE job_id = ? AND claimed_by = ''
+ORDER BY created_at ASC
+LIMIT 1
+`, jobID).Scan(&queueID)
+		return err == nil
+	}, 10*time.Second, 250*time.Millisecond)
+	s.Require().NotEmpty(queueID)
+
+	staleClaimedAt := time.Now().UTC().Add(-5 * time.Minute)
+	result, err := catalogDB.ExecContext(ctx, `
+UPDATE run_queue
+SET claimed_by = ?, claimed_at = ?
+WHERE id = ? AND claimed_by = ''
+`, "lost-leader/e2e", staleClaimedAt, queueID)
+	s.Require().NoError(err)
+	affected, err := result.RowsAffected()
+	s.Require().NoError(err)
+	s.Equal(int64(1), affected)
+}
+
+func (s *IntegrationTestSuite) awaitRunStatus(jobID, runID string, timeout time.Duration, statuses ...string) runResponse {
+	s.T().Helper()
+	want := make(map[string]struct{}, len(statuses))
+	for _, status := range statuses {
+		want[status] = struct{}{}
+	}
+	deadline := time.Now().Add(timeout)
+	for {
+		if time.Now().After(deadline) {
+			s.T().Fatalf("timeout waiting for run %s to reach one of %v", runID, statuses)
+		}
+		run := s.fetchRun(jobID, runID)
+		if _, ok := want[run.Status]; ok {
+			return run
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func (s *IntegrationTestSuite) awaitRunHasTasks(jobID, runID string, timeout time.Duration) runResponse {
+	s.T().Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		if time.Now().After(deadline) {
+			s.T().Fatalf("timeout waiting for run %s to materialize tasks", runID)
+		}
+		run := s.fetchRun(jobID, runID)
+		if len(run.Tasks) > 0 {
+			return run
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+func concurrencyJobManifest(alias, strategy, command string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  concurrency:
+    maxRuns: 1
+    strategy: %s
+trigger:
+  type: cron
+  configuration:
+    cron: "0 0 1 1 *"
+steps:
+  - name: hold
+    image: alpine:3.23
+    command: ["sh", "-c", %q]
+`, alias, strategy, command)
+}


### PR DESCRIPTION
## Summary
**Wave 3, Stream C** — run concurrency strategies (roadmap §1.3). Gates a *new run* when a job is already at `maxRuns`, applying `skip`/`fail`/`replace`/`queue`.

- **C1 — atomic admission:** a single conditional `INSERT … SELECT … WHERE (count < maxRuns)` (deriving admitted from `RowsAffected`, **not** a CountActive-then-Create read-then-write — the cross-node TOCTOU fix), via an `admit()` helper invoked from **all three** creation paths (REST `store.Start`, the cron/HTTP `resolveRun` **before** the `FindRunning` attach, and `StartForBackfill`). `skip`→202, `fail`→409, every `run.ID` deref nil-guarded.
- **C2 — `replace` + cancellation primitive:** a new `StatusCancelled` + `CancelRun` that **atomically** transitions the JobRun, its non-terminal `task_runs`, and its `run_leases` row in one transaction — so the claimer stops selecting the cancelled run and its lease can't renew. `replace` cancels the oldest active run then admits the new one.
- **C3 — durable `run_queue` + leader-gated dequeuer:** a catalog `RunQueue` model + a `dqlite.IsLocalLeader`-gated dequeuer that drains priority-first via an **atomic optimistic row-claim** (no double-launch), with a **stale-claim reaper** (the leader-crash fence) and a max queue depth.

## Review
Opus 3-lens adversarial review: **atomic-admission + cancellation-race CLEAN with detailed proof** (TOCTOU guard holds; cancel/claimer race closed); one should-fix (the run_queue stale-claim reaper) added. Host vet clean; the `-race` unit-test OOMs the compiler locally (env — CI runs it).

## Test plan
- [x] host go vet clean on changed packages
- [ ] just integration-test — Phase 6.5 gate: skip/fail/replace/queue + concurrent-TOCTOU + stale-claim reaper, driven against a live server
- Note: `-race` unit-test OOMs on local Docker (compiler SIGKILL on pgx/k8s deps); CI runs it on adequate runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)