### PR TITLE
Add Phase-0 incident substrate: models, ExitCode capture, classifier, subscriber, scrubber, timer (agent-in-the-loop-remediation W1-α)

### DIFF
--- a/api/rest/service/system/system.go
+++ b/api/rest/service/system/system.go
@@ -34,9 +34,10 @@ type Node struct {
 }
 
 type Features struct {
-	DatabaseConsoleEnabled bool   `json:"database_console_enabled"`
-	LogConsoleEnabled      bool   `json:"log_console_enabled"`
-	ExternalURL            string `json:"external_url,omitempty"`
+	DatabaseConsoleEnabled  bool   `json:"database_console_enabled"`
+	LogConsoleEnabled       bool   `json:"log_console_enabled"`
+	ExternalURL             string `json:"external_url,omitempty"`
+	AgentRemediationEnabled bool   `json:"agent_remediation_enabled"`
 }
 
 type Service struct {
@@ -122,8 +123,9 @@ func (s *Service) Nodes() ([]Node, error) {
 func (s *Service) Features() (*Features, error) {
 	v := env.Variables()
 	return &Features{
-		DatabaseConsoleEnabled: v.DatabaseConsoleEnabled,
-		LogConsoleEnabled:      v.LogConsoleEnabled,
-		ExternalURL:            v.APIExternalURL,
+		DatabaseConsoleEnabled:  v.DatabaseConsoleEnabled,
+		LogConsoleEnabled:       v.LogConsoleEnabled,
+		ExternalURL:             v.APIExternalURL,
+		AgentRemediationEnabled: v.AgentRemediationEnabled,
 	}, nil
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -24,6 +24,7 @@ import (
 	dispatchpki "github.com/caesium-cloud/caesium/internal/dispatch/pki"
 	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/executor"
+	"github.com/caesium-cloud/caesium/internal/incident"
 	"github.com/caesium-cloud/caesium/internal/jobdef"
 	"github.com/caesium-cloud/caesium/internal/jobdef/git"
 	"github.com/caesium-cloud/caesium/internal/jobdef/runtime"
@@ -444,6 +445,30 @@ func start(cmd *cobra.Command, args []string) error {
 			if err := watcher.Start(ctx); err != nil && ctx.Err() == nil {
 				log.Error("notification watcher exited", "error", err)
 			}
+		})
+	}
+
+	// --- Agent-in-the-Loop Remediation (Phase 0 incident substrate) ---
+	//
+	// The whole feature is gated behind CAESIUM_AGENT_REMEDIATION_ENABLED; a
+	// deployment that never enables it starts neither the incident subscriber nor
+	// the timer sweeper and pays nothing. Both are leader-gated
+	// (dqlite.IsLocalLeader, like the run-queue dequeuer) so an N-node cluster
+	// opens exactly one incident per failure and fires each durable timer once.
+	if vars.AgentRemediationEnabled {
+		incConn := db.Connection()
+		incidentSub := incident.NewSubscriber(bus, incConn, dqlite.IsLocalLeader, vars.AgentIncidentCooldown)
+		runAsync(func() {
+			log.Info("launching incident subscriber", "cooldown", vars.AgentIncidentCooldown)
+			if err := incidentSub.Start(ctx); err != nil && ctx.Err() == nil {
+				log.Error("incident subscriber exited", "error", err)
+			}
+		})
+
+		timerSweeper := incident.NewTimerSupervisor(incConn, dqlite.IsLocalLeader, 0)
+		runAsync(func() {
+			log.Info("launching incident timer sweeper")
+			timerSweeper.Run(ctx)
 		})
 	}
 

--- a/internal/atom/atom.go
+++ b/internal/atom/atom.go
@@ -15,6 +15,13 @@ type Atom interface {
 	ID() string
 	State() State
 	Result() Result
+	// ExitCode returns the raw process exit code the underlying container/pod
+	// reported. Result() folds this code into a coarse Result and discards it;
+	// ExitCode preserves the raw value for the incident classifier. It returns 0
+	// when the atom never produced an exit code (still running, or the engine
+	// could not read one) — callers that must distinguish "code 0" from "no code"
+	// should also consult State().
+	ExitCode() int
 	CreatedAt() time.Time
 	StartedAt() time.Time
 	StoppedAt() time.Time

--- a/internal/atom/atom.go
+++ b/internal/atom/atom.go
@@ -17,11 +17,11 @@ type Atom interface {
 	Result() Result
 	// ExitCode returns the raw process exit code the underlying container/pod
 	// reported. Result() folds this code into a coarse Result and discards it;
-	// ExitCode preserves the raw value for the incident classifier. It returns 0
-	// when the atom never produced an exit code (still running, or the engine
-	// could not read one) — callers that must distinguish "code 0" from "no code"
-	// should also consult State().
-	ExitCode() int
+	// ExitCode preserves the raw value for the incident classifier. It returns
+	// nil when the atom never produced an exit code (still running, or the engine
+	// could not read one), so callers can distinguish "exit code 0" from "no
+	// code captured" and persist NULL rather than a spurious 0.
+	ExitCode() *int
 	CreatedAt() time.Time
 	StartedAt() time.Time
 	StoppedAt() time.Time

--- a/internal/atom/docker/atom.go
+++ b/internal/atom/docker/atom.go
@@ -40,8 +40,12 @@ func (c *Atom) Result() atom.Result {
 
 // ExitCode returns the raw Docker container exit code, preserved for the
 // incident classifier before Result() folds it into a coarse Result.
-func (c *Atom) ExitCode() int {
-	return c.metadata.State.ExitCode
+func (c *Atom) ExitCode() *int {
+	if c.metadata.State == nil {
+		return nil
+	}
+	code := c.metadata.State.ExitCode
+	return &code
 }
 
 // CreatedAt returns the UTC time the Atom was created.

--- a/internal/atom/docker/atom.go
+++ b/internal/atom/docker/atom.go
@@ -38,6 +38,12 @@ func (c *Atom) Result() atom.Result {
 	return atom.Unknown
 }
 
+// ExitCode returns the raw Docker container exit code, preserved for the
+// incident classifier before Result() folds it into a coarse Result.
+func (c *Atom) ExitCode() int {
+	return c.metadata.State.ExitCode
+}
+
 // CreatedAt returns the UTC time the Atom was created.
 func (c *Atom) CreatedAt() time.Time {
 	t, _ := time.Parse(time.RFC3339Nano, c.metadata.Created)

--- a/internal/atom/kubernetes/atom.go
+++ b/internal/atom/kubernetes/atom.go
@@ -54,13 +54,14 @@ func (c *Atom) Result() atom.Result {
 }
 
 // ExitCode returns the terminated container's raw exit code, preserved for the
-// incident classifier before Result() folds it into a coarse Result. Returns 0
+// incident classifier before Result() folds it into a coarse Result. Returns nil
 // when no container has reached a terminated state.
-func (c *Atom) ExitCode() int {
+func (c *Atom) ExitCode() *int {
 	if term := terminatedState(c.metadata); term != nil {
-		return int(term.ExitCode)
+		code := int(term.ExitCode)
+		return &code
 	}
-	return 0
+	return nil
 }
 
 // CreatedAt returns the UTC time the Atom was created.

--- a/internal/atom/kubernetes/atom.go
+++ b/internal/atom/kubernetes/atom.go
@@ -53,6 +53,16 @@ func (c *Atom) Result() atom.Result {
 	}
 }
 
+// ExitCode returns the terminated container's raw exit code, preserved for the
+// incident classifier before Result() folds it into a coarse Result. Returns 0
+// when no container has reached a terminated state.
+func (c *Atom) ExitCode() int {
+	if term := terminatedState(c.metadata); term != nil {
+		return int(term.ExitCode)
+	}
+	return 0
+}
+
 // CreatedAt returns the UTC time the Atom was created.
 func (c *Atom) CreatedAt() time.Time {
 	return c.metadata.CreationTimestamp.Time

--- a/internal/atom/podman/atom.go
+++ b/internal/atom/podman/atom.go
@@ -30,6 +30,12 @@ func (a *Atom) Result() atom.Result {
 	return atom.Unknown
 }
 
+// ExitCode returns the raw Podman container exit code, preserved for the
+// incident classifier before Result() folds it into a coarse Result.
+func (a *Atom) ExitCode() int {
+	return int(a.metadata.State.ExitCode)
+}
+
 func (a *Atom) CreatedAt() time.Time {
 	return a.metadata.Created
 }

--- a/internal/atom/podman/atom.go
+++ b/internal/atom/podman/atom.go
@@ -32,8 +32,12 @@ func (a *Atom) Result() atom.Result {
 
 // ExitCode returns the raw Podman container exit code, preserved for the
 // incident classifier before Result() folds it into a coarse Result.
-func (a *Atom) ExitCode() int {
-	return int(a.metadata.State.ExitCode)
+func (a *Atom) ExitCode() *int {
+	if a.metadata.State == nil {
+		return nil
+	}
+	code := int(a.metadata.State.ExitCode)
+	return &code
 }
 
 func (a *Atom) CreatedAt() time.Time {

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -43,6 +43,11 @@ const (
 	TypeRunRetried        Type = "run_retried"
 	TypeRunTimedOut       Type = "run_timed_out"
 	TypeSLAMissed         Type = "sla_missed"
+	// TypeSchemaViolationRecorded is emitted when a task's output violates its
+	// declared schema in "warn" mode — the task does NOT fail, so the incident
+	// manager would otherwise never see the violation. In "fail" mode the task
+	// failure already carries the violations, so no separate event is emitted.
+	TypeSchemaViolationRecorded Type = "schema_violation_recorded"
 )
 
 // Event represents a system event.

--- a/internal/incident/classifier.go
+++ b/internal/incident/classifier.go
@@ -1,0 +1,172 @@
+// Package incident implements the Phase-0 incident substrate for
+// agent-in-the-loop remediation: a deterministic failure classifier, a
+// leader-gated dedupe subscriber, the incident store and status machine, a
+// free-text log scrubber, and a durable-timer supervisor. Nothing in this
+// package invokes an LLM or takes an autonomous action — it diagnoses failures
+// and records incidents.
+package incident
+
+import (
+	"regexp"
+
+	"github.com/caesium-cloud/caesium/internal/atom"
+	"github.com/caesium-cloud/caesium/internal/event"
+)
+
+// FailureClass buckets a failure for remediation routing. The classifier is
+// purely deterministic — the same Signal always yields the same class.
+type FailureClass string
+
+const (
+	// ClassTransientInfra covers startup/resource engine failures that a plain
+	// retry often clears.
+	ClassTransientInfra FailureClass = "transient_infra"
+	// ClassSchemaViolation covers a task whose output violated its declared
+	// schema (in warn mode the task did not fail).
+	ClassSchemaViolation FailureClass = "schema_violation"
+	// ClassSLARisk covers run timeouts and SLA misses.
+	ClassSLARisk FailureClass = "sla_risk"
+	// ClassDataUnavailable covers missing/unreachable inputs.
+	ClassDataUnavailable FailureClass = "data_unavailable"
+	// ClassAuthFailure covers credential/permission failures.
+	ClassAuthFailure FailureClass = "auth_failure"
+	// ClassOOM covers out-of-memory kills. Best-effort until the OOM-flag
+	// detection from design-resource-right-sizing lands.
+	ClassOOM FailureClass = "oom"
+	// ClassQuota covers rate limits / quota exhaustion.
+	ClassQuota FailureClass = "quota"
+	// ClassUnknown is the fallback — always agent-eligible.
+	ClassUnknown FailureClass = "unknown"
+)
+
+// Signal is the deterministic input the classifier consumes. It is derived from
+// a bus event plus the persisted TaskRun (Result/ExitCode/SchemaViolations/
+// LogText/Error), never from an LLM.
+type Signal struct {
+	// EventType is the bus event.Type string that triggered classification.
+	EventType string
+	// Result is the atom.Result string persisted on TaskRun.Result.
+	Result string
+	// HasSchemaViolations reports whether the task run recorded schema violations.
+	HasSchemaViolations bool
+	// ExitCode is the raw process exit code, or nil when none was captured.
+	ExitCode *int
+	// LogTail is the (already-scrubbed) tail of the task log.
+	LogTail string
+	// Error is the TaskRun.Error text.
+	Error string
+}
+
+// logRule maps a compiled regex over the log tail / error text to a class. Rules
+// are evaluated in slice order so classification is deterministic.
+type logRule struct {
+	re    *regexp.Regexp
+	class FailureClass
+}
+
+// Classifier maps a Signal to a FailureClass using a fixed precedence of
+// structured signals (event type, schema violations, engine result) followed by
+// a configurable exit-code table and log-tail regex table. It holds no state
+// beyond its rule tables and is safe for concurrent use.
+type Classifier struct {
+	// exitCodeRules maps a raw exit code to a class. Consulted after the log
+	// rules so a specific log pattern wins over a coarse code.
+	exitCodeRules map[int]FailureClass
+	// logRules are evaluated in order against LogTail then Error.
+	logRules []logRule
+}
+
+// NewClassifier returns a Classifier seeded with sane default rules.
+func NewClassifier() *Classifier {
+	return &Classifier{
+		exitCodeRules: defaultExitCodeRules(),
+		logRules:      defaultLogRules(),
+	}
+}
+
+// defaultExitCodeRules ships one conservative default: 137 (SIGKILL, the code an
+// OOM kill surfaces as) maps to oom. This stays best-effort until the OOM-flag
+// detection substrate lands — 137 can also be a deliberate kill.
+func defaultExitCodeRules() map[int]FailureClass {
+	return map[int]FailureClass{
+		137: ClassOOM,
+	}
+}
+
+// defaultLogRules ships case-insensitive patterns for the four log-driven
+// classes. Order encodes precedence: oom, then auth, then quota, then data.
+func defaultLogRules() []logRule {
+	return []logRule{
+		{re: regexp.MustCompile(`(?i)(out of memory|oomkilled|oom-kill|cannot allocate memory|killed process|memory cgroup out of memory)`), class: ClassOOM},
+		{re: regexp.MustCompile(`(?i)(permission denied|unauthorized|forbidden|authentication failed|invalid credentials|access denied|401|403|expired token|invalid api key)`), class: ClassAuthFailure},
+		{re: regexp.MustCompile(`(?i)(quota exceeded|rate limit|ratelimit|too many requests|429|throttl|limit exceeded)`), class: ClassQuota},
+		{re: regexp.MustCompile(`(?i)(no such file|not found|does not exist|doesn't exist|connection refused|could not connect|could not resolve|no route to host|no data available|table.*(not exist|missing))`), class: ClassDataUnavailable},
+	}
+}
+
+// WithExitCodeRule overrides or adds an exit-code rule (configuration hook).
+func (c *Classifier) WithExitCodeRule(code int, class FailureClass) *Classifier {
+	if c.exitCodeRules == nil {
+		c.exitCodeRules = map[int]FailureClass{}
+	}
+	c.exitCodeRules[code] = class
+	return c
+}
+
+// WithLogRule appends a log-tail rule (configuration hook). Appended rules are
+// evaluated after the defaults.
+func (c *Classifier) WithLogRule(pattern string, class FailureClass) (*Classifier, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return c, err
+	}
+	c.logRules = append(c.logRules, logRule{re: re, class: class})
+	return c, nil
+}
+
+// Classify maps a Signal to a FailureClass. Precedence, top to bottom:
+//
+//	1. run_timed_out / sla_missed          → sla_risk
+//	2. schema_violation event / violations → schema_violation
+//	3. StartupFailure / ResourceFailure    → transient_infra
+//	4. log-tail regex table                → data_unavailable|auth_failure|oom|quota
+//	5. exit-code table                     → (default 137 → oom)
+//	6. fallback                            → unknown
+func (c *Classifier) Classify(sig Signal) FailureClass {
+	switch event.Type(sig.EventType) {
+	case event.TypeRunTimedOut, event.TypeSLAMissed:
+		return ClassSLARisk
+	case event.TypeSchemaViolationRecorded:
+		return ClassSchemaViolation
+	}
+
+	if sig.HasSchemaViolations {
+		return ClassSchemaViolation
+	}
+
+	switch atom.Result(sig.Result) {
+	case atom.StartupFailure, atom.ResourceFailure:
+		return ClassTransientInfra
+	}
+
+	// Log-tail regex table (LogTail first, then Error text).
+	for _, corpus := range []string{sig.LogTail, sig.Error} {
+		if corpus == "" {
+			continue
+		}
+		for _, rule := range c.logRules {
+			if rule.re.MatchString(corpus) {
+				return rule.class
+			}
+		}
+	}
+
+	// Exit-code table.
+	if sig.ExitCode != nil {
+		if class, ok := c.exitCodeRules[*sig.ExitCode]; ok {
+			return class
+		}
+	}
+
+	return ClassUnknown
+}

--- a/internal/incident/classifier.go
+++ b/internal/incident/classifier.go
@@ -93,14 +93,23 @@ func defaultExitCodeRules() map[int]FailureClass {
 	}
 }
 
+// Default log-rule patterns, compiled once at package load rather than on every
+// NewClassifier() call.
+var (
+	oomLogRe             = regexp.MustCompile(`(?i)(out of memory|oomkilled|oom-kill|cannot allocate memory|killed process|memory cgroup out of memory)`)
+	authFailureLogRe     = regexp.MustCompile(`(?i)(permission denied|unauthorized|forbidden|authentication failed|invalid credentials|access denied|401|403|expired token|invalid api key)`)
+	quotaLogRe           = regexp.MustCompile(`(?i)(quota exceeded|rate limit|ratelimit|too many requests|429|throttl|limit exceeded)`)
+	dataUnavailableLogRe = regexp.MustCompile(`(?i)(no such file|not found|does not exist|doesn't exist|connection refused|could not connect|could not resolve|no route to host|no data available|table.*(not exist|missing))`)
+)
+
 // defaultLogRules ships case-insensitive patterns for the four log-driven
 // classes. Order encodes precedence: oom, then auth, then quota, then data.
 func defaultLogRules() []logRule {
 	return []logRule{
-		{re: regexp.MustCompile(`(?i)(out of memory|oomkilled|oom-kill|cannot allocate memory|killed process|memory cgroup out of memory)`), class: ClassOOM},
-		{re: regexp.MustCompile(`(?i)(permission denied|unauthorized|forbidden|authentication failed|invalid credentials|access denied|401|403|expired token|invalid api key)`), class: ClassAuthFailure},
-		{re: regexp.MustCompile(`(?i)(quota exceeded|rate limit|ratelimit|too many requests|429|throttl|limit exceeded)`), class: ClassQuota},
-		{re: regexp.MustCompile(`(?i)(no such file|not found|does not exist|doesn't exist|connection refused|could not connect|could not resolve|no route to host|no data available|table.*(not exist|missing))`), class: ClassDataUnavailable},
+		{re: oomLogRe, class: ClassOOM},
+		{re: authFailureLogRe, class: ClassAuthFailure},
+		{re: quotaLogRe, class: ClassQuota},
+		{re: dataUnavailableLogRe, class: ClassDataUnavailable},
 	}
 }
 
@@ -126,12 +135,12 @@ func (c *Classifier) WithLogRule(pattern string, class FailureClass) (*Classifie
 
 // Classify maps a Signal to a FailureClass. Precedence, top to bottom:
 //
-//	1. run_timed_out / sla_missed          → sla_risk
-//	2. schema_violation event / violations → schema_violation
-//	3. StartupFailure / ResourceFailure    → transient_infra
-//	4. log-tail regex table                → data_unavailable|auth_failure|oom|quota
-//	5. exit-code table                     → (default 137 → oom)
-//	6. fallback                            → unknown
+//  1. run_timed_out / sla_missed          → sla_risk
+//  2. schema_violation event / violations → schema_violation
+//  3. StartupFailure / ResourceFailure    → transient_infra
+//  4. log-tail regex table                → data_unavailable|auth_failure|oom|quota
+//  5. exit-code table                     → (default 137 → oom)
+//  6. fallback                            → unknown
 func (c *Classifier) Classify(sig Signal) FailureClass {
 	switch event.Type(sig.EventType) {
 	case event.TypeRunTimedOut, event.TypeSLAMissed:

--- a/internal/incident/classifier_test.go
+++ b/internal/incident/classifier_test.go
@@ -1,0 +1,114 @@
+package incident
+
+import (
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/atom"
+	"github.com/caesium-cloud/caesium/internal/event"
+)
+
+func intp(v int) *int { return &v }
+
+func TestClassifyStructuredSignals(t *testing.T) {
+	c := NewClassifier()
+	cases := []struct {
+		name string
+		sig  Signal
+		want FailureClass
+	}{
+		{"run_timed_out", Signal{EventType: string(event.TypeRunTimedOut)}, ClassSLARisk},
+		{"sla_missed", Signal{EventType: string(event.TypeSLAMissed)}, ClassSLARisk},
+		{"schema_event", Signal{EventType: string(event.TypeSchemaViolationRecorded)}, ClassSchemaViolation},
+		{"schema_flag", Signal{EventType: string(event.TypeTaskFailed), HasSchemaViolations: true}, ClassSchemaViolation},
+		{"startup_failure", Signal{EventType: string(event.TypeTaskFailed), Result: string(atom.StartupFailure)}, ClassTransientInfra},
+		{"resource_failure", Signal{EventType: string(event.TypeTaskFailed), Result: string(atom.ResourceFailure)}, ClassTransientInfra},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := c.Classify(tc.sig); got != tc.want {
+				t.Fatalf("Classify(%+v) = %q, want %q", tc.sig, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyLogTable(t *testing.T) {
+	c := NewClassifier()
+	cases := []struct {
+		name string
+		log  string
+		want FailureClass
+	}{
+		{"oom", "container killed process: out of memory", ClassOOM},
+		{"oomkilled", "reason: OOMKilled", ClassOOM},
+		{"auth", "Error: 403 Forbidden: invalid credentials", ClassAuthFailure},
+		{"auth_permission", "permission denied while reading /data", ClassAuthFailure},
+		{"quota", "API quota exceeded, too many requests (429)", ClassQuota},
+		{"data_unavailable", "psycopg2: could not connect to server: connection refused", ClassDataUnavailable},
+		{"data_notfound", "FileNotFoundError: no such file or directory: input.csv", ClassDataUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := c.Classify(Signal{EventType: string(event.TypeTaskFailed), Result: string(atom.Failure), LogTail: tc.log})
+			if got != tc.want {
+				t.Fatalf("Classify(log=%q) = %q, want %q", tc.log, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyLogFallsBackToErrorText(t *testing.T) {
+	c := NewClassifier()
+	got := c.Classify(Signal{EventType: string(event.TypeTaskFailed), Error: "unauthorized: token expired"})
+	if got != ClassAuthFailure {
+		t.Fatalf("expected auth_failure from Error text, got %q", got)
+	}
+}
+
+func TestClassifyExitCodeTable(t *testing.T) {
+	c := NewClassifier()
+	got := c.Classify(Signal{EventType: string(event.TypeTaskFailed), Result: string(atom.Killed), ExitCode: intp(137)})
+	if got != ClassOOM {
+		t.Fatalf("expected oom from exit 137, got %q", got)
+	}
+}
+
+func TestClassifyFallbackUnknown(t *testing.T) {
+	c := NewClassifier()
+	cases := []Signal{
+		{EventType: string(event.TypeTaskFailed)},
+		{EventType: string(event.TypeTaskFailed), Result: string(atom.Failure), ExitCode: intp(1)},
+		{EventType: string(event.TypeRunFailed), LogTail: "some generic stack trace with no known signature"},
+	}
+	for i, sig := range cases {
+		if got := c.Classify(sig); got != ClassUnknown {
+			t.Fatalf("case %d: Classify(%+v) = %q, want unknown", i, sig, got)
+		}
+	}
+}
+
+func TestClassifyPrecedenceSchemaOverLog(t *testing.T) {
+	c := NewClassifier()
+	// A schema violation should win even if the log contains an auth-like string.
+	got := c.Classify(Signal{
+		EventType:           string(event.TypeSchemaViolationRecorded),
+		HasSchemaViolations: true,
+		LogTail:             "403 forbidden",
+	})
+	if got != ClassSchemaViolation {
+		t.Fatalf("expected schema_violation precedence, got %q", got)
+	}
+}
+
+func TestClassifierConfigurableRules(t *testing.T) {
+	c := NewClassifier().WithExitCodeRule(42, ClassDataUnavailable)
+	if got := c.Classify(Signal{Result: string(atom.Failure), ExitCode: intp(42)}); got != ClassDataUnavailable {
+		t.Fatalf("custom exit-code rule not applied: got %q", got)
+	}
+	if _, err := c.WithLogRule(`(?i)deadlock detected`, ClassTransientInfra); err != nil {
+		t.Fatalf("WithLogRule: %v", err)
+	}
+	if got := c.Classify(Signal{LogTail: "ERROR: deadlock detected"}); got != ClassTransientInfra {
+		t.Fatalf("custom log rule not applied: got %q", got)
+	}
+}

--- a/internal/incident/incident.go
+++ b/internal/incident/incident.go
@@ -1,0 +1,66 @@
+package incident
+
+import (
+	"fmt"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+// DedupeKey is the stable correlation key for an incident:
+// (job_id, task_name, failure_class). Failures sharing a key fold into one
+// incident rather than opening twins.
+func DedupeKey(jobID uuid.UUID, taskName string, class FailureClass) string {
+	return fmt.Sprintf("%s|%s|%s", jobID.String(), taskName, class)
+}
+
+// allowedTransitions encodes the incident status machine:
+//
+//	open → triaging → (awaiting_approval ↔ triaging) → remediated | escalated → closed
+//
+// plus suppressed / abandoned as terminal dispositions reachable from any
+// non-terminal state. remediated and escalated are pre-terminal (they still
+// transition to closed); closed/suppressed/abandoned are terminal.
+var allowedTransitions = map[models.IncidentStatus]map[models.IncidentStatus]struct{}{
+	models.IncidentStatusOpen: {
+		models.IncidentStatusTriaging:   {},
+		models.IncidentStatusEscalated:  {},
+		models.IncidentStatusRemediated: {},
+		models.IncidentStatusSuppressed: {},
+		models.IncidentStatusAbandoned:  {},
+	},
+	models.IncidentStatusTriaging: {
+		models.IncidentStatusAwaitingApproval: {},
+		models.IncidentStatusRemediated:       {},
+		models.IncidentStatusEscalated:        {},
+		models.IncidentStatusSuppressed:       {},
+		models.IncidentStatusAbandoned:        {},
+	},
+	models.IncidentStatusAwaitingApproval: {
+		models.IncidentStatusTriaging:   {},
+		models.IncidentStatusRemediated: {},
+		models.IncidentStatusEscalated:  {},
+		models.IncidentStatusSuppressed: {},
+		models.IncidentStatusAbandoned:  {},
+	},
+	models.IncidentStatusRemediated: {
+		models.IncidentStatusClosed: {},
+	},
+	models.IncidentStatusEscalated: {
+		models.IncidentStatusClosed:    {},
+		models.IncidentStatusAbandoned: {},
+	},
+}
+
+// CanTransition reports whether the status machine permits from → to.
+func CanTransition(from, to models.IncidentStatus) bool {
+	if from == to {
+		return false
+	}
+	targets, ok := allowedTransitions[from]
+	if !ok {
+		return false
+	}
+	_, ok = targets[to]
+	return ok
+}

--- a/internal/incident/incident_test.go
+++ b/internal/incident/incident_test.go
@@ -1,0 +1,55 @@
+package incident
+
+import (
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+func TestDedupeKeyStable(t *testing.T) {
+	id := uuid.New()
+	a := DedupeKey(id, "extract", ClassDataUnavailable)
+	b := DedupeKey(id, "extract", ClassDataUnavailable)
+	if a != b {
+		t.Fatalf("dedupe key not stable: %q != %q", a, b)
+	}
+	if a == DedupeKey(id, "extract", ClassAuthFailure) {
+		t.Fatalf("dedupe key must differ by class")
+	}
+	if a == DedupeKey(uuid.New(), "extract", ClassDataUnavailable) {
+		t.Fatalf("dedupe key must differ by job")
+	}
+}
+
+func TestCanTransition(t *testing.T) {
+	allowed := [][2]models.IncidentStatus{
+		{models.IncidentStatusOpen, models.IncidentStatusTriaging},
+		{models.IncidentStatusTriaging, models.IncidentStatusAwaitingApproval},
+		{models.IncidentStatusAwaitingApproval, models.IncidentStatusTriaging},
+		{models.IncidentStatusTriaging, models.IncidentStatusRemediated},
+		{models.IncidentStatusTriaging, models.IncidentStatusEscalated},
+		{models.IncidentStatusRemediated, models.IncidentStatusClosed},
+		{models.IncidentStatusEscalated, models.IncidentStatusClosed},
+		{models.IncidentStatusOpen, models.IncidentStatusSuppressed},
+		{models.IncidentStatusTriaging, models.IncidentStatusAbandoned},
+	}
+	for _, tc := range allowed {
+		if !CanTransition(tc[0], tc[1]) {
+			t.Errorf("expected %s → %s allowed", tc[0], tc[1])
+		}
+	}
+
+	denied := [][2]models.IncidentStatus{
+		{models.IncidentStatusOpen, models.IncidentStatusOpen},           // self
+		{models.IncidentStatusClosed, models.IncidentStatusTriaging},     // out of terminal
+		{models.IncidentStatusOpen, models.IncidentStatusClosed},         // must pass through remediated/escalated
+		{models.IncidentStatusRemediated, models.IncidentStatusTriaging}, // no going back
+		{models.IncidentStatusSuppressed, models.IncidentStatusOpen},     // terminal
+	}
+	for _, tc := range denied {
+		if CanTransition(tc[0], tc[1]) {
+			t.Errorf("expected %s → %s denied", tc[0], tc[1])
+		}
+	}
+}

--- a/internal/incident/scrubber.go
+++ b/internal/incident/scrubber.go
@@ -1,0 +1,203 @@
+package incident
+
+import (
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// Redacted is the placeholder substituted for a scrubbed secret value or token.
+const Redacted = "[REDACTED]"
+
+// minScrubLength is the minimum length a resolved secret value must have before
+// the scrubber will blanket-replace it by exact match. Below this, an exact
+// replacement of a common short value (e.g. "true", "8080") would destroy
+// unrelated log text, so it is skipped — we rely on the structured-env knowledge
+// that the value came from a secret:// ref rather than blind string matching.
+const minScrubLength = 6
+
+// literalDenylist is a small set of common boolean/word literals that must never
+// be blanket-replaced even if a secret resolves to them (structured-env
+// over-redaction guard). Small integers are handled separately by the
+// numeric check.
+var literalDenylist = map[string]struct{}{
+	"true":     {},
+	"false":    {},
+	"null":     {},
+	"none":     {},
+	"nil":      {},
+	"password": {},
+	"secret":   {},
+	"token":    {},
+	"changeme": {},
+	"admin":    {},
+}
+
+// highEntropyTokenRe matches token-shaped substrings (long runs of
+// base64/hex/url-safe characters) that are candidates for entropy-based
+// redaction. The min length is deliberately high to avoid catching ordinary
+// words, paths, or identifiers.
+var highEntropyTokenRe = regexp.MustCompile(`[A-Za-z0-9+/=_\-]{20,}`)
+
+// Scrubber removes secret material from free-text log output before it enters a
+// triage bundle, an agent-readable endpoint, or an escalation message. It does
+// exact removal of every resolved secret:// value (subject to the
+// over-redaction guard) plus a conservative high-entropy token heuristic.
+type Scrubber struct {
+	// secrets is the deduplicated, guard-filtered set of exact values to remove,
+	// sorted longest-first so a longer secret that contains a shorter one is
+	// replaced before the shorter match can fragment it.
+	secrets []string
+}
+
+// NewScrubber builds a Scrubber from a set of resolved secret values. Values
+// that fail the over-redaction guard (too short, a denylisted literal, or a
+// bare small number) are dropped from exact-match scrubbing.
+func NewScrubber(secretValues []string) *Scrubber {
+	seen := make(map[string]struct{}, len(secretValues))
+	kept := make([]string, 0, len(secretValues))
+	for _, v := range secretValues {
+		if !scrubbable(v) {
+			continue
+		}
+		if _, dup := seen[v]; dup {
+			continue
+		}
+		seen[v] = struct{}{}
+		kept = append(kept, v)
+	}
+	sort.SliceStable(kept, func(i, j int) bool {
+		return len(kept[i]) > len(kept[j])
+	})
+	return &Scrubber{secrets: kept}
+}
+
+// SecretValuesFromEnv extracts the resolved values of the env keys whose raw
+// value was a secret:// reference. raw is the pre-resolution env (key -> raw
+// value, some carrying the secret:// scheme); resolved is the post-resolution
+// env (key -> actual value). Only keys that were secret refs contribute, so a
+// literal env value that merely looks sensitive is not scrubbed here.
+func SecretValuesFromEnv(raw, resolved map[string]string) []string {
+	const secretRefPrefix = "secret://"
+	out := make([]string, 0)
+	for k, rawVal := range raw {
+		if !strings.HasPrefix(rawVal, secretRefPrefix) {
+			continue
+		}
+		if val, ok := resolved[k]; ok && val != "" {
+			out = append(out, val)
+		}
+	}
+	return out
+}
+
+// scrubbable reports whether a resolved secret value is safe to blanket-replace
+// by exact match without destroying unrelated log text.
+func scrubbable(v string) bool {
+	if len(v) < minScrubLength {
+		return false
+	}
+	if _, denied := literalDenylist[strings.ToLower(v)]; denied {
+		return false
+	}
+	if isAllDigits(v) {
+		// A bare number (even a long one) is too likely to collide with
+		// unrelated log content (timestamps, ids); skip exact scrubbing.
+		return false
+	}
+	return true
+}
+
+func isAllDigits(v string) bool {
+	if v == "" {
+		return false
+	}
+	for _, r := range v {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// Scrub returns text with every guard-passing secret value removed by exact
+// replacement and every high-entropy token redacted. The exact-match pass runs
+// first so a known secret is always removed even if the entropy heuristic would
+// have missed it.
+func (s *Scrubber) Scrub(text string) string {
+	if text == "" {
+		return text
+	}
+	out := text
+	for _, secret := range s.secrets {
+		out = strings.ReplaceAll(out, secret, Redacted)
+	}
+	out = s.scrubHighEntropy(out)
+	return out
+}
+
+// scrubHighEntropy replaces token-shaped substrings whose Shannon entropy is
+// high enough to look like a credential. The bar is intentionally conservative
+// (long, mixed, high-entropy) so ordinary log text stays readable.
+func (s *Scrubber) scrubHighEntropy(text string) string {
+	return highEntropyTokenRe.ReplaceAllStringFunc(text, func(tok string) string {
+		if tok == Redacted {
+			return tok
+		}
+		if looksLikeSecretToken(tok) {
+			return Redacted
+		}
+		return tok
+	})
+}
+
+// looksLikeSecretToken applies the conservative heuristic: the token must be
+// long, contain a mix of character classes (so it is not an all-lowercase word
+// or an all-numeric id), and have high per-character entropy.
+func looksLikeSecretToken(tok string) bool {
+	if len(tok) < 20 {
+		return false
+	}
+	var hasLower, hasUpper, hasDigit bool
+	for _, r := range tok {
+		switch {
+		case r >= 'a' && r <= 'z':
+			hasLower = true
+		case r >= 'A' && r <= 'Z':
+			hasUpper = true
+		case r >= '0' && r <= '9':
+			hasDigit = true
+		}
+	}
+	classes := 0
+	for _, c := range []bool{hasLower, hasUpper, hasDigit} {
+		if c {
+			classes++
+		}
+	}
+	// Require at least two character classes: a random-looking mix, not a plain
+	// word or a bare number.
+	if classes < 2 {
+		return false
+	}
+	return shannonEntropy(tok) >= 3.5
+}
+
+// shannonEntropy returns the per-character Shannon entropy (in bits) of s.
+func shannonEntropy(s string) float64 {
+	if s == "" {
+		return 0
+	}
+	counts := make(map[rune]int, len(s))
+	for _, r := range s {
+		counts[r]++
+	}
+	n := float64(len([]rune(s)))
+	var h float64
+	for _, c := range counts {
+		p := float64(c) / n
+		h -= p * math.Log2(p)
+	}
+	return h
+}

--- a/internal/incident/scrubber.go
+++ b/internal/incident/scrubber.go
@@ -5,7 +5,14 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
+
+// hexTokenRe matches a purely hexadecimal token (git commit SHAs, Docker image
+// digests, hashes). These have a high character-class mix and high entropy, so
+// the entropy heuristic would flag them — but they are non-sensitive identifiers
+// whose redaction only destroys log readability. Excluded from token scrubbing.
+var hexTokenRe = regexp.MustCompile(`^[0-9a-fA-F]+$`)
 
 // Redacted is the placeholder substituted for a scrubbed secret value or token.
 const Redacted = "[REDACTED]"
@@ -159,6 +166,11 @@ func looksLikeSecretToken(tok string) bool {
 	if len(tok) < 20 {
 		return false
 	}
+	// A purely-hex token is a git SHA / image digest / hash — a non-sensitive
+	// identifier, not a secret. Redacting it only hurts log readability.
+	if hexTokenRe.MatchString(tok) {
+		return false
+	}
 	var hasLower, hasUpper, hasDigit bool
 	for _, r := range tok {
 		switch {
@@ -193,7 +205,7 @@ func shannonEntropy(s string) float64 {
 	for _, r := range s {
 		counts[r]++
 	}
-	n := float64(len([]rune(s)))
+	n := float64(utf8.RuneCountInString(s))
 	var h float64
 	for _, c := range counts {
 		p := float64(c) / n

--- a/internal/incident/scrubber_test.go
+++ b/internal/incident/scrubber_test.go
@@ -1,0 +1,97 @@
+package incident
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScrubExactSecretRemoved(t *testing.T) {
+	s := NewScrubber([]string{"hunter2-super-secret-value"})
+	log := "connecting with password hunter2-super-secret-value to db"
+	out := s.Scrub(log)
+	if strings.Contains(out, "hunter2-super-secret-value") {
+		t.Fatalf("secret value not removed: %q", out)
+	}
+	if !strings.Contains(out, Redacted) {
+		t.Fatalf("expected redaction placeholder, got %q", out)
+	}
+}
+
+// The load-bearing over-redaction guard test: a secret whose resolved value is
+// "true" must NOT scrub every "true" in the log.
+func TestScrubDoesNotOverRedactBooleanLiteral(t *testing.T) {
+	s := NewScrubber([]string{"true"})
+	log := "feature_enabled=true retries_exhausted=true status=true"
+	out := s.Scrub(log)
+	if out != log {
+		t.Fatalf("boolean literal secret over-redacted the log.\n got: %q\nwant: %q", out, log)
+	}
+	if strings.Count(out, "true") != 3 {
+		t.Fatalf("expected all 3 'true' tokens preserved, got %q", out)
+	}
+}
+
+func TestScrubGuardsShortAndNumericAndDenylisted(t *testing.T) {
+	// Short value, denylisted literal, and a bare number must all be skipped for
+	// exact scrubbing.
+	s := NewScrubber([]string{"abc", "false", "8080", "password"})
+	log := "port 8080 flag false pass password prefix abc123"
+	out := s.Scrub(log)
+	if out != log {
+		t.Fatalf("guarded values over-redacted: %q", out)
+	}
+}
+
+func TestScrubHighEntropyToken(t *testing.T) {
+	s := NewScrubber(nil)
+	// A long, mixed, random-looking token should be redacted by the heuristic
+	// even though it was not supplied as a known secret.
+	token := "AKIAJ83HFKD9SLXMZ7Q2b8Xy1pQ9rT4"
+	log := "aws credential " + token + " loaded"
+	out := s.Scrub(log)
+	if strings.Contains(out, token) {
+		t.Fatalf("high-entropy token not redacted: %q", out)
+	}
+}
+
+func TestScrubHighEntropyLeavesOrdinaryWords(t *testing.T) {
+	s := NewScrubber(nil)
+	log := "the quick brown fox jumps over the lazy dog repeatedly today"
+	out := s.Scrub(log)
+	if out != log {
+		t.Fatalf("ordinary prose was redacted: %q", out)
+	}
+}
+
+func TestScrubHighEntropyLeavesLongLowercaseWord(t *testing.T) {
+	s := NewScrubber(nil)
+	// Long, single-class (all lowercase) identifier must not be redacted.
+	log := "processing supercalifragilisticexpialidocious path"
+	out := s.Scrub(log)
+	if out != log {
+		t.Fatalf("long single-class word redacted: %q", out)
+	}
+}
+
+func TestSecretValuesFromEnv(t *testing.T) {
+	raw := map[string]string{
+		"DB_PASSWORD": "secret://vault/db#password",
+		"LOG_LEVEL":   "info",
+		"API_KEY":     "secret://env/API_KEY",
+	}
+	resolved := map[string]string{
+		"DB_PASSWORD": "s3cr3t-db-passphrase",
+		"LOG_LEVEL":   "info",
+		"API_KEY":     "ak-1234567890abcdef",
+	}
+	got := SecretValuesFromEnv(raw, resolved)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 secret values, got %d: %v", len(got), got)
+	}
+	// The non-secret LOG_LEVEL value must not be included.
+	for _, v := range got {
+		if v == "info" {
+			t.Fatalf("non-secret value leaked into scrub set: %v", got)
+		}
+	}
+}

--- a/internal/incident/store.go
+++ b/internal/incident/store.go
@@ -3,6 +3,7 @@ package incident
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -32,14 +33,14 @@ func (s *Store) DB() *gorm.DB { return s.db }
 
 // OpenParams describes a failure the subscriber wants to record as an incident.
 type OpenParams struct {
-	Namespace *string
-	JobID     uuid.UUID
-	RunID     *uuid.UUID
-	TaskID    *uuid.UUID
-	TaskName  string
-	Class     FailureClass
-	LastError string
-	Evidence  datatypes.JSON
+	Namespace  *string
+	JobID      uuid.UUID
+	RunID      *uuid.UUID
+	TaskID     *uuid.UUID
+	TaskName   string
+	Class      FailureClass
+	LastError  string
+	Evidence   datatypes.JSON
 	BackfillID *uuid.UUID
 	// RemediationTargetRunID is the run whose later success would close this
 	// incident as remediated.
@@ -108,27 +109,40 @@ func (s *Store) OpenOrAppend(ctx context.Context, p OpenParams) (*models.Inciden
 		UpdatedAt:              now,
 	}
 
-	// Atomic conditional insert: on conflict with an existing non-terminal
-	// incident sharing active_dedupe_key, do nothing (RowsAffected == 0).
-	res := s.db.WithContext(ctx).
-		Clauses(clause.OnConflict{
-			Columns:   []clause.Column{{Name: "active_dedupe_key"}},
-			DoNothing: true,
-		}).
-		Create(inc)
-	if res.Error != nil {
-		return nil, "", res.Error
-	}
-	if res.RowsAffected == 1 {
-		return inc, OutcomeOpened, nil
-	}
+	// Atomic conditional insert with a bounded retry. On conflict with an existing
+	// non-terminal incident sharing active_dedupe_key, DoNothing (RowsAffected==0)
+	// and fold the failure in as an occurrence. If that twin is transitioned to a
+	// terminal state (which nulls active_dedupe_key) between our conflict and the
+	// append — a race with the leader's timer supervisor or success path —
+	// appendOccurrence finds no active row (ErrRecordNotFound); retry, and the
+	// now-free key lets the insert win instead of dropping the failure.
+	const maxOpenAttempts = 3
+	for attempt := 0; attempt < maxOpenAttempts; attempt++ {
+		res := s.db.WithContext(ctx).
+			Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "active_dedupe_key"}},
+				DoNothing: true,
+			}).
+			Create(inc)
+		if res.Error != nil {
+			return nil, "", res.Error
+		}
+		if res.RowsAffected == 1 {
+			return inc, OutcomeOpened, nil
+		}
 
-	// A twin already exists — fold in as an occurrence and advance the target.
-	existing, err := s.appendOccurrence(ctx, key, p, now)
-	if err != nil {
-		return nil, "", err
+		existing, err := s.appendOccurrence(ctx, key, p, now)
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// The twin closed between the conflict and the append; the dedupe
+				// key is free now — retry the insert.
+				continue
+			}
+			return nil, "", err
+		}
+		return existing, OutcomeAppended, nil
 	}
-	return existing, OutcomeAppended, nil
+	return nil, "", fmt.Errorf("incident: OpenOrAppend exhausted retries opening incident for dedupe key %q", key)
 }
 
 // appendOccurrence increments the occurrence counter on the open incident for
@@ -236,11 +250,14 @@ func (s *Store) Remediate(ctx context.Context, id uuid.UUID, summary string) (*m
 // name matches. Used by the terminal-verification success path.
 func (s *Store) OpenForJobTask(ctx context.Context, jobID uuid.UUID, taskName string) ([]models.Incident, error) {
 	var incidents []models.Incident
+	// Match task_name EXACTLY, including the empty string: a run-level success
+	// event (run_completed, no TaskID) carries taskName == "" and must remediate
+	// only run-level incidents (which store task_name == ""), never every open
+	// incident for the job. Per-task success (task_succeeded) carries the task
+	// name and remediates that task's incidents. This mirrors the (job, task,
+	// class) dedupe correlation key.
 	q := s.db.WithContext(ctx).
-		Where("job_id = ? AND active_dedupe_key IS NOT NULL", jobID)
-	if taskName != "" {
-		q = q.Where("task_name = ?", taskName)
-	}
+		Where("job_id = ? AND task_name = ? AND active_dedupe_key IS NOT NULL", jobID, taskName)
 	if err := q.Find(&incidents).Error; err != nil {
 		return nil, err
 	}

--- a/internal/incident/store.go
+++ b/internal/incident/store.go
@@ -1,0 +1,326 @@
+package incident
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// ErrInvalidTransition is returned when a status transition is not permitted by
+// the incident status machine.
+var ErrInvalidTransition = errors.New("incident: invalid status transition")
+
+// Store persists incidents. It is the single writer the leader-gated subscriber
+// uses to open, correlate, and advance incidents.
+type Store struct {
+	db *gorm.DB
+}
+
+// NewStore returns an incident store over db.
+func NewStore(db *gorm.DB) *Store {
+	return &Store{db: db}
+}
+
+// DB exposes the underlying handle for read APIs built on top of the store.
+func (s *Store) DB() *gorm.DB { return s.db }
+
+// OpenParams describes a failure the subscriber wants to record as an incident.
+type OpenParams struct {
+	Namespace *string
+	JobID     uuid.UUID
+	RunID     *uuid.UUID
+	TaskID    *uuid.UUID
+	TaskName  string
+	Class     FailureClass
+	LastError string
+	Evidence  datatypes.JSON
+	BackfillID *uuid.UUID
+	// RemediationTargetRunID is the run whose later success would close this
+	// incident as remediated.
+	RemediationTargetRunID *uuid.UUID
+	// Cooldown suppresses re-opening within this window after the last incident
+	// for the same key closed. Zero disables cooldown suppression.
+	Cooldown time.Duration
+}
+
+// OpenOutcome describes what OpenOrAppend did.
+type OpenOutcome string
+
+const (
+	// OutcomeOpened: a new incident row was created.
+	OutcomeOpened OpenOutcome = "opened"
+	// OutcomeAppended: an existing open incident absorbed this as an occurrence.
+	OutcomeAppended OpenOutcome = "appended"
+	// OutcomeSuppressed: skipped because a same-key incident closed within the
+	// cooldown window.
+	OutcomeSuppressed OpenOutcome = "suppressed"
+)
+
+// OpenOrAppend opens exactly one incident per dedupe key or folds the failure
+// into the existing open incident as an occurrence. The open is an ATOMIC
+// conditional insert on active_dedupe_key (unique index, ON CONFLICT DO
+// NOTHING), so failover races and duplicate per-node sla_missed events cannot
+// open twins. A recently-closed same-key incident within Cooldown suppresses a
+// fresh open.
+func (s *Store) OpenOrAppend(ctx context.Context, p OpenParams) (*models.Incident, OpenOutcome, error) {
+	key := DedupeKey(p.JobID, p.TaskName, p.Class)
+	now := time.Now().UTC()
+
+	// Cooldown: skip if a same-key incident closed within the window.
+	if p.Cooldown > 0 {
+		var last models.Incident
+		err := s.db.WithContext(ctx).
+			Where("dedupe_key = ? AND closed_at IS NOT NULL", key).
+			Order("closed_at DESC").
+			First(&last).Error
+		if err == nil && last.ClosedAt != nil && now.Sub(last.ClosedAt.UTC()) < p.Cooldown {
+			return &last, OutcomeSuppressed, nil
+		} else if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, "", err
+		}
+	}
+
+	activeKey := key
+	inc := &models.Incident{
+		ID:                     uuid.New(),
+		Namespace:              p.Namespace,
+		JobID:                  p.JobID,
+		RunID:                  p.RunID,
+		TaskID:                 p.TaskID,
+		TaskName:               p.TaskName,
+		Class:                  string(p.Class),
+		Status:                 models.IncidentStatusOpen,
+		DedupeKey:              key,
+		ActiveDedupeKey:        &activeKey,
+		OccurrenceCount:        1,
+		BackfillID:             p.BackfillID,
+		RemediationTargetRunID: p.RemediationTargetRunID,
+		LastError:              p.LastError,
+		Evidence:               p.Evidence,
+		OpenedAt:               now,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+
+	// Atomic conditional insert: on conflict with an existing non-terminal
+	// incident sharing active_dedupe_key, do nothing (RowsAffected == 0).
+	res := s.db.WithContext(ctx).
+		Clauses(clause.OnConflict{
+			Columns:   []clause.Column{{Name: "active_dedupe_key"}},
+			DoNothing: true,
+		}).
+		Create(inc)
+	if res.Error != nil {
+		return nil, "", res.Error
+	}
+	if res.RowsAffected == 1 {
+		return inc, OutcomeOpened, nil
+	}
+
+	// A twin already exists — fold in as an occurrence and advance the target.
+	existing, err := s.appendOccurrence(ctx, key, p, now)
+	if err != nil {
+		return nil, "", err
+	}
+	return existing, OutcomeAppended, nil
+}
+
+// appendOccurrence increments the occurrence counter on the open incident for
+// key and advances its remediation target / last error.
+func (s *Store) appendOccurrence(ctx context.Context, key string, p OpenParams, now time.Time) (*models.Incident, error) {
+	updates := map[string]any{
+		"occurrence_count": gorm.Expr("occurrence_count + 1"),
+		"updated_at":       now,
+	}
+	if p.LastError != "" {
+		updates["last_error"] = p.LastError
+	}
+	if p.RemediationTargetRunID != nil {
+		updates["remediation_target_run_id"] = *p.RemediationTargetRunID
+	}
+	if p.RunID != nil {
+		updates["run_id"] = *p.RunID
+	}
+	if err := s.db.WithContext(ctx).
+		Model(&models.Incident{}).
+		Where("active_dedupe_key = ?", key).
+		Updates(updates).Error; err != nil {
+		return nil, err
+	}
+	var existing models.Incident
+	if err := s.db.WithContext(ctx).
+		Where("active_dedupe_key = ?", key).
+		First(&existing).Error; err != nil {
+		return nil, err
+	}
+	return &existing, nil
+}
+
+// Transition advances an incident to a new status, enforcing the status machine.
+// On any terminal transition it clears active_dedupe_key (so a future same-key
+// failure may open a fresh incident) and stamps closed_at. remediated/escalated
+// set closed_at only when they are the final state reached (they still permit a
+// later → closed transition, which is a no-op on closed_at).
+func (s *Store) Transition(ctx context.Context, id uuid.UUID, to models.IncidentStatus, summary string) (*models.Incident, error) {
+	var inc *models.Incident
+	err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var cur models.Incident
+		if err := tx.Clauses(clause.Locking{Strength: "UPDATE"}).
+			First(&cur, "id = ?", id).Error; err != nil {
+			return err
+		}
+		if !CanTransition(cur.Status, to) {
+			return ErrInvalidTransition
+		}
+		now := time.Now().UTC()
+		updates := map[string]any{
+			"status":     to,
+			"updated_at": now,
+		}
+		if summary != "" {
+			updates["resolution_summary"] = summary
+		}
+		// Clearing the active key on any terminal transition frees the dedupe key.
+		if to.IsTerminal() {
+			updates["active_dedupe_key"] = nil
+			if cur.ClosedAt == nil {
+				updates["closed_at"] = now
+			}
+		}
+		if err := tx.Model(&models.Incident{}).Where("id = ?", id).Updates(updates).Error; err != nil {
+			return err
+		}
+		// Cancel any pending durable timers owned by this incident on a terminal
+		// transition: a stale timer must never fire a retry against a closed
+		// incident (A6 invariant).
+		if to.IsTerminal() {
+			if err := tx.Model(&models.RemediationTimer{}).
+				Where("incident_id = ? AND status = ?", id, models.RemediationTimerStatusPending).
+				Updates(map[string]any{
+					"status":     models.RemediationTimerStatusCancelled,
+					"updated_at": now,
+				}).Error; err != nil {
+				return err
+			}
+		}
+		var reloaded models.Incident
+		if err := tx.First(&reloaded, "id = ?", id).Error; err != nil {
+			return err
+		}
+		inc = &reloaded
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return inc, nil
+}
+
+// Remediate marks an incident remediated then closed in one step. It is the
+// terminal-verified success path: the caller invokes it only when a subsequent
+// run for the incident's job/task actually succeeded.
+func (s *Store) Remediate(ctx context.Context, id uuid.UUID, summary string) (*models.Incident, error) {
+	if _, err := s.Transition(ctx, id, models.IncidentStatusRemediated, summary); err != nil {
+		return nil, err
+	}
+	return s.Transition(ctx, id, models.IncidentStatusClosed, summary)
+}
+
+// OpenForJobTask returns the open (non-terminal) incidents for a job whose task
+// name matches. Used by the terminal-verification success path.
+func (s *Store) OpenForJobTask(ctx context.Context, jobID uuid.UUID, taskName string) ([]models.Incident, error) {
+	var incidents []models.Incident
+	q := s.db.WithContext(ctx).
+		Where("job_id = ? AND active_dedupe_key IS NOT NULL", jobID)
+	if taskName != "" {
+		q = q.Where("task_name = ?", taskName)
+	}
+	if err := q.Find(&incidents).Error; err != nil {
+		return nil, err
+	}
+	return incidents, nil
+}
+
+// Get returns a single incident by id.
+func (s *Store) Get(ctx context.Context, id uuid.UUID) (*models.Incident, error) {
+	var inc models.Incident
+	if err := s.db.WithContext(ctx).First(&inc, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &inc, nil
+}
+
+// ScheduleTimer persists a durable timer owned by an incident. The timer
+// survives restart/failover so a pending snooze/retry is not lost.
+func (s *Store) ScheduleTimer(ctx context.Context, incidentID uuid.UUID, kind string, fireAt time.Time, payload datatypes.JSON, actionID *uuid.UUID, namespace *string) (*models.RemediationTimer, error) {
+	now := time.Now().UTC()
+	timer := &models.RemediationTimer{
+		ID:         uuid.New(),
+		Namespace:  namespace,
+		IncidentID: incidentID,
+		ActionID:   actionID,
+		Kind:       kind,
+		Payload:    payload,
+		Status:     models.RemediationTimerStatusPending,
+		FireAt:     fireAt.UTC(),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.db.WithContext(ctx).Create(timer).Error; err != nil {
+		return nil, err
+	}
+	return timer, nil
+}
+
+// CancelTimersForIncident cancels all pending timers for an incident (used on
+// human take-over). Terminal transitions already cancel via Transition.
+func (s *Store) CancelTimersForIncident(ctx context.Context, incidentID uuid.UUID) (int64, error) {
+	res := s.db.WithContext(ctx).
+		Model(&models.RemediationTimer{}).
+		Where("incident_id = ? AND status = ?", incidentID, models.RemediationTimerStatusPending).
+		Updates(map[string]any{
+			"status":     models.RemediationTimerStatusCancelled,
+			"updated_at": time.Now().UTC(),
+		})
+	return res.RowsAffected, res.Error
+}
+
+// DueTimers returns pending timers whose fire time has passed.
+func (s *Store) DueTimers(ctx context.Context, now time.Time, limit int) ([]models.RemediationTimer, error) {
+	var timers []models.RemediationTimer
+	q := s.db.WithContext(ctx).
+		Where("status = ? AND fire_at <= ?", models.RemediationTimerStatusPending, now.UTC()).
+		Order("fire_at ASC")
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if err := q.Find(&timers).Error; err != nil {
+		return nil, err
+	}
+	return timers, nil
+}
+
+// ClaimTimer atomically flips a pending timer to fired, returning true if this
+// caller won the claim. The conditional update (status = pending) makes the
+// claim safe even if two sweeps race.
+func (s *Store) ClaimTimer(ctx context.Context, id uuid.UUID) (bool, error) {
+	now := time.Now().UTC()
+	res := s.db.WithContext(ctx).
+		Model(&models.RemediationTimer{}).
+		Where("id = ? AND status = ?", id, models.RemediationTimerStatusPending).
+		Updates(map[string]any{
+			"status":     models.RemediationTimerStatusFired,
+			"fired_at":   now,
+			"updated_at": now,
+		})
+	if res.Error != nil {
+		return false, res.Error
+	}
+	return res.RowsAffected == 1, nil
+}

--- a/internal/incident/store_test.go
+++ b/internal/incident/store_test.go
@@ -78,6 +78,36 @@ func TestTerminalTransitionFreesDedupeKey(t *testing.T) {
 	testutil.AssertCount(t, db, &models.Incident{}, 2)
 }
 
+func TestOpenForJobTaskMatchesTaskNameExactly(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	jobID := uuid.New()
+
+	// One per-task incident and one run-level incident (empty task name) for the
+	// same job.
+	_, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "extract", Class: ClassDataUnavailable})
+	require.NoError(t, err)
+	_, _, err = store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "", Class: ClassSLARisk})
+	require.NoError(t, err)
+
+	// A per-task success (task_succeeded → task name) must match ONLY that task's
+	// incident.
+	perTask, err := store.OpenForJobTask(ctx, jobID, "extract")
+	require.NoError(t, err)
+	require.Len(t, perTask, 1)
+	require.Equal(t, "extract", perTask[0].TaskName)
+
+	// A run-level success (run_completed → empty task name) must match ONLY the
+	// run-level incident, never wildcard-close the per-task one.
+	runLevel, err := store.OpenForJobTask(ctx, jobID, "")
+	require.NoError(t, err)
+	require.Len(t, runLevel, 1)
+	require.Equal(t, "", runLevel[0].TaskName)
+	require.Equal(t, string(ClassSLARisk), runLevel[0].Class)
+}
+
 func TestInvalidTransitionRejected(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })

--- a/internal/incident/store_test.go
+++ b/internal/incident/store_test.go
@@ -1,0 +1,114 @@
+package incident
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenOrAppendOpensThenAppends(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	jobID := uuid.New()
+
+	p := OpenParams{JobID: jobID, TaskName: "extract", Class: ClassDataUnavailable, LastError: "boom"}
+
+	inc1, outcome, err := store.OpenOrAppend(ctx, p)
+	require.NoError(t, err)
+	require.Equal(t, OutcomeOpened, outcome)
+	require.Equal(t, 1, inc1.OccurrenceCount)
+
+	// A second independent same-key failure must append an occurrence, not open
+	// a twin (the A4 acceptance invariant).
+	inc2, outcome, err := store.OpenOrAppend(ctx, p)
+	require.NoError(t, err)
+	require.Equal(t, OutcomeAppended, outcome)
+	require.Equal(t, inc1.ID, inc2.ID)
+	require.Equal(t, 2, inc2.OccurrenceCount)
+
+	testutil.AssertCount(t, db, &models.Incident{}, 1)
+}
+
+func TestOpenOrAppendDistinctClassOpensSeparate(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	jobID := uuid.New()
+
+	_, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "t", Class: ClassAuthFailure})
+	require.NoError(t, err)
+	_, outcome, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "t", Class: ClassOOM})
+	require.NoError(t, err)
+	require.Equal(t, OutcomeOpened, outcome)
+	testutil.AssertCount(t, db, &models.Incident{}, 2)
+}
+
+func TestTerminalTransitionFreesDedupeKey(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	jobID := uuid.New()
+	p := OpenParams{JobID: jobID, TaskName: "t", Class: ClassUnknown}
+
+	inc, _, err := store.OpenOrAppend(ctx, p)
+	require.NoError(t, err)
+
+	// Drive it to a terminal state; the active dedupe key must clear so a fresh
+	// same-key failure opens a NEW incident.
+	_, err = store.Transition(ctx, inc.ID, models.IncidentStatusTriaging, "")
+	require.NoError(t, err)
+	closed, err := store.Remediate(ctx, inc.ID, "fixed")
+	require.NoError(t, err)
+	require.Equal(t, models.IncidentStatusClosed, closed.Status)
+	require.NotNil(t, closed.ClosedAt)
+
+	inc2, outcome, err := store.OpenOrAppend(ctx, p) // no cooldown
+	require.NoError(t, err)
+	require.Equal(t, OutcomeOpened, outcome)
+	require.NotEqual(t, inc.ID, inc2.ID)
+	testutil.AssertCount(t, db, &models.Incident{}, 2)
+}
+
+func TestInvalidTransitionRejected(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: uuid.New(), TaskName: "t", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	// open → closed is not a valid direct transition.
+	_, err = store.Transition(ctx, inc.ID, models.IncidentStatusClosed, "")
+	require.ErrorIs(t, err, ErrInvalidTransition)
+}
+
+func TestCooldownSuppressesReopen(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	jobID := uuid.New()
+	p := OpenParams{JobID: jobID, TaskName: "t", Class: ClassUnknown, Cooldown: time.Hour}
+
+	inc, _, err := store.OpenOrAppend(ctx, p)
+	require.NoError(t, err)
+	_, err = store.Transition(ctx, inc.ID, models.IncidentStatusEscalated, "")
+	require.NoError(t, err)
+	_, err = store.Transition(ctx, inc.ID, models.IncidentStatusClosed, "")
+	require.NoError(t, err)
+
+	// Within the cooldown window a fresh same-key failure is suppressed.
+	_, outcome, err := store.OpenOrAppend(ctx, p)
+	require.NoError(t, err)
+	require.Equal(t, OutcomeSuppressed, outcome)
+	testutil.AssertCount(t, db, &models.Incident{}, 1)
+}

--- a/internal/incident/subscriber.go
+++ b/internal/incident/subscriber.go
@@ -1,0 +1,284 @@
+package incident
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// LeaderCheck reports whether this node currently hosts the cluster leader. The
+// incident subscriber is leader-gated (mirroring the run-queue dequeuer, NOT the
+// per-node notification subscriber) so an N-node cluster opens exactly one
+// incident per failure. A nil LeaderCheck means "always act" (single-node).
+type LeaderCheck func(context.Context) (bool, error)
+
+// classifierFailureTypes are the failure events that can open/append incidents.
+var classifierFailureTypes = []event.Type{
+	event.TypeTaskFailed,
+	event.TypeRunFailed,
+	event.TypeRunTimedOut,
+	event.TypeSLAMissed,
+	event.TypeSchemaViolationRecorded,
+}
+
+// successTypes are the events that verify a remediation actually worked: an
+// incident may reach `remediated` only when a subsequent run for its job/task
+// succeeds.
+var successTypes = []event.Type{
+	event.TypeTaskSucceeded,
+	event.TypeRunCompleted,
+}
+
+// Subscriber is the leader-gated incident manager. It consumes failure events,
+// classifies each, and opens/correlates an incident; it consumes success events
+// to close incidents as remediated when a later run succeeds. It never invokes
+// an LLM or takes an autonomous action.
+type Subscriber struct {
+	bus         event.Bus
+	db          *gorm.DB
+	store       *Store
+	classifier  *Classifier
+	leaderCheck LeaderCheck
+	cooldown    time.Duration
+}
+
+// NewSubscriber constructs an incident subscriber.
+func NewSubscriber(bus event.Bus, db *gorm.DB, leaderCheck LeaderCheck, cooldown time.Duration) *Subscriber {
+	return &Subscriber{
+		bus:         bus,
+		db:          db,
+		store:       NewStore(db),
+		classifier:  NewClassifier(),
+		leaderCheck: leaderCheck,
+		cooldown:    cooldown,
+	}
+}
+
+// Start subscribes to the failure and success event types and processes them
+// until ctx is cancelled.
+func (s *Subscriber) Start(ctx context.Context) error {
+	return s.StartWithReady(ctx, nil)
+}
+
+// StartWithReady subscribes and signals readiness once the subscription is live
+// (used by tests to avoid a publish race).
+func (s *Subscriber) StartWithReady(ctx context.Context, ready chan<- struct{}) error {
+	types := append(append([]event.Type{}, classifierFailureTypes...), successTypes...)
+	ch, err := s.bus.Subscribe(ctx, event.Filter{Types: types})
+	if err != nil {
+		return err
+	}
+	if ready != nil {
+		close(ready)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case evt, ok := <-ch:
+			if !ok {
+				return nil
+			}
+			s.handle(ctx, evt)
+		}
+	}
+}
+
+// isLeader reports whether this node should act on the event.
+func (s *Subscriber) isLeader(ctx context.Context) bool {
+	if s.leaderCheck == nil {
+		return true
+	}
+	leader, err := s.leaderCheck(ctx)
+	if err != nil {
+		log.Warn("incident: leader check failed; skipping event", "error", err)
+		return false
+	}
+	return leader
+}
+
+func (s *Subscriber) handle(ctx context.Context, evt event.Event) {
+	if evt.Quarantine {
+		return
+	}
+	if !s.isLeader(ctx) {
+		return
+	}
+	switch evt.Type {
+	case event.TypeTaskSucceeded, event.TypeRunCompleted:
+		s.handleSuccess(ctx, evt)
+	default:
+		s.handleFailure(ctx, evt)
+	}
+}
+
+// failureContext carries the resolved facts a failure event contributes.
+type failureContext struct {
+	jobID      uuid.UUID
+	taskName   string
+	taskRun    *models.TaskRun
+	backfillID *uuid.UUID
+}
+
+// resolveContext fills in job id, task name, task-run detail, and backfill id
+// from the event and the DB.
+func (s *Subscriber) resolveContext(ctx context.Context, evt event.Event) failureContext {
+	fc := failureContext{jobID: evt.JobID}
+
+	if evt.RunID != uuid.Nil {
+		var jr models.JobRun
+		if err := s.db.WithContext(ctx).
+			Select("id", "job_id", "backfill_id").
+			First(&jr, "id = ?", evt.RunID).Error; err == nil {
+			if fc.jobID == uuid.Nil {
+				fc.jobID = jr.JobID
+			}
+			fc.backfillID = jr.BackfillID
+		}
+	}
+
+	if evt.TaskID != uuid.Nil && evt.RunID != uuid.Nil {
+		var tr models.TaskRun
+		if err := s.db.WithContext(ctx).
+			Where("job_run_id = ? AND task_id = ?", evt.RunID, evt.TaskID).
+			First(&tr).Error; err == nil {
+			fc.taskRun = &tr
+		}
+		var task models.Task
+		if err := s.db.WithContext(ctx).Select("name").First(&task, "id = ?", evt.TaskID).Error; err == nil {
+			fc.taskName = task.Name
+		}
+	}
+	return fc
+}
+
+func (s *Subscriber) handleFailure(ctx context.Context, evt event.Event) {
+	fc := s.resolveContext(ctx, evt)
+	if fc.jobID == uuid.Nil {
+		log.Warn("incident: could not resolve job for failure event", "type", evt.Type, "run_id", evt.RunID)
+		return
+	}
+
+	sig := Signal{EventType: string(evt.Type)}
+	var exitCode *int
+	if fc.taskRun != nil {
+		sig.Result = fc.taskRun.Result
+		sig.HasSchemaViolations = len(fc.taskRun.SchemaViolations) > 0
+		sig.LogTail = fc.taskRun.LogText
+		sig.Error = fc.taskRun.Error
+		sig.ExitCode = fc.taskRun.ExitCode
+		exitCode = fc.taskRun.ExitCode
+	}
+
+	class := s.classifier.Classify(sig)
+
+	var runID *uuid.UUID
+	if evt.RunID != uuid.Nil {
+		r := evt.RunID
+		runID = &r
+	}
+	var taskID *uuid.UUID
+	if evt.TaskID != uuid.Nil {
+		t := evt.TaskID
+		taskID = &t
+	}
+
+	params := OpenParams{
+		JobID:                  fc.jobID,
+		RunID:                  runID,
+		TaskID:                 taskID,
+		TaskName:               fc.taskName,
+		Class:                  class,
+		LastError:              sig.Error,
+		Evidence:               buildEvidence(class, exitCode, sig.Result),
+		BackfillID:             fc.backfillID,
+		RemediationTargetRunID: runID,
+		Cooldown:               s.cooldown,
+	}
+
+	inc, outcome, err := s.store.OpenOrAppend(ctx, params)
+	if err != nil {
+		log.Error("incident: failed to open/append incident", "job_id", fc.jobID, "class", class, "error", err)
+		return
+	}
+	if outcome == OutcomeSuppressed {
+		log.Debug("incident: suppressed by cooldown", "job_id", fc.jobID, "class", class)
+		return
+	}
+	metrics.IncidentsTotal.WithLabelValues(string(class), string(inc.Status)).Inc()
+	log.Info("incident recorded",
+		"incident_id", inc.ID,
+		"job_id", fc.jobID,
+		"task", fc.taskName,
+		"class", class,
+		"outcome", outcome,
+		"occurrences", inc.OccurrenceCount,
+	)
+}
+
+// handleSuccess closes open incidents whose job/task later ran green — the
+// terminal-verified remediation path.
+func (s *Subscriber) handleSuccess(ctx context.Context, evt event.Event) {
+	jobID := evt.JobID
+	taskName := ""
+	if evt.RunID != uuid.Nil {
+		var jr models.JobRun
+		if err := s.db.WithContext(ctx).Select("id", "job_id").First(&jr, "id = ?", evt.RunID).Error; err == nil && jobID == uuid.Nil {
+			jobID = jr.JobID
+		}
+	}
+	if evt.TaskID != uuid.Nil {
+		var task models.Task
+		if err := s.db.WithContext(ctx).Select("name").First(&task, "id = ?", evt.TaskID).Error; err == nil {
+			taskName = task.Name
+		}
+	}
+	if jobID == uuid.Nil {
+		return
+	}
+
+	incidents, err := s.store.OpenForJobTask(ctx, jobID, taskName)
+	if err != nil {
+		log.Warn("incident: failed to load open incidents for success", "job_id", jobID, "error", err)
+		return
+	}
+	for i := range incidents {
+		inc := &incidents[i]
+		remediated, err := s.store.Remediate(ctx, inc.ID, "subsequent run succeeded")
+		if err != nil {
+			// A concurrent transition or an incident not in a remediable state is
+			// non-fatal — just skip it.
+			log.Debug("incident: could not remediate on success", "incident_id", inc.ID, "error", err)
+			continue
+		}
+		metrics.IncidentsTotal.WithLabelValues(remediated.Class, string(models.IncidentStatusRemediated)).Inc()
+		if !inc.OpenedAt.IsZero() {
+			metrics.IncidentResolutionSeconds.WithLabelValues(remediated.Class).Observe(time.Since(inc.OpenedAt).Seconds())
+		}
+		log.Info("incident remediated", "incident_id", inc.ID, "job_id", jobID, "task", taskName)
+	}
+}
+
+// buildEvidence renders a small JSON evidence blob for the incident feed.
+func buildEvidence(class FailureClass, exitCode *int, result string) datatypes.JSON {
+	m := map[string]any{"class": string(class)}
+	if exitCode != nil {
+		m["exit_code"] = *exitCode
+	}
+	if result != "" {
+		m["result"] = result
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		return nil
+	}
+	return datatypes.JSON(b)
+}

--- a/internal/incident/subscriber_test.go
+++ b/internal/incident/subscriber_test.go
@@ -30,7 +30,7 @@ func seedFailedTask(t *testing.T, db *gorm.DB, logText string) (jobID, runID, ta
 	}).Error)
 	require.NoError(t, db.Create(&models.TaskRun{
 		ID: uuid.New(), JobRunID: runID, TaskID: taskID, AtomID: uuid.New(),
-		Engine: models.AtomEngineDocker, Image: "busybox", Command: "sh",
+		Engine: models.AtomEngineDocker, Image: "busybox:1.36.1", Command: "sh",
 		Status: "failed", Result: "failure", LogText: logText,
 		CreatedAt: now, UpdatedAt: now,
 	}).Error)

--- a/internal/incident/subscriber_test.go
+++ b/internal/incident/subscriber_test.go
@@ -1,0 +1,128 @@
+package incident
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedFailedTask inserts a JobRun, Task, and failed TaskRun the subscriber can
+// resolve, returning the ids needed to publish an event.
+func seedFailedTask(t *testing.T, db *gorm.DB, logText string) (jobID, runID, taskID uuid.UUID) {
+	t.Helper()
+	now := time.Now().UTC()
+	jobID = uuid.New()
+	runID = uuid.New()
+	taskID = uuid.New()
+
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: runID, JobID: jobID, Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Task{
+		ID: taskID, JobID: jobID, AtomID: uuid.New(), Name: "extract", CreatedAt: now, UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: runID, TaskID: taskID, AtomID: uuid.New(),
+		Engine: models.AtomEngineDocker, Image: "busybox", Command: "sh",
+		Status: "failed", Result: "failure", LogText: logText,
+		CreatedAt: now, UpdatedAt: now,
+	}).Error)
+	return jobID, runID, taskID
+}
+
+func startSubscriber(t *testing.T, bus event.Bus, db *gorm.DB, cooldown time.Duration) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	sub := NewSubscriber(bus, db, nil, cooldown)
+	ready := make(chan struct{})
+	go func() { _ = sub.StartWithReady(ctx, ready) }()
+	<-ready
+	return ctx
+}
+
+func waitForIncidents(t *testing.T, db *gorm.DB, want int64) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		var n int64
+		require.NoError(t, db.Model(&models.Incident{}).Count(&n).Error)
+		if n == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	var n int64
+	db.Model(&models.Incident{}).Count(&n)
+	t.Fatalf("expected %d incidents, got %d", want, n)
+}
+
+func TestSubscriberOpensClassifiedIncident(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+	startSubscriber(t, bus, db, 0)
+
+	jobID, runID, taskID := seedFailedTask(t, db, "Error: permission denied reading /secure")
+
+	bus.Publish(event.Event{Type: event.TypeTaskFailed, JobID: jobID, RunID: runID, TaskID: taskID, Timestamp: time.Now()})
+	waitForIncidents(t, db, 1)
+
+	var inc models.Incident
+	require.NoError(t, db.First(&inc).Error)
+	require.Equal(t, string(ClassAuthFailure), inc.Class)
+	require.Equal(t, models.IncidentStatusOpen, inc.Status)
+	require.Equal(t, 1, inc.OccurrenceCount)
+}
+
+func TestSubscriberAppendsOccurrenceNoTwin(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+	startSubscriber(t, bus, db, 0)
+
+	jobID, runID, taskID := seedFailedTask(t, db, "quota exceeded: too many requests")
+	evt := event.Event{Type: event.TypeTaskFailed, JobID: jobID, RunID: runID, TaskID: taskID, Timestamp: time.Now()}
+
+	bus.Publish(evt)
+	waitForIncidents(t, db, 1)
+	bus.Publish(evt)
+
+	// Give the subscriber a moment; count must stay at 1 with occurrence 2.
+	require.Eventually(t, func() bool {
+		var inc models.Incident
+		if err := db.First(&inc).Error; err != nil {
+			return false
+		}
+		return inc.OccurrenceCount == 2
+	}, 3*time.Second, 10*time.Millisecond)
+	testutil.AssertCount(t, db, &models.Incident{}, 1)
+}
+
+func TestSubscriberRemediatesOnSuccess(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+	startSubscriber(t, bus, db, 0)
+
+	jobID, runID, taskID := seedFailedTask(t, db, "could not connect: connection refused")
+	bus.Publish(event.Event{Type: event.TypeTaskFailed, JobID: jobID, RunID: runID, TaskID: taskID, Timestamp: time.Now()})
+	waitForIncidents(t, db, 1)
+
+	// A later success for the same job/task closes the incident as remediated.
+	bus.Publish(event.Event{Type: event.TypeTaskSucceeded, JobID: jobID, RunID: runID, TaskID: taskID, Timestamp: time.Now()})
+	require.Eventually(t, func() bool {
+		var inc models.Incident
+		if err := db.First(&inc).Error; err != nil {
+			return false
+		}
+		return inc.Status == models.IncidentStatusClosed && inc.ClosedAt != nil
+	}, 3*time.Second, 10*time.Millisecond)
+}

--- a/internal/incident/timer.go
+++ b/internal/incident/timer.go
@@ -1,0 +1,128 @@
+package incident
+
+import (
+	"context"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"gorm.io/gorm"
+)
+
+// TimerFunc handles a fired durable timer. Stream B registers the concrete
+// snooze_retry handler; in Phase 0 with no handler registered the sweeper simply
+// records the timer as fired.
+type TimerFunc func(ctx context.Context, timer models.RemediationTimer) error
+
+// TimerSupervisor is the leader-gated durable-timer sweeper. It periodically
+// fires due RemediationTimer rows so a pending snooze/retry survives
+// restart/failover (no in-process time.NewTimer is the sole record). Timers
+// whose owning incident has reached a terminal state are never fired — they are
+// cancelled at the transition, and the sweeper double-checks before firing.
+type TimerSupervisor struct {
+	db          *gorm.DB
+	store       *Store
+	leaderCheck LeaderCheck
+	interval    time.Duration
+	batch       int
+	handlers    map[string]TimerFunc
+}
+
+// NewTimerSupervisor constructs the sweeper. A zero interval defaults to 5s.
+func NewTimerSupervisor(db *gorm.DB, leaderCheck LeaderCheck, interval time.Duration) *TimerSupervisor {
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+	return &TimerSupervisor{
+		db:          db,
+		store:       NewStore(db),
+		leaderCheck: leaderCheck,
+		interval:    interval,
+		batch:       100,
+		handlers:    make(map[string]TimerFunc),
+	}
+}
+
+// RegisterHandler registers the handler invoked when a timer of the given kind
+// fires.
+func (t *TimerSupervisor) RegisterHandler(kind string, fn TimerFunc) {
+	t.handlers[kind] = fn
+}
+
+// Run drives the sweep loop until ctx is cancelled.
+func (t *TimerSupervisor) Run(ctx context.Context) {
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := t.SweepOnce(ctx); err != nil && ctx.Err() == nil {
+				log.Error("incident timer sweep failed", "error", err)
+			}
+		}
+	}
+}
+
+// SweepOnce fires all due timers once. It is leader-gated so an N-node cluster
+// fires each timer exactly once.
+func (t *TimerSupervisor) SweepOnce(ctx context.Context) error {
+	if t.leaderCheck != nil {
+		leader, err := t.leaderCheck(ctx)
+		if err != nil {
+			return err
+		}
+		if !leader {
+			return nil
+		}
+	}
+
+	due, err := t.store.DueTimers(ctx, time.Now().UTC(), t.batch)
+	if err != nil {
+		return err
+	}
+	for i := range due {
+		t.fire(ctx, due[i])
+	}
+	return nil
+}
+
+// fire claims and dispatches a single due timer. A timer whose owning incident
+// is terminal is cancelled rather than fired.
+func (t *TimerSupervisor) fire(ctx context.Context, timer models.RemediationTimer) {
+	// Double-check the owning incident is not terminal before firing (guards the
+	// close-races-with-fire window).
+	inc, err := t.store.Get(ctx, timer.IncidentID)
+	if err != nil {
+		log.Warn("incident timer: owning incident lookup failed; skipping", "timer_id", timer.ID, "error", err)
+		return
+	}
+	if inc.Status.IsTerminal() {
+		if _, cerr := t.store.CancelTimersForIncident(ctx, timer.IncidentID); cerr != nil {
+			log.Warn("incident timer: failed to cancel timer for terminal incident", "timer_id", timer.ID, "error", cerr)
+		}
+		return
+	}
+
+	claimed, err := t.store.ClaimTimer(ctx, timer.ID)
+	if err != nil {
+		log.Warn("incident timer: claim failed", "timer_id", timer.ID, "error", err)
+		return
+	}
+	if !claimed {
+		// Another sweep or a cancellation won the race.
+		return
+	}
+
+	handler, ok := t.handlers[timer.Kind]
+	if !ok {
+		// Phase 0: no handler registered (Stream B provides them). The timer is
+		// already recorded as fired; nothing else to do.
+		log.Info("incident timer fired (no handler registered)", "timer_id", timer.ID, "kind", timer.Kind, "incident_id", timer.IncidentID)
+		return
+	}
+	if err := handler(ctx, timer); err != nil {
+		log.Error("incident timer handler failed", "timer_id", timer.ID, "kind", timer.Kind, "error", err)
+	}
+}

--- a/internal/incident/timer_test.go
+++ b/internal/incident/timer_test.go
@@ -1,0 +1,108 @@
+package incident
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func newIncidentForTimer(t *testing.T, store *Store) *models.Incident {
+	t.Helper()
+	inc, _, err := store.OpenOrAppend(context.Background(), OpenParams{JobID: uuid.New(), TaskName: "t", Class: ClassUnknown})
+	require.NoError(t, err)
+	return inc
+}
+
+func TestTimerSweepFiresDueTimer(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	inc := newIncidentForTimer(t, store)
+
+	_, err := store.ScheduleTimer(ctx, inc.ID, "snooze_retry", time.Now().Add(-time.Minute), nil, nil, nil)
+	require.NoError(t, err)
+
+	sup := NewTimerSupervisor(db, nil, time.Second)
+	fired := 0
+	sup.RegisterHandler("snooze_retry", func(context.Context, models.RemediationTimer) error {
+		fired++
+		return nil
+	})
+	require.NoError(t, sup.SweepOnce(ctx))
+	require.Equal(t, 1, fired, "due timer should fire exactly once")
+
+	// A second sweep must not re-fire the already-claimed timer.
+	require.NoError(t, sup.SweepOnce(ctx))
+	require.Equal(t, 1, fired)
+
+	var timer models.RemediationTimer
+	require.NoError(t, db.First(&timer, "incident_id = ?", inc.ID).Error)
+	require.Equal(t, models.RemediationTimerStatusFired, timer.Status)
+}
+
+func TestTimerNotYetDueDoesNotFire(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	inc := newIncidentForTimer(t, store)
+
+	_, err := store.ScheduleTimer(ctx, inc.ID, "snooze_retry", time.Now().Add(time.Hour), nil, nil, nil)
+	require.NoError(t, err)
+
+	sup := NewTimerSupervisor(db, nil, time.Second)
+	fired := 0
+	sup.RegisterHandler("snooze_retry", func(context.Context, models.RemediationTimer) error { fired++; return nil })
+	require.NoError(t, sup.SweepOnce(ctx))
+	require.Equal(t, 0, fired)
+}
+
+func TestTerminalIncidentCancelsTimer(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	inc := newIncidentForTimer(t, store)
+
+	_, err := store.ScheduleTimer(ctx, inc.ID, "snooze_retry", time.Now().Add(-time.Minute), nil, nil, nil)
+	require.NoError(t, err)
+
+	// Closing the incident must cancel its pending timers (A6 invariant): a stale
+	// timer can never fire a retry against a closed incident.
+	_, err = store.Transition(ctx, inc.ID, models.IncidentStatusEscalated, "")
+	require.NoError(t, err)
+	_, err = store.Transition(ctx, inc.ID, models.IncidentStatusClosed, "")
+	require.NoError(t, err)
+
+	var timer models.RemediationTimer
+	require.NoError(t, db.First(&timer, "incident_id = ?", inc.ID).Error)
+	require.Equal(t, models.RemediationTimerStatusCancelled, timer.Status)
+
+	sup := NewTimerSupervisor(db, nil, time.Second)
+	fired := 0
+	sup.RegisterHandler("snooze_retry", func(context.Context, models.RemediationTimer) error { fired++; return nil })
+	require.NoError(t, sup.SweepOnce(ctx))
+	require.Equal(t, 0, fired, "cancelled timer must never fire")
+}
+
+func TestLeaderGateSkipsSweep(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ctx := context.Background()
+	inc := newIncidentForTimer(t, store)
+	_, err := store.ScheduleTimer(ctx, inc.ID, "snooze_retry", time.Now().Add(-time.Minute), nil, nil, nil)
+	require.NoError(t, err)
+
+	sup := NewTimerSupervisor(db, func(context.Context) (bool, error) { return false, nil }, time.Second)
+	fired := 0
+	sup.RegisterHandler("snooze_retry", func(context.Context, models.RemediationTimer) error { fired++; return nil })
+	require.NoError(t, sup.SweepOnce(ctx))
+	require.Equal(t, 0, fired, "non-leader must not fire timers")
+}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -860,6 +860,12 @@ func (j *job) Run(ctx context.Context) error {
 			a = result.atom
 			log.Info("atom finished", "job_id", j.id, "task_id", taskID, "atom_id", a.ID(), "result", a.Result())
 
+			// Capture the raw exit code before Result() folds it into a coarse
+			// status and the incident classifier loses it. Best-effort.
+			if exitErr := store.SetTaskExitCode(runID, taskID, a.ExitCode()); exitErr != nil {
+				log.Warn("failed to persist task exit code", "task_id", taskID, "error", exitErr)
+			}
+
 			// Parse both structured outputs and branch markers in a single
 			// pass over the log stream (no full buffering).
 			var taskOutput map[string]string

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -763,6 +763,7 @@ type fakeAtom struct {
 	engine    atom.Engine
 	state     atom.State
 	result    atom.Result
+	exitCode  int
 	createdAt time.Time
 	startedAt time.Time
 	stoppedAt time.Time
@@ -771,6 +772,7 @@ type fakeAtom struct {
 func (a *fakeAtom) ID() string           { return a.id }
 func (a *fakeAtom) State() atom.State    { return a.state }
 func (a *fakeAtom) Result() atom.Result  { return a.result }
+func (a *fakeAtom) ExitCode() int        { return a.exitCode }
 func (a *fakeAtom) CreatedAt() time.Time { return a.createdAt }
 func (a *fakeAtom) StartedAt() time.Time { return a.startedAt }
 func (a *fakeAtom) StoppedAt() time.Time { return a.stoppedAt }

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -763,7 +763,7 @@ type fakeAtom struct {
 	engine    atom.Engine
 	state     atom.State
 	result    atom.Result
-	exitCode  int
+	exitCode  *int
 	createdAt time.Time
 	startedAt time.Time
 	stoppedAt time.Time
@@ -772,7 +772,7 @@ type fakeAtom struct {
 func (a *fakeAtom) ID() string           { return a.id }
 func (a *fakeAtom) State() atom.State    { return a.state }
 func (a *fakeAtom) Result() atom.Result  { return a.result }
-func (a *fakeAtom) ExitCode() int        { return a.exitCode }
+func (a *fakeAtom) ExitCode() *int       { return a.exitCode }
 func (a *fakeAtom) CreatedAt() time.Time { return a.createdAt }
 func (a *fakeAtom) StartedAt() time.Time { return a.startedAt }
 func (a *fakeAtom) StoppedAt() time.Time { return a.stoppedAt }

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -490,6 +490,29 @@ var (
 		},
 		[]string{"reason"},
 	)
+
+	// IncidentsTotal counts incident lifecycle transitions by failure class and
+	// resulting status. The class label is bounded by the classifier's fixed set
+	// of failure classes and status by the incident status machine, so cardinality
+	// is bounded (agent-in-the-loop remediation, Phase 0).
+	IncidentsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_incidents_total",
+			Help: "Total incident lifecycle transitions by failure class and status.",
+		},
+		[]string{"class", "status"},
+	)
+
+	// IncidentResolutionSeconds measures time from incident open to a terminal
+	// disposition, labelled by failure class.
+	IncidentResolutionSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "caesium_incident_resolution_seconds",
+			Help:    "Time from incident open to terminal disposition in seconds, by failure class.",
+			Buckets: []float64{1, 5, 30, 60, 300, 900, 1800, 3600, 14400, 86400},
+		},
+		[]string{"class"},
+	)
 )
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
@@ -546,6 +569,8 @@ func Register() {
 			DispatchSentTotal,
 			CompleteReportFailedTotal,
 			CompleteRetryableTotal,
+			IncidentsTotal,
+			IncidentResolutionSeconds,
 		)
 	})
 }

--- a/internal/models/agent_action.go
+++ b/internal/models/agent_action.go
@@ -1,0 +1,60 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// AgentActionStatus enumerates an action's lifecycle in the audit spine.
+type AgentActionStatus string
+
+const (
+	AgentActionStatusProposed AgentActionStatus = "proposed"
+	AgentActionStatusApproved AgentActionStatus = "approved"
+	AgentActionStatusRejected AgentActionStatus = "rejected"
+	AgentActionStatusExecuted AgentActionStatus = "executed"
+	AgentActionStatusFailed   AgentActionStatus = "failed"
+)
+
+// AgentActionActor identifies who originated an action row.
+type AgentActionActor string
+
+const (
+	// ActorPolicy is a deterministic server-side rule (Phase 0) — no container.
+	AgentActionActorPolicy AgentActionActor = "policy"
+	// ActorAgent is the container-native agent (Phase 1+).
+	AgentActionActorAgent AgentActionActor = "agent"
+	// ActorHuman is an operator action.
+	AgentActionActorHuman AgentActionActor = "human"
+)
+
+// AgentAction is the audit spine: every remediation attempt (whether taken by a
+// deterministic policy rule, the container agent, or a human) is recorded as a
+// row. The incident reference is NON-NULLABLE so the timeline reconstructs for
+// actor=policy|human rows that have no session; the session reference is
+// nullable. Append-only, low-volume.
+type AgentAction struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	// Namespace is nullable from day one (design Open Question 4).
+	Namespace *string `gorm:"type:text;index" json:"namespace,omitempty"`
+
+	// IncidentID is non-nullable — the audit spine always ties to an incident.
+	IncidentID uuid.UUID `gorm:"type:uuid;index;not null" json:"incident_id"`
+	Incident   Incident  `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+
+	// SessionID is nullable: policy/human rows have no agent session.
+	SessionID *uuid.UUID    `gorm:"type:uuid;index" json:"session_id,omitempty"`
+	Session   *AgentSession `gorm:"constraint:OnDelete:SET NULL" json:"-"`
+
+	Type   string            `gorm:"type:text;index;not null" json:"type"`
+	Params datatypes.JSON    `gorm:"type:json" json:"params,omitempty"`
+	Tier   int               `gorm:"not null;default:0" json:"tier"`
+	Status AgentActionStatus `gorm:"type:text;index;not null" json:"status"`
+	Result datatypes.JSON    `gorm:"type:json" json:"result,omitempty"`
+	Actor  AgentActionActor  `gorm:"type:text;index;not null" json:"actor"`
+
+	CreatedAt time.Time `gorm:"not null;index" json:"created_at"`
+	UpdatedAt time.Time `gorm:"not null" json:"updated_at"`
+}

--- a/internal/models/agent_profile.go
+++ b/internal/models/agent_profile.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// AgentProfile is the server-side resource declaring how a remediation agent
+// runs: its container image/engine, resource limits, model-credential
+// secret:// references, session budgets, and the default playbook. It is
+// referenced by a job's metadata.remediation block. Low-volume catalog row.
+type AgentProfile struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	// Namespace is nullable from day one (design Open Question 4).
+	Namespace *string `gorm:"type:text;index" json:"namespace,omitempty"`
+
+	Name   string     `gorm:"uniqueIndex;not null" json:"name"`
+	Image  string     `gorm:"type:text;not null" json:"image"`
+	Engine AtomEngine `gorm:"type:text;not null;default:'docker'" json:"engine"`
+
+	// Limits holds resource limits (cpu/memory/wall-clock) as JSON.
+	Limits datatypes.JSON `gorm:"type:json" json:"limits,omitempty"`
+	// SecretRefs holds secret:// references (e.g. the model API key) as JSON.
+	// Never resolved values — only the references.
+	SecretRefs datatypes.JSON `gorm:"type:json" json:"secret_refs,omitempty"`
+	// Budgets holds per-session budget defaults (max actions, token/cost caps).
+	Budgets datatypes.JSON `gorm:"type:json" json:"budgets,omitempty"`
+	// Playbook holds the default action-catalog policy for jobs using this profile.
+	Playbook datatypes.JSON `gorm:"type:json" json:"playbook,omitempty"`
+
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	CreatedAt time.Time      `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time      `gorm:"not null" json:"updated_at"`
+}

--- a/internal/models/agent_session.go
+++ b/internal/models/agent_session.go
@@ -1,0 +1,61 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// AgentSessionState enumerates the terminal-tracked lifecycle of an agent
+// container session.
+type AgentSessionState string
+
+const (
+	AgentSessionStatePending   AgentSessionState = "pending"
+	AgentSessionStateRunning   AgentSessionState = "running"
+	AgentSessionStateSucceeded AgentSessionState = "succeeded"
+	AgentSessionStateFailed    AgentSessionState = "failed"
+	AgentSessionStateTimedOut  AgentSessionState = "timed_out"
+	AgentSessionStateCancelled AgentSessionState = "cancelled"
+)
+
+// AgentSession records a single agent container run launched through the
+// existing atom.Engine to triage an incident. It is DELIBERATELY NOT a JobRun /
+// TaskRun: a session materialized as a run would pollute the quarantine-filtered
+// run statistics and feed its own exhaust back into the incident bus. Low-volume.
+type AgentSession struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	// Namespace is nullable from day one (design Open Question 4).
+	Namespace *string `gorm:"type:text;index" json:"namespace,omitempty"`
+
+	IncidentID uuid.UUID `gorm:"type:uuid;index;not null" json:"incident_id"`
+	Incident   Incident  `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+
+	ProfileID *uuid.UUID    `gorm:"type:uuid;index" json:"profile_id,omitempty"`
+	Profile   *AgentProfile `gorm:"constraint:OnDelete:SET NULL" json:"-"`
+
+	Engine AtomEngine `gorm:"type:text" json:"engine,omitempty"`
+	// AtomID / ContainerID identify the launched container/atom for the UI and
+	// for stop/cleanup.
+	AtomID      *uuid.UUID `gorm:"type:uuid;index" json:"atom_id,omitempty"`
+	ContainerID string     `gorm:"type:text" json:"container_id,omitempty"`
+
+	// TokenID is the scoped, short-lived agent credential bound to this session.
+	TokenID *uuid.UUID `gorm:"type:uuid;index" json:"token_id,omitempty"`
+
+	State AgentSessionState `gorm:"type:text;index;not null;default:'pending'" json:"state"`
+	// SessionLog is the persisted agent-container log for the UI timeline.
+	SessionLog string `gorm:"type:text" json:"session_log,omitempty"`
+
+	// Budget counters. These are best-effort accounting the executor increments.
+	ActionsUsed int `gorm:"not null;default:0" json:"actions_used"`
+	TokensUsed  int `gorm:"not null;default:0" json:"tokens_used"`
+
+	StartedAt   *time.Time `json:"started_at,omitempty"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	CreatedAt   time.Time  `gorm:"not null" json:"created_at"`
+	UpdatedAt   time.Time  `gorm:"not null" json:"updated_at"`
+	// Extra carries additional session metadata (e.g. frozen allowlist) as JSON.
+	Extra datatypes.JSON `gorm:"type:json" json:"extra,omitempty"`
+}

--- a/internal/models/approval_request.go
+++ b/internal/models/approval_request.go
@@ -1,0 +1,45 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ApprovalDecision enumerates the outcome of a tier-3 approval request.
+type ApprovalDecision string
+
+const (
+	ApprovalDecisionPending  ApprovalDecision = "pending"
+	ApprovalDecisionApproved ApprovalDecision = "approved"
+	ApprovalDecisionRejected ApprovalDecision = "rejected"
+	ApprovalDecisionExpired  ApprovalDecision = "expired"
+)
+
+// ApprovalRequest is created by every tier-3 action and resolved by a human
+// operator. Tier-3 actions are NEVER auto-executed regardless of config, so an
+// approval always terminates at a human decision. Low-volume catalog row.
+type ApprovalRequest struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	// Namespace is nullable from day one (design Open Question 4).
+	Namespace *string `gorm:"type:text;index" json:"namespace,omitempty"`
+
+	// IncidentID lets the operator read API filter approvals by incident without
+	// a join through the action.
+	IncidentID uuid.UUID `gorm:"type:uuid;index;not null" json:"incident_id"`
+
+	ActionID uuid.UUID   `gorm:"type:uuid;index;not null" json:"action_id"`
+	Action   AgentAction `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+
+	// ApproversHint is a free-text hint for who should decide (role/channel).
+	ApproversHint string           `gorm:"type:text" json:"approvers_hint,omitempty"`
+	Decision      ApprovalDecision `gorm:"type:text;index;not null;default:'pending'" json:"decision"`
+	// Decider records the operator identity that resolved the request.
+	Decider string `gorm:"type:text" json:"decider,omitempty"`
+	Reason  string `gorm:"type:text" json:"reason,omitempty"`
+
+	ExpiresAt  *time.Time `gorm:"index" json:"expires_at,omitempty"`
+	DecidedAt  *time.Time `json:"decided_at,omitempty"`
+	CreatedAt  time.Time  `gorm:"not null" json:"created_at"`
+	UpdatedAt  time.Time  `gorm:"not null" json:"updated_at"`
+}

--- a/internal/models/approval_request.go
+++ b/internal/models/approval_request.go
@@ -38,8 +38,8 @@ type ApprovalRequest struct {
 	Decider string `gorm:"type:text" json:"decider,omitempty"`
 	Reason  string `gorm:"type:text" json:"reason,omitempty"`
 
-	ExpiresAt  *time.Time `gorm:"index" json:"expires_at,omitempty"`
-	DecidedAt  *time.Time `json:"decided_at,omitempty"`
-	CreatedAt  time.Time  `gorm:"not null" json:"created_at"`
-	UpdatedAt  time.Time  `gorm:"not null" json:"updated_at"`
+	ExpiresAt *time.Time `gorm:"index" json:"expires_at,omitempty"`
+	DecidedAt *time.Time `json:"decided_at,omitempty"`
+	CreatedAt time.Time  `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time  `gorm:"not null" json:"updated_at"`
 }

--- a/internal/models/incident.go
+++ b/internal/models/incident.go
@@ -1,0 +1,93 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// IncidentStatus enumerates the states of the incident status machine
+// (design-agent-in-the-loop.md, Phase 0). The lifecycle is:
+//
+//	open → triaging → (awaiting_approval ↔ triaging) → remediated | escalated → closed
+//
+// with suppressed and abandoned as additional terminal dispositions.
+type IncidentStatus string
+
+const (
+	IncidentStatusOpen             IncidentStatus = "open"
+	IncidentStatusTriaging         IncidentStatus = "triaging"
+	IncidentStatusAwaitingApproval IncidentStatus = "awaiting_approval"
+	IncidentStatusRemediated       IncidentStatus = "remediated"
+	IncidentStatusEscalated        IncidentStatus = "escalated"
+	IncidentStatusClosed           IncidentStatus = "closed"
+	IncidentStatusSuppressed       IncidentStatus = "suppressed"
+	IncidentStatusAbandoned        IncidentStatus = "abandoned"
+)
+
+// IsTerminal reports whether the status is a terminal incident disposition.
+func (s IncidentStatus) IsTerminal() bool {
+	switch s {
+	case IncidentStatusClosed, IncidentStatusSuppressed, IncidentStatusAbandoned:
+		return true
+	default:
+		return false
+	}
+}
+
+// Incident records a classified failure that Caesium's incident manager opened
+// from the event bus. Incidents are append-mostly, low-volume catalog rows —
+// NOT a hot per-run table — so they are not listed in hotPathModels().
+type Incident struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	// Namespace is nullable from day one (design Open Question 4). Empty/NULL
+	// means the default namespace; a value scopes the incident to a tenant.
+	Namespace *string `gorm:"type:text;index" json:"namespace,omitempty"`
+
+	JobID    uuid.UUID  `gorm:"type:uuid;index;not null" json:"job_id"`
+	RunID    *uuid.UUID `gorm:"type:uuid;index" json:"run_id,omitempty"`
+	TaskID   *uuid.UUID `gorm:"type:uuid;index" json:"task_id,omitempty"`
+	TaskName string     `gorm:"type:text" json:"task_name,omitempty"`
+
+	// Class is the deterministic failure_class the classifier assigned.
+	Class string `gorm:"type:text;index;not null" json:"class"`
+	// Status is the current position in the incident status machine.
+	Status IncidentStatus `gorm:"type:text;index;not null" json:"status"`
+
+	// DedupeKey is the stable correlation key (job_id, task_name, failure_class).
+	// It is recorded on every incident (open or closed) for history and querying.
+	DedupeKey string `gorm:"type:text;index;not null" json:"dedupe_key"`
+	// ActiveDedupeKey enforces "at most one non-terminal incident per dedupe key":
+	// it holds DedupeKey while the incident is open and is set NULL on any terminal
+	// transition. The unique index only constrains non-NULL rows (dqlite/SQLite
+	// semantics), so closed incidents never collide — mirroring the nullable
+	// unique-index pattern used by JobRun.ReplayFingerprint. Incident-open is an
+	// atomic conditional insert on this column.
+	ActiveDedupeKey *string `gorm:"type:text;uniqueIndex:idx_incidents_active_dedupe" json:"-"`
+
+	// OccurrenceCount counts distinct failures folded into this incident (the
+	// first open is occurrence 1; an independent same-key failure appends one).
+	OccurrenceCount int `gorm:"not null;default:1" json:"occurrence_count"`
+	// Attempt counts remediation attempts taken against this incident.
+	Attempt int `gorm:"not null;default:0" json:"attempt"`
+	// BackfillID storm-controls backfill-originated failures so a single backfill
+	// does not open one incident per spawned run.
+	BackfillID *uuid.UUID `gorm:"type:uuid;index" json:"backfill_id,omitempty"`
+
+	// RemediationTargetRunID is the run whose success closes the incident as
+	// remediated. It advances when a new occurrence folds in.
+	RemediationTargetRunID *uuid.UUID `gorm:"type:uuid" json:"remediation_target_run_id,omitempty"`
+
+	// LastError is the failing task's error text captured at open, for the feed.
+	LastError string `gorm:"type:text" json:"last_error,omitempty"`
+	// ResolutionSummary is a short human/agent summary written at close.
+	ResolutionSummary string `gorm:"type:text" json:"resolution_summary,omitempty"`
+	// Evidence carries classifier evidence (exit code, matched rule) as JSON.
+	Evidence datatypes.JSON `gorm:"type:json" json:"evidence,omitempty"`
+
+	OpenedAt  time.Time  `gorm:"not null;index" json:"opened_at"`
+	ClosedAt  *time.Time `json:"closed_at,omitempty"`
+	CreatedAt time.Time  `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time  `gorm:"not null" json:"updated_at"`
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -44,4 +44,16 @@ var All = []interface{}{
 	// follow Job (FK parent). Rebuilt from the manifest on every apply; not a
 	// hot per-run table.
 	&DatasetDeclaration{},
+	// Agent-in-the-loop remediation (Phase 0) incident substrate. These are
+	// append-mostly, low-volume catalog tables — NOT hot per-run tables, so they
+	// are deliberately absent from hotPathModels()/hotTables. Parents precede
+	// children so AutoMigrate can build FK constraints: Incident and AgentProfile
+	// first, then AgentSession (FK incident+profile), AgentAction (FK
+	// incident+session), ApprovalRequest (FK action), RemediationTimer (FK incident).
+	&Incident{},
+	&AgentProfile{},
+	&AgentSession{},
+	&AgentAction{},
+	&ApprovalRequest{},
+	&RemediationTimer{},
 }

--- a/internal/models/remediation_timer.go
+++ b/internal/models/remediation_timer.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// RemediationTimerStatus enumerates the lifecycle of a durable timer.
+type RemediationTimerStatus string
+
+const (
+	// Pending: not yet due / not yet fired.
+	RemediationTimerStatusPending RemediationTimerStatus = "pending"
+	// Fired: the sweeper fired the timer's action.
+	RemediationTimerStatusFired RemediationTimerStatus = "fired"
+	// Cancelled: the owning incident reached a terminal transition or a human
+	// took over, so the timer must never fire.
+	RemediationTimerStatusCancelled RemediationTimerStatus = "cancelled"
+)
+
+// RemediationTimer is a durable snooze/retry row backing snooze_retry actions.
+// Every existing delay in Caesium is an in-process time.NewTimer lost on
+// restart/failover; this row survives failover so a leader-gated sweeper can
+// fire due timers. Timers are OWNED BY THEIR INCIDENT and cancelled on any
+// terminal transition or human take-over. Low-volume catalog row.
+type RemediationTimer struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+	// Namespace is nullable from day one (design Open Question 4).
+	Namespace *string `gorm:"type:text;index" json:"namespace,omitempty"`
+
+	IncidentID uuid.UUID `gorm:"type:uuid;index;not null" json:"incident_id"`
+	Incident   Incident  `gorm:"constraint:OnDelete:CASCADE" json:"-"`
+
+	// ActionID optionally links the timer to the AgentAction that scheduled it.
+	ActionID *uuid.UUID `gorm:"type:uuid;index" json:"action_id,omitempty"`
+
+	// Kind identifies what the sweeper should do when the timer fires
+	// (e.g. "snooze_retry").
+	Kind string `gorm:"type:text;not null" json:"kind"`
+	// Payload carries the fire-time parameters (e.g. target run id) as JSON.
+	Payload datatypes.JSON `gorm:"type:json" json:"payload,omitempty"`
+
+	Status RemediationTimerStatus `gorm:"type:text;index;not null;default:'pending'" json:"status"`
+	// FireAt is when the timer becomes due. Indexed so the sweeper's due-scan
+	// (status = pending AND fire_at <= now) is cheap.
+	FireAt  time.Time  `gorm:"not null;index" json:"fire_at"`
+	FiredAt *time.Time `json:"fired_at,omitempty"`
+
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+	UpdatedAt time.Time `gorm:"not null" json:"updated_at"`
+}

--- a/internal/models/run.go
+++ b/internal/models/run.go
@@ -117,7 +117,15 @@ type TaskRun struct {
 	// SchemaValidation snapshots the job's schema validation mode onto the task run.
 	SchemaValidation string `gorm:"type:text;not null;default:''" json:"-"`
 	// SchemaViolations stores any output schema violations detected at runtime.
-	SchemaViolations        datatypes.JSON `gorm:"type:json" json:"schema_violations,omitempty"`
+	SchemaViolations datatypes.JSON `gorm:"type:json" json:"schema_violations,omitempty"`
+	// ExitCode is the raw process exit code the container/pod reported at task
+	// completion. Every engine folds this code into an atom.Result and discards
+	// it today; this column preserves it so the incident classifier can map
+	// exit-code + log-tail patterns to a failure_class (design Phase 0). Nullable:
+	// unset (NULL) when the task never produced an exit code (engine wait error,
+	// startup failure before a code was assigned). A value of 0 is a real,
+	// captured success code — distinct from NULL "never captured".
+	ExitCode                *int           `gorm:"type:integer" json:"exit_code,omitempty"`
 	ExecutionDescriptor     datatypes.JSON `gorm:"type:json" json:"-"`
 	LogText                 string         `gorm:"type:text" json:"-"`
 	LogTruncated            bool           `gorm:"not null;default:false" json:"-"`

--- a/internal/run/schema_validation.go
+++ b/internal/run/schema_validation.go
@@ -1,8 +1,11 @@
 package run
 
 import (
+	"encoding/json"
 	"fmt"
+	"time"
 
+	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	pkgtask "github.com/caesium-cloud/caesium/pkg/task"
@@ -31,8 +34,35 @@ func ValidateTaskOutputSchema(store *Store, runID, taskID uuid.UUID, output map[
 	}
 
 	if schemaValidation == jobdef.SchemaValidationFail {
+		// In fail mode the task fails and its task_failed event already carries
+		// the violations, so no separate event is emitted.
 		return fmt.Errorf("task %s output violates declared schema: %d violation(s)", taskID, len(violations))
 	}
 
+	// In warn mode the task does NOT fail, so the incident manager would never
+	// observe the violation. Emit a dedicated schema_violation_recorded event so
+	// the leader-gated incident subscriber can open a schema_violation incident.
+	publishSchemaViolationEvent(store, runID, taskID, len(violations))
+
 	return nil
+}
+
+// publishSchemaViolationEvent emits a schema_violation_recorded event for a
+// warn-mode violation. Best-effort: a nil bus/store is a no-op. The event
+// carries RunID/TaskID; the subscriber resolves job_id and task_name from the
+// run when correlating.
+func publishSchemaViolationEvent(store *Store, runID, taskID uuid.UUID, count int) {
+	if store == nil {
+		return
+	}
+	payload, _ := json.Marshal(struct {
+		Violations int `json:"violations"`
+	}{Violations: count})
+	store.PublishEvents(event.Event{
+		Type:      event.TypeSchemaViolationRecorded,
+		RunID:     runID,
+		TaskID:    taskID,
+		Timestamp: time.Now().UTC(),
+		Payload:   payload,
+	})
 }

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -2135,6 +2135,16 @@ func (s *Store) SaveTaskLogSnapshot(runID, taskID uuid.UUID, snapshot *TaskLogSn
 		}).Error
 }
 
+// SetTaskExitCode persists the raw process exit code the engine reported at
+// task completion onto the task run. The incident classifier reads this
+// alongside SchemaViolations/Result to bucket a failure into a failure_class.
+// Best-effort: a nil-safe no-op when the row is gone.
+func (s *Store) SetTaskExitCode(runID, taskID uuid.UUID, exitCode int) error {
+	return s.db.Model(&models.TaskRun{}).
+		Where("job_run_id = ? AND task_id = ?", runID, taskID).
+		Update("exit_code", exitCode).Error
+}
+
 // SaveSchemaViolations persists schema validation violations for a task run.
 func (s *Store) SaveSchemaViolations(runID, taskID uuid.UUID, violations []pkgtask.SchemaViolation) error {
 	if len(violations) == 0 {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -2139,7 +2139,7 @@ func (s *Store) SaveTaskLogSnapshot(runID, taskID uuid.UUID, snapshot *TaskLogSn
 // task completion onto the task run. The incident classifier reads this
 // alongside SchemaViolations/Result to bucket a failure into a failure_class.
 // Best-effort: a nil-safe no-op when the row is gone.
-func (s *Store) SetTaskExitCode(runID, taskID uuid.UUID, exitCode int) error {
+func (s *Store) SetTaskExitCode(runID, taskID uuid.UUID, exitCode *int) error {
 	return s.db.Model(&models.TaskRun{}).
 		Where("job_run_id = ? AND task_id = ?", runID, taskID).
 		Update("exit_code", exitCode).Error

--- a/internal/worker/runtime_executor.go
+++ b/internal/worker/runtime_executor.go
@@ -537,6 +537,13 @@ func (e *runtimeExecutor) executeTask(ctx context.Context, taskRun *models.TaskR
 	// state and would report Result=Unknown for the kubernetes engine.
 	a = finalAtom
 
+	// Capture the raw exit code before Result() folds it into a coarse status and
+	// the incident classifier loses it. Best-effort: a persistence failure must
+	// not fail an otherwise-complete task.
+	if err := e.store.SetTaskExitCode(taskRun.JobRunID, taskRun.TaskID, a.ExitCode()); err != nil {
+		log.Warn("failed to persist task exit code", "task_id", taskRun.TaskID, "error", err)
+	}
+
 	// Parse structured task output and branch markers in a single pass
 	// over the log stream (no full buffering). Logs must be fetched before
 	// engine.Stop runs, because Stop tears down the underlying container/pod.

--- a/internal/worker/runtime_executor_test.go
+++ b/internal/worker/runtime_executor_test.go
@@ -86,7 +86,7 @@ type fakeMonitorAtom struct {
 func (a *fakeMonitorAtom) ID() string           { return a.id }
 func (a *fakeMonitorAtom) State() atom.State    { return atom.Stopped }
 func (a *fakeMonitorAtom) Result() atom.Result  { return a.result }
-func (a *fakeMonitorAtom) ExitCode() int        { return 0 }
+func (a *fakeMonitorAtom) ExitCode() *int       { return nil }
 func (a *fakeMonitorAtom) CreatedAt() time.Time { return time.Time{} }
 func (a *fakeMonitorAtom) StartedAt() time.Time { return time.Time{} }
 func (a *fakeMonitorAtom) StoppedAt() time.Time { return time.Time{} }

--- a/internal/worker/runtime_executor_test.go
+++ b/internal/worker/runtime_executor_test.go
@@ -86,6 +86,7 @@ type fakeMonitorAtom struct {
 func (a *fakeMonitorAtom) ID() string           { return a.id }
 func (a *fakeMonitorAtom) State() atom.State    { return atom.Stopped }
 func (a *fakeMonitorAtom) Result() atom.Result  { return a.result }
+func (a *fakeMonitorAtom) ExitCode() int        { return 0 }
 func (a *fakeMonitorAtom) CreatedAt() time.Time { return time.Time{} }
 func (a *fakeMonitorAtom) StartedAt() time.Time { return time.Time{} }
 func (a *fakeMonitorAtom) StoppedAt() time.Time { return time.Time{} }

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -276,6 +276,16 @@ type Environment struct {
 	// fast failover.  Default false — when off, completions take the proven
 	// SQL-advancement path (B2), byte-identical.  Requires RUN_OWNER_ENABLED.
 	RunOwnerInMemory bool `envconfig:"RUN_OWNER_IN_MEMORY" default:"false"`
+
+	// Agent-in-the-loop remediation (Phase 0). The whole feature is gated behind
+	// CAESIUM_AGENT_REMEDIATION_ENABLED — a deployment that never enables it pays
+	// nothing (the leader-gated incident subscriber and timer sweeper are not
+	// started). Default false.
+	AgentRemediationEnabled bool `envconfig:"AGENT_REMEDIATION_ENABLED" default:"false"`
+	// CAESIUM_AGENT_INCIDENT_COOLDOWN suppresses re-opening an incident for the
+	// same (job, task, class) key within this window after the previous one
+	// closed, damping flapping. Default 15m.
+	AgentIncidentCooldown time.Duration `envconfig:"AGENT_INCIDENT_COOLDOWN" default:"15m"`
 }
 
 // SSOEnabled reports whether any SSO provider is configured.


### PR DESCRIPTION
## Summary

First implementation wave (W1-α) of [`docs/exec-plans/active/agent-in-the-loop-remediation.md`](https://github.com/caesium-cloud/caesium/blob/master/docs/exec-plans/active/agent-in-the-loop-remediation.md) — **Stream A**, the entire Phase-0 incident substrate. Delivers standalone failure-diagnosis value with **no LLM and no autonomous actions** — everything is gated behind a default-off master flag, so a deployment that never enables it pays nothing.

- **A1 — models:** six low-volume GORM models (`Incident`, `AgentSession`, `AgentAction`, `ApprovalRequest`, `AgentProfile`, `RemediationTimer`), each with a nullable `namespace` from day one, registered in `models.All` in FK-dependency order (not hot per-run tables). `AgentAction.IncidentID` is non-nullable / `SessionID` nullable (the audit spine reconstructs for policy/human rows). `Incident` carries a nullable `active_dedupe_key` unique index so incident-open is an atomic conditional insert (`ON CONFLICT DO NOTHING`).
- **A2 — exit-code capture:** `TaskRun.ExitCode *int` added beside `SchemaViolations`, captured via a new `atom.Atom.ExitCode()` implemented in all three engines (docker/podman/kubernetes) and persisted by `Store.SetTaskExitCode` in **both** the worker and local execution paths. New `schema_violation_recorded` event emitted from warn-mode schema validation. (Honest limit: full `oom` classification still needs the OOM-flag detection `design-resource-right-sizing.md` builds — this ships the `ExitCode` substrate, not the OOM flag.)
- **A3 — classifier:** `internal/incident/classifier.go`, deterministic and no-LLM, with a configurable exit-code + log-tail regex table (sane defaults) → `transient_infra` / `schema_violation` / `sla_risk` / `data_unavailable` / `auth_failure` / `oom` / `quota`, `unknown` fallback. Every class + fallback unit-tested.
- **A4 — subscriber:** leader-gated (`dqlite.IsLocalLeader`, like the run-queue dequeuer — not the per-node notification subscriber) incident subscriber + `Store.OpenOrAppend` (conditional insert on the dedupe key) + status machine + cooldown suppression + terminal-verified remediate-on-success. Adds `CAESIUM_AGENT_REMEDIATION_ENABLED` (default `false`) + `CAESIUM_AGENT_INCIDENT_COOLDOWN`, the `agent_remediation_enabled` Features flag, and `caesium_incidents_total{class,status}` / `caesium_incident_resolution_seconds` metrics. Wired into `cmd/start/start.go` behind the master gate.
- **A5 — scrubber:** `internal/incident/scrubber.go` — exact `secret://`-value removal with an over-redaction guard (min length 6, common-literal denylist, all-numeric skip) plus a conservative high-entropy heuristic. Test asserts a secret value of `"true"` does not scrub every `true` in the log.
- **A6 — timer:** durable `RemediationTimer` store + a leader-gated `TimerSupervisor` sweeper so a pending snooze/retry survives failover; terminal incident transitions cancel pending timers.

## Test plan

- [x] `gofmt` clean
- [x] `go build ./...` — full dqlite-CGO module incl. all three engines (verified by orchestrator on a Docker-capable checkout)
- [x] `go vet` clean across affected packages
- [x] `golangci-lint run` — 0 issues
- [x] `go test ./internal/incident/... ./internal/models/... ./internal/run/... ./internal/metrics/...` (+ worker/job/atom) — 21 new unit tests: classifier classes + fallback, scrubber over-redaction guard (incl. the `"true"` case), status-machine transitions, dedupe conditional-insert / no-twin, cooldown, timer fire/cancel/leader-gate, bus-driven subscriber open→append→remediate
- [ ] `just integration-test` — the single-node "opens exactly one incident / appends an occurrence" acceptance probe needs Docker; it runs here in CI (the dev sandbox has no Docker). Covered locally by the store + bus-driven subscriber unit tests.

## Notes

- Exit-code folding lives on the `Atom` implementations (`resultMap`), not `engine.go` as the plan text approximated; `ExitCode()` was added to the `atom.Atom` interface + all three atoms (and their test fakes) — the faithful location.
- All new wiring (event type, env fields, metrics, Features flag, startup block, `models.All`) is additive; later W2 streams append alongside. The only file shared with the sibling freshness PR (#277) is `internal/models/models.go` (the `All` append) — a clean union-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh)_