### PR TITLE
Don't resurrect a cancelled task on concurrency replace (local mode)

### DIFF
--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1578,7 +1578,7 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 		err := s.db.Transaction(func(tx *gorm.DB) error {
 			now := time.Now().UTC()
 			if err := tx.Model(&models.TaskRun{}).
-				Where("job_run_id = ? AND task_id = ?", runID, taskID).
+				Where("job_run_id = ? AND task_id = ? AND status NOT IN ?", runID, taskID, terminalTaskStatuses()).
 				Updates(map[string]interface{}{
 					"status":                 string(TaskStatusRunning),
 					"runtime_id":             runtimeID,
@@ -1920,6 +1920,9 @@ func (s *Store) cacheHitTask(runID, taskID uuid.UUID, source CacheHitSource, res
 					return ErrTaskClaimMismatch
 				}
 				return err
+			}
+			if IsTerminal(TaskStatus(taskRun.Status)) {
+				return nil
 			}
 
 			updateQuery := tx.Model(&models.TaskRun{}).
@@ -2593,6 +2596,18 @@ func (s *Store) completeTask(runID, taskID uuid.UUID, result, claimedBy string, 
 				taskQuery = taskQuery.Where("claimed_by = ?", claimedBy)
 			}
 			if err := taskQuery.First(&taskRun).Error; err == nil {
+				if IsTerminal(TaskStatus(taskRun.Status)) {
+					// A terminal task must not be resurrected by a late completion. In local
+					// execution mode a concurrency replace cancels the run's task while its
+					// orphaned container is still running; without this guard the container's
+					// eventual exit would overwrite cancelled -> succeeded. The claimed path is
+					// already protected by the claimed_by guard; this covers the unclaimed
+					// local path. Returning nil is a no-op that also (correctly) skips the DAG
+					// cascade: a terminal task has already been accounted for, and in the
+					// replace-cancel case that motivates this the run is cancelled, so no
+					// successor should advance.
+					return nil
+				}
 				var jobRun models.JobRun
 				if err := tx.First(&jobRun, "id = ?", runID).Error; err == nil {
 					if !taskRun.Quarantine && !jobRun.Quarantine {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -1577,15 +1577,26 @@ func (s *Store) StartTask(runID, taskID uuid.UUID, runtimeID string) error {
 		attemptEvents := make([]event.Event, 0, 1)
 		err := s.db.Transaction(func(tx *gorm.DB) error {
 			now := time.Now().UTC()
-			if err := tx.Model(&models.TaskRun{}).
+			result := tx.Model(&models.TaskRun{}).
 				Where("job_run_id = ? AND task_id = ? AND status NOT IN ?", runID, taskID, terminalTaskStatuses()).
 				Updates(map[string]interface{}{
 					"status":                 string(TaskStatusRunning),
 					"runtime_id":             runtimeID,
 					"started_at":             now,
 					"rate_limit_retry_after": nil,
-				}).Error; err != nil {
-				return err
+				})
+			if result.Error != nil {
+				return result.Error
+			}
+			if result.RowsAffected == 0 {
+				// The task is already terminal (e.g. cancelled by a concurrency
+				// replace while its orphaned container was starting), so the guarded
+				// UPDATE touched no rows. Skip the metric bump and the TypeTaskStarted
+				// event — emitting one here would publish a phantom task_started for a
+				// task that is still cancelled in the DB. Mirrors StartTaskClaimed's
+				// RowsAffected==0 gate (which returns a claim mismatch; a local no-op
+				// is benign, so return nil).
+				return nil
 			}
 			counts.addTaskRunStatus(1)
 			if s.eventStore != nil {

--- a/test/run_concurrency_test.go
+++ b/test/run_concurrency_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -51,8 +52,19 @@ func (s *IntegrationTestSuite) TestRunConcurrencyStrategies() {
 		s.NotEmpty(secondRunID)
 		s.NotEqual(firstRunID, secondRunID)
 
-		cancelled := s.awaitRunStatus(job.ID, firstRunID, 10*time.Second, "cancelled")
+		// The replace flips the run and its non-terminal tasks to "cancelled" in
+		// a single transaction, and the store now refuses to resurrect a terminal
+		// task (StartTask/completeTask skip an already-cancelled row), so in local
+		// execution mode the orphaned container can no longer overwrite the task
+		// back to running/succeeded — the cancelled state is durable. The only
+		// remaining transient is a torn read under the read/write connection
+		// split, where a GET can momentarily surface the cancelled run alongside a
+		// task still reporting its pre-cancel "running" value. Poll until the run
+		// and every task converge rather than snapshotting the instant the
+		// run-level status flips.
+		cancelled := s.awaitRunCancelled(job.ID, firstRunID, 15*time.Second)
 		s.Equal("cancelled", cancelled.Status)
+		s.NotEmpty(cancelled.Tasks, "cancelled run should still expose its tasks")
 		for _, task := range cancelled.Tasks {
 			s.Equal("cancelled", task.Status, "cancelled run's tasks must be unclaimable")
 		}
@@ -208,6 +220,55 @@ WHERE id = ? AND claimed_by = ''
 	affected, err := result.RowsAffected()
 	s.Require().NoError(err)
 	s.Equal(int64(1), affected)
+}
+
+// awaitRunCancelled polls until the run reaches the terminal "cancelled" status
+// AND every one of its tasks has also converged to "cancelled". A concurrency
+// "replace" flips the run and its non-terminal tasks in a single transaction,
+// but under the read/write connection split a GET can momentarily observe the
+// cancelled run alongside a task still reporting its pre-cancel "running" state.
+// Since the committed end state is always all-cancelled, we wait for it to
+// converge instead of asserting on the first cancelled snapshot. A task that
+// genuinely ended in another terminal status (e.g. "succeeded") never satisfies
+// the predicate, so a real "ran to completion despite cancel" regression still
+// fails here — loudly, with the observed statuses.
+func (s *IntegrationTestSuite) awaitRunCancelled(jobID, runID string, timeout time.Duration) runResponse {
+	s.T().Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		run := s.fetchRun(jobID, runID)
+		if run.Status == "cancelled" && allTasksHaveStatus(run.Tasks, "cancelled") {
+			return run
+		}
+		if time.Now().After(deadline) {
+			s.T().Fatalf("timeout waiting for run %s and all tasks to converge to cancelled; last run status=%q tasks=[%s]",
+				runID, run.Status, taskStatusSummary(run.Tasks))
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+// allTasksHaveStatus reports whether every task carries status. It returns false
+// for an empty slice so callers cannot mistake "no tasks yet" for convergence.
+func allTasksHaveStatus(tasks []runTaskResponse, status string) bool {
+	if len(tasks) == 0 {
+		return false
+	}
+	for _, t := range tasks {
+		if t.Status != status {
+			return false
+		}
+	}
+	return true
+}
+
+// taskStatusSummary renders "id=status" pairs for a timeout failure message.
+func taskStatusSummary(tasks []runTaskResponse) string {
+	parts := make([]string, 0, len(tasks))
+	for _, t := range tasks {
+		parts = append(parts, fmt.Sprintf("%s=%s", t.ID, t.Status))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func (s *IntegrationTestSuite) awaitRunStatus(jobID, runID string, timeout time.Duration, statuses ...string) runResponse {


### PR DESCRIPTION
## Summary

`TestRunConcurrencyStrategies/replace_cancels_oldest_and_starts_fresh` had been flaking on the podman/helm/arm64 integration lanes with `expected "cancelled", actual "running"`. Investigation showed the "flake" is a **real product bug**, not just a timing-sensitive assertion.

## Root cause

A concurrency `replace` cancels the oldest running run **and its non-terminal tasks** in one transaction (`cancelRunTx`). But in **local execution mode** the run executes in a detached `context.Background()` goroutine, so the replace — a DB-only transaction — never kills the orphaned container. The local (unclaimed, `enforceClaim=false`) task writers had **no terminal-status guard**, so when the orphaned `sleep` container started/finished they overwrote the already-cancelled task:

```
t+01s  run=cancelled  task=cancelled     ← replace-cancel took effect
t+02s…t+09s  run=cancelled  task=running  ← StartTask resurrected it
t+10s…t+16s  run=cancelled  task=succeeded ← completeTask overwrote it
```

Final state: `run=cancelled` + `task=succeeded` — inconsistent, and the replaced run's work ran to completion. The **distributed** writers (`StartTaskClaimed`/`CompleteTaskClaimed`) are immune because they guard on `claimed_by = ? AND status = 'running'` and cancel strips `claimed_by`; only the local path lacked the invariant.

## Changes

**1. Product fix (`internal/run/store.go`)** — give the local writers the same "a terminal task must not be resurrected" invariant the distributed writers already have:
- `StartTask`: add `status NOT IN (terminal)` to the UPDATE — a cancelled task can't flip back to running.
- `completeTask` / `cacheHitTask`: after loading the task, early-`return nil` when it's already terminal — a late completion can't overwrite it, and the DAG cascade is (correctly) skipped for the already-terminal run.

Retry is unaffected (`retryTask` resets `failed → pending` first); normal execution operates on non-terminal tasks, so the guards are inert on the happy path. Local DAG advancement is driven in-memory (`internal/job/job.go`), not by `completeTask`'s DB cascade, so the early-return can't stall a run.

**2. Test de-flake (`test/run_concurrency_test.go`)** — replace the single-snapshot per-task assertion with `awaitRunCancelled`, which polls until the run **and every task** converge to `cancelled`. This absorbs the only remaining transient (a torn read under the read/write connection split at the cancel instant) while still failing loudly, with the observed per-task statuses, if a task genuinely ends non-cancelled.

## Verification (all against a live, sharded server — no k8s needed)

- **Runtime probe:** with the fix, a replace-cancelled task stays `cancelled` durably through the orphaned container's full lifetime (no resurrection). Without the fix, it went `cancelled → running → succeeded`.
- **Stress:** the subtest 30× → **30 PASS, 0 FAIL**.
- **Full integration suite:** `just integration-test` → **ok, 348s** (cache / retry / replay / all concurrency strategies green).
- **`just lint`:** 0 issues. **`just unit-test`:** all pass (`internal/run` ok).
- **Adversarial Opus review:** verdict **SHIP** — confirmed no stall risk, no dropped work, distributed path provably untouched, retry/recovery/requeue paths reset to non-terminal before `StartTask` so the guard is inert there.

## Scope note

This fixes the task-record correctness (parity with distributed mode). The orphaned container still runs to completion in local mode — killing it on replace (wiring run-cancellation into the executor context) is a larger, separate enhancement, not required for record consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)