### PR TITLE
Add concurrency queue + replace hydrate examples

### DIFF
--- a/docs/examples/concurrency-queue.job.yaml
+++ b/docs/examples/concurrency-queue.job.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Job
+metadata:
+  alias: concurrency-queue
+  # This job's step runs longer than its 2-minute schedule, so a new run fires
+  # while the previous one is still active. With `strategy: queue` the overflow
+  # run is parked in a durable run-queue (never dropped) and drained as a slot
+  # frees. The dequeuer drains priority-first, so `priority: high` overflow is
+  # admitted ahead of lower-priority work waiting in the same queue.
+  priority: high
+  concurrency:
+    maxRuns: 1
+    strategy: queue
+trigger:
+  type: cron
+  configuration:
+    cron: "*/2 * * * *"
+    timezone: "UTC"
+steps:
+  - name: process-batch
+    image: alpine:3.23
+    # Sleeps past the 2-minute interval so overlapping fires queue up.
+    command: ["sh", "-c", "echo processing batch; sleep 150"]

--- a/docs/examples/concurrency-replace.job.yaml
+++ b/docs/examples/concurrency-replace.job.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Job
+metadata:
+  alias: concurrency-replace
+  # Only the freshest run matters (e.g. rebuilding a cache from the latest
+  # inputs). With `strategy: replace`, when a new run is admitted while an older
+  # one is still active, Caesium cancels the oldest active run — and its running
+  # tasks — then starts the new run fresh, keeping at most `maxRuns` active.
+  concurrency:
+    maxRuns: 1
+    strategy: replace
+trigger:
+  type: cron
+  configuration:
+    cron: "*/2 * * * *"
+    timezone: "UTC"
+steps:
+  - name: refresh-cache
+    image: alpine:3.23
+    # Sleeps past the 2-minute interval so the next fire supersedes this one.
+    command: ["sh", "-c", "echo refreshing cache from latest inputs; sleep 150"]

--- a/docs/job-definitions.md
+++ b/docs/job-definitions.md
@@ -368,6 +368,8 @@ In this manifest, `fetch-data` inherits the job-level 24-hour TTL, `transform` o
   - Event-triggered workflow with content filtering (`event-trigger.job.yaml`).
   - Lifecycle-triggered chaining workflow (`event-chaining.job.yaml`).
   - Run-level concurrency skip policy (`concurrency-skip.job.yaml`).
+  - Run-level concurrency queue policy — durable overflow run-queue drained priority-first (`concurrency-queue.job.yaml`).
+  - Run-level concurrency replace-oldest policy — cancel the in-flight run and start fresh (`concurrency-replace.job.yaml`).
   - Priority and shared resource rate-limit scheduling (`priority-ratelimit.job.yaml`).
 
 The CLI surfaces both `caesium job apply` and `caesium job lint`; REST automation is available via `POST /v1/jobdefs/apply`, which accepts the same `force` and `prune` controls as the CLI apply workflow.


### PR DESCRIPTION
## Summary
Rounds out the `just hydrate` example set for the recently-shipped **concurrency strategies** (roadmap §1.3 / §1.4). The set already demonstrated `skip` (`concurrency-skip.job.yaml`) and priority + rate limits (`priority-ratelimit.job.yaml`); this adds the two strategies with the most machinery behind them:

- **`concurrency-queue.job.yaml`** — `strategy: queue` + `priority: high`: overflow runs park in the durable `run_queue` and drain **priority-first**.
- **`concurrency-replace.job.yaml`** — `strategy: replace`: a new run cancels the in-flight older run (and its tasks) and starts fresh.

Both steps `sleep 150` against a `*/2` cron so the policy actually **triggers at hydrate time**, not just showcases the schema. Also lists both in `docs/job-definitions.md`.

## Test plan
- [x] `go test ./pkg/jobdef/ -run TestParseRepositoryExamples` — both new manifests pass the real `Parse()`→`Validate()` path (strategy/priority enums included)
- [x] `go test ./internal/guardrails/ -run TestJobDefinitionsDocReferencesEveryExampleManifest` — the doc example-list stays in sync with the files on disk

Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)