### PR TITLE
Add incident action executor, retry safety valves, tier-1/2 catalog (agent-in-the-loop-remediation W2-β)

### DIFF
--- a/cmd/start/incident_ops.go
+++ b/cmd/start/incident_ops.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/incident"
 	"github.com/caesium-cloud/caesium/internal/run"
 	"github.com/google/uuid"
 )
@@ -34,6 +36,12 @@ func newIncidentActionOps(runStore *run.Store) *incidentActionOps {
 
 func (o *incidentActionOps) RetryFromFailure(_ context.Context, runID uuid.UUID) error {
 	_, err := o.runStore.RetryFromFailureAdmitted(runID)
+	// A paused job or an exhausted concurrency slot is a transient, retryable
+	// refusal: surface it as incident.ErrRetryDeferred so a fired snooze_retry
+	// timer re-arms instead of dropping the retry.
+	if err != nil && (errors.Is(err, run.ErrJobPaused) || errors.Is(err, run.ErrMaxConcurrentRunsReached)) {
+		return fmt.Errorf("%w: %v", incident.ErrRetryDeferred, err)
+	}
 	return err
 }
 

--- a/cmd/start/incident_ops.go
+++ b/cmd/start/incident_ops.go
@@ -1,0 +1,74 @@
+package start
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+)
+
+// errIncidentOpNotWired marks a tier-1/2 action whose concrete server-side
+// operation is not yet wired in this phase. The live Phase-0 path only exercises
+// RetryFromFailure (the deterministic auto_retry_backoff rule and the
+// snooze_retry timer both retry a run); the remaining catalog operations get
+// their concrete wiring when Stream C lands the /v1/agent/* endpoint, and no
+// surface reaches them until then.
+var errIncidentOpNotWired = errors.New("incident: action operation not wired in this phase")
+
+// incidentActionOps is the Phase-0 server-side implementation of
+// incident.ActionOps. It backs the durable snooze_retry timer and the
+// deterministic auto_retry_backoff rule with the admit-aware retry entry point
+// (run.Store.RetryFromFailureAdmitted — the retry safety valves), so the
+// autonomous Phase-0 path actually runs. The other methods are unreachable until
+// Stream C wires the agent tool surface and return errIncidentOpNotWired.
+type incidentActionOps struct {
+	runStore *run.Store
+}
+
+func newIncidentActionOps(runStore *run.Store) *incidentActionOps {
+	return &incidentActionOps{runStore: runStore}
+}
+
+func (o *incidentActionOps) RetryFromFailure(_ context.Context, runID uuid.UUID) error {
+	_, err := o.runStore.RetryFromFailureAdmitted(runID)
+	return err
+}
+
+func (o *incidentActionOps) RetryCallbacks(_ context.Context, _ uuid.UUID) error {
+	return errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) RerunWithParams(_ context.Context, _ uuid.UUID, _ map[string]string) (uuid.UUID, error) {
+	return uuid.Nil, errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) QuarantineReplay(_ context.Context, _ uuid.UUID, _ map[string]string) (json.RawMessage, error) {
+	return nil, errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) Notify(_ context.Context, _, _ string) error {
+	return errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) Escalate(_ context.Context, _ uuid.UUID, _, _ string) error {
+	return errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) SetJobPaused(_ context.Context, _ uuid.UUID, _ bool) error {
+	return errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) ClearCacheEntry(_ context.Context, _ uuid.UUID, _ string) error {
+	return errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) SuppressDownstreamAlerts(_ context.Context, _ uuid.UUID, _ time.Time) error {
+	return errIncidentOpNotWired
+}
+
+func (o *incidentActionOps) ExtendSLAOnce(_ context.Context, _ uuid.UUID, _ time.Duration) error {
+	return errIncidentOpNotWired
+}

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -457,7 +457,16 @@ func start(cmd *cobra.Command, args []string) error {
 	// opens exactly one incident per failure and fires each durable timer once.
 	if vars.AgentRemediationEnabled {
 		incConn := db.Connection()
+
+		// The action executor backs the deterministic Phase-0 remediation and the
+		// durable snooze_retry timer with the admit-aware retry entry point. It is
+		// shared by the subscriber (deterministic rules on incident open) and the
+		// timer sweeper (RegisterTimerHandlers), so the snooze_retry handler fires
+		// instead of being claimed-and-skipped.
+		incExecutor := incident.NewExecutor(incident.NewStore(incConn), newIncidentActionOps(run.NewStore(incConn)))
+
 		incidentSub := incident.NewSubscriber(bus, incConn, dqlite.IsLocalLeader, vars.AgentIncidentCooldown)
+		incidentSub.SetRemediator(incExecutor, incident.DefaultRuleSet())
 		runAsync(func() {
 			log.Info("launching incident subscriber", "cooldown", vars.AgentIncidentCooldown)
 			if err := incidentSub.Start(ctx); err != nil && ctx.Err() == nil {
@@ -466,6 +475,7 @@ func start(cmd *cobra.Command, args []string) error {
 		})
 
 		timerSweeper := incident.NewTimerSupervisor(incConn, dqlite.IsLocalLeader, 0)
+		incExecutor.RegisterTimerHandlers(timerSweeper)
 		runAsync(func() {
 			log.Info("launching incident timer sweeper")
 			timerSweeper.Run(ctx)

--- a/internal/incident/actions.go
+++ b/internal/incident/actions.go
@@ -10,6 +10,7 @@ import (
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
 	"gorm.io/datatypes"
+	"gorm.io/gorm"
 )
 
 // Typed action catalog (design-agent-in-the-loop.md). The agent never gets
@@ -149,6 +150,41 @@ type ActionOps interface {
 // errNoOps signals a dispatching action with no ActionOps configured.
 var errNoOps = errors.New("incident: no action ops configured")
 
+// ErrCrossBoundaryTarget is returned when an action names a run or job that does
+// not belong to the incident's own job. The incident boundary is the security
+// boundary: an action allowed for incident X must never reach across it to
+// retry, pause, rerun, or clear the cache of an unrelated job/run — even if the
+// playbook allows that action type. Recorded as a failed AgentAction.
+var ErrCrossBoundaryTarget = errors.New("incident: action target crosses the incident boundary")
+
+// verifyActionBoundary rejects any explicit run/job target that does not belong
+// to the incident's job. It runs before every dispatch. Empty targets are
+// in-boundary by construction (resolveRunID/resolveJobID fall back to the
+// incident's own run/job). Namespace is not yet a column on Job/JobRun (it lands
+// with multi-tenancy, design Open Question 4); until then job-id identity is the
+// enforced boundary and the incident's namespace travels with its own job.
+func (e *Executor) verifyActionBoundary(ctx context.Context, inc *models.Incident, params ActionParams) error {
+	if params.JobID != nil && *params.JobID != uuid.Nil && *params.JobID != inc.JobID {
+		return fmt.Errorf("%w: job %s is not incident job %s", ErrCrossBoundaryTarget, *params.JobID, inc.JobID)
+	}
+	if params.RunID != nil && *params.RunID != uuid.Nil {
+		var jr models.JobRun
+		err := e.store.DB().WithContext(ctx).
+			Select("id", "job_id").
+			First(&jr, "id = ?", *params.RunID).Error
+		if err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("%w: run %s not found", ErrCrossBoundaryTarget, *params.RunID)
+			}
+			return err
+		}
+		if jr.JobID != inc.JobID {
+			return fmt.Errorf("%w: run %s belongs to job %s, not incident job %s", ErrCrossBoundaryTarget, *params.RunID, jr.JobID, inc.JobID)
+		}
+	}
+	return nil
+}
+
 // resolveRunID picks the params run id, falling back to the incident's
 // remediation target then its run.
 func resolveRunID(inc *models.Incident, params ActionParams) (uuid.UUID, error) {
@@ -176,6 +212,11 @@ func resolveJobID(inc *models.Incident, params ActionParams) uuid.UUID {
 // result to record on the action row. The playbook is consulted only where an
 // action needs it (rerun_with_params override whitelist).
 func (e *Executor) dispatch(ctx context.Context, actionType string, inc *models.Incident, action *models.AgentAction, params ActionParams, pb Playbook) (map[string]any, error) {
+	// Enforce the incident boundary before any dispatch: an explicit run/job
+	// target must belong to the incident's job.
+	if err := e.verifyActionBoundary(ctx, inc, params); err != nil {
+		return nil, err
+	}
 	switch actionType {
 	case ActionTypeRetryFromFailure:
 		runID, err := resolveRunID(inc, params)

--- a/internal/incident/actions.go
+++ b/internal/incident/actions.go
@@ -1,0 +1,384 @@
+package incident
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// Typed action catalog (design-agent-in-the-loop.md). The agent never gets
+// shell, SQL, or generic HTTP; it selects one of these typed actions and the
+// executor validates + dispatches it server-side onto machinery that already
+// exists.
+const (
+	// Tier 1 — default autonomous.
+	ActionTypeQuarantineReplay = "quarantine_replay"
+	ActionTypeSnoozeRetry      = "snooze_retry"
+	ActionTypeRetryFromFailure = "retry_from_failure"
+	ActionTypeRetryCallbacks   = "retry_callbacks"
+	ActionTypeNotify           = "notify"
+	ActionTypeEscalate         = "escalate"
+
+	// Tier 2 — autonomous only if explicitly allowed by the playbook.
+	ActionTypeRerunWithParams          = "rerun_with_params"
+	ActionTypePauseJob                 = "pause_job"
+	ActionTypeUnpauseJob               = "unpause_job"
+	ActionTypeClearCacheEntry          = "clear_cache_entry"
+	ActionTypeSuppressDownstreamAlerts = "suppress_downstream_alerts"
+	ActionTypeExtendSLAOnce            = "extend_sla_once"
+
+	// Tier 3 — always approval-gated, never auto-executed. The producers ship in
+	// Stream B4; they are registered here so the executor knows their tier and
+	// routes them through the approval gate rather than rejecting them as unknown.
+	ActionTypeSkipTask           = "skip_task"
+	ActionTypeOverrideSchemaGate = "override_schema_gate"
+	ActionTypeApplyJobdefPatch   = "apply_jobdef_patch"
+)
+
+// TimerKindSnoozeRetry identifies snooze_retry durable timers.
+const TimerKindSnoozeRetry = "snooze_retry"
+
+// actionCatalog maps every known action type to its tier. It is the single
+// source of truth for "does this action exist and what tier is it."
+var actionCatalog = map[string]int{
+	ActionTypeQuarantineReplay:         TierAutonomous,
+	ActionTypeSnoozeRetry:              TierAutonomous,
+	ActionTypeRetryFromFailure:         TierAutonomous,
+	ActionTypeRetryCallbacks:           TierAutonomous,
+	ActionTypeNotify:                   TierAutonomous,
+	ActionTypeEscalate:                 TierAutonomous,
+	ActionTypeRerunWithParams:          TierGated,
+	ActionTypePauseJob:                 TierGated,
+	ActionTypeUnpauseJob:               TierGated,
+	ActionTypeClearCacheEntry:          TierGated,
+	ActionTypeSuppressDownstreamAlerts: TierGated,
+	ActionTypeExtendSLAOnce:            TierGated,
+	ActionTypeSkipTask:                 TierApproval,
+	ActionTypeOverrideSchemaGate:       TierApproval,
+	ActionTypeApplyJobdefPatch:         TierApproval,
+}
+
+// ActionTier returns the tier for an action type and whether it is in the
+// catalog.
+func ActionTier(actionType string) (int, bool) {
+	tier, ok := actionCatalog[actionType]
+	return tier, ok
+}
+
+// ActionParams is the union of typed parameters across the action catalog. Each
+// handler reads and validates only the fields it needs.
+type ActionParams struct {
+	// RunID targets a specific run (retry, snooze, replay, extend_sla). Defaults
+	// to the incident's remediation-target run when unset.
+	RunID *uuid.UUID `json:"run_id,omitempty"`
+	// JobID targets a specific job (pause/unpause, clear_cache, rerun). Defaults
+	// to the incident's job when unset.
+	JobID *uuid.UUID `json:"job_id,omitempty"`
+	// TaskName targets a task (clear_cache_entry). Defaults to the incident task.
+	TaskName string `json:"task_name,omitempty"`
+	// Channel names a notification channel (notify, escalate).
+	Channel string `json:"channel,omitempty"`
+	// Message is a notify body.
+	Message string `json:"message,omitempty"`
+	// Summary is an escalation RCA summary.
+	Summary string `json:"summary,omitempty"`
+	// Overrides carries whitelisted param overrides (rerun_with_params) or replay
+	// --set values (quarantine_replay).
+	Overrides map[string]string `json:"overrides,omitempty"`
+	// DelaySeconds defers a snooze_retry / bounds a suppress_downstream_alerts
+	// window.
+	DelaySeconds int64 `json:"delay_seconds,omitempty"`
+	// ExtendSeconds extends a per-run SLA once (extend_sla_once).
+	ExtendSeconds int64 `json:"extend_seconds,omitempty"`
+}
+
+// encode marshals the params for the AgentAction row. It never fails the caller;
+// an unmarshalable value yields nil.
+func (p ActionParams) encode() datatypes.JSON {
+	b, err := json.Marshal(p)
+	if err != nil {
+		return nil
+	}
+	return datatypes.JSON(b)
+}
+
+func (p ActionParams) delay() time.Duration  { return time.Duration(p.DelaySeconds) * time.Second }
+func (p ActionParams) extend() time.Duration { return time.Duration(p.ExtendSeconds) * time.Second }
+
+// snoozePayload is persisted on a snooze_retry durable timer.
+type snoozePayload struct {
+	RunID uuid.UUID `json:"run_id"`
+}
+
+// ActionOps is the server-side operations surface the tier-1/2 catalog dispatches
+// onto. It is an interface so the executor is unit-testable with a fake and so
+// the incident package does not hard-depend on the run/callback/notification/
+// replay/cache subsystems — Stream C wires the concrete adapters. All methods
+// map onto machinery that already exists (design action-catalog table).
+type ActionOps interface {
+	// RetryFromFailure re-runs a failed run through the admit-aware retry entry
+	// point (run.Store.RetryFromFailureAdmitted — the B2 safety valves).
+	RetryFromFailure(ctx context.Context, runID uuid.UUID) error
+	// RetryCallbacks re-runs a run's failed callbacks (Dispatcher.RetryFailed).
+	RetryCallbacks(ctx context.Context, runID uuid.UUID) error
+	// RerunWithParams starts a new run with whitelisted param overrides, stamped
+	// with the incident (new-run semantics: params feed cache identity).
+	RerunWithParams(ctx context.Context, jobID uuid.UUID, params map[string]string) (uuid.UUID, error)
+	// QuarantineReplay runs a side-effect-free what-if replay with --set params.
+	QuarantineReplay(ctx context.Context, runID uuid.UUID, set map[string]string) (json.RawMessage, error)
+	// Notify posts a structured update to a notification channel.
+	Notify(ctx context.Context, channel, message string) error
+	// Escalate pages a channel with an RCA summary.
+	Escalate(ctx context.Context, incidentID uuid.UUID, channel, summary string) error
+	// SetJobPaused pauses/unpauses a job (Job.Paused).
+	SetJobPaused(ctx context.Context, jobID uuid.UUID, paused bool) error
+	// ClearCacheEntry deletes a task's cache entry.
+	ClearCacheEntry(ctx context.Context, jobID uuid.UUID, taskName string) error
+	// SuppressDownstreamAlerts suppresses downstream alerts until a deadline.
+	SuppressDownstreamAlerts(ctx context.Context, incidentID uuid.UUID, until time.Time) error
+	// ExtendSLAOnce writes a durable per-run SLA override.
+	ExtendSLAOnce(ctx context.Context, runID uuid.UUID, extend time.Duration) error
+}
+
+// errNoOps signals a dispatching action with no ActionOps configured.
+var errNoOps = errors.New("incident: no action ops configured")
+
+// resolveRunID picks the params run id, falling back to the incident's
+// remediation target then its run.
+func resolveRunID(inc *models.Incident, params ActionParams) (uuid.UUID, error) {
+	if params.RunID != nil && *params.RunID != uuid.Nil {
+		return *params.RunID, nil
+	}
+	if inc.RemediationTargetRunID != nil && *inc.RemediationTargetRunID != uuid.Nil {
+		return *inc.RemediationTargetRunID, nil
+	}
+	if inc.RunID != nil && *inc.RunID != uuid.Nil {
+		return *inc.RunID, nil
+	}
+	return uuid.Nil, errors.New("incident: action requires a run id (none in params or incident)")
+}
+
+// resolveJobID picks the params job id, falling back to the incident's job.
+func resolveJobID(inc *models.Incident, params ActionParams) uuid.UUID {
+	if params.JobID != nil && *params.JobID != uuid.Nil {
+		return *params.JobID
+	}
+	return inc.JobID
+}
+
+// dispatch executes a permitted tier-1/2 action server-side and returns a JSON
+// result to record on the action row. The playbook is consulted only where an
+// action needs it (rerun_with_params override whitelist).
+func (e *Executor) dispatch(ctx context.Context, actionType string, inc *models.Incident, action *models.AgentAction, params ActionParams, pb Playbook) (map[string]any, error) {
+	switch actionType {
+	case ActionTypeRetryFromFailure:
+		runID, err := resolveRunID(inc, params)
+		if err != nil {
+			return nil, err
+		}
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		if err := e.ops.RetryFromFailure(ctx, runID); err != nil {
+			return nil, err
+		}
+		return map[string]any{"run_id": runID.String()}, nil
+
+	case ActionTypeSnoozeRetry:
+		runID, err := resolveRunID(inc, params)
+		if err != nil {
+			return nil, err
+		}
+		if params.delay() <= 0 {
+			return nil, errors.New("incident: snooze_retry requires a positive delay_seconds")
+		}
+		fireAt := time.Now().UTC().Add(params.delay())
+		timer, err := e.store.ScheduleTimer(ctx, inc.ID, TimerKindSnoozeRetry, fireAt, encodeJSON(snoozePayload{RunID: runID}), &action.ID, inc.Namespace)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"timer_id": timer.ID.String(),
+			"run_id":   runID.String(),
+			"fire_at":  fireAt.Format(time.RFC3339),
+		}, nil
+
+	case ActionTypeRetryCallbacks:
+		runID, err := resolveRunID(inc, params)
+		if err != nil {
+			return nil, err
+		}
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		if err := e.ops.RetryCallbacks(ctx, runID); err != nil {
+			return nil, err
+		}
+		return map[string]any{"run_id": runID.String()}, nil
+
+	case ActionTypeNotify:
+		if params.Channel == "" {
+			return nil, errors.New("incident: notify requires a channel")
+		}
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		if err := e.ops.Notify(ctx, params.Channel, params.Message); err != nil {
+			return nil, err
+		}
+		return map[string]any{"channel": params.Channel}, nil
+
+	case ActionTypeEscalate:
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		if err := e.ops.Escalate(ctx, inc.ID, params.Channel, params.Summary); err != nil {
+			return nil, err
+		}
+		return map[string]any{"channel": params.Channel, "escalated": true}, nil
+
+	case ActionTypeRerunWithParams:
+		if len(params.Overrides) == 0 {
+			return nil, errors.New("incident: rerun_with_params requires overrides")
+		}
+		if err := validateParamOverrides(params.Overrides, pb.ParamOverrides); err != nil {
+			return nil, err
+		}
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		jobID := resolveJobID(inc, params)
+		newRunID, err := e.ops.RerunWithParams(ctx, jobID, params.Overrides)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{
+			"job_id":     jobID.String(),
+			"new_run_id": newRunID.String(),
+			"overrides":  params.Overrides,
+			// New-run semantics: params feed cache identity so the DAG re-keys and
+			// recomputes. Disclose the cost on the action record.
+			"recompute": true,
+		}, nil
+
+	case ActionTypePauseJob:
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		jobID := resolveJobID(inc, params)
+		if err := e.ops.SetJobPaused(ctx, jobID, true); err != nil {
+			return nil, err
+		}
+		return map[string]any{"job_id": jobID.String(), "paused": true}, nil
+
+	case ActionTypeUnpauseJob:
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		jobID := resolveJobID(inc, params)
+		if err := e.ops.SetJobPaused(ctx, jobID, false); err != nil {
+			return nil, err
+		}
+		return map[string]any{"job_id": jobID.String(), "paused": false}, nil
+
+	case ActionTypeClearCacheEntry:
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		jobID := resolveJobID(inc, params)
+		taskName := params.TaskName
+		if taskName == "" {
+			taskName = inc.TaskName
+		}
+		if taskName == "" {
+			return nil, errors.New("incident: clear_cache_entry requires a task name")
+		}
+		if err := e.ops.ClearCacheEntry(ctx, jobID, taskName); err != nil {
+			return nil, err
+		}
+		return map[string]any{"job_id": jobID.String(), "task_name": taskName}, nil
+
+	case ActionTypeSuppressDownstreamAlerts:
+		if params.delay() <= 0 {
+			return nil, errors.New("incident: suppress_downstream_alerts requires a positive delay_seconds")
+		}
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		until := time.Now().UTC().Add(params.delay())
+		if err := e.ops.SuppressDownstreamAlerts(ctx, inc.ID, until); err != nil {
+			return nil, err
+		}
+		return map[string]any{"until": until.Format(time.RFC3339)}, nil
+
+	case ActionTypeExtendSLAOnce:
+		runID, err := resolveRunID(inc, params)
+		if err != nil {
+			return nil, err
+		}
+		if params.extend() <= 0 {
+			return nil, errors.New("incident: extend_sla_once requires a positive extend_seconds")
+		}
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		if err := e.ops.ExtendSLAOnce(ctx, runID, params.extend()); err != nil {
+			return nil, err
+		}
+		return map[string]any{"run_id": runID.String(), "extend_seconds": params.ExtendSeconds}, nil
+
+	case ActionTypeQuarantineReplay:
+		runID, err := resolveRunID(inc, params)
+		if err != nil {
+			return nil, err
+		}
+		if e.ops == nil {
+			return nil, errNoOps
+		}
+		result, err := e.ops.QuarantineReplay(ctx, runID, params.Overrides)
+		if err != nil {
+			return nil, err
+		}
+		out := map[string]any{"run_id": runID.String()}
+		if len(result) > 0 {
+			out["replay"] = result
+		}
+		return out, nil
+
+	default:
+		// Tier-3 producers reach here only if mis-routed; they must go through the
+		// approval gate (decisionApprove), never dispatch. Guard defensively.
+		return nil, fmt.Errorf("%w: %q has no autonomous executor (tier-3 or deferred)", ErrUnknownAction, actionType)
+	}
+}
+
+// validateParamOverrides enforces the rerun_with_params whitelist: every key must
+// be whitelisted and its value must be among the allowed values for that key.
+func validateParamOverrides(overrides map[string]string, whitelist map[string][]string) error {
+	for key, val := range overrides {
+		allowed, ok := whitelist[key]
+		if !ok {
+			return fmt.Errorf("incident: rerun_with_params key %q is not whitelisted", key)
+		}
+		if len(allowed) == 0 {
+			continue
+		}
+		match := false
+		for _, a := range allowed {
+			if a == val {
+				match = true
+				break
+			}
+		}
+		if !match {
+			return fmt.Errorf("incident: rerun_with_params value %q for key %q is not whitelisted", val, key)
+		}
+	}
+	return nil
+}

--- a/internal/incident/actions.go
+++ b/internal/incident/actions.go
@@ -112,9 +112,12 @@ func (p ActionParams) encode() datatypes.JSON {
 func (p ActionParams) delay() time.Duration  { return time.Duration(p.DelaySeconds) * time.Second }
 func (p ActionParams) extend() time.Duration { return time.Duration(p.ExtendSeconds) * time.Second }
 
-// snoozePayload is persisted on a snooze_retry durable timer.
+// snoozePayload is persisted on a snooze_retry durable timer. Rearm counts how
+// many times a retryable refusal (e.g. the job was paused when the timer fired)
+// re-armed a fresh timer; it is capped so a permanently-paused job cannot loop.
 type snoozePayload struct {
 	RunID uuid.UUID `json:"run_id"`
+	Rearm int       `json:"rearm,omitempty"`
 }
 
 // ActionOps is the server-side operations surface the tier-1/2 catalog dispatches

--- a/internal/incident/actions_test.go
+++ b/internal/incident/actions_test.go
@@ -1,0 +1,152 @@
+package incident
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionTierCatalog(t *testing.T) {
+	cases := map[string]int{
+		ActionTypeRetryFromFailure:         TierAutonomous,
+		ActionTypeSnoozeRetry:              TierAutonomous,
+		ActionTypeNotify:                   TierAutonomous,
+		ActionTypeEscalate:                 TierAutonomous,
+		ActionTypeQuarantineReplay:         TierAutonomous,
+		ActionTypeRerunWithParams:          TierGated,
+		ActionTypePauseJob:                 TierGated,
+		ActionTypeUnpauseJob:               TierGated,
+		ActionTypeClearCacheEntry:          TierGated,
+		ActionTypeSuppressDownstreamAlerts: TierGated,
+		ActionTypeExtendSLAOnce:            TierGated,
+		ActionTypeSkipTask:                 TierApproval,
+		ActionTypeOverrideSchemaGate:       TierApproval,
+		ActionTypeApplyJobdefPatch:         TierApproval,
+	}
+	for actionType, wantTier := range cases {
+		tier, ok := ActionTier(actionType)
+		require.Truef(t, ok, "%s must be in the catalog", actionType)
+		require.Equalf(t, wantTier, tier, "%s tier", actionType)
+	}
+	_, ok := ActionTier("nope")
+	require.False(t, ok)
+}
+
+func TestValidateParamOverrides(t *testing.T) {
+	whitelist := map[string][]string{
+		"badRowPolicy": {"quarantine", "skip"},
+		"anyValue":     {}, // empty allowed-set means any value is fine
+	}
+	require.NoError(t, validateParamOverrides(map[string]string{"badRowPolicy": "quarantine"}, whitelist))
+	require.NoError(t, validateParamOverrides(map[string]string{"anyValue": "whatever"}, whitelist))
+	require.Error(t, validateParamOverrides(map[string]string{"badRowPolicy": "drop"}, whitelist))
+	require.Error(t, validateParamOverrides(map[string]string{"unlisted": "x"}, whitelist))
+}
+
+func TestNotifyRequiresChannel(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeNotify,
+		Params:     ActionParams{Message: "hi"},
+		Playbook:   Playbook{},
+	})
+	require.Error(t, err)
+	require.Equal(t, models.AgentActionStatusFailed, action.Status)
+	require.Empty(t, ops.notify)
+
+	action2, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeNotify,
+		Params:     ActionParams{Channel: "data-oncall", Message: "late file"},
+		Playbook:   Playbook{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action2.Status)
+	require.Len(t, ops.notify, 1)
+	require.Equal(t, "data-oncall", ops.notify[0].channel)
+}
+
+func TestClearCacheEntryDefaultsToIncidentTask(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store) // task_name "extract"
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeClearCacheEntry,
+		Playbook:   Playbook{Allow: map[string]bool{ActionTypeClearCacheEntry: true}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action.Status)
+	require.Len(t, ops.clearCache, 1)
+	require.Equal(t, "extract", ops.clearCache[0].taskName)
+	require.Equal(t, inc.JobID, ops.clearCache[0].jobID)
+}
+
+func TestExtendSLAOnceRequiresPositiveWindow(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, runID := seedIncident(t, store)
+	pb := Playbook{Allow: map[string]bool{ActionTypeExtendSLAOnce: true}}
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeExtendSLAOnce,
+		Playbook:   pb,
+	})
+	require.Error(t, err)
+	require.Equal(t, models.AgentActionStatusFailed, action.Status)
+
+	action2, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeExtendSLAOnce,
+		Params:     ActionParams{ExtendSeconds: 3600},
+		Playbook:   pb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action2.Status)
+	require.Len(t, ops.extendSLA, 1)
+	require.Equal(t, runID, ops.extendSLA[0].runID)
+}
+
+func TestEscalateDispatches(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	_, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeEscalate,
+		Params:     ActionParams{Channel: "pagerduty", Summary: "vendor file 2h late"},
+		Playbook:   Playbook{},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops.escalate, 1)
+	require.Equal(t, inc.ID, ops.escalate[0].incidentID)
+	require.Equal(t, "pagerduty", ops.escalate[0].channel)
+}
+
+func TestRerunWithParamsExplicitJobID(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+	otherJob := uuid.New()
+
+	_, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeRerunWithParams,
+		Params: ActionParams{
+			JobID:     &otherJob,
+			Overrides: map[string]string{"k": "v"},
+		},
+		Playbook: Playbook{
+			Allow:          map[string]bool{ActionTypeRerunWithParams: true},
+			ParamOverrides: map[string][]string{"k": {"v"}},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, ops.rerun, 1)
+	require.Equal(t, otherJob, ops.rerun[0].jobID)
+}

--- a/internal/incident/actions_test.go
+++ b/internal/incident/actions_test.go
@@ -3,6 +3,7 @@ package incident
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/google/uuid"
@@ -129,16 +130,17 @@ func TestEscalateDispatches(t *testing.T) {
 	require.Equal(t, "pagerduty", ops.escalate[0].channel)
 }
 
+// A rerun_with_params targeting the incident's OWN job (explicit but in-boundary)
+// is allowed.
 func TestRerunWithParamsExplicitJobID(t *testing.T) {
 	_, store, ops, exec := newExecutorTest(t)
 	inc, _ := seedIncident(t, store)
-	otherJob := uuid.New()
 
 	_, err := exec.Execute(context.Background(), ActionRequest{
 		IncidentID: inc.ID,
 		Type:       ActionTypeRerunWithParams,
 		Params: ActionParams{
-			JobID:     &otherJob,
+			JobID:     &inc.JobID, // same job — in boundary
 			Overrides: map[string]string{"k": "v"},
 		},
 		Playbook: Playbook{
@@ -148,5 +150,62 @@ func TestRerunWithParamsExplicitJobID(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, ops.rerun, 1)
-	require.Equal(t, otherJob, ops.rerun[0].jobID)
+	require.Equal(t, inc.JobID, ops.rerun[0].jobID)
+}
+
+// An allowed action whose params.JobID points at a DIFFERENT job is refused at
+// the incident boundary and recorded failed — even though the action is allowed.
+func TestExecuteRefusesCrossBoundaryJobTarget(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+	otherJob := uuid.New()
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypePauseJob,
+		Params:     ActionParams{JobID: &otherJob},
+		Playbook:   Playbook{Allow: map[string]bool{ActionTypePauseJob: true}},
+	})
+	require.ErrorIs(t, err, ErrCrossBoundaryTarget)
+	require.Equal(t, models.AgentActionStatusFailed, action.Status)
+	require.Empty(t, ops.setPaused, "a cross-boundary target must never dispatch")
+}
+
+// An allowed retry whose params.RunID belongs to another job is refused at the
+// incident boundary.
+func TestExecuteRefusesCrossBoundaryRunTarget(t *testing.T) {
+	db, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	// A run owned by an unrelated job.
+	otherRun := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: otherRun, JobID: uuid.New(), Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeRetryFromFailure,
+		Params:     ActionParams{RunID: &otherRun},
+		Playbook:   Playbook{},
+	})
+	require.ErrorIs(t, err, ErrCrossBoundaryTarget)
+	require.Equal(t, models.AgentActionStatusFailed, action.Status)
+	require.Empty(t, ops.retryFromFailure, "a cross-boundary run target must never retry")
+}
+
+// A run target that does not exist is treated as cross-boundary (fail closed).
+func TestExecuteRefusesUnknownRunTarget(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+	ghost := uuid.New()
+
+	_, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeRetryFromFailure,
+		Params:     ActionParams{RunID: &ghost},
+	})
+	require.ErrorIs(t, err, ErrCrossBoundaryTarget)
+	require.Empty(t, ops.retryFromFailure)
 }

--- a/internal/incident/executor.go
+++ b/internal/incident/executor.go
@@ -1,0 +1,323 @@
+package incident
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// Action tiers (design-agent-in-the-loop.md, "Action catalog: typed,
+// server-enforced, tiered"). Tier semantics: tier 0/1 default autonomous, tier 2
+// autonomous only if explicitly allowed by the playbook, tier 3 always produces
+// an ApprovalRequest and is never auto-executed in v1 regardless of config.
+const (
+	TierReadOnly   = 0
+	TierAutonomous = 1
+	TierGated      = 2
+	TierApproval   = 3
+)
+
+// Executor is the typed, server-enforced action layer. The agent never gets
+// shell, SQL, or generic HTTP: every mutation arrives as a typed action, is
+// validated against the effective playbook, executed server-side through the
+// injected ActionOps, and recorded as an AgentAction audit row with the right
+// actor/tier/status. Deterministic Phase-0 rules run through the same recording
+// path with actor=policy and no container launch.
+type Executor struct {
+	store *Store
+	ops   ActionOps
+}
+
+// NewExecutor constructs an executor over the incident store and the action
+// operations surface (implemented by Stream C's concrete adapters; a fake in
+// tests). A nil ops is tolerated for actions that never dispatch through it
+// (deny/approve paths), but executing a dispatching action then panics — callers
+// must supply ops in any path that executes.
+func NewExecutor(store *Store, ops ActionOps) *Executor {
+	return &Executor{store: store, ops: ops}
+}
+
+// ErrUnknownAction is returned when the action type is not in the catalog.
+var ErrUnknownAction = errors.New("incident: unknown action type")
+
+// ErrActionNotPermitted is returned when the effective playbook denies an
+// action (not autonomously allowed and not routed to approval).
+var ErrActionNotPermitted = errors.New("incident: action not permitted by playbook")
+
+// Playbook is the effective, resolved remediation policy the executor enforces
+// for one incident. Stream E produces it from metadata.remediation overriding
+// the AgentProfile defaults; here it is purely the enforcement input. A zero
+// Playbook (no Allow/RequireApproval) means "unconfigured": tier 0/1 actions
+// default autonomous, tier 2 requires explicit allow, tier 3 always approval.
+type Playbook struct {
+	// Allow is the set of action types the agent may take autonomously.
+	Allow map[string]bool
+	// RequireApproval forces listed action types through the approval gate even
+	// if their tier would otherwise be autonomous.
+	RequireApproval map[string]bool
+	// ParamOverrides whitelists rerun_with_params keys → allowed values.
+	ParamOverrides map[string][]string
+}
+
+// decision is the executor's routing verdict for one action.
+type decision int
+
+const (
+	decisionExecute decision = iota
+	decisionApprove
+	decisionDeny
+)
+
+// allowsAutonomous reports whether an action type may run autonomously under the
+// playbook's allow list. An empty allow list means unconfigured — tier 0/1
+// default autonomous — so it returns true; a non-empty list is the
+// server-enforced allowlist and governs.
+func (pb Playbook) allowsAutonomous(actionType string) bool {
+	if len(pb.Allow) == 0 {
+		return true
+	}
+	return pb.Allow[actionType]
+}
+
+// decide routes an action to execute / approve / deny per the tier semantics.
+func (pb Playbook) decide(actionType string, tier int) decision {
+	// An explicit approval requirement always wins for non-fatal tiers.
+	if pb.RequireApproval[actionType] {
+		return decisionApprove
+	}
+	// Tier 3 always terminates at a human, never auto-executed in v1.
+	if tier >= TierApproval {
+		return decisionApprove
+	}
+	if tier <= TierAutonomous {
+		// Tier 0/1 default autonomous, still subject to the allowlist if present.
+		if pb.allowsAutonomous(actionType) {
+			return decisionExecute
+		}
+		return decisionDeny
+	}
+	// Tier 2: autonomous only if explicitly allowed.
+	if pb.Allow[actionType] {
+		return decisionExecute
+	}
+	return decisionDeny
+}
+
+// ActionRequest is one typed action to validate, record, and (when permitted)
+// execute against an incident.
+type ActionRequest struct {
+	IncidentID uuid.UUID
+	// SessionID links the action to an agent session (nil for actor=policy|human).
+	SessionID *uuid.UUID
+	// Actor originates the row (agent|human; deterministic rules use ExecutePolicy
+	// which stamps policy).
+	Actor models.AgentActionActor
+	// Type is the catalog action type (e.g. "retry_from_failure").
+	Type string
+	// Params carries the typed action parameters.
+	Params ActionParams
+	// Playbook is the effective policy the action is validated against.
+	Playbook Playbook
+}
+
+// Execute validates a typed action against the effective playbook, records it as
+// an AgentAction row, and — when the playbook permits autonomous execution —
+// dispatches it server-side. Tier-3 actions and playbook-gated actions are
+// recorded as proposed (awaiting approval) without executing; playbook-denied
+// actions are recorded as rejected and return ErrActionNotPermitted.
+func (e *Executor) Execute(ctx context.Context, req ActionRequest) (*models.AgentAction, error) {
+	tier, ok := ActionTier(req.Type)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownAction, req.Type)
+	}
+	actor := req.Actor
+	if actor == "" {
+		actor = models.AgentActionActorAgent
+	}
+
+	inc, err := e.store.Get(ctx, req.IncidentID)
+	if err != nil {
+		return nil, fmt.Errorf("incident: load incident for action: %w", err)
+	}
+
+	dec := req.Playbook.decide(req.Type, tier)
+
+	action := e.newAction(inc, req, tier, actor)
+	if err := e.store.DB().WithContext(ctx).Create(action).Error; err != nil {
+		return nil, fmt.Errorf("incident: record action: %w", err)
+	}
+
+	switch dec {
+	case decisionDeny:
+		e.finish(ctx, action, models.AgentActionStatusRejected, map[string]any{
+			"reason": "action not permitted by effective playbook",
+		})
+		return action, fmt.Errorf("%w: %s", ErrActionNotPermitted, req.Type)
+	case decisionApprove:
+		// Recorded as proposed; the tier-3 approval flow (Stream D / B4) creates
+		// the ApprovalRequest and resolves it. No execution here.
+		e.observe(action)
+		e.mirrorAudit(ctx, action, "proposed")
+		return action, nil
+	}
+
+	// decisionExecute: dispatch server-side.
+	result, execErr := e.dispatch(ctx, req.Type, inc, action, req.Params, req.Playbook)
+	if execErr != nil {
+		e.finish(ctx, action, models.AgentActionStatusFailed, map[string]any{"error": execErr.Error()})
+		return action, execErr
+	}
+	e.finish(ctx, action, models.AgentActionStatusExecuted, result)
+	return action, nil
+}
+
+// ExecutePolicy runs a deterministic server-side action as actor=policy: no
+// playbook allowlist gate (a deterministic rule is pre-approved by being
+// deterministic) and no agent session, but the same audit recording, metric, and
+// dispatch path. Used by the Phase-0 deterministic rules (rules.go).
+func (e *Executor) ExecutePolicy(ctx context.Context, incidentID uuid.UUID, actionType string, params ActionParams) (*models.AgentAction, error) {
+	tier, ok := ActionTier(actionType)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownAction, actionType)
+	}
+	inc, err := e.store.Get(ctx, incidentID)
+	if err != nil {
+		return nil, fmt.Errorf("incident: load incident for policy action: %w", err)
+	}
+	action := e.newAction(inc, ActionRequest{
+		IncidentID: incidentID,
+		Type:       actionType,
+		Params:     params,
+	}, tier, models.AgentActionActorPolicy)
+	if err := e.store.DB().WithContext(ctx).Create(action).Error; err != nil {
+		return nil, fmt.Errorf("incident: record policy action: %w", err)
+	}
+	result, execErr := e.dispatch(ctx, actionType, inc, action, params, Playbook{})
+	if execErr != nil {
+		e.finish(ctx, action, models.AgentActionStatusFailed, map[string]any{"error": execErr.Error()})
+		return action, execErr
+	}
+	e.finish(ctx, action, models.AgentActionStatusExecuted, result)
+	return action, nil
+}
+
+// newAction builds a proposed AgentAction row for an incident.
+func (e *Executor) newAction(inc *models.Incident, req ActionRequest, tier int, actor models.AgentActionActor) *models.AgentAction {
+	now := time.Now().UTC()
+	return &models.AgentAction{
+		ID:         uuid.New(),
+		Namespace:  inc.Namespace,
+		IncidentID: inc.ID,
+		SessionID:  req.SessionID,
+		Type:       req.Type,
+		Params:     req.Params.encode(),
+		Tier:       tier,
+		Status:     models.AgentActionStatusProposed,
+		Actor:      actor,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+}
+
+// finish stamps a terminal status + result on an action, emits the metric, and
+// mirrors tier-2/3 executions into the audit log.
+func (e *Executor) finish(ctx context.Context, action *models.AgentAction, status models.AgentActionStatus, result any) {
+	action.Status = status
+	action.Result = encodeJSON(result)
+	action.UpdatedAt = time.Now().UTC()
+	if err := e.store.DB().WithContext(ctx).
+		Model(&models.AgentAction{}).
+		Where("id = ?", action.ID).
+		Updates(map[string]any{
+			"status":     status,
+			"result":     action.Result,
+			"updated_at": action.UpdatedAt,
+		}).Error; err != nil {
+		log.Warn("incident: failed to update action status", "action_id", action.ID, "error", err)
+	}
+	e.observe(action)
+	e.mirrorAudit(ctx, action, string(status))
+}
+
+// observe increments caesium_agent_actions_total for this action.
+func (e *Executor) observe(action *models.AgentAction) {
+	metrics.AgentActionsTotal.
+		WithLabelValues(action.Type, strconv.Itoa(action.Tier), string(action.Actor)).
+		Inc()
+}
+
+// mirrorAudit writes tier-2/3 executions into AuditLog (design Security Posture:
+// "AuditLog entries mirror tier 2/3 executions"). Tier 0/1 rows live only in the
+// AgentAction timeline.
+func (e *Executor) mirrorAudit(ctx context.Context, action *models.AgentAction, outcome string) {
+	if action.Tier < TierGated {
+		return
+	}
+	// Policy denials (rejected) are not executions; they live only on the action
+	// timeline, not the audit log.
+	if action.Status == models.AgentActionStatusRejected {
+		return
+	}
+	entry := &models.AuditLog{
+		ID:           uuid.New(),
+		Timestamp:    time.Now().UTC(),
+		Actor:        "agent:" + string(action.Actor),
+		Action:       "agent.action." + action.Type,
+		ResourceType: "incident",
+		ResourceID:   action.IncidentID.String(),
+		Outcome:      outcome,
+		Metadata:     encodeJSON(map[string]any{"action_id": action.ID.String(), "tier": action.Tier}),
+	}
+	if err := e.store.DB().WithContext(ctx).Create(entry).Error; err != nil {
+		log.Warn("incident: failed to mirror action to audit log", "action_id", action.ID, "error", err)
+	}
+	metrics.AuditLogEntriesTotal.WithLabelValues(entry.Action, outcome).Inc()
+}
+
+// RegisterTimerHandlers wires the durable-timer handlers this executor owns onto
+// a TimerSupervisor. snooze_retry timers fire an admit-aware retry when due.
+func (e *Executor) RegisterTimerHandlers(sup *TimerSupervisor) {
+	sup.RegisterHandler(TimerKindSnoozeRetry, e.fireSnoozeRetry)
+}
+
+// fireSnoozeRetry is the durable-timer handler for a due snooze_retry: it runs
+// the admit-aware retry for the snoozed run.
+func (e *Executor) fireSnoozeRetry(ctx context.Context, timer models.RemediationTimer) error {
+	var payload snoozePayload
+	if len(timer.Payload) > 0 {
+		if err := json.Unmarshal(timer.Payload, &payload); err != nil {
+			return fmt.Errorf("incident: decode snooze timer payload: %w", err)
+		}
+	}
+	if payload.RunID == uuid.Nil {
+		return errors.New("incident: snooze timer missing run id")
+	}
+	if e.ops == nil {
+		return errors.New("incident: no action ops configured for snooze_retry")
+	}
+	if err := e.ops.RetryFromFailure(ctx, payload.RunID); err != nil {
+		return fmt.Errorf("incident: snooze_retry fire: %w", err)
+	}
+	return nil
+}
+
+// encodeJSON marshals v into datatypes.JSON, returning nil on nil/empty or error.
+func encodeJSON(v any) datatypes.JSON {
+	if v == nil {
+		return nil
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return datatypes.JSON(b)
+}

--- a/internal/incident/executor.go
+++ b/internal/incident/executor.go
@@ -53,6 +53,14 @@ var ErrUnknownAction = errors.New("incident: unknown action type")
 // action (not autonomously allowed and not routed to approval).
 var ErrActionNotPermitted = errors.New("incident: action not permitted by playbook")
 
+// ErrRetryDeferred marks a retry refused by a transient, retryable admission
+// condition — the job is paused, or a concurrency slot is not yet free — that
+// will clear on its own. ActionOps.RetryFromFailure implementations return it
+// (wrapping the underlying cause) so a fired snooze_retry timer re-arms instead
+// of being consumed and lost. A non-ErrRetryDeferred error is treated as a
+// permanent failure.
+var ErrRetryDeferred = errors.New("incident: retry deferred; retry once the condition clears")
+
 // Playbook is the effective, resolved remediation policy the executor enforces
 // for one incident. Stream E produces it from metadata.remediation overriding
 // the AgentProfile defaults; here it is purely the enforcement input. A zero
@@ -310,10 +318,101 @@ func (e *Executor) fireSnoozeRetry(ctx context.Context, timer models.Remediation
 	if e.ops == nil {
 		return errors.New("incident: no action ops configured for snooze_retry")
 	}
-	if err := e.ops.RetryFromFailure(ctx, payload.RunID); err != nil {
-		return fmt.Errorf("incident: snooze_retry fire: %w", err)
+	err := e.ops.RetryFromFailure(ctx, payload.RunID)
+	if err == nil {
+		return nil
 	}
+	// The supervisor already claimed this timer as fired. A retryable refusal
+	// (job paused, or capacity not yet free) means the retry never happened, so
+	// consuming the timer would silently drop the remediation. Re-arm a fresh
+	// timer with bounded backoff instead so the retry lands once the condition
+	// clears; a permanent failure (e.g. the run is gone) is consumed as before.
+	if errors.Is(err, ErrRetryDeferred) {
+		return e.rearmSnooze(ctx, timer, payload, err)
+	}
+	return fmt.Errorf("incident: snooze_retry fire: %w", err)
+}
+
+// snooze re-arm bounds: exponential backoff base × 2^rearm, capped, with a hard
+// re-arm ceiling so a job left paused forever cannot re-arm indefinitely.
+const (
+	snoozeRearmBackoffBase = time.Minute
+	snoozeRearmBackoffMax  = time.Hour
+	maxSnoozeRearm         = 12
+)
+
+// snoozeRearmBackoff returns the bounded backoff before the nth re-arm.
+func snoozeRearmBackoff(rearm int) time.Duration {
+	d := snoozeRearmBackoffBase
+	for i := 1; i < rearm && d < snoozeRearmBackoffMax; i++ {
+		d *= 2
+	}
+	if d > snoozeRearmBackoffMax {
+		return snoozeRearmBackoffMax
+	}
+	return d
+}
+
+// rearmSnooze schedules a fresh snooze timer after a retryable refusal, recording
+// the re-arm on the audit spine. Beyond maxSnoozeRearm it gives up (records a
+// failed action and returns the cause so the sweeper logs it), so a permanently
+// paused job cannot loop forever.
+func (e *Executor) rearmSnooze(ctx context.Context, timer models.RemediationTimer, payload snoozePayload, cause error) error {
+	if payload.Rearm >= maxSnoozeRearm {
+		e.recordSnoozeEvent(ctx, timer, models.AgentActionStatusFailed, map[string]any{
+			"run_id":     payload.RunID.String(),
+			"rearm":      payload.Rearm,
+			"gave_up":    true,
+			"last_error": cause.Error(),
+		})
+		return fmt.Errorf("incident: snooze_retry exhausted %d re-arms: %w", maxSnoozeRearm, cause)
+	}
+	next := payload
+	next.Rearm++
+	fireAt := time.Now().UTC().Add(snoozeRearmBackoff(next.Rearm))
+	newTimer, err := e.store.ScheduleTimer(ctx, timer.IncidentID, TimerKindSnoozeRetry, fireAt, encodeJSON(next), timer.ActionID, timer.Namespace)
+	if err != nil {
+		return fmt.Errorf("incident: re-arm snooze timer: %w", err)
+	}
+	e.recordSnoozeEvent(ctx, timer, models.AgentActionStatusExecuted, map[string]any{
+		"run_id":        payload.RunID.String(),
+		"rearm":         next.Rearm,
+		"deferred":      true,
+		"reason":        cause.Error(),
+		"next_timer_id": newTimer.ID.String(),
+		"fire_at":       fireAt.Format(time.RFC3339),
+	})
+	log.Info("incident: snooze_retry deferred; re-armed",
+		"incident_id", timer.IncidentID,
+		"run_id", payload.RunID,
+		"rearm", next.Rearm,
+		"fire_at", fireAt,
+		"reason", cause,
+	)
 	return nil
+}
+
+// recordSnoozeEvent appends a policy AgentAction row documenting a snooze re-arm
+// or give-up, so the deferral is observable on the incident timeline.
+func (e *Executor) recordSnoozeEvent(ctx context.Context, timer models.RemediationTimer, status models.AgentActionStatus, result map[string]any) {
+	now := time.Now().UTC()
+	action := &models.AgentAction{
+		ID:         uuid.New(),
+		Namespace:  timer.Namespace,
+		IncidentID: timer.IncidentID,
+		Type:       ActionTypeSnoozeRetry,
+		Tier:       TierAutonomous,
+		Status:     status,
+		Actor:      models.AgentActionActorPolicy,
+		Result:     encodeJSON(result),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := e.store.DB().WithContext(ctx).Create(action).Error; err != nil {
+		log.Warn("incident: failed to record snooze re-arm event", "incident_id", timer.IncidentID, "error", err)
+		return
+	}
+	e.observe(action)
 }
 
 // encodeJSON marshals v into datatypes.JSON, returning nil on nil/empty or error.

--- a/internal/incident/executor.go
+++ b/internal/incident/executor.go
@@ -148,6 +148,9 @@ func (e *Executor) Execute(ctx context.Context, req ActionRequest) (*models.Agen
 	if err != nil {
 		return nil, fmt.Errorf("incident: load incident for action: %w", err)
 	}
+	if inc == nil {
+		return nil, errors.New("incident: incident not found")
+	}
 
 	dec := req.Playbook.decide(req.Type, tier)
 
@@ -192,6 +195,9 @@ func (e *Executor) ExecutePolicy(ctx context.Context, incidentID uuid.UUID, acti
 	inc, err := e.store.Get(ctx, incidentID)
 	if err != nil {
 		return nil, fmt.Errorf("incident: load incident for policy action: %w", err)
+	}
+	if inc == nil {
+		return nil, errors.New("incident: incident not found")
 	}
 	action := e.newAction(inc, ActionRequest{
 		IncidentID: incidentID,

--- a/internal/incident/executor_test.go
+++ b/internal/incident/executor_test.go
@@ -1,0 +1,400 @@
+package incident
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	mtest "github.com/caesium-cloud/caesium/internal/metrics/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// fakeOps records calls to the ActionOps surface so tests can assert dispatch
+// without wiring the real run/callback/notification/replay subsystems.
+type fakeOps struct {
+	retryFromFailure []uuid.UUID
+	retryCallbacks   []uuid.UUID
+	rerun            []rerunCall
+	notify           []notifyCall
+	escalate         []escalateCall
+	setPaused        []pauseCall
+	clearCache       []cacheCall
+	suppress         []time.Time
+	extendSLA        []extendCall
+	replay           []uuid.UUID
+
+	retryErr error
+	rerunID  uuid.UUID
+}
+
+type rerunCall struct {
+	jobID  uuid.UUID
+	params map[string]string
+}
+type notifyCall struct{ channel, message string }
+type escalateCall struct {
+	incidentID       uuid.UUID
+	channel, summary string
+}
+type pauseCall struct {
+	jobID  uuid.UUID
+	paused bool
+}
+type cacheCall struct {
+	jobID    uuid.UUID
+	taskName string
+}
+type extendCall struct {
+	runID  uuid.UUID
+	extend time.Duration
+}
+
+func (f *fakeOps) RetryFromFailure(_ context.Context, runID uuid.UUID) error {
+	f.retryFromFailure = append(f.retryFromFailure, runID)
+	return f.retryErr
+}
+func (f *fakeOps) RetryCallbacks(_ context.Context, runID uuid.UUID) error {
+	f.retryCallbacks = append(f.retryCallbacks, runID)
+	return nil
+}
+func (f *fakeOps) RerunWithParams(_ context.Context, jobID uuid.UUID, params map[string]string) (uuid.UUID, error) {
+	f.rerun = append(f.rerun, rerunCall{jobID: jobID, params: params})
+	if f.rerunID == uuid.Nil {
+		f.rerunID = uuid.New()
+	}
+	return f.rerunID, nil
+}
+func (f *fakeOps) QuarantineReplay(_ context.Context, runID uuid.UUID, _ map[string]string) (json.RawMessage, error) {
+	f.replay = append(f.replay, runID)
+	return json.RawMessage(`{"ok":true}`), nil
+}
+func (f *fakeOps) Notify(_ context.Context, channel, message string) error {
+	f.notify = append(f.notify, notifyCall{channel: channel, message: message})
+	return nil
+}
+func (f *fakeOps) Escalate(_ context.Context, incidentID uuid.UUID, channel, summary string) error {
+	f.escalate = append(f.escalate, escalateCall{incidentID: incidentID, channel: channel, summary: summary})
+	return nil
+}
+func (f *fakeOps) SetJobPaused(_ context.Context, jobID uuid.UUID, paused bool) error {
+	f.setPaused = append(f.setPaused, pauseCall{jobID: jobID, paused: paused})
+	return nil
+}
+func (f *fakeOps) ClearCacheEntry(_ context.Context, jobID uuid.UUID, taskName string) error {
+	f.clearCache = append(f.clearCache, cacheCall{jobID: jobID, taskName: taskName})
+	return nil
+}
+func (f *fakeOps) SuppressDownstreamAlerts(_ context.Context, _ uuid.UUID, until time.Time) error {
+	f.suppress = append(f.suppress, until)
+	return nil
+}
+func (f *fakeOps) ExtendSLAOnce(_ context.Context, runID uuid.UUID, extend time.Duration) error {
+	f.extendSLA = append(f.extendSLA, extendCall{runID: runID, extend: extend})
+	return nil
+}
+
+// seedIncident opens an incident with a remediation-target run so run-scoped
+// actions can resolve their run id from the incident.
+func seedIncident(t *testing.T, store *Store) (*models.Incident, uuid.UUID) {
+	t.Helper()
+	runID := uuid.New()
+	inc, outcome, err := store.OpenOrAppend(context.Background(), OpenParams{
+		JobID:                  uuid.New(),
+		RunID:                  &runID,
+		TaskName:               "extract",
+		Class:                  ClassTransientInfra,
+		RemediationTargetRunID: &runID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, OutcomeOpened, outcome)
+	return inc, runID
+}
+
+func newExecutorTest(t *testing.T) (*gorm.DB, *Store, *fakeOps, *Executor) {
+	t.Helper()
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+	ops := &fakeOps{}
+	return db, store, ops, NewExecutor(store, ops)
+}
+
+func TestExecuteTier1AutonomousRetry(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, runID := seedIncident(t, store)
+
+	before := mtest.CounterValue(t, metrics.AgentActionsTotal, ActionTypeRetryFromFailure, "1", string(models.AgentActionActorAgent))
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Actor:      models.AgentActionActorAgent,
+		Type:       ActionTypeRetryFromFailure,
+		Playbook:   Playbook{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action.Status)
+	require.Equal(t, models.AgentActionActorAgent, action.Actor)
+	require.Equal(t, TierAutonomous, action.Tier)
+	require.Equal(t, []uuid.UUID{runID}, ops.retryFromFailure)
+
+	after := mtest.CounterValue(t, metrics.AgentActionsTotal, ActionTypeRetryFromFailure, "1", string(models.AgentActionActorAgent))
+	require.Equal(t, before+1, after)
+
+	// Tier 1 is NOT mirrored into the audit log.
+	var audits int64
+	require.NoError(t, store.DB().Model(&models.AuditLog{}).Count(&audits).Error)
+	require.Zero(t, audits)
+}
+
+func TestExecuteTier2RequiresExplicitAllow(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	// Tier-2 pause_job with an empty allow list is denied (recorded rejected).
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypePauseJob,
+		Playbook:   Playbook{},
+	})
+	require.ErrorIs(t, err, ErrActionNotPermitted)
+	require.Equal(t, models.AgentActionStatusRejected, action.Status)
+	require.Empty(t, ops.setPaused)
+
+	// Explicitly allowed → executes and mirrors into the audit log (tier 2).
+	action2, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypePauseJob,
+		Playbook:   Playbook{Allow: map[string]bool{ActionTypePauseJob: true}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action2.Status)
+	require.Len(t, ops.setPaused, 1)
+	require.True(t, ops.setPaused[0].paused)
+	require.Equal(t, inc.JobID, ops.setPaused[0].jobID)
+
+	var audits int64
+	require.NoError(t, store.DB().Model(&models.AuditLog{}).
+		Where("action = ?", "agent.action."+ActionTypePauseJob).Count(&audits).Error)
+	require.Equal(t, int64(1), audits, "tier-2 execution must mirror into the audit log")
+}
+
+func TestExecuteTier3AlwaysProposedNeverExecuted(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	// Even with the action explicitly allowed, tier 3 is never auto-executed.
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeApplyJobdefPatch,
+		Playbook:   Playbook{Allow: map[string]bool{ActionTypeApplyJobdefPatch: true}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusProposed, action.Status)
+	require.Equal(t, TierApproval, action.Tier)
+	require.Empty(t, ops.setPaused)
+	require.Empty(t, ops.retryFromFailure)
+}
+
+func TestExecuteRequireApprovalRoutesTier1ToProposed(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeRetryFromFailure,
+		Playbook:   Playbook{RequireApproval: map[string]bool{ActionTypeRetryFromFailure: true}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusProposed, action.Status)
+	require.Empty(t, ops.retryFromFailure, "an approval-gated action must not execute")
+}
+
+func TestExecuteUnknownAction(t *testing.T) {
+	_, store, _, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	_, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       "definitely_not_a_real_action",
+	})
+	require.ErrorIs(t, err, ErrUnknownAction)
+}
+
+func TestExecuteRerunWithParamsWhitelist(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	inc, _ := seedIncident(t, store)
+
+	pb := Playbook{
+		Allow:          map[string]bool{ActionTypeRerunWithParams: true},
+		ParamOverrides: map[string][]string{"badRowPolicy": {"quarantine"}},
+	}
+
+	// A non-whitelisted value is rejected (recorded failed).
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeRerunWithParams,
+		Params:     ActionParams{Overrides: map[string]string{"badRowPolicy": "drop"}},
+		Playbook:   pb,
+	})
+	require.Error(t, err)
+	require.Equal(t, models.AgentActionStatusFailed, action.Status)
+	require.Empty(t, ops.rerun)
+
+	// A whitelisted value runs.
+	action2, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeRerunWithParams,
+		Params:     ActionParams{Overrides: map[string]string{"badRowPolicy": "quarantine"}},
+		Playbook:   pb,
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action2.Status)
+	require.Len(t, ops.rerun, 1)
+	require.Equal(t, "quarantine", ops.rerun[0].params["badRowPolicy"])
+}
+
+func TestExecutePolicyDeterministicRuleRecordsActorPolicy(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	// transient_infra → auto_retry_backoff (retry_from_failure) deterministic rule.
+	inc, runID := seedIncident(t, store)
+
+	action, matched, err := exec.ApplyDeterministicRule(context.Background(), inc, DefaultRuleSet())
+	require.NoError(t, err)
+	require.True(t, matched)
+	require.Equal(t, models.AgentActionActorPolicy, action.Actor)
+	require.Equal(t, models.AgentActionStatusExecuted, action.Status)
+	require.Equal(t, ActionTypeRetryFromFailure, action.Type)
+	require.Equal(t, []uuid.UUID{runID}, ops.retryFromFailure)
+}
+
+func TestApplyDeterministicRuleNoMatch(t *testing.T) {
+	_, store, _, exec := newExecutorTest(t)
+	// auth_failure has no default deterministic rule → agent path.
+	runID := uuid.New()
+	inc, _, err := store.OpenOrAppend(context.Background(), OpenParams{
+		JobID:                  uuid.New(),
+		RunID:                  &runID,
+		TaskName:               "extract",
+		Class:                  ClassAuthFailure,
+		RemediationTargetRunID: &runID,
+	})
+	require.NoError(t, err)
+
+	action, matched, err := exec.ApplyDeterministicRule(context.Background(), inc, DefaultRuleSet())
+	require.NoError(t, err)
+	require.False(t, matched)
+	require.Nil(t, action)
+}
+
+func TestSnoozeRetrySchedulesDurableTimerAndFires(t *testing.T) {
+	db, store, ops, exec := newExecutorTest(t)
+	// Use a data_unavailable incident so a snooze is the natural remediation.
+	runID := uuid.New()
+	inc, _, err := store.OpenOrAppend(context.Background(), OpenParams{
+		JobID:                  uuid.New(),
+		RunID:                  &runID,
+		TaskName:               "extract",
+		Class:                  ClassDataUnavailable,
+		RemediationTargetRunID: &runID,
+	})
+	require.NoError(t, err)
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeSnoozeRetry,
+		Params:     ActionParams{DelaySeconds: 2700},
+		Playbook:   Playbook{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action.Status)
+
+	// A durable timer must exist, pending, owned by the incident, linked to the
+	// action — no retry has fired yet.
+	var timer models.RemediationTimer
+	require.NoError(t, db.First(&timer, "incident_id = ?", inc.ID).Error)
+	require.Equal(t, models.RemediationTimerStatusPending, timer.Status)
+	require.Equal(t, TimerKindSnoozeRetry, timer.Kind)
+	require.NotNil(t, timer.ActionID)
+	require.Equal(t, action.ID, *timer.ActionID)
+	require.Empty(t, ops.retryFromFailure)
+
+	// Backdate the timer so it is due, then sweep: the handler must fire the
+	// admit-aware retry for the snoozed run.
+	require.NoError(t, db.Model(&models.RemediationTimer{}).
+		Where("id = ?", timer.ID).
+		Update("fire_at", time.Now().UTC().Add(-time.Minute)).Error)
+
+	sup := NewTimerSupervisor(db, nil, time.Second)
+	exec.RegisterTimerHandlers(sup)
+	require.NoError(t, sup.SweepOnce(context.Background()))
+
+	require.Equal(t, []uuid.UUID{runID}, ops.retryFromFailure)
+
+	var fired models.RemediationTimer
+	require.NoError(t, db.First(&fired, "id = ?", timer.ID).Error)
+	require.Equal(t, models.RemediationTimerStatusFired, fired.Status)
+}
+
+func TestSnoozeTimerCancelledOnTerminalIncidentIsNotFired(t *testing.T) {
+	db, store, ops, exec := newExecutorTest(t)
+	runID := uuid.New()
+	inc, _, err := store.OpenOrAppend(context.Background(), OpenParams{
+		JobID:                  uuid.New(),
+		RunID:                  &runID,
+		TaskName:               "extract",
+		Class:                  ClassDataUnavailable,
+		RemediationTargetRunID: &runID,
+	})
+	require.NoError(t, err)
+
+	_, err = exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeSnoozeRetry,
+		Params:     ActionParams{DelaySeconds: 2700},
+	})
+	require.NoError(t, err)
+
+	// The incident is abandoned (budget exhausted); this terminal transition must
+	// cancel the timer so it never fires a retry against a closed incident.
+	_, err = store.Transition(context.Background(), inc.ID, models.IncidentStatusAbandoned, "budget exhausted")
+	require.NoError(t, err)
+
+	var timer models.RemediationTimer
+	require.NoError(t, db.First(&timer, "incident_id = ?", inc.ID).Error)
+	require.Equal(t, models.RemediationTimerStatusCancelled, timer.Status)
+
+	// Even backdated, a cancelled timer is not swept.
+	require.NoError(t, db.Model(&models.RemediationTimer{}).
+		Where("id = ?", timer.ID).
+		Update("fire_at", time.Now().UTC().Add(-time.Minute)).Error)
+	sup := NewTimerSupervisor(db, nil, time.Second)
+	exec.RegisterTimerHandlers(sup)
+	require.NoError(t, sup.SweepOnce(context.Background()))
+	require.Empty(t, ops.retryFromFailure)
+}
+
+func TestSnoozeRetryFireHandlerErrPropagates(t *testing.T) {
+	_, store, ops, exec := newExecutorTest(t)
+	ops.retryErr = errors.New("boom")
+	runID := uuid.New()
+	timer := models.RemediationTimer{
+		Payload: mustJSON(t, snoozePayload{RunID: runID}),
+	}
+	err := exec.fireSnoozeRetry(context.Background(), timer)
+	require.Error(t, err)
+	_ = store
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/internal/incident/executor_test.go
+++ b/internal/incident/executor_test.go
@@ -398,3 +398,108 @@ func mustJSON(t *testing.T, v any) []byte {
 	require.NoError(t, err)
 	return b
 }
+
+func pendingTimers(t *testing.T, db *gorm.DB, incidentID uuid.UUID) []models.RemediationTimer {
+	t.Helper()
+	var timers []models.RemediationTimer
+	require.NoError(t, db.Where("incident_id = ? AND status = ?", incidentID, models.RemediationTimerStatusPending).Find(&timers).Error)
+	return timers
+}
+
+func decodeSnoozePayload(t *testing.T, raw []byte) snoozePayload {
+	t.Helper()
+	var p snoozePayload
+	require.NoError(t, json.Unmarshal(raw, &p))
+	return p
+}
+
+// A snooze_retry whose job is paused (retryable refusal) must NOT consume the
+// timer and drop the retry: it re-arms a fresh pending timer, and once the job
+// is unpaused the re-armed timer's fire retries successfully.
+func TestSnoozeRetryRearmsOnDeferredThenSucceeds(t *testing.T) {
+	db, store, ops, exec := newExecutorTest(t)
+	inc, runID := seedIncident(t, store)
+
+	// Simulate a paused job: the retry is deferred, not permanently failed.
+	ops.retryErr = ErrRetryDeferred
+
+	action, err := exec.Execute(context.Background(), ActionRequest{
+		IncidentID: inc.ID,
+		Type:       ActionTypeSnoozeRetry,
+		Params:     ActionParams{DelaySeconds: 2700},
+		Playbook:   Playbook{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, models.AgentActionStatusExecuted, action.Status)
+
+	pend := pendingTimers(t, db, inc.ID)
+	require.Len(t, pend, 1)
+	original := pend[0]
+
+	// Backdate + sweep: the deferred retry must re-arm a NEW pending timer, not
+	// vanish.
+	require.NoError(t, db.Model(&models.RemediationTimer{}).Where("id = ?", original.ID).
+		Update("fire_at", time.Now().UTC().Add(-time.Minute)).Error)
+	sup := NewTimerSupervisor(db, nil, time.Second)
+	exec.RegisterTimerHandlers(sup)
+	require.NoError(t, sup.SweepOnce(context.Background()))
+
+	// The original attempt was made (and deferred) — the run is NOT yet retried.
+	require.Equal(t, []uuid.UUID{runID}, ops.retryFromFailure)
+
+	// The original timer is consumed (fired) but a fresh pending timer re-armed
+	// for the same run, rearm=1.
+	var originalAfter models.RemediationTimer
+	require.NoError(t, db.First(&originalAfter, "id = ?", original.ID).Error)
+	require.Equal(t, models.RemediationTimerStatusFired, originalAfter.Status)
+
+	rearmed := pendingTimers(t, db, inc.ID)
+	require.Len(t, rearmed, 1, "a retryable refusal must leave exactly one pending re-armed timer")
+	require.NotEqual(t, original.ID, rearmed[0].ID)
+	rp := decodeSnoozePayload(t, rearmed[0].Payload)
+	require.Equal(t, runID, rp.RunID)
+	require.Equal(t, 1, rp.Rearm)
+
+	// The re-arm is observable on the audit spine as a policy snooze_retry row
+	// (distinct from the original agent-scheduled snooze action).
+	var rearmActions int64
+	require.NoError(t, db.Model(&models.AgentAction{}).
+		Where("incident_id = ? AND type = ? AND actor = ? AND status = ?",
+			inc.ID, ActionTypeSnoozeRetry, models.AgentActionActorPolicy, models.AgentActionStatusExecuted).
+		Count(&rearmActions).Error)
+	require.Equal(t, int64(1), rearmActions, "the re-arm must be recorded on the timeline")
+
+	// Job unpaused: the re-armed timer's fire now retries successfully.
+	ops.retryErr = nil
+	require.NoError(t, db.Model(&models.RemediationTimer{}).Where("id = ?", rearmed[0].ID).
+		Update("fire_at", time.Now().UTC().Add(-time.Minute)).Error)
+	require.NoError(t, sup.SweepOnce(context.Background()))
+
+	require.Equal(t, []uuid.UUID{runID, runID}, ops.retryFromFailure, "the re-armed timer retried the run")
+	require.Empty(t, pendingTimers(t, db, inc.ID), "no timers left pending after a successful retry")
+}
+
+// Beyond the re-arm ceiling a permanently-deferred snooze gives up: no new timer,
+// a failed audit row, and an error surfaced to the sweeper.
+func TestSnoozeRetryRearmGivesUpAtCeiling(t *testing.T) {
+	db, store, ops, exec := newExecutorTest(t)
+	inc, runID := seedIncident(t, store)
+	ops.retryErr = ErrRetryDeferred
+
+	timer := models.RemediationTimer{
+		IncidentID: inc.ID,
+		Namespace:  inc.Namespace,
+		Payload:    mustJSON(t, snoozePayload{RunID: runID, Rearm: maxSnoozeRearm}),
+	}
+	err := exec.fireSnoozeRetry(context.Background(), timer)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrRetryDeferred)
+
+	require.Empty(t, pendingTimers(t, db, inc.ID), "at the ceiling no further timer is armed")
+
+	var gaveUp int64
+	require.NoError(t, db.Model(&models.AgentAction{}).
+		Where("incident_id = ? AND type = ? AND status = ?", inc.ID, ActionTypeSnoozeRetry, models.AgentActionStatusFailed).
+		Count(&gaveUp).Error)
+	require.Equal(t, int64(1), gaveUp)
+}

--- a/internal/incident/rules.go
+++ b/internal/incident/rules.go
@@ -1,0 +1,106 @@
+package incident
+
+import (
+	"context"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+// Deterministic Phase-0 rule names (design-agent-in-the-loop.md, "Playbook
+// match"): if a failure class maps to a deterministic rule, the incident manager
+// executes it directly and records it as an AgentAction with actor=policy — same
+// audit trail, no container launch.
+const (
+	// RuleAutoRetryBackoff re-runs a failed run after a fixed backoff — the
+	// cheap path for transient-infra failures a plain retry clears.
+	RuleAutoRetryBackoff = "auto_retry_backoff"
+	// RuleSnoozeUntilCron defers a retry (e.g. wait for a late vendor file) via a
+	// durable snooze timer rather than an in-process delay.
+	RuleSnoozeUntilCron = "snooze_until_cron"
+)
+
+// DeterministicRule maps a failure class to a server-side remediation that runs
+// without an agent container. Delay is the backoff/snooze applied before the
+// concrete action.
+type DeterministicRule struct {
+	// Name is the operator-facing rule name recorded on the incident timeline.
+	Name string
+	// Class is the failure class this rule fires for.
+	Class FailureClass
+	// ActionType is the concrete catalog action the rule performs.
+	ActionType string
+	// Delay is the backoff before a retry (auto_retry_backoff) or the snooze
+	// window (snooze_until_cron). Zero means immediate.
+	Delay time.Duration
+}
+
+// DefaultRules ships the two Phase-0 deterministic rules the design names.
+func DefaultRules() []DeterministicRule {
+	return []DeterministicRule{
+		{
+			Name:       RuleAutoRetryBackoff,
+			Class:      ClassTransientInfra,
+			ActionType: ActionTypeRetryFromFailure,
+			Delay:      0,
+		},
+		{
+			Name:       RuleSnoozeUntilCron,
+			Class:      ClassDataUnavailable,
+			ActionType: ActionTypeSnoozeRetry,
+			Delay:      45 * time.Minute,
+		},
+	}
+}
+
+// Rules is a deterministic rule table keyed by failure class. It holds no state
+// beyond its table and is safe for concurrent reads.
+type Rules struct {
+	byClass map[FailureClass]DeterministicRule
+}
+
+// NewRules builds a rule table from the supplied rules (last rule for a class
+// wins).
+func NewRules(rules ...DeterministicRule) *Rules {
+	byClass := make(map[FailureClass]DeterministicRule, len(rules))
+	for _, r := range rules {
+		byClass[r.Class] = r
+	}
+	return &Rules{byClass: byClass}
+}
+
+// DefaultRuleSet returns the shipped default deterministic rule table.
+func DefaultRuleSet() *Rules { return NewRules(DefaultRules()...) }
+
+// Match returns the deterministic rule for a class, if one exists.
+func (r *Rules) Match(class FailureClass) (DeterministicRule, bool) {
+	if r == nil {
+		return DeterministicRule{}, false
+	}
+	rule, ok := r.byClass[class]
+	return rule, ok
+}
+
+// ApplyDeterministicRule runs the deterministic rule for the incident's class (if
+// any) as an actor=policy action, returning the recorded action and true. It
+// returns (nil, false, nil) when no rule matches the class — the caller then
+// dispatches an agent session instead. The rule's concrete action is executed
+// through the same recording/metric/audit path as an agent action, so the
+// timeline reconstructs uniformly.
+func (e *Executor) ApplyDeterministicRule(ctx context.Context, inc *models.Incident, rules *Rules) (*models.AgentAction, bool, error) {
+	rule, ok := rules.Match(FailureClass(inc.Class))
+	if !ok {
+		return nil, false, nil
+	}
+	params := ActionParams{}
+	if rule.ActionType == ActionTypeSnoozeRetry {
+		params.DelaySeconds = int64(rule.Delay / time.Second)
+	}
+	// The concrete run target defaults from the incident (resolveRunID) when the
+	// rule does not carry an explicit one.
+	action, err := e.ExecutePolicy(ctx, inc.ID, rule.ActionType, params)
+	if err != nil {
+		return action, true, err
+	}
+	return action, true, nil
+}

--- a/internal/incident/subscriber.go
+++ b/internal/incident/subscriber.go
@@ -39,8 +39,9 @@ var successTypes = []event.Type{
 
 // Subscriber is the leader-gated incident manager. It consumes failure events,
 // classifies each, and opens/correlates an incident; it consumes success events
-// to close incidents as remediated when a later run succeeds. It never invokes
-// an LLM or takes an autonomous action.
+// to close incidents as remediated when a later run succeeds. When a remediator
+// is wired (SetRemediator, behind the master gate) it also runs the Phase-0
+// deterministic rules on incident open; it never invokes an LLM.
 type Subscriber struct {
 	bus         event.Bus
 	db          *gorm.DB
@@ -48,6 +49,11 @@ type Subscriber struct {
 	classifier  *Classifier
 	leaderCheck LeaderCheck
 	cooldown    time.Duration
+	// executor + rules drive the Phase-0 deterministic remediation on incident
+	// open. Both are nil unless SetRemediator is called, so default-off
+	// deployments and tests take no autonomous action.
+	executor *Executor
+	rules    *Rules
 }
 
 // NewSubscriber constructs an incident subscriber.
@@ -60,6 +66,17 @@ func NewSubscriber(bus event.Bus, db *gorm.DB, leaderCheck LeaderCheck, cooldown
 		leaderCheck: leaderCheck,
 		cooldown:    cooldown,
 	}
+}
+
+// SetRemediator wires the deterministic-rule executor and rule table so that
+// opening an incident whose class maps to a deterministic rule
+// (auto_retry_backoff / snooze_until_cron) runs that rule as an actor=policy
+// action — the live Phase-0 autonomous path. Only invoked behind the master gate
+// (CAESIUM_AGENT_REMEDIATION_ENABLED) from cmd/start. A subscriber without a
+// remediator opens and classifies incidents but takes no autonomous action.
+func (s *Subscriber) SetRemediator(executor *Executor, rules *Rules) {
+	s.executor = executor
+	s.rules = rules
 }
 
 // Start subscribes to the failure and success event types and processes them
@@ -222,6 +239,19 @@ func (s *Subscriber) handleFailure(ctx context.Context, evt event.Event) {
 		"outcome", outcome,
 		"occurrences", inc.OccurrenceCount,
 	)
+
+	// Phase-0 deterministic remediation: only on a freshly OPENED incident (not on
+	// an appended recurrence, which would double-fire the rule), run the class's
+	// deterministic rule as an actor=policy action if one matches and a remediator
+	// is wired. Firing only on open keeps the loop bounded: a retried run that
+	// fails again appends an occurrence and does not re-fire.
+	if outcome == OutcomeOpened && s.executor != nil && s.rules != nil {
+		if _, matched, rerr := s.executor.ApplyDeterministicRule(ctx, inc, s.rules); rerr != nil {
+			log.Warn("incident: deterministic rule failed", "incident_id", inc.ID, "class", class, "error", rerr)
+		} else if matched {
+			log.Info("incident: deterministic rule applied", "incident_id", inc.ID, "class", class)
+		}
+	}
 }
 
 // handleSuccess closes open incidents whose job/task later ran green — the

--- a/internal/incident/subscriber_remediation_test.go
+++ b/internal/incident/subscriber_remediation_test.go
@@ -1,0 +1,112 @@
+package incident
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/atom"
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedTransientInfraFailure inserts a JobRun/Task/TaskRun whose engine result is
+// a startup failure, which the classifier buckets as transient_infra.
+func seedTransientInfraFailure(t *testing.T, db *gorm.DB) (jobID, runID, taskID uuid.UUID) {
+	t.Helper()
+	now := time.Now().UTC()
+	jobID = uuid.New()
+	runID = uuid.New()
+	taskID = uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: runID, JobID: jobID, Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Task{
+		ID: taskID, JobID: jobID, AtomID: uuid.New(), Name: "extract", CreatedAt: now, UpdatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID: uuid.New(), JobRunID: runID, TaskID: taskID, AtomID: uuid.New(),
+		Engine: models.AtomEngineDocker, Image: "busybox:1.36.1", Command: "sh",
+		Status: "failed", Result: string(atom.StartupFailure),
+		CreatedAt: now, UpdatedAt: now,
+	}).Error)
+	return jobID, runID, taskID
+}
+
+func waitForAction(t *testing.T, db *gorm.DB) models.AgentAction {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		var a models.AgentAction
+		if err := db.First(&a).Error; err == nil {
+			return a
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("expected a deterministic AgentAction row, got none")
+	return models.AgentAction{}
+}
+
+// A transient_infra incident open must run the deterministic auto_retry_backoff
+// rule as an actor=policy retry_from_failure — the live Phase-0 autonomous path
+// (design "Playbook match"). Without SetRemediator no action is taken.
+func TestSubscriberDeterministicRuleOnOpen(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	sub := NewSubscriber(bus, db, nil, 0)
+	ops := &fakeOps{}
+	sub.SetRemediator(NewExecutor(NewStore(db), ops), DefaultRuleSet())
+	ready := make(chan struct{})
+	go func() { _ = sub.StartWithReady(ctx, ready) }()
+	<-ready
+
+	jobID, runID, taskID := seedTransientInfraFailure(t, db)
+	bus.Publish(event.Event{Type: event.TypeTaskFailed, JobID: jobID, RunID: runID, TaskID: taskID, Timestamp: time.Now()})
+
+	action := waitForAction(t, db)
+	require.Equal(t, models.AgentActionActorPolicy, action.Actor)
+	require.Equal(t, ActionTypeRetryFromFailure, action.Type)
+	require.Equal(t, models.AgentActionStatusExecuted, action.Status)
+
+	// The recorded result names the incident's own run — proving the policy rule
+	// retried the failing run.
+	var result struct {
+		RunID string `json:"run_id"`
+	}
+	require.NoError(t, json.Unmarshal(action.Result, &result))
+	require.Equal(t, runID.String(), result.RunID)
+}
+
+// Without a remediator wired, the subscriber classifies and opens the incident
+// but takes no autonomous action (default-off deployments).
+func TestSubscriberNoRemediatorTakesNoAction(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	sub := NewSubscriber(bus, db, nil, 0)
+	ready := make(chan struct{})
+	go func() { _ = sub.StartWithReady(ctx, ready) }()
+	<-ready
+
+	jobID, runID, taskID := seedTransientInfraFailure(t, db)
+	bus.Publish(event.Event{Type: event.TypeTaskFailed, JobID: jobID, RunID: runID, TaskID: taskID, Timestamp: time.Now()})
+	waitForIncidents(t, db, 1)
+
+	// Give any (erroneous) action a chance to land, then assert none did.
+	time.Sleep(50 * time.Millisecond)
+	var actions int64
+	require.NoError(t, db.Model(&models.AgentAction{}).Count(&actions).Error)
+	require.Zero(t, actions)
+}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -513,6 +513,19 @@ var (
 		},
 		[]string{"class"},
 	)
+
+	// AgentActionsTotal counts remediation actions recorded by the incident action
+	// executor, by action type, tier, and actor (policy|agent|human). The type
+	// label is bounded by the fixed typed-action catalog, tier by {0,1,2,3}, and
+	// actor by the fixed actor set, so cardinality is bounded (agent-in-the-loop
+	// remediation, Stream B).
+	AgentActionsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_agent_actions_total",
+			Help: "Total remediation actions recorded by the incident action executor, by action type, tier, and actor.",
+		},
+		[]string{"type", "tier", "actor"},
+	)
 )
 
 // Register registers all custom Caesium metrics with the default Prometheus registry.
@@ -571,6 +584,7 @@ func Register() {
 			CompleteRetryableTotal,
 			IncidentsTotal,
 			IncidentResolutionSeconds,
+			AgentActionsTotal,
 		)
 	})
 }

--- a/internal/run/retry_admit_test.go
+++ b/internal/run/retry_admit_test.go
@@ -1,0 +1,147 @@
+package run
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// seedFailedRun creates a terminal (failed) run for a job so retry paths have a
+// run to reset.
+func seedFailedRun(t *testing.T, db *gorm.DB, jobID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:          runID,
+		JobID:       jobID,
+		Status:      string(StatusFailed),
+		StartedAt:   now.Add(-time.Minute),
+		CompletedAt: &now,
+		CreatedAt:   now.Add(-time.Minute),
+		UpdatedAt:   now,
+	}).Error)
+	return runID
+}
+
+func seedRunningRun(t *testing.T, db *gorm.DB, jobID uuid.UUID) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:        runID,
+		JobID:     jobID,
+		Status:    string(StatusRunning),
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	return runID
+}
+
+// Safety valve 1: an agent retry is refused while the job is paused; a manual
+// retry (human decision) is not.
+func TestRetryFromFailureAdmittedRefusesPausedJob(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	job := createConcurrencyJob(t, db, "paused-retry", jobdef.ConcurrencyStrategyQueue, 1)
+	require.NoError(t, db.Model(&models.Job{}).Where("id = ?", job.ID).Update("paused", true).Error)
+	runID := seedFailedRun(t, db, job.ID)
+
+	_, err := store.RetryFromFailureAdmitted(runID)
+	require.ErrorIs(t, err, ErrJobPaused)
+
+	// The run must remain terminal — the refused retry did not flip it.
+	var row models.JobRun
+	require.NoError(t, db.First(&row, "id = ?", runID).Error)
+	require.Equal(t, string(StatusFailed), row.Status)
+
+	// The manual/human entry point ignores the pause and retries.
+	r, err := store.RetryFromFailure(runID)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.NoError(t, db.First(&row, "id = ?", runID).Error)
+	require.Equal(t, string(StatusRunning), row.Status)
+}
+
+// Safety valve 2: an agent retry re-admits under queue semantics. On a job at
+// max concurrency it is refused (never replace-cancels the live run), even when
+// the declared strategy is replace.
+func TestRetryFromFailureAdmittedRefusesWhenNoSlot(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	// Declared strategy is replace — an agent retry must NOT honor it.
+	job := createConcurrencyJob(t, db, "full-retry", jobdef.ConcurrencyStrategyReplace, 1)
+	liveRun := seedRunningRun(t, db, job.ID) // occupies the single slot
+	failedRun := seedFailedRun(t, db, job.ID)
+
+	_, err := store.RetryFromFailureAdmitted(failedRun)
+	require.ErrorIs(t, err, ErrMaxConcurrentRunsReached)
+
+	// The live run is untouched (no replace-cancel) and the failed run stays failed.
+	var live models.JobRun
+	require.NoError(t, db.First(&live, "id = ?", liveRun).Error)
+	require.Equal(t, string(StatusRunning), live.Status)
+	var failed models.JobRun
+	require.NoError(t, db.First(&failed, "id = ?", failedRun).Error)
+	require.Equal(t, string(StatusFailed), failed.Status)
+}
+
+// With a free slot the admit-aware retry succeeds.
+func TestRetryFromFailureAdmittedAdmitsWhenSlotFree(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	job := createConcurrencyJob(t, db, "free-retry", jobdef.ConcurrencyStrategyQueue, 1)
+	failedRun := seedFailedRun(t, db, job.ID)
+
+	r, err := store.RetryFromFailureAdmitted(failedRun)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+
+	var row models.JobRun
+	require.NoError(t, db.First(&row, "id = ?", failedRun).Error)
+	require.Equal(t, string(StatusRunning), row.Status)
+}
+
+// A job with no concurrency policy admits the agent retry unconditionally.
+func TestRetryFromFailureAdmittedNoPolicy(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	store := NewStore(db)
+
+	now := time.Now().UTC()
+	trigger := &models.Trigger{
+		ID:            uuid.New(),
+		Alias:         "nopolicy-retry-trigger",
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"cron":"0 * * * *","timezone":"UTC"}`,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	require.NoError(t, db.Create(trigger).Error)
+	job := &models.Job{ID: uuid.New(), Alias: "nopolicy-retry", TriggerID: trigger.ID, CreatedAt: now, UpdatedAt: now}
+	require.NoError(t, db.Create(job).Error)
+
+	// Even with an active run, no policy means no slot cap.
+	seedRunningRun(t, db, job.ID)
+	failedRun := seedFailedRun(t, db, job.ID)
+
+	r, err := store.RetryFromFailureAdmitted(failedRun)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	var row models.JobRun
+	require.NoError(t, db.First(&row, "id = ?", failedRun).Error)
+	require.Equal(t, string(StatusRunning), row.Status)
+}

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -242,6 +242,10 @@ var (
 	ErrRunSkipped               = errors.New("run: skipped by concurrency policy")
 	ErrRunQueued                = errors.New("run: queued by concurrency policy")
 	ErrMaxConcurrentRunsReached = errors.New("run: max concurrent runs reached")
+	// ErrJobPaused is returned by RetryFromFailureAdmitted when an agent-initiated
+	// retry is refused because the job is paused. A human pause outranks an agent
+	// retry (design-agent-in-the-loop.md, retry safety valves).
+	ErrJobPaused = errors.New("run: cannot retry while job is paused")
 )
 
 type admissionDecision int
@@ -4647,9 +4651,93 @@ func effectiveTaskHash(hash, effectiveHash string) string {
 	return hash
 }
 
+// readmitRetryTx flips a terminal run back to running as part of a retry. For a
+// manual retry (admit=false) it is an unconditional UPDATE. For an agent retry
+// (admit=true) on a non-quarantine job that declares a concurrency policy, it is
+// a QUEUE-semantics conditional UPDATE: the flip takes effect only if the active
+// running count for the job is under maxRuns, so an agent retry can never exceed
+// the declared concurrency nor replace-cancel a live run. On a full job it
+// returns ErrMaxConcurrentRunsReached and leaves the run terminal.
+func (s *Store) readmitRetryTx(tx *gorm.DB, jobRun *models.JobRun, admit bool) error {
+	unconditional := func() error {
+		return tx.Model(jobRun).Updates(map[string]interface{}{
+			"status":       string(StatusRunning),
+			"completed_at": nil,
+			"error":        "",
+		}).Error
+	}
+	if !admit || jobRun.Quarantine {
+		return unconditional()
+	}
+	cfg, hasPolicy, err := s.concurrencyConfigTx(tx, jobRun.JobID)
+	if err != nil {
+		return err
+	}
+	if !hasPolicy {
+		return unconditional()
+	}
+	// Conditional flip: succeed only if a slot is free. The run being retried is
+	// currently terminal so it is not in the active count; id <> ? excludes it
+	// defensively. The quarantine <> true / backfill_id IS NULL predicates mirror
+	// the admission count used by insertRunIfSlotTx so agent retries admit against
+	// the same slot definition as new runs.
+	res := tx.Exec(`
+UPDATE job_runs
+SET status = ?, completed_at = NULL, error = ''
+WHERE id = ?
+	AND status IN (?, ?)
+	AND (
+		SELECT count(*)
+		FROM job_runs
+		WHERE job_id = ?
+			AND status = ?
+			AND quarantine <> true
+			AND backfill_id IS NULL
+			AND id <> ?
+	) < ?`,
+		string(StatusRunning),
+		jobRun.ID,
+		string(StatusFailed), string(StatusSucceeded),
+		jobRun.JobID,
+		string(StatusRunning),
+		jobRun.ID,
+		cfg.maxRuns,
+	)
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected != 1 {
+		return ErrMaxConcurrentRunsReached
+	}
+	return nil
+}
+
 // RetryFromFailure resets a failed run so that previously-succeeded and cached
 // tasks are preserved and only failed/pending/skipped tasks are re-executed.
+// This is the manual/human retry entry point (caesium run retry); it performs no
+// concurrency re-admission and does not consult Job.Paused — a human retrying a
+// paused job's run is a deliberate human decision.
 func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
+	return s.retryFromFailure(runID, false)
+}
+
+// RetryFromFailureAdmitted is the admit-aware retry entry point used by the
+// incident action executor's retry actions (retry_from_failure, snooze_retry,
+// retry_callbacks re-run). It adds the two safety valves the plain
+// RetryFromFailure store call lacks (design-agent-in-the-loop.md):
+//
+//  1. It refuses while the job is Paused (returns ErrJobPaused) — a human pause
+//     outranks an agent retry.
+//  2. It re-admits against metadata.concurrency using QUEUE semantics regardless
+//     of the job's declared strategy: the run is flipped back to running only if
+//     a concurrency slot is free (returns ErrMaxConcurrentRunsReached otherwise).
+//     An agent retry must never replace-cancel a live run, nor race the next cron
+//     tick for a slot admission never granted.
+func (s *Store) RetryFromFailureAdmitted(runID uuid.UUID) (*JobRun, error) {
+	return s.retryFromFailure(runID, true)
+}
+
+func (s *Store) retryFromFailure(runID uuid.UUID, admit bool) (*JobRun, error) {
 	pendingEvents := make([]event.Event, 0, 2)
 	var jobID uuid.UUID
 	var quarantine bool
@@ -4667,12 +4755,20 @@ func (s *Store) RetryFromFailure(runID uuid.UUID) (*JobRun, error) {
 		jobID = jobRun.JobID
 		quarantine = jobRun.Quarantine
 
+		// Safety valve 1 (agent retries only): a human pause outranks an agent
+		// retry, so refuse while the owning job is paused.
+		if admit {
+			var job models.Job
+			if err := tx.Select("paused").First(&job, "id = ?", jobRun.JobID).Error; err != nil {
+				return err
+			}
+			if job.Paused {
+				return ErrJobPaused
+			}
+		}
+
 		// 2. Reset the job run status to running.
-		if err := tx.Model(&jobRun).Updates(map[string]interface{}{
-			"status":       string(StatusRunning),
-			"completed_at": nil,
-			"error":        "",
-		}).Error; err != nil {
+		if err := s.readmitRetryTx(tx, &jobRun, admit); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
## Summary

Second wave (W2-β) of [`docs/exec-plans/active/agent-in-the-loop-remediation.md`](https://github.com/caesium-cloud/caesium/blob/master/docs/exec-plans/active/agent-in-the-loop-remediation.md) — **Stream B** (items B1–B3). Builds on the Phase-0 incident substrate from #278. All action execution stays server-enforced and behind the default-off master flag.

- **B1 — executor** (`internal/incident/executor.go` + `rules.go`): the typed, server-enforced action executor. Validates a typed action against the effective playbook (tier 0/1 default autonomous, tier 2 only if explicitly allowed, **tier 3 always approval-gated / never auto-executed**), records every attempt as an `AgentAction` row with the right actor/tier/status, emits `caesium_agent_actions_total{type,tier,actor}`, and mirrors tier-2/3 executions into `AuditLog`. Deterministic Phase-0 rules (`auto_retry_backoff`, `snooze_until_cron`) run the same recording path as `actor=policy` with no container launch.
- **B2 — retry safety valves** (`internal/run/store.go`): `RetryFromFailureAdmitted` refuses while `Job.Paused` (`ErrJobPaused`) and re-admits under **queue** semantics regardless of the job's declared strategy (an agent retry never `replace`-cancels a live run). Manual `RetryFromFailure` is unchanged.
- **B3 — tier-1/2 catalog** (`internal/incident/actions.go`): `snooze_retry` (via the durable `RemediationTimer`), `retry_from_failure`, `retry_callbacks`, `notify`, `escalate`, `quarantine_replay`, `rerun_with_params` (whitelist-enforced), `pause_job`/`unpause_job`, `clear_cache_entry`, `suppress_downstream_alerts`, `extend_sla_once` — dispatched onto an injected `ActionOps` interface (Stream C wires the concretes).

**B4 (tier-3 producers) is deferred** — it depends on D1's approval flow, shipping in the sibling Stream D PR this wave.

## Test plan

- [x] `gofmt` clean
- [x] `go build ./internal/...` (full dqlite-CGO build; orchestrator re-verified)
- [x] `go vet` clean
- [x] `golangci-lint run ./internal/incident/... ./internal/run/...` — 0 issues
- [x] `go test ./internal/incident/... ./internal/run/... ./internal/metrics/...` — green (executor tier gating + AgentAction recording, both retry valves incl. `Job.Paused` refusal and queue-only re-admission, the tier-1/2 catalog)
- [ ] `just integration-test` — runs in CI; the executor is exercised end-to-end once Stream C's `/v1/agent/*` actions endpoint (which calls it) lands

## Coordination

- `internal/metrics/metrics.go` — appends only `AgentActionsTotal` (both edit sites) after A4's incident metrics.
- `internal/run/store.go` — adds `RetryFromFailureAdmitted` + `readmitRetryTx` + `ErrJobPaused` and refactors `RetryFromFailure` to a shared body; a distinct seam from the freshness W2 run-completion changes (union-merge).
- Does not touch `/v1/agent/*` routes, the approval flow, `auth_scope.go`, or `session.go` (Streams C/D own those); the executor API is exposed for Stream C's actions endpoint to call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh)_