### PR TITLE
Add datasets schema, DatasetDeclaration registry & cross-job lint (freshness-scheduling W1-α)

### DIFF
--- a/api/rest/controller/jobdef/lint.go
+++ b/api/rest/controller/jobdef/lint.go
@@ -60,6 +60,11 @@ func Lint(c *echo.Context) error {
 			resp.Errors = append(resp.Errors, LintMessage{Message: err.Error()})
 		}
 	}
+	if len(resp.Errors) == 0 {
+		if err := internaljobdef.ValidateDatasetGraph(c.Request().Context(), db.Connection(), req.Definitions); err != nil {
+			resp.Errors = append(resp.Errors, LintMessage{Message: err.Error()})
+		}
+	}
 
 	var stepsSummary string
 	if len(resp.Errors) == 0 {

--- a/cmd/job/lint.go
+++ b/cmd/job/lint.go
@@ -51,6 +51,9 @@ var lintCmd = &cobra.Command{
 		if err := internaljobdef.ValidateTriggerChains(cmd.Context(), nil, defs); err != nil {
 			return err
 		}
+		if err := internaljobdef.ValidateDatasetGraph(cmd.Context(), nil, defs); err != nil {
+			return err
+		}
 
 		if !lintCheckSecrets {
 			if err := writeCmdOut(cmd, "Validated %d job definition(s)\n", len(defs)); err != nil {

--- a/internal/freshness/graph.go
+++ b/internal/freshness/graph.go
@@ -1,0 +1,191 @@
+package freshness
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+var (
+	// ErrDatasetMultipleProducers is returned when more than one job declares
+	// that it produces the same dataset.
+	ErrDatasetMultipleProducers = errors.New("dataset produced by multiple jobs")
+	// ErrDatasetUnresolvedConsumes is returned when a consumed dataset is
+	// neither produced by any job nor declared as a source.
+	ErrDatasetUnresolvedConsumes = errors.New("consumed dataset is not produced or declared")
+	// ErrDatasetGraphCycle is returned when the producer→consumer graph contains
+	// a cross-job cycle (a dataset cycle is a derivation cycle).
+	ErrDatasetGraphCycle = errors.New("dataset dependency cycle detected")
+)
+
+// ValidateGraph runs the cross-job declared-graph checks over the full set of
+// declarations — the applied set plus any persisted declarations from jobs not
+// being replaced:
+//
+//   - exactly one job produces a given dataset (any number consume);
+//   - every consumed dataset resolves to a produced dataset or a declared
+//     source (external:true is a declared source); and
+//   - the producer→consumer graph is acyclic across jobs.
+//
+// It is a pure function over the declaration rows so it can be unit-tested
+// without a database; the caller (internal/jobdef) is responsible for gathering
+// the applied + persisted declarations and excluding replaced jobs.
+func ValidateGraph(decls []models.DatasetDeclaration) error {
+	producers := make(map[string]map[string]struct{}) // dataset name -> set of producer job aliases
+	sources := make(map[string]struct{})              // dataset names declared as a source
+	type consumeEdge struct{ alias, name string }
+	consumes := make([]consumeEdge, 0)
+
+	for i := range decls {
+		d := &decls[i]
+		name := strings.TrimSpace(d.Name)
+		alias := strings.TrimSpace(d.JobAlias)
+		if name == "" {
+			continue
+		}
+		switch d.Direction {
+		case models.DatasetDirectionProduces:
+			if producers[name] == nil {
+				producers[name] = make(map[string]struct{})
+			}
+			if alias != "" {
+				producers[name][alias] = struct{}{}
+			}
+		case models.DatasetDirectionSource:
+			sources[name] = struct{}{}
+		case models.DatasetDirectionConsumes:
+			consumes = append(consumes, consumeEdge{alias: alias, name: name})
+		}
+	}
+
+	// Single-producer: at most one job may produce a given dataset.
+	for _, name := range sortedMapKeys(producers) {
+		if len(producers[name]) > 1 {
+			owners := sortedSetKeys(producers[name])
+			return fmt.Errorf("%w: %q produced by %s", ErrDatasetMultipleProducers, name, strings.Join(owners, ", "))
+		}
+	}
+
+	// Resolution: every consumed dataset must be produced or declared as a source.
+	sort.Slice(consumes, func(i, j int) bool {
+		if consumes[i].name != consumes[j].name {
+			return consumes[i].name < consumes[j].name
+		}
+		return consumes[i].alias < consumes[j].alias
+	})
+	for _, c := range consumes {
+		if _, ok := producers[c.name]; ok {
+			continue
+		}
+		if _, ok := sources[c.name]; ok {
+			continue
+		}
+		return fmt.Errorf("%w: job %q consumes %q which is not produced by any job or declared as a source", ErrDatasetUnresolvedConsumes, c.alias, c.name)
+	}
+
+	// Cross-job cycle detection over producer→consumer edges. An edge P→C means
+	// job C consumes a dataset produced by job P.
+	graph := make(map[string]map[string]struct{})
+	addEdge := func(from, to string) {
+		if from == "" || to == "" || from == to {
+			return
+		}
+		if graph[from] == nil {
+			graph[from] = make(map[string]struct{})
+		}
+		graph[from][to] = struct{}{}
+	}
+	for _, c := range consumes {
+		for producer := range producers[c.name] {
+			addEdge(producer, c.alias)
+		}
+	}
+	if cycle := detectGraphCycle(graph); len(cycle) > 0 {
+		return fmt.Errorf("%w: %s", ErrDatasetGraphCycle, strings.Join(cycle, " -> "))
+	}
+
+	return nil
+}
+
+func sortedMapKeys(m map[string]map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedSetKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// detectGraphCycle returns a readable node path if the directed graph contains a
+// cycle, or nil otherwise. Iteration is over sorted nodes/edges for a
+// deterministic path in the error message.
+func detectGraphCycle(graph map[string]map[string]struct{}) []string {
+	const (
+		unvisited = iota
+		visiting
+		visited
+	)
+	state := make(map[string]int, len(graph))
+	stack := make([]string, 0, len(graph))
+
+	nodes := make([]string, 0, len(graph))
+	for node := range graph {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	var visit func(string) []string
+	visit = func(node string) []string {
+		state[node] = visiting
+		stack = append(stack, node)
+		succs := sortedSetKeys(graph[node])
+		for _, next := range succs {
+			switch state[next] {
+			case unvisited:
+				if cycle := visit(next); len(cycle) > 0 {
+					return cycle
+				}
+			case visiting:
+				return graphCyclePath(stack, next)
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[node] = visited
+		return nil
+	}
+
+	for _, node := range nodes {
+		if state[node] != unvisited {
+			continue
+		}
+		if cycle := visit(node); len(cycle) > 0 {
+			return cycle
+		}
+	}
+	return nil
+}
+
+func graphCyclePath(stack []string, repeated string) []string {
+	start := 0
+	for idx, node := range stack {
+		if node == repeated {
+			start = idx
+			break
+		}
+	}
+	cycle := append([]string{}, stack[start:]...)
+	cycle = append(cycle, repeated)
+	return cycle
+}

--- a/internal/freshness/graph_test.go
+++ b/internal/freshness/graph_test.go
@@ -1,0 +1,90 @@
+package freshness
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+func produces(alias, name string) models.DatasetDeclaration {
+	return models.DatasetDeclaration{JobAlias: alias, Direction: models.DatasetDirectionProduces, Name: name}
+}
+
+func consumes(alias, name string) models.DatasetDeclaration {
+	return models.DatasetDeclaration{JobAlias: alias, Direction: models.DatasetDirectionConsumes, Name: name}
+}
+
+func source(alias, name string, external bool) models.DatasetDeclaration {
+	return models.DatasetDeclaration{JobAlias: alias, Direction: models.DatasetDirectionSource, Name: name, External: external}
+}
+
+func TestValidateGraphAcceptsValidChain(t *testing.T) {
+	decls := []models.DatasetDeclaration{
+		source("orders", "raw.vendor_x", true),
+		consumes("orders", "raw.vendor_x"),
+		produces("orders", "staging.orders"),
+		consumes("rollup", "staging.orders"),
+		produces("rollup", "analytics.orders_daily"),
+	}
+	if err := ValidateGraph(decls); err != nil {
+		t.Fatalf("expected valid graph, got %v", err)
+	}
+}
+
+func TestValidateGraphRejectsTwoProducers(t *testing.T) {
+	decls := []models.DatasetDeclaration{
+		produces("job_a", "analytics.orders_daily"),
+		produces("job_b", "analytics.orders_daily"),
+	}
+	err := ValidateGraph(decls)
+	if !errors.Is(err, ErrDatasetMultipleProducers) {
+		t.Fatalf("expected ErrDatasetMultipleProducers, got %v", err)
+	}
+}
+
+func TestValidateGraphRejectsUnresolvedConsume(t *testing.T) {
+	decls := []models.DatasetDeclaration{
+		consumes("rollup", "nowhere.dataset"),
+	}
+	err := ValidateGraph(decls)
+	if !errors.Is(err, ErrDatasetUnresolvedConsumes) {
+		t.Fatalf("expected ErrDatasetUnresolvedConsumes, got %v", err)
+	}
+}
+
+func TestValidateGraphResolvesExternalSource(t *testing.T) {
+	decls := []models.DatasetDeclaration{
+		source("orders", "raw.vendor_x", true),
+		consumes("orders", "raw.vendor_x"),
+	}
+	if err := ValidateGraph(decls); err != nil {
+		t.Fatalf("external source should resolve consume, got %v", err)
+	}
+}
+
+func TestValidateGraphRejectsCrossJobCycle(t *testing.T) {
+	// job_a produces X and consumes Y; job_b produces Y and consumes X → cycle.
+	decls := []models.DatasetDeclaration{
+		produces("job_a", "X"),
+		consumes("job_a", "Y"),
+		produces("job_b", "Y"),
+		consumes("job_b", "X"),
+	}
+	err := ValidateGraph(decls)
+	if !errors.Is(err, ErrDatasetGraphCycle) {
+		t.Fatalf("expected ErrDatasetGraphCycle, got %v", err)
+	}
+}
+
+func TestValidateGraphAllowsSelfProduceAndConsume(t *testing.T) {
+	// A job consuming a dataset it also produces must not be treated as a cycle
+	// (it is a within-job step ordering, not a cross-job derivation loop).
+	decls := []models.DatasetDeclaration{
+		produces("job_a", "staging.orders"),
+		consumes("job_a", "staging.orders"),
+	}
+	if err := ValidateGraph(decls); err != nil {
+		t.Fatalf("self produce/consume must be allowed, got %v", err)
+	}
+}

--- a/internal/freshness/registry.go
+++ b/internal/freshness/registry.go
@@ -1,0 +1,171 @@
+// Package freshness holds the data-freshness scheduling substrate: the declared
+// dataset registry (this file) and — in later streams — the dataset state store
+// and the leader-gated evaluator. The declared registry is the complement to
+// the observed lineage graph: it is rebuilt from job manifests on every apply
+// and requires no OpenLineage.
+package freshness
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// Registry is the typed store over the declared dataset graph
+// (dataset_declarations). It is a projection of the applied manifest set — the
+// importer rebuilds a job's rows on every apply and prunes them on retire — so
+// callers read it as the authoritative declared graph.
+type Registry struct {
+	db *gorm.DB
+}
+
+// NewRegistry constructs a Registry over the provided connection.
+func NewRegistry(db *gorm.DB) *Registry {
+	return &Registry{db: db}
+}
+
+// BuildDeclarations projects a validated job definition into the declaration
+// rows that represent its slice of the declared graph: one row per declared
+// source, produced dataset, and consumed dataset. The definition must have
+// passed schema.Definition.Validate first. jobID/jobAlias identify the owning
+// job (jobAlias is denormalized onto each row for cross-job lint).
+func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string) ([]models.DatasetDeclaration, error) {
+	if def == nil {
+		return nil, nil
+	}
+	alias := strings.TrimSpace(jobAlias)
+	if alias == "" {
+		alias = strings.TrimSpace(def.Metadata.Alias)
+	}
+
+	decls := make([]models.DatasetDeclaration, 0)
+
+	if def.Metadata.Datasets != nil {
+		for i := range def.Metadata.Datasets.Sources {
+			src := &def.Metadata.Datasets.Sources[i]
+			name := strings.TrimSpace(src.Name)
+			if name == "" {
+				continue
+			}
+			binding, err := marshalArrivalBinding(src.Arrival)
+			if err != nil {
+				return nil, err
+			}
+			decls = append(decls, models.DatasetDeclaration{
+				ID:             uuid.New(),
+				JobID:          jobID,
+				JobAlias:       alias,
+				Name:           name,
+				Direction:      models.DatasetDirectionSource,
+				ExpectedEvery:  strings.TrimSpace(src.ExpectedEvery),
+				External:       src.External,
+				ArrivalBinding: binding,
+			})
+		}
+	}
+
+	for i := range def.Steps {
+		step := &def.Steps[i]
+		if step.Datasets == nil {
+			continue
+		}
+		for j := range step.Datasets.Produces {
+			p := &step.Datasets.Produces[j]
+			name := strings.TrimSpace(p.Name)
+			if name == "" {
+				continue
+			}
+			watermarkKey := ""
+			if p.Watermark != nil {
+				watermarkKey = strings.TrimSpace(p.Watermark.Key)
+			}
+			decls = append(decls, models.DatasetDeclaration{
+				ID:           uuid.New(),
+				JobID:        jobID,
+				JobAlias:     alias,
+				StepName:     step.Name,
+				Name:         name,
+				Direction:    models.DatasetDirectionProduces,
+				Freshness:    strings.TrimSpace(p.Freshness),
+				MaxStaleness: strings.TrimSpace(p.MaxStaleness),
+				WatermarkKey: watermarkKey,
+			})
+		}
+		for _, raw := range step.Datasets.Consumes {
+			name := strings.TrimSpace(raw)
+			if name == "" {
+				continue
+			}
+			decls = append(decls, models.DatasetDeclaration{
+				ID:        uuid.New(),
+				JobID:     jobID,
+				JobAlias:  alias,
+				StepName:  step.Name,
+				Name:      name,
+				Direction: models.DatasetDirectionConsumes,
+			})
+		}
+	}
+
+	return decls, nil
+}
+
+func marshalArrivalBinding(arrival *schema.Arrival) (datatypes.JSON, error) {
+	if arrival == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(arrival)
+	if err != nil {
+		return nil, err
+	}
+	return datatypes.JSON(data), nil
+}
+
+// ReplaceForJobTx rebuilds a single job's declarations inside an existing
+// transaction: it hard-deletes the job's current rows and inserts the supplied
+// set. This is the per-apply upsert seam — rebuilding from the manifest means a
+// declaration removed from the manifest is pruned. Passing an empty slice
+// clears the job's declarations (a job that dropped its datasets surface).
+func ReplaceForJobTx(tx *gorm.DB, jobID uuid.UUID, decls []models.DatasetDeclaration) error {
+	if err := tx.Where("job_id = ?", jobID).Delete(&models.DatasetDeclaration{}).Error; err != nil {
+		return err
+	}
+	if len(decls) == 0 {
+		return nil
+	}
+	return tx.Create(&decls).Error
+}
+
+// DeleteForJobsTx removes all declarations for the given jobs inside an existing
+// transaction. Used when jobs are retired/pruned so the declared graph never
+// references a job that no longer exists.
+func DeleteForJobsTx(tx *gorm.DB, jobIDs []uuid.UUID) error {
+	if len(jobIDs) == 0 {
+		return nil
+	}
+	return tx.Where("job_id IN ?", jobIDs).Delete(&models.DatasetDeclaration{}).Error
+}
+
+// ListAll returns every declaration in the registry.
+func (r *Registry) ListAll(ctx context.Context) ([]models.DatasetDeclaration, error) {
+	var out []models.DatasetDeclaration
+	if err := r.db.WithContext(ctx).Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// ListByJob returns the declarations owned by a single job.
+func (r *Registry) ListByJob(ctx context.Context, jobID uuid.UUID) ([]models.DatasetDeclaration, error) {
+	var out []models.DatasetDeclaration
+	if err := r.db.WithContext(ctx).Where("job_id = ?", jobID).Find(&out).Error; err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/freshness/registry_test.go
+++ b/internal/freshness/registry_test.go
@@ -1,0 +1,157 @@
+package freshness
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func openRegistryDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := "file:" + uuid.NewString() + "?mode=memory&cache=shared&_busy_timeout=5000"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("sql.DB: %v", err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(models.All...); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+const registrySampleJob = `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: orders-daily
+  datasets:
+    sources:
+      - name: raw.vendor_x
+        expectedEvery: 24h
+        external: true
+        arrival:
+          event:
+            type: "s3:ObjectCreated"
+          watermark: "$.detail.object.key"
+trigger:
+  type: cron
+  configuration: {expression: "0 */6 * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+    datasets:
+      consumes: [raw.vendor_x]
+      produces:
+        - name: staging.orders
+          freshness: 8h
+          watermark: { key: max_order_ts }
+`
+
+func TestBuildDeclarations(t *testing.T) {
+	def, err := schema.Parse([]byte(registrySampleJob))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	jobID := uuid.New()
+	decls, err := BuildDeclarations(def, jobID, def.Metadata.Alias)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	// 1 source + 1 consume + 1 produce
+	if len(decls) != 3 {
+		t.Fatalf("expected 3 declarations, got %d: %+v", len(decls), decls)
+	}
+
+	byDir := map[string]models.DatasetDeclaration{}
+	for _, d := range decls {
+		byDir[d.Direction] = d
+		if d.JobID != jobID || d.JobAlias != "orders-daily" {
+			t.Fatalf("declaration missing job identity: %+v", d)
+		}
+	}
+
+	src := byDir[models.DatasetDirectionSource]
+	if src.Name != "raw.vendor_x" || src.ExpectedEvery != "24h" || !src.External {
+		t.Fatalf("unexpected source declaration: %+v", src)
+	}
+	if len(src.ArrivalBinding) == 0 {
+		t.Fatalf("expected arrival binding JSON on source")
+	}
+	var arrival schema.Arrival
+	if err := json.Unmarshal(src.ArrivalBinding, &arrival); err != nil {
+		t.Fatalf("arrival binding not valid JSON: %v", err)
+	}
+	if arrival.Watermark != "$.detail.object.key" {
+		t.Fatalf("arrival binding watermark = %q", arrival.Watermark)
+	}
+
+	prod := byDir[models.DatasetDirectionProduces]
+	if prod.Name != "staging.orders" || prod.Freshness != "8h" || prod.WatermarkKey != "max_order_ts" || prod.StepName != "extract" {
+		t.Fatalf("unexpected produce declaration: %+v", prod)
+	}
+
+	con := byDir[models.DatasetDirectionConsumes]
+	if con.Name != "raw.vendor_x" || con.StepName != "extract" {
+		t.Fatalf("unexpected consume declaration: %+v", con)
+	}
+}
+
+func TestReplaceForJobTxRebuildsAndPrunes(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	reg := NewRegistry(db)
+	jobID := uuid.New()
+
+	decls := []models.DatasetDeclaration{
+		{ID: uuid.New(), JobID: jobID, JobAlias: "j", Name: "a", Direction: models.DatasetDirectionProduces},
+		{ID: uuid.New(), JobID: jobID, JobAlias: "j", Name: "b", Direction: models.DatasetDirectionConsumes},
+	}
+	if err := ReplaceForJobTx(db, jobID, decls); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	got, err := reg.ListByJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(got))
+	}
+
+	// Rebuild with a smaller set → the removed declaration is pruned.
+	fewer := []models.DatasetDeclaration{
+		{ID: uuid.New(), JobID: jobID, JobAlias: "j", Name: "a", Direction: models.DatasetDirectionProduces},
+	}
+	if err := ReplaceForJobTx(db, jobID, fewer); err != nil {
+		t.Fatalf("replace 2: %v", err)
+	}
+	got, err = reg.ListByJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("list 2: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != "a" {
+		t.Fatalf("expected only dataset 'a' after rebuild, got %+v", got)
+	}
+
+	// DeleteForJobsTx clears the job entirely.
+	if err := DeleteForJobsTx(db, []uuid.UUID{jobID}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	got, err = reg.ListAll(ctx)
+	if err != nil {
+		t.Fatalf("list all: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("expected 0 rows after delete, got %d", len(got))
+	}
+}

--- a/internal/jobdef/dataset_graph.go
+++ b/internal/jobdef/dataset_graph.go
@@ -1,0 +1,96 @@
+package jobdef
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/freshness"
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ValidateDatasetGraph runs the cross-job declared-graph lint over the incoming
+// definitions PLUS the persisted declarations of jobs that are not being
+// replaced: exactly one job produces a given dataset, every consumed dataset
+// resolves to a produced dataset or a declared source across the whole set, and
+// the declared graph is acyclic across jobs. It is the batch counterpart to the
+// per-definition dataset validation in pkg/jobdef (which sees one job at a time
+// and cannot prove a cross-job cycle or a duplicate producer).
+//
+// conn may be nil (e.g. `caesium job lint` with no server), in which case only
+// the incoming set is checked. The pure graph algorithm lives in
+// internal/freshness so it is unit-testable without a database.
+func ValidateDatasetGraph(ctx context.Context, conn *gorm.DB, defs []schema.Definition) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	incomingAliases := make(map[string]struct{}, len(defs))
+	decls := make([]models.DatasetDeclaration, 0)
+	for i := range defs {
+		alias := strings.TrimSpace(defs[i].Metadata.Alias)
+		if alias == "" {
+			return fmt.Errorf("definition %d: metadata.alias is required", i)
+		}
+		incomingAliases[alias] = struct{}{}
+		built, err := freshness.BuildDeclarations(&defs[i], uuid.Nil, alias)
+		if err != nil {
+			return err
+		}
+		decls = append(decls, built...)
+	}
+
+	existing, err := existingDatasetDeclarations(ctx, conn, incomingAliases)
+	if err != nil {
+		return err
+	}
+	decls = append(decls, existing...)
+
+	return freshness.ValidateGraph(decls)
+}
+
+// existingDatasetDeclarations loads persisted declarations for live jobs,
+// excluding any job whose alias (or job id) appears in the incoming set — those
+// declarations are being replaced by this apply and must not double-count as a
+// second producer or a stale edge, mirroring the trigger-chain exclusion.
+func existingDatasetDeclarations(ctx context.Context, conn *gorm.DB, incomingAliases map[string]struct{}) ([]models.DatasetDeclaration, error) {
+	if conn == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	incomingJobIDs, err := existingJobIDsByAlias(ctx, conn, incomingAliases)
+	if err != nil {
+		return nil, err
+	}
+	incomingJobIDSet := make(map[uuid.UUID]struct{}, len(incomingJobIDs))
+	for _, id := range incomingJobIDs {
+		incomingJobIDSet[id] = struct{}{}
+	}
+
+	var rows []models.DatasetDeclaration
+	err = conn.WithContext(ctx).
+		Where("job_id IN (SELECT id FROM jobs WHERE deleted_at IS NULL)").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]models.DatasetDeclaration, 0, len(rows))
+	for idx := range rows {
+		row := rows[idx]
+		if _, replaced := incomingAliases[strings.TrimSpace(row.JobAlias)]; replaced {
+			continue
+		}
+		if _, replaced := incomingJobIDSet[row.JobID]; replaced {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out, nil
+}

--- a/internal/jobdef/importer.go
+++ b/internal/jobdef/importer.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/freshness"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/dqlite"
@@ -150,6 +151,9 @@ func (i *Importer) ApplyWithOptions(ctx context.Context, def *schema.Definition,
 				return err
 			}
 			if err := i.reconcileCallbacksTx(tx, jobModel.ID, def.Callbacks); err != nil {
+				return err
+			}
+			if err := i.reconcileDatasetDeclarationsTx(tx, jobModel, def); err != nil {
 				return err
 			}
 			if err := i.softDeleteAtomsTx(tx, retiredAtomIDs); err != nil {
@@ -929,6 +933,21 @@ func callbackSignature(cbType models.CallbackType, cfg string) string {
 	return string(cbType) + "\x00" + cfg
 }
 
+// reconcileDatasetDeclarationsTx rebuilds this job's slice of the declared
+// dataset graph from the manifest. Rebuilding (rather than diffing) means a
+// declaration removed from the manifest is pruned. Declarations are scheduling
+// metadata only and never touch the cache identity or the execution path.
+func (i *Importer) reconcileDatasetDeclarationsTx(tx *gorm.DB, jobModel *models.Job, def *schema.Definition) error {
+	decls, err := freshness.BuildDeclarations(def, jobModel.ID, jobModel.Alias)
+	if err != nil {
+		return fmt.Errorf("dataset declarations: %w", err)
+	}
+	if err := freshness.ReplaceForJobTx(tx, jobModel.ID, decls); err != nil {
+		return fmt.Errorf("dataset declarations: %w", err)
+	}
+	return nil
+}
+
 func (i *Importer) softDeleteAtomsTx(tx *gorm.DB, atomIDs []uuid.UUID) error {
 	if len(atomIDs) == 0 {
 		return nil
@@ -961,6 +980,12 @@ func (i *Importer) retireJobsTx(tx *gorm.DB, jobs []*models.Job) error {
 	}
 
 	if err := tx.Where("job_id IN ?", jobIDs).Delete(&models.Callback{}).Error; err != nil {
+		return err
+	}
+
+	// dataset_declarations is a rebuilt-from-manifest projection, so a retired
+	// job's declarations are hard-deleted rather than left dangling.
+	if err := freshness.DeleteForJobsTx(tx, jobIDs); err != nil {
 		return err
 	}
 

--- a/internal/jobdef/trigger_cycle.go
+++ b/internal/jobdef/trigger_cycle.go
@@ -37,7 +37,10 @@ func (i *Importer) ValidateBatch(ctx context.Context, defs []schema.Definition) 
 			return fmt.Errorf("definition %s: %w", defs[idx].Metadata.Alias, err)
 		}
 	}
-	return ValidateTriggerChains(ctx, i.db, defs)
+	if err := ValidateTriggerChains(ctx, i.db, defs); err != nil {
+		return err
+	}
+	return ValidateDatasetGraph(ctx, i.db, defs)
 }
 
 func ValidateTriggerChains(ctx context.Context, conn *gorm.DB, defs []schema.Definition) error {

--- a/internal/models/dataset_declaration.go
+++ b/internal/models/dataset_declaration.go
@@ -1,0 +1,75 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// Dataset declaration direction values. They mirror the jobdef constants
+// (pkg/jobdef.DatasetDirection*) and are duplicated here so the models package
+// stays free of a jobdef import.
+const (
+	DatasetDirectionProduces = "produces"
+	DatasetDirectionConsumes = "consumes"
+	DatasetDirectionSource   = "source"
+)
+
+// DatasetDeclaration is the persisted *declared* dataset graph — the
+// complement to the *observed* LineageDataset graph (which requires
+// OpenLineage). One row is written per (job, step, dataset, direction)
+// relationship declared in a job's `datasets` surface, rebuilt from the
+// manifest on every apply so a removed declaration is pruned. It stores only
+// scheduling metadata (SLOs, watermark key, arrival binding); it never enters
+// the cache identity and is not a hot per-run table.
+//
+// Dataset identity is keyed on Name in v1. Namespace is nullable and carried
+// from day one (per the design's Non-goals) so cross-instance namespacing can
+// be added later without a migration rewrite; it is not populated in v1.
+type DatasetDeclaration struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+
+	// JobID links this declaration to its job. Rows are cascade-deleted when the
+	// job is hard-deleted; the importer also rebuilds a job's declarations on
+	// every apply and prunes them when the job is retired.
+	JobID uuid.UUID `gorm:"type:uuid;not null;index:idx_dataset_decl_job" json:"job_id"`
+	Job   Job       `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+
+	// JobAlias is denormalized so the cross-job lint can resolve producers and
+	// build the derivation graph without joining back to jobs.
+	JobAlias string `gorm:"type:text;not null;index:idx_dataset_decl_alias" json:"job_alias"`
+
+	// StepName is the producing/consuming step. It is empty for a
+	// metadata-level source declaration (direction=source).
+	StepName string `gorm:"type:text;not null;default:''" json:"step_name"`
+
+	// Namespace is nullable (reserved for cross-instance datasets, unused in v1).
+	// Name is the dataset identity the whole feature keys on.
+	Namespace *string `gorm:"type:text;index:idx_dataset_decl_identity,priority:1" json:"namespace,omitempty"`
+	Name      string  `gorm:"type:text;not null;index:idx_dataset_decl_identity,priority:2" json:"name"`
+
+	// Direction is one of DatasetDirectionProduces / Consumes / Source.
+	Direction string `gorm:"type:text;not null;index:idx_dataset_decl_identity,priority:3" json:"direction"`
+
+	// Freshness / MaxStaleness are the produced dataset's SLO (Go duration
+	// strings). ExpectedEvery is the source dataset's cadence expectation. All
+	// empty when not applicable to the direction.
+	Freshness     string `gorm:"type:text;not null;default:''" json:"freshness,omitempty"`
+	MaxStaleness  string `gorm:"type:text;not null;default:''" json:"max_staleness,omitempty"`
+	ExpectedEvery string `gorm:"type:text;not null;default:''" json:"expected_every,omitempty"`
+
+	// WatermarkKey is the ##caesium::output key a producing step emits to
+	// advance the dataset. Empty in degraded mode (no declared watermark).
+	WatermarkKey string `gorm:"type:text;not null;default:''" json:"watermark_key,omitempty"`
+
+	// External marks a source dataset nobody in Caesium produces.
+	External bool `gorm:"not null;default:false" json:"external"`
+
+	// ArrivalBinding is the source dataset's arrival event pattern + watermark
+	// JSONPath, stored as JSON. Empty for produced/consumed declarations.
+	ArrivalBinding datatypes.JSON `gorm:"type:json" json:"arrival_binding,omitempty"`
+
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"not null" json:"updated_at"`
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -40,4 +40,8 @@ var All = []interface{}{
 	// dag_snapshots is append-only topology history (data-plane-memory B1).
 	// Must follow Job (FK parent) so AutoMigrate creates the parent table first.
 	&DagSnapshot{},
+	// dataset_declarations is the declared dataset graph (freshness A2). Must
+	// follow Job (FK parent). Rebuilt from the manifest on every apply; not a
+	// hot per-run table.
+	&DatasetDeclaration{},
 }

--- a/pkg/jobdef/datasets_test.go
+++ b/pkg/jobdef/datasets_test.go
@@ -113,6 +113,16 @@ func TestValidateDatasetsRejectsBadInputs(t *testing.T) {
 			want: "maxStaleness",
 		},
 		{
+			name: "non-positive freshness duration",
+			yaml: datasetStep(`produces: [{name: a, freshness: "-6h"}]`),
+			want: "freshness \"-6h\" must be a positive duration",
+		},
+		{
+			name: "zero maxStaleness duration",
+			yaml: datasetStep(`produces: [{name: a, maxStaleness: "0s"}]`),
+			want: "maxStaleness \"0s\" must be a positive duration",
+		},
+		{
 			name: "watermark without key",
 			yaml: datasetStep(`produces: [{name: a, watermark: {}}]`),
 			want: "watermark.key is required",

--- a/pkg/jobdef/datasets_test.go
+++ b/pkg/jobdef/datasets_test.go
@@ -1,0 +1,265 @@
+package jobdef
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/cache"
+)
+
+const datasetsJob = `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: orders-daily
+  datasets:
+    sources:
+      - name: raw.vendor_x
+        expectedEvery: 24h
+        external: true
+        arrival:
+          event:
+            type: "s3:ObjectCreated"
+            filter: { "detail.bucket.name": "vendor-x-drop" }
+          watermark: "$.detail.object.key"
+trigger:
+  type: cron
+  configuration:
+    expression: "0 */6 * * *"
+steps:
+  - name: extract
+    image: etl:1.4
+    datasets:
+      consumes: [raw.vendor_x]
+      produces:
+        - name: staging.orders
+          freshness: 8h
+          watermark: { key: max_order_ts }
+  - name: transform
+    image: etl:1.4
+    datasets:
+      consumes: [staging.orders]
+      produces:
+        - name: analytics.orders_daily
+          freshness: 6h
+          maxStaleness: 12h
+          watermark: { key: max_order_ts }
+`
+
+func TestParseDatasetsSurface(t *testing.T) {
+	def, err := Parse([]byte(datasetsJob))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if def.Metadata.Datasets == nil || len(def.Metadata.Datasets.Sources) != 1 {
+		t.Fatalf("expected 1 source, got %+v", def.Metadata.Datasets)
+	}
+	src := def.Metadata.Datasets.Sources[0]
+	if src.Name != "raw.vendor_x" || src.ExpectedEvery != "24h" || !src.External {
+		t.Fatalf("unexpected source: %+v", src)
+	}
+	if src.Arrival == nil || src.Arrival.Event == nil || src.Arrival.Event.Type != "s3:ObjectCreated" {
+		t.Fatalf("unexpected arrival: %+v", src.Arrival)
+	}
+	if src.Arrival.Watermark != "$.detail.object.key" {
+		t.Fatalf("unexpected arrival watermark: %q", src.Arrival.Watermark)
+	}
+
+	extract := def.Steps[0]
+	if extract.Datasets == nil || len(extract.Datasets.Consumes) != 1 || extract.Datasets.Consumes[0] != "raw.vendor_x" {
+		t.Fatalf("unexpected extract consumes: %+v", extract.Datasets)
+	}
+	if len(extract.Datasets.Produces) != 1 {
+		t.Fatalf("expected 1 produced dataset")
+	}
+	p := extract.Datasets.Produces[0]
+	if p.Name != "staging.orders" || p.Freshness != "8h" || p.Watermark == nil || p.Watermark.Key != "max_order_ts" {
+		t.Fatalf("unexpected produced dataset: %+v", p)
+	}
+}
+
+// datasetStep builds a minimal single-step job whose step carries the provided
+// inline `datasets:` body, for table-driven validation tests.
+func datasetStep(datasetsBody string) string {
+	return `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: s
+    image: etl:1
+    datasets: {` + datasetsBody + `}
+`
+}
+
+func TestValidateDatasetsRejectsBadInputs(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "bad freshness duration",
+			yaml: datasetStep(`produces: [{name: a, freshness: "6hours"}]`),
+			want: "freshness",
+		},
+		{
+			name: "bad maxStaleness duration",
+			yaml: datasetStep(`produces: [{name: a, maxStaleness: nope}]`),
+			want: "maxStaleness",
+		},
+		{
+			name: "watermark without key",
+			yaml: datasetStep(`produces: [{name: a, watermark: {}}]`),
+			want: "watermark.key is required",
+		},
+		{
+			name: "duplicate produced name",
+			yaml: datasetStep(`produces: [{name: a}, {name: a}]`),
+			want: "produced more than once",
+		},
+		{
+			name: "empty consumes entry",
+			yaml: datasetStep(`consumes: [""]`),
+			want: "must not be empty",
+		},
+		{
+			name: "duplicate consumes entry",
+			yaml: datasetStep(`consumes: [a, a]`),
+			want: "duplicate entry",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateDatasetsRejectsBadArrivalJSONPath(t *testing.T) {
+	y := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+  datasets:
+    sources:
+      - name: raw.x
+        arrival:
+          watermark: "not a jsonpath"
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: s
+    image: etl:1
+`
+	_, err := Parse([]byte(y))
+	if err == nil || !strings.Contains(err.Error(), "arrival.watermark") {
+		t.Fatalf("expected arrival.watermark error, got %v", err)
+	}
+}
+
+// TestValidateDatasetsAllowsCrossJobConsume asserts the single-definition
+// validator does NOT reject a consumes name that resolves to no dataset in this
+// job — cross-job resolution is the batch validator's responsibility (A3).
+func TestValidateDatasetsAllowsCrossJobConsume(t *testing.T) {
+	y := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: downstream
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: rollup
+    image: etl:1
+    datasets:
+      consumes: [analytics.orders_daily]
+`
+	if _, err := Parse([]byte(y)); err != nil {
+		t.Fatalf("cross-job consume should validate at single-def level, got %v", err)
+	}
+}
+
+// TestDatasetsDoNotAffectCacheHash proves datasets are scheduling metadata:
+// adding a datasets block to a step leaves the container spec that feeds the
+// cache identity — and thus HashInput.Compute() — byte-identical.
+func TestDatasetsDoNotAffectCacheHash(t *testing.T) {
+	base := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+    command: ["sh", "-c", "run"]
+`
+	withDatasets := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+  datasets:
+    sources:
+      - name: raw.x
+        external: true
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+    command: ["sh", "-c", "run"]
+    datasets:
+      consumes: [raw.x]
+      produces:
+        - name: staging.orders
+          freshness: 6h
+          maxStaleness: 12h
+          watermark: { key: max_order_ts }
+`
+
+	hashFor := func(y string) string {
+		def, err := Parse([]byte(y))
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		step := &def.Steps[0]
+		spec, err := def.RuntimeSpecForStep(step)
+		if err != nil {
+			t.Fatalf("runtime spec: %v", err)
+		}
+		h := cache.HashInput{
+			JobAlias:             def.Metadata.Alias,
+			TaskName:             step.Name,
+			Image:                step.Image,
+			Command:              step.Command,
+			Env:                  spec.Env,
+			WorkDir:              spec.WorkDir,
+			Mounts:               spec.Mounts,
+			ResolvedVolumeMounts: spec.ResolvedVolumeMounts,
+			Kubernetes:           spec.Kubernetes,
+		}
+		return h.Compute()
+	}
+
+	if got, want := hashFor(withDatasets), hashFor(base); got != want {
+		t.Fatalf("datasets changed the cache hash: with=%s without=%s", got, want)
+	}
+}

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -120,6 +120,9 @@ type Metadata struct {
 	ServiceAccountName           string            `yaml:"serviceAccountName,omitempty" json:"serviceAccountName,omitempty"`
 	PodAnnotations               map[string]string `yaml:"podAnnotations,omitempty" json:"podAnnotations,omitempty"`
 	AutomountServiceAccountToken *bool             `yaml:"automountServiceAccountToken,omitempty" json:"automountServiceAccountToken,omitempty"`
+	// Datasets declares the external source datasets this job's steps consume.
+	// It is scheduling metadata for freshness and does not affect the cache hash.
+	Datasets *MetadataDatasets `yaml:"datasets,omitempty" json:"datasets,omitempty"`
 }
 
 // Concurrency controls admission of new runs for the same job.
@@ -210,6 +213,80 @@ type StepRateLimit struct {
 	Units    int    `yaml:"units" json:"units"`
 }
 
+// Dataset direction constants describe how a declaration relates a step (or the
+// job's metadata) to a dataset. They are the canonical values persisted on the
+// DatasetDeclaration registry model and read by the cross-job lint.
+const (
+	// DatasetDirectionProduces marks a dataset a step produces (carries the SLO).
+	DatasetDirectionProduces = "produces"
+	// DatasetDirectionConsumes marks a dataset a step consumes.
+	DatasetDirectionConsumes = "consumes"
+	// DatasetDirectionSource marks an external dataset declared under
+	// metadata.datasets.sources that nobody in this instance produces.
+	DatasetDirectionSource = "source"
+)
+
+// Watermark identifies the ##caesium::output key a producing step emits to
+// advance its dataset. It is not a JSONPath — it names an output key on the
+// existing zero-SDK output contract (echo '##caesium::output {"<key>": ...}').
+type Watermark struct {
+	Key string `yaml:"key,omitempty" json:"key,omitempty"`
+}
+
+// ProducedDataset declares a dataset a step produces plus the freshness SLO
+// consumers care about. The SLO fields are scheduling metadata, not execution
+// inputs — they never enter the cache identity hash.
+type ProducedDataset struct {
+	// Name is the dataset identity (keyed on name in v1; namespace is reserved).
+	Name string `yaml:"name" json:"name"`
+	// Freshness is the target staleness SLO as a Go duration string (e.g. "6h").
+	Freshness string `yaml:"freshness,omitempty" json:"freshness,omitempty"`
+	// MaxStaleness is the hard bound whose breach emits freshness_violated.
+	MaxStaleness string `yaml:"maxStaleness,omitempty" json:"maxStaleness,omitempty"`
+	// Watermark names the output key this step emits to advance the dataset.
+	Watermark *Watermark `yaml:"watermark,omitempty" json:"watermark,omitempty"`
+}
+
+// StepDatasets is the per-step datasets surface: the datasets a step consumes
+// and the datasets it produces (with their freshness SLOs).
+type StepDatasets struct {
+	Consumes []string          `yaml:"consumes,omitempty" json:"consumes,omitempty"`
+	Produces []ProducedDataset `yaml:"produces,omitempty" json:"produces,omitempty"`
+}
+
+// ArrivalEvent is the event pattern a source dataset's arrival binds to. It
+// mirrors the shipped event-trigger matcher shape (type + string filter).
+type ArrivalEvent struct {
+	Type   string            `yaml:"type,omitempty" json:"type,omitempty"`
+	Filter map[string]string `yaml:"filter,omitempty" json:"filter,omitempty"`
+}
+
+// Arrival binds an external event to a source dataset advance: when an ingested
+// event matches Event, Watermark (a JSONPath into the event payload) is
+// extracted as the new watermark value.
+type Arrival struct {
+	Event     *ArrivalEvent `yaml:"event,omitempty" json:"event,omitempty"`
+	Watermark string        `yaml:"watermark,omitempty" json:"watermark,omitempty"`
+}
+
+// SourceDataset declares an external dataset nobody in Caesium produces — the
+// upstream a consuming step depends on. expectedEvery is a cadence expectation;
+// a late arrival surfaces as stale-upstream rather than a failed run.
+type SourceDataset struct {
+	Name          string   `yaml:"name" json:"name"`
+	ExpectedEvery string   `yaml:"expectedEvery,omitempty" json:"expectedEvery,omitempty"`
+	Arrival       *Arrival `yaml:"arrival,omitempty" json:"arrival,omitempty"`
+	// External marks the dataset as intentionally produced outside Caesium so
+	// the cross-job lint does not demand a producing job.
+	External bool `yaml:"external,omitempty" json:"external,omitempty"`
+}
+
+// MetadataDatasets is the job-level datasets surface: the external source
+// datasets the job's steps consume.
+type MetadataDatasets struct {
+	Sources []SourceDataset `yaml:"sources,omitempty" json:"sources,omitempty"`
+}
+
 // Step defines an execution step.
 type Step struct {
 	Name         string            `yaml:"name" json:"name"`
@@ -241,8 +318,11 @@ type Step struct {
 	OutputSchema map[string]any `yaml:"outputSchema,omitempty" json:"outputSchema,omitempty"`
 	// InputSchema maps predecessor step names to JSON Schema fragments describing
 	// which keys this step requires from each predecessor's output.
-	InputSchema    map[string]map[string]any `yaml:"inputSchema,omitempty" json:"inputSchema,omitempty"`
-	Cache          interface{}               `yaml:"cache,omitempty" json:"cache"`
+	InputSchema map[string]map[string]any `yaml:"inputSchema,omitempty" json:"inputSchema,omitempty"`
+	// Datasets declares the datasets this step consumes and produces. It is
+	// scheduling metadata for freshness and does not affect the cache hash.
+	Datasets       *StepDatasets `yaml:"datasets,omitempty" json:"datasets,omitempty"`
+	Cache          interface{}   `yaml:"cache,omitempty" json:"cache"`
 	container.Spec `yaml:",inline" json:",inline"`
 }
 
@@ -270,6 +350,7 @@ func (s *Step) UnmarshalYAML(value *yaml.Node) error {
 		RateLimit                    *StepRateLimit            `yaml:"rateLimit"`
 		OutputSchema                 map[string]any            `yaml:"outputSchema"`
 		InputSchema                  map[string]map[string]any `yaml:"inputSchema"`
+		Datasets                     *StepDatasets             `yaml:"datasets"`
 		Cache                        interface{}               `yaml:"cache"`
 		container.Spec               `yaml:",inline"`
 	}
@@ -316,6 +397,7 @@ func (s *Step) UnmarshalYAML(value *yaml.Node) error {
 	s.RateLimit = rs.RateLimit
 	s.OutputSchema = rs.OutputSchema
 	s.InputSchema = rs.InputSchema
+	s.Datasets = rs.Datasets
 	s.Cache = rs.Cache
 	s.Spec = rs.Spec
 
@@ -347,6 +429,7 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 		RateLimit                    *StepRateLimit            `json:"rateLimit"`
 		OutputSchema                 map[string]any            `json:"outputSchema"`
 		InputSchema                  map[string]map[string]any `json:"inputSchema"`
+		Datasets                     *StepDatasets             `json:"datasets"`
 		Cache                        interface{}               `json:"cache"`
 		container.Spec               `json:",inline"`
 	}
@@ -383,6 +466,7 @@ func (s *Step) UnmarshalJSON(data []byte) error {
 	s.RateLimit = rs.RateLimit
 	s.OutputSchema = rs.OutputSchema
 	s.InputSchema = rs.InputSchema
+	s.Datasets = rs.Datasets
 	s.Cache = rs.Cache
 	s.Spec = rs.Spec
 
@@ -441,6 +525,110 @@ func (d *Definition) Validate() error {
 	if err := validateSteps(d.Steps, volumes, rateLimitResources); err != nil {
 		return err
 	}
+	if err := validateDatasets(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateDatasets performs single-definition validation of the datasets
+// surface: SLO fields parse as Go durations, arrival watermarks are well-formed
+// JSONPaths, produced/source names are unique within the job, and consumes
+// entries are non-empty and de-duplicated. It deliberately does NOT reject a
+// consumes name that resolves to no dataset in THIS definition: a step may
+// consume a dataset produced by another job, and that cross-job resolution
+// (produced-in-applied-set / declared-source / external:true) is the batch
+// validator's job (internal/jobdef, item A3), which sees the whole applied set
+// plus persisted declarations. Datasets are scheduling metadata and never enter
+// the cache identity hash.
+func validateDatasets(d *Definition) error {
+	produced := make(map[string]struct{})
+	sources := make(map[string]struct{})
+
+	if d.Metadata.Datasets != nil {
+		for i := range d.Metadata.Datasets.Sources {
+			src := &d.Metadata.Datasets.Sources[i]
+			name := strings.TrimSpace(src.Name)
+			if name == "" {
+				return fmt.Errorf("metadata.datasets.sources[%d].name is required", i)
+			}
+			if _, exists := sources[name]; exists {
+				return fmt.Errorf("metadata.datasets.sources[%d].name %q duplicates another source", i, name)
+			}
+			sources[name] = struct{}{}
+			if strings.TrimSpace(src.ExpectedEvery) != "" {
+				if _, err := time.ParseDuration(src.ExpectedEvery); err != nil {
+					return fmt.Errorf("metadata.datasets.sources[%d].expectedEvery %q must be a valid duration: %w", i, src.ExpectedEvery, err)
+				}
+			}
+			if src.Arrival != nil {
+				if src.Arrival.Event != nil && strings.TrimSpace(src.Arrival.Event.Type) == "" {
+					return fmt.Errorf("metadata.datasets.sources[%d].arrival.event.type is required when event is set", i)
+				}
+				if wm := strings.TrimSpace(src.Arrival.Watermark); wm != "" {
+					if err := validateSimpleJSONPath(wm); err != nil {
+						return fmt.Errorf("metadata.datasets.sources[%d].arrival.watermark: %w", i, err)
+					}
+				}
+			}
+			src.Name = name
+		}
+	}
+
+	for i := range d.Steps {
+		step := &d.Steps[i]
+		if step.Datasets == nil {
+			continue
+		}
+		for j := range step.Datasets.Produces {
+			p := &step.Datasets.Produces[j]
+			name := strings.TrimSpace(p.Name)
+			if name == "" {
+				return fmt.Errorf("steps[%d].datasets.produces[%d].name is required", i, j)
+			}
+			if _, exists := produced[name]; exists {
+				return fmt.Errorf("steps[%d].datasets.produces[%d].name %q is produced more than once in this job", i, j, name)
+			}
+			if _, exists := sources[name]; exists {
+				return fmt.Errorf("steps[%d].datasets.produces[%d].name %q is also declared under metadata.datasets.sources", i, j, name)
+			}
+			produced[name] = struct{}{}
+			if strings.TrimSpace(p.Freshness) != "" {
+				if _, err := time.ParseDuration(p.Freshness); err != nil {
+					return fmt.Errorf("steps[%d].datasets.produces[%d].freshness %q must be a valid duration: %w", i, j, p.Freshness, err)
+				}
+			}
+			if strings.TrimSpace(p.MaxStaleness) != "" {
+				if _, err := time.ParseDuration(p.MaxStaleness); err != nil {
+					return fmt.Errorf("steps[%d].datasets.produces[%d].maxStaleness %q must be a valid duration: %w", i, j, p.MaxStaleness, err)
+				}
+			}
+			if p.Watermark != nil && strings.TrimSpace(p.Watermark.Key) == "" {
+				return fmt.Errorf("steps[%d].datasets.produces[%d].watermark.key is required when watermark is set", i, j)
+			}
+			p.Name = name
+		}
+	}
+
+	for i := range d.Steps {
+		step := &d.Steps[i]
+		if step.Datasets == nil {
+			continue
+		}
+		seen := make(map[string]struct{}, len(step.Datasets.Consumes))
+		for j, raw := range step.Datasets.Consumes {
+			name := strings.TrimSpace(raw)
+			if name == "" {
+				return fmt.Errorf("steps[%d].datasets.consumes[%d] must not be empty", i, j)
+			}
+			if _, dup := seen[name]; dup {
+				return fmt.Errorf("steps[%d].datasets.consumes contains duplicate entry %q", i, name)
+			}
+			seen[name] = struct{}{}
+			step.Datasets.Consumes[j] = name
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -557,8 +557,12 @@ func validateDatasets(d *Definition) error {
 			}
 			sources[name] = struct{}{}
 			if strings.TrimSpace(src.ExpectedEvery) != "" {
-				if _, err := time.ParseDuration(src.ExpectedEvery); err != nil {
+				dur, err := time.ParseDuration(src.ExpectedEvery)
+				if err != nil {
 					return fmt.Errorf("metadata.datasets.sources[%d].expectedEvery %q must be a valid duration: %w", i, src.ExpectedEvery, err)
+				}
+				if dur <= 0 {
+					return fmt.Errorf("metadata.datasets.sources[%d].expectedEvery %q must be a positive duration", i, src.ExpectedEvery)
 				}
 			}
 			if src.Arrival != nil {
@@ -594,13 +598,21 @@ func validateDatasets(d *Definition) error {
 			}
 			produced[name] = struct{}{}
 			if strings.TrimSpace(p.Freshness) != "" {
-				if _, err := time.ParseDuration(p.Freshness); err != nil {
+				dur, err := time.ParseDuration(p.Freshness)
+				if err != nil {
 					return fmt.Errorf("steps[%d].datasets.produces[%d].freshness %q must be a valid duration: %w", i, j, p.Freshness, err)
+				}
+				if dur <= 0 {
+					return fmt.Errorf("steps[%d].datasets.produces[%d].freshness %q must be a positive duration", i, j, p.Freshness)
 				}
 			}
 			if strings.TrimSpace(p.MaxStaleness) != "" {
-				if _, err := time.ParseDuration(p.MaxStaleness); err != nil {
+				dur, err := time.ParseDuration(p.MaxStaleness)
+				if err != nil {
 					return fmt.Errorf("steps[%d].datasets.produces[%d].maxStaleness %q must be a valid duration: %w", i, j, p.MaxStaleness, err)
+				}
+				if dur <= 0 {
+					return fmt.Errorf("steps[%d].datasets.produces[%d].maxStaleness %q must be a positive duration", i, j, p.MaxStaleness)
 				}
 			}
 			if p.Watermark != nil && strings.TrimSpace(p.Watermark.Key) == "" {


### PR DESCRIPTION
## Summary

First implementation wave (W1-α) of [`docs/exec-plans/active/freshness-scheduling.md`](https://github.com/caesium-cloud/caesium/blob/master/docs/exec-plans/active/freshness-scheduling.md) — **Stream A**, the P0 foundation. This is the canonical shared dataset substrate that the `data-circuit-breaker` and `contract-enforcement` plans are written to extend, so the model/field names here are load-bearing.

- **A1 — jobdef surface:** `Step.Datasets` (`consumes: [name…]`, `produces []{name, freshness, maxStaleness, watermark{key}}`) and `Metadata.Datasets.Sources []{name, expectedEvery, arrival{event{type,filter}, watermark}, external}`, wired through the dual `Step`/`rawStep` YAML **and** JSON unmarshalers. Single-definition validation in `Definition.Validate()`: SLO fields parse as Go durations, `arrival.watermark` is a well-formed JSONPath, produced/source names are unique, a watermark requires a key. Cross-job consume-resolution is deliberately deferred to the batch validator (A3) so legitimate cross-job consumes don't false-fail at single-def validate.
- **A2 — registry:** new `DatasetDeclaration` GORM model (canonical table `dataset_declarations`, nullable `namespace` + `name`, direction, SLO fields, watermark key, arrival-binding JSON), registered in `models.All` after `Job`. New `internal/freshness` package with the declared-registry store; the declared graph is rebuilt-from-manifest on the shared `ApplyWithOptions` transaction (covers REST apply, git-sync, CLI apply) and pruned on job retire. Not a hot per-run table.
- **A3 — cross-job lint:** batch validator (single-producer, consume resolution across the applied set **plus** persisted declarations excluding replaced jobs, cross-job acyclicity). Pure graph algorithm in `internal/freshness` (unit-tested); DB glue in `internal/jobdef`. Wired into `ValidateBatch`, `caesium job lint`, and the REST lint controller.
- **No cache change:** datasets are scheduling metadata; a hash-stability test asserts adding a `datasets` block leaves `HashInput.Compute()` byte-identical.

**Canonical names (relied on by sibling plans):** model `DatasetDeclaration`, table `dataset_declarations`, jobdef identity keyed on `name`, nullable `namespace` from day one.

## Test plan

- [x] `gofmt` clean on all changed files
- [x] `go build ./...` — full dqlite-CGO module compiles (verified by orchestrator on a Docker-capable checkout)
- [x] `go vet` clean
- [x] `golangci-lint run` — 0 issues across scoped packages
- [x] `go test ./pkg/jobdef/... ./internal/freshness/... ./internal/models/... ./internal/cache/...` — green (validation cases, single-producer + cross-job-cycle rejection, hash-stability)
- [ ] `just integration-test` — the containerized end-to-end gate runs here in CI (the dev sandbox has no Docker); the plan's Stream-A integration scenarios follow with the operator surface in a later wave

## Notes

- New package `internal/freshness/` (only `registry.go` + `graph.go` this wave; state/evaluator come in Streams B/C). Import direction `internal/jobdef → internal/freshness` is acyclic.
- `pkg/jobdef/schema.go` intentionally untouched — it is exclusively the input/output JSON-Schema validator and holds no jobdef-shape document; the datasets shape lives in the Go structs + `validateDatasets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh)_