### PR TITLE
Add metadata.remediation jobdef block + AgentProfile CRUD (agent-in-the-loop-remediation W2-ε)

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -2,6 +2,7 @@ package bind
 
 import (
 	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	agentprofilectrl "github.com/caesium-cloud/caesium/api/rest/controller/agentprofile"
 	"github.com/caesium-cloud/caesium/api/rest/controller/atom"
 	authctrl "github.com/caesium-cloud/caesium/api/rest/controller/auth"
 	"github.com/caesium-cloud/caesium/api/rest/controller/backfill"
@@ -179,6 +180,16 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		g.POST("/notifications/policies", notifctrl.CreatePolicy)
 		g.PATCH("/notifications/policies/:id", notifctrl.UpdatePolicy)
 		g.DELETE("/notifications/policies/:id", notifctrl.DeletePolicy)
+	}
+
+	// agent profiles (agent-in-the-loop-remediation E2): the AgentProfile
+	// server-side resource metadata.remediation.profile references.
+	{
+		g.GET("/agentprofiles", agentprofilectrl.List)
+		g.GET("/agentprofiles/:id", agentprofilectrl.Get)
+		g.POST("/agentprofiles", agentprofilectrl.Create)
+		g.PATCH("/agentprofiles/:id", agentprofilectrl.Update)
+		g.DELETE("/agentprofiles/:id", agentprofilectrl.Delete)
 	}
 
 	// nodes

--- a/api/rest/controller/agentprofile/agentprofile.go
+++ b/api/rest/controller/agentprofile/agentprofile.go
@@ -170,19 +170,26 @@ func serviceError(err error) error {
 	}
 }
 
+// maxListLimit caps the page size a client may request, so an oversized
+// limit can't force an unbounded scan/allocation.
+const maxListLimit = 1000
+
 func parseListRequest(c *echo.Context) (*svc.ListRequest, error) {
 	req := &svc.ListRequest{}
 
 	if limit := c.QueryParam("limit"); limit != "" {
-		v, err := strconv.ParseUint(limit, 10, 64)
+		v, err := strconv.ParseUint(limit, 10, 32)
 		if err != nil {
 			return nil, err
+		}
+		if v > maxListLimit {
+			v = maxListLimit
 		}
 		req.Limit = v
 	}
 
 	if offset := c.QueryParam("offset"); offset != "" {
-		v, err := strconv.ParseUint(offset, 10, 64)
+		v, err := strconv.ParseUint(offset, 10, 32)
 		if err != nil {
 			return nil, err
 		}

--- a/api/rest/controller/agentprofile/agentprofile.go
+++ b/api/rest/controller/agentprofile/agentprofile.go
@@ -1,0 +1,235 @@
+// Package agentprofile is the REST surface for the AgentProfile resource
+// (docs/design-agent-in-the-loop.md, agent-in-the-loop-remediation Stream
+// E2). It mirrors api/rest/controller/notification's channel CRUD.
+package agentprofile
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	svc "github.com/caesium-cloud/caesium/api/rest/service/agentprofile"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+// allowedOrderColumns is the allowlist of columns that may appear in order_by.
+var allowedOrderColumns = map[string]struct{}{
+	"name":       {},
+	"image":      {},
+	"engine":     {},
+	"created_at": {},
+	"updated_at": {},
+}
+
+func List(c *echo.Context) error {
+	req, err := parseListRequest(c)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	profiles, err := svc.New(c.Request().Context()).List(req)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	views := make([]profileView, len(profiles))
+	for i := range profiles {
+		views[i] = toView(profiles[i])
+	}
+	return c.JSON(http.StatusOK, views)
+}
+
+func Get(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	p, err := svc.New(c.Request().Context()).Get(id)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, toView(*p))
+}
+
+func Create(c *echo.Context) error {
+	req := &svc.CreateRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	p, err := svc.New(c.Request().Context()).Create(req)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusCreated, toView(*p))
+}
+
+func Update(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	req := &svc.UpdateRequest{}
+	if err := c.Bind(req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	p, err := svc.New(c.Request().Context()).Update(id, req)
+	if err != nil {
+		return serviceError(err)
+	}
+	return c.JSON(http.StatusOK, toView(*p))
+}
+
+func Delete(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	if err := svc.New(c.Request().Context()).Delete(id); err != nil {
+		return serviceError(err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// profileView is the API response for an AgentProfile. SecretRefs holds only
+// secret:// URIs — never resolved values — so unlike notification channel
+// config it needs no redaction (the model comment on
+// internal/models.AgentProfile documents this invariant).
+type profileView struct {
+	ID         uuid.UUID              `json:"id"`
+	Name       string                 `json:"name"`
+	Image      string                 `json:"image"`
+	Engine     models.AtomEngine      `json:"engine"`
+	Limits     map[string]interface{} `json:"limits,omitempty"`
+	SecretRefs map[string]string      `json:"secret_refs,omitempty"`
+	Budgets    map[string]interface{} `json:"budgets,omitempty"`
+	Playbook   map[string]interface{} `json:"playbook,omitempty"`
+	CreatedAt  time.Time              `json:"created_at"`
+	UpdatedAt  time.Time              `json:"updated_at"`
+}
+
+func toView(p models.AgentProfile) profileView {
+	view := profileView{
+		ID:        p.ID,
+		Name:      p.Name,
+		Image:     p.Image,
+		Engine:    p.Engine,
+		CreatedAt: p.CreatedAt,
+		UpdatedAt: p.UpdatedAt,
+	}
+	if len(p.Limits) > 0 {
+		var m map[string]interface{}
+		if err := json.Unmarshal(p.Limits, &m); err == nil {
+			view.Limits = m
+		}
+	}
+	if len(p.SecretRefs) > 0 {
+		var m map[string]string
+		if err := json.Unmarshal(p.SecretRefs, &m); err == nil {
+			view.SecretRefs = m
+		}
+	}
+	if len(p.Budgets) > 0 {
+		var m map[string]interface{}
+		if err := json.Unmarshal(p.Budgets, &m); err == nil {
+			view.Budgets = m
+		}
+	}
+	if len(p.Playbook) > 0 {
+		var m map[string]interface{}
+		if err := json.Unmarshal(p.Playbook, &m); err == nil {
+			view.Playbook = m
+		}
+	}
+	return view
+}
+
+func serviceError(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return echo.ErrNotFound
+	case errors.Is(err, svc.ErrProfileNameConflict):
+		return echo.NewHTTPError(http.StatusConflict, "conflict").Wrap(err)
+	case errors.Is(err, svc.ErrInvalidProfile):
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+}
+
+func parseListRequest(c *echo.Context) (*svc.ListRequest, error) {
+	req := &svc.ListRequest{}
+
+	if limit := c.QueryParam("limit"); limit != "" {
+		v, err := strconv.ParseUint(limit, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		req.Limit = v
+	}
+
+	if offset := c.QueryParam("offset"); offset != "" {
+		v, err := strconv.ParseUint(offset, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		req.Offset = v
+	}
+
+	if orderBy := c.QueryParam("order_by"); orderBy != "" {
+		clauses, err := parseSafeOrderBy(orderBy)
+		if err != nil {
+			return nil, err
+		}
+		req.OrderBy = clauses
+	}
+
+	return req, nil
+}
+
+// parseSafeOrderBy validates and sanitizes order_by terms against the
+// allowlist, mirroring api/rest/controller/notification's implementation.
+func parseSafeOrderBy(raw string) ([]string, error) {
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		tokens := strings.Fields(part)
+		col := strings.ToLower(tokens[0])
+		if _, ok := allowedOrderColumns[col]; !ok {
+			return nil, fmt.Errorf("invalid order_by column: %q", tokens[0])
+		}
+		dir := "asc"
+		if len(tokens) > 1 {
+			switch strings.ToLower(tokens[1]) {
+			case "asc":
+				dir = "asc"
+			case "desc":
+				dir = "desc"
+			default:
+				return nil, fmt.Errorf("invalid order_by direction: %q", tokens[1])
+			}
+		}
+		if len(tokens) > 2 {
+			return nil, fmt.Errorf("invalid order_by term: %q", part)
+		}
+		result = append(result, col+" "+dir)
+	}
+	return result, nil
+}

--- a/api/rest/controller/jobdef/lint.go
+++ b/api/rest/controller/jobdef/lint.go
@@ -65,6 +65,11 @@ func Lint(c *echo.Context) error {
 			resp.Errors = append(resp.Errors, LintMessage{Message: err.Error()})
 		}
 	}
+	if len(resp.Errors) == 0 {
+		if err := internaljobdef.ValidateAgentProfileRefs(c.Request().Context(), db.Connection(), req.Definitions); err != nil {
+			resp.Errors = append(resp.Errors, LintMessage{Message: err.Error()})
+		}
+	}
 
 	var stepsSummary string
 	if len(resp.Errors) == 0 {

--- a/api/rest/service/agentprofile/agentprofile.go
+++ b/api/rest/service/agentprofile/agentprofile.go
@@ -1,0 +1,397 @@
+// Package agentprofile implements the AgentProfile server-side resource:
+// the declarative image/engine/limits, secret:// model-credential
+// references, session budgets, and default playbook a job's
+// metadata.remediation.profile field references
+// (docs/design-agent-in-the-loop.md "Declarative policy", Stream E2). It
+// mirrors the api/rest/service/notification channel CRUD shape.
+package agentprofile
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrInvalidProfile      = errors.New("invalid agent profile")
+	ErrProfileNameConflict = errors.New("agent profile name conflict")
+)
+
+// DefaultTriageOnlyProfileName is the shipped zero-risk default profile: tier
+// 0 (deterministic rules only) plus escalate, so teams can adopt
+// agent-in-the-loop remediation incrementally without granting any
+// autonomous action. See docs/design-agent-in-the-loop.md.
+const DefaultTriageOnlyProfileName = "triage-only"
+
+// allowedSecretProviders is the set of secret:// providers a SecretRefs entry
+// may reference. It mirrors the providers internal/jobdef/secret resolves
+// (env, k8s, vault) without importing its unexported provider constants.
+var allowedSecretProviders = map[string]struct{}{
+	"env":        {},
+	"k8s":        {},
+	"kubernetes": {},
+	"vault":      {},
+}
+
+// Service manages AgentProfile resources.
+type Service interface {
+	List(req *ListRequest) ([]models.AgentProfile, error)
+	Get(id uuid.UUID) (*models.AgentProfile, error)
+	Create(req *CreateRequest) (*models.AgentProfile, error)
+	Update(id uuid.UUID, req *UpdateRequest) (*models.AgentProfile, error)
+	Delete(id uuid.UUID) error
+}
+
+type service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+var seedDefaultsOnce sync.Once
+
+// New returns a new AgentProfile service. The first call in the process
+// lazily seeds the shipped triage-only default profile (idempotent —
+// guarded by the unique name index as well as sync.Once) so a fresh
+// deployment has a zero-risk profile to reference without an operator having
+// to author one by hand.
+func New(ctx context.Context) Service {
+	conn := db.Connection()
+	seedDefaultsOnce.Do(func() {
+		_ = SeedDefaults(context.Background(), conn)
+	})
+	return &service{ctx: ctx, db: conn}
+}
+
+// --- Request types ---
+
+type ListRequest struct {
+	Limit   uint64
+	Offset  uint64
+	OrderBy []string
+}
+
+type CreateRequest struct {
+	Name       string                 `json:"name"`
+	Image      string                 `json:"image"`
+	Engine     models.AtomEngine      `json:"engine,omitempty"`
+	Limits     map[string]interface{} `json:"limits,omitempty"`
+	SecretRefs map[string]string      `json:"secret_refs,omitempty"`
+	Budgets    map[string]interface{} `json:"budgets,omitempty"`
+	Playbook   map[string]interface{} `json:"playbook,omitempty"`
+}
+
+type UpdateRequest struct {
+	Name       *string                `json:"name,omitempty"`
+	Image      *string                `json:"image,omitempty"`
+	Engine     *models.AtomEngine     `json:"engine,omitempty"`
+	Limits     map[string]interface{} `json:"limits,omitempty"`
+	SecretRefs map[string]string      `json:"secret_refs,omitempty"`
+	Budgets    map[string]interface{} `json:"budgets,omitempty"`
+	Playbook   map[string]interface{} `json:"playbook,omitempty"`
+}
+
+// --- CRUD ---
+
+func (s *service) List(req *ListRequest) ([]models.AgentProfile, error) {
+	var profiles []models.AgentProfile
+	q := s.db.WithContext(s.ctx)
+
+	if req != nil {
+		if req.Limit > 0 {
+			q = q.Limit(int(req.Limit))
+		}
+		if req.Offset > 0 {
+			q = q.Offset(int(req.Offset))
+		}
+		for _, ob := range req.OrderBy {
+			q = q.Order(ob)
+		}
+	}
+
+	return profiles, q.Find(&profiles).Error
+}
+
+func (s *service) Get(id uuid.UUID) (*models.AgentProfile, error) {
+	var p models.AgentProfile
+	return &p, s.db.WithContext(s.ctx).First(&p, "id = ?", id).Error
+}
+
+func (s *service) Create(req *CreateRequest) (*models.AgentProfile, error) {
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, fmt.Errorf("%w: name is required", ErrInvalidProfile)
+	}
+	image := strings.TrimSpace(req.Image)
+	if image == "" {
+		return nil, fmt.Errorf("%w: image is required", ErrInvalidProfile)
+	}
+	engine, err := validateEngine(req.Engine)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateSecretRefs(req.SecretRefs); err != nil {
+		return nil, err
+	}
+
+	if err := ensureNameAvailable(s.db.WithContext(s.ctx), name, uuid.Nil); err != nil {
+		return nil, err
+	}
+
+	limitsJSON, err := marshalJSONMap(req.Limits)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid limits: %w", ErrInvalidProfile, err)
+	}
+	secretRefsJSON, err := marshalJSONMapString(req.SecretRefs)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid secret_refs: %w", ErrInvalidProfile, err)
+	}
+	budgetsJSON, err := marshalJSONMap(req.Budgets)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid budgets: %w", ErrInvalidProfile, err)
+	}
+	playbookJSON, err := marshalJSONMap(req.Playbook)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid playbook: %w", ErrInvalidProfile, err)
+	}
+
+	p := models.AgentProfile{
+		ID:         uuid.New(),
+		Name:       name,
+		Image:      image,
+		Engine:     engine,
+		Limits:     limitsJSON,
+		SecretRefs: secretRefsJSON,
+		Budgets:    budgetsJSON,
+		Playbook:   playbookJSON,
+	}
+
+	if err := s.db.WithContext(s.ctx).Create(&p).Error; err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *service) Update(id uuid.UUID, req *UpdateRequest) (*models.AgentProfile, error) {
+	var p models.AgentProfile
+	if err := s.db.WithContext(s.ctx).First(&p, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+
+	updates := map[string]interface{}{}
+
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if name == "" {
+			return nil, fmt.Errorf("%w: name cannot be empty", ErrInvalidProfile)
+		}
+		if err := ensureNameAvailable(s.db.WithContext(s.ctx), name, id); err != nil {
+			return nil, err
+		}
+		updates["name"] = name
+	}
+
+	if req.Image != nil {
+		image := strings.TrimSpace(*req.Image)
+		if image == "" {
+			return nil, fmt.Errorf("%w: image cannot be empty", ErrInvalidProfile)
+		}
+		updates["image"] = image
+	}
+
+	if req.Engine != nil {
+		engine, err := validateEngine(*req.Engine)
+		if err != nil {
+			return nil, err
+		}
+		updates["engine"] = engine
+	}
+
+	if req.Limits != nil {
+		limitsJSON, err := marshalJSONMap(req.Limits)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid limits: %w", ErrInvalidProfile, err)
+		}
+		updates["limits"] = limitsJSON
+	}
+
+	if req.SecretRefs != nil {
+		if err := validateSecretRefs(req.SecretRefs); err != nil {
+			return nil, err
+		}
+		secretRefsJSON, err := marshalJSONMapString(req.SecretRefs)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid secret_refs: %w", ErrInvalidProfile, err)
+		}
+		updates["secret_refs"] = secretRefsJSON
+	}
+
+	if req.Budgets != nil {
+		budgetsJSON, err := marshalJSONMap(req.Budgets)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid budgets: %w", ErrInvalidProfile, err)
+		}
+		updates["budgets"] = budgetsJSON
+	}
+
+	if req.Playbook != nil {
+		playbookJSON, err := marshalJSONMap(req.Playbook)
+		if err != nil {
+			return nil, fmt.Errorf("%w: invalid playbook: %w", ErrInvalidProfile, err)
+		}
+		updates["playbook"] = playbookJSON
+	}
+
+	if len(updates) > 0 {
+		if err := s.db.WithContext(s.ctx).Model(&p).Updates(updates).Error; err != nil {
+			return nil, err
+		}
+	}
+
+	if err := s.db.WithContext(s.ctx).First(&p, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *service) Delete(id uuid.UUID) error {
+	return s.db.WithContext(s.ctx).Delete(&models.AgentProfile{}, "id = ?", id).Error
+}
+
+// --- Helpers ---
+
+func validateEngine(engine models.AtomEngine) (models.AtomEngine, error) {
+	if strings.TrimSpace(string(engine)) == "" {
+		return models.AtomEngineDocker, nil
+	}
+	switch engine {
+	case models.AtomEngineDocker, models.AtomEngineKubernetes, models.AtomEnginePodman:
+		return engine, nil
+	default:
+		return "", fmt.Errorf("%w: unsupported engine %q", ErrInvalidProfile, engine)
+	}
+}
+
+// validateSecretRefs checks that every value is a syntactically valid
+// secret:// URI from a known provider. It never resolves the value — only
+// the reference is stored, exactly like other secret-bearing job-definition
+// config (internal/jobdef/secret).
+func validateSecretRefs(refs map[string]string) error {
+	for key, ref := range refs {
+		ref = strings.TrimSpace(ref)
+		if ref == "" {
+			return fmt.Errorf("%w: secret_refs[%q] must not be empty", ErrInvalidProfile, key)
+		}
+		if !strings.HasPrefix(ref, "secret://") {
+			return fmt.Errorf("%w: secret_refs[%q] must be a secret:// reference", ErrInvalidProfile, key)
+		}
+		parsed, err := secret.Parse(ref)
+		if err != nil {
+			return fmt.Errorf("%w: secret_refs[%q]: %w", ErrInvalidProfile, key, err)
+		}
+		if _, ok := allowedSecretProviders[parsed.Provider]; !ok {
+			return fmt.Errorf("%w: secret_refs[%q] has unsupported provider %q", ErrInvalidProfile, key, parsed.Provider)
+		}
+	}
+	return nil
+}
+
+func ensureNameAvailable(q *gorm.DB, name string, excludeID uuid.UUID) error {
+	var existing models.AgentProfile
+	query := q.Where("name = ?", name)
+	if excludeID != uuid.Nil {
+		query = query.Where("id <> ?", excludeID)
+	}
+	err := query.First(&existing).Error
+	switch {
+	case err == nil:
+		return fmt.Errorf("%w: name %q already exists", ErrProfileNameConflict, name)
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return nil
+	default:
+		return err
+	}
+}
+
+func marshalJSONMap(m map[string]interface{}) (datatypes.JSON, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return datatypes.JSON(data), nil
+}
+
+func marshalJSONMapString(m map[string]string) (datatypes.JSON, error) {
+	if len(m) == 0 {
+		return nil, nil
+	}
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return datatypes.JSON(data), nil
+}
+
+// SeedDefaults idempotently creates the shipped triage-only default profile
+// (tier 0 + escalate; zero-risk) if it does not already exist, so a fresh
+// deployment always has one AgentProfile a job can reference to adopt
+// remediation incrementally. Safe to call concurrently / repeatedly: the
+// unique name index makes the create a no-op race rather than a duplicate.
+func SeedDefaults(ctx context.Context, conn *gorm.DB) error {
+	if conn == nil {
+		return nil
+	}
+	var existing models.AgentProfile
+	err := conn.WithContext(ctx).Where("name = ?", DefaultTriageOnlyProfileName).First(&existing).Error
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+
+	playbook, err := json.Marshal(map[string]interface{}{
+		"autonomy": map[string]interface{}{
+			"allow": []string{},
+		},
+		"escalation": map[string]interface{}{
+			"after": "15m",
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	p := models.AgentProfile{
+		ID:       uuid.New(),
+		Name:     DefaultTriageOnlyProfileName,
+		Image:    "caesiumcloud/triage-agent:latest",
+		Engine:   models.AtomEngineDocker,
+		Playbook: datatypes.JSON(playbook),
+	}
+	if err := conn.WithContext(ctx).Create(&p).Error; err != nil {
+		// A concurrent seeder or an operator-created row with the same name
+		// racing us is not an error — the profile exists either way.
+		if errors.Is(err, gorm.ErrDuplicatedKey) {
+			return nil
+		}
+		var check models.AgentProfile
+		if lookupErr := conn.WithContext(ctx).Where("name = ?", DefaultTriageOnlyProfileName).First(&check).Error; lookupErr == nil {
+			return nil
+		}
+		return err
+	}
+	return nil
+}

--- a/api/rest/service/agentprofile/agentprofile.go
+++ b/api/rest/service/agentprofile/agentprofile.go
@@ -27,11 +27,11 @@ var (
 	ErrProfileNameConflict = errors.New("agent profile name conflict")
 )
 
-// DefaultTriageOnlyProfileName is the shipped zero-risk default profile: tier
-// 0 (deterministic rules only) plus escalate, so teams can adopt
-// agent-in-the-loop remediation incrementally without granting any
-// autonomous action. See docs/design-agent-in-the-loop.md.
-const DefaultTriageOnlyProfileName = "triage-only"
+// DefaultTriageOnlyProfileName is the shipped zero-risk default profile name.
+// It is defined canonically on the model so internal/jobdef's server-side
+// lint can treat it as always resolvable; re-exported here for callers of
+// this package.
+const DefaultTriageOnlyProfileName = models.DefaultTriageOnlyProfileName
 
 // allowedSecretProviders is the set of secret:// providers a SecretRefs entry
 // may reference. It mirrors the providers internal/jobdef/secret resolves
@@ -57,19 +57,42 @@ type service struct {
 	db  *gorm.DB
 }
 
-var seedDefaultsOnce sync.Once
+// seededDefaults uses double-checked locking rather than sync.Once so a
+// transient seed failure (e.g. the DB not yet reachable on the first call)
+// is retried on the next New() instead of being permanently swallowed: the
+// "done" flag is set only after a successful seed.
+var (
+	seedMu   sync.RWMutex
+	seededOK bool
+)
 
-// New returns a new AgentProfile service. The first call in the process
-// lazily seeds the shipped triage-only default profile (idempotent —
-// guarded by the unique name index as well as sync.Once) so a fresh
-// deployment has a zero-risk profile to reference without an operator having
-// to author one by hand.
+// New returns a new AgentProfile service. It lazily seeds the shipped
+// triage-only default profile (idempotent — guarded by the unique name index
+// as well as the double-checked flag) so a fresh deployment has a zero-risk
+// profile to reference without an operator having to author one by hand. A
+// failed seed is retried on a later call.
 func New(ctx context.Context) Service {
 	conn := db.Connection()
-	seedDefaultsOnce.Do(func() {
-		_ = SeedDefaults(context.Background(), conn)
-	})
+	ensureSeeded(conn)
 	return &service{ctx: ctx, db: conn}
+}
+
+func ensureSeeded(conn *gorm.DB) {
+	seedMu.RLock()
+	done := seededOK
+	seedMu.RUnlock()
+	if done {
+		return
+	}
+
+	seedMu.Lock()
+	defer seedMu.Unlock()
+	if seededOK {
+		return
+	}
+	if err := SeedDefaults(context.Background(), conn); err == nil {
+		seededOK = true
+	}
 }
 
 // --- Request types ---
@@ -282,9 +305,10 @@ func validateEngine(engine models.AtomEngine) (models.AtomEngine, error) {
 }
 
 // validateSecretRefs checks that every value is a syntactically valid
-// secret:// URI from a known provider. It never resolves the value — only
-// the reference is stored, exactly like other secret-bearing job-definition
-// config (internal/jobdef/secret).
+// secret:// URI from a known provider and writes the trimmed value back into
+// the map so the stored reference is clean. It never resolves the value —
+// only the reference is stored, exactly like other secret-bearing
+// job-definition config (internal/jobdef/secret).
 func validateSecretRefs(refs map[string]string) error {
 	for key, ref := range refs {
 		ref = strings.TrimSpace(ref)
@@ -301,6 +325,7 @@ func validateSecretRefs(refs map[string]string) error {
 		if _, ok := allowedSecretProviders[parsed.Provider]; !ok {
 			return fmt.Errorf("%w: secret_refs[%q] has unsupported provider %q", ErrInvalidProfile, key, parsed.Provider)
 		}
+		refs[key] = ref
 	}
 	return nil
 }
@@ -348,10 +373,12 @@ func marshalJSONMapString(m map[string]string) (datatypes.JSON, error) {
 // (tier 0 + escalate; zero-risk) if it does not already exist, so a fresh
 // deployment always has one AgentProfile a job can reference to adopt
 // remediation incrementally. Safe to call concurrently / repeatedly: the
-// unique name index makes the create a no-op race rather than a duplicate.
+// unique name index makes the create a no-op race rather than a duplicate. A
+// nil connection is a retryable failure (not a silent no-op) so ensureSeeded
+// tries again once the DB is reachable rather than marking seeding done.
 func SeedDefaults(ctx context.Context, conn *gorm.DB) error {
 	if conn == nil {
-		return nil
+		return errors.New("agentprofile: cannot seed defaults with a nil database connection")
 	}
 	var existing models.AgentProfile
 	err := conn.WithContext(ctx).Where("name = ?", DefaultTriageOnlyProfileName).First(&existing).Error

--- a/api/rest/service/agentprofile/agentprofile_test.go
+++ b/api/rest/service/agentprofile/agentprofile_test.go
@@ -2,6 +2,7 @@ package agentprofile
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -132,6 +133,58 @@ func (s *AgentProfileSuite) TestCreateRejectsUnsupportedSecretProvider() {
 func (s *AgentProfileSuite) TestSeedDefaultsIsIdempotent() {
 	s.Require().NoError(SeedDefaults(context.Background(), s.db))
 	s.Require().NoError(SeedDefaults(context.Background(), s.db))
+
+	var profiles []models.AgentProfile
+	s.Require().NoError(s.db.Where("name = ?", DefaultTriageOnlyProfileName).Find(&profiles).Error)
+	s.Len(profiles, 1)
+}
+
+func (s *AgentProfileSuite) TestDefaultTriageOnlyProfileNameMatchesModel() {
+	s.Equal(models.DefaultTriageOnlyProfileName, DefaultTriageOnlyProfileName)
+}
+
+func (s *AgentProfileSuite) TestCreateTrimsSecretRefValue() {
+	svc := s.svc()
+	created, err := svc.Create(&CreateRequest{
+		Name:       "trim-secret",
+		Image:      "img",
+		SecretRefs: map[string]string{"key": "  secret://env/AGENT_KEY  "},
+	})
+	s.Require().NoError(err)
+
+	fetched, err := svc.Get(created.ID)
+	s.Require().NoError(err)
+	var refs map[string]string
+	s.Require().NoError(json.Unmarshal(fetched.SecretRefs, &refs))
+	s.Equal("secret://env/AGENT_KEY", refs["key"], "stored secret ref should be trimmed")
+}
+
+// TestEnsureSeededRetriesAfterFailure proves seeding is retryable rather than
+// permanently swallowed on a transient failure: a nil DB fails to seed and
+// leaves the done flag unset, so a later ensureSeeded with a live DB succeeds.
+func (s *AgentProfileSuite) TestEnsureSeededRetriesAfterFailure() {
+	seedMu.Lock()
+	seededOK = false
+	seedMu.Unlock()
+	s.T().Cleanup(func() {
+		seedMu.Lock()
+		seededOK = false
+		seedMu.Unlock()
+	})
+
+	// A failed seed (nil conn) must not set the done flag.
+	ensureSeeded(nil)
+	seedMu.RLock()
+	doneAfterFail := seededOK
+	seedMu.RUnlock()
+	s.False(doneAfterFail, "a failed seed must leave the retry flag unset")
+
+	// A subsequent seed against a live DB succeeds and materializes the row.
+	ensureSeeded(s.db)
+	seedMu.RLock()
+	doneAfterSuccess := seededOK
+	seedMu.RUnlock()
+	s.True(doneAfterSuccess)
 
 	var profiles []models.AgentProfile
 	s.Require().NoError(s.db.Where("name = ?", DefaultTriageOnlyProfileName).Find(&profiles).Error)

--- a/api/rest/service/agentprofile/agentprofile_test.go
+++ b/api/rest/service/agentprofile/agentprofile_test.go
@@ -1,0 +1,139 @@
+package agentprofile
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+type AgentProfileSuite struct {
+	suite.Suite
+	db *gorm.DB
+}
+
+func TestAgentProfileSuite(t *testing.T) {
+	suite.Run(t, new(AgentProfileSuite))
+}
+
+func (s *AgentProfileSuite) SetupTest() {
+	dsn := "file:" + uuid.NewString() + "?mode=memory&cache=shared"
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	s.Require().NoError(err)
+	s.Require().NoError(db.AutoMigrate(models.All...))
+	s.db = db
+}
+
+func (s *AgentProfileSuite) TearDownTest() {
+	if s.db != nil {
+		sqlDB, _ := s.db.DB()
+		if sqlDB != nil {
+			_ = sqlDB.Close()
+		}
+	}
+}
+
+func (s *AgentProfileSuite) svc() *service {
+	return &service{ctx: context.Background(), db: s.db}
+}
+
+func (s *AgentProfileSuite) TestCreateGetListUpdateDelete() {
+	svc := s.svc()
+
+	created, err := svc.Create(&CreateRequest{
+		Name:  "test-profile",
+		Image: "example/agent:latest",
+		Limits: map[string]interface{}{
+			"cpu": "1",
+		},
+		SecretRefs: map[string]string{
+			"model_api_key": "secret://env/AGENT_KEY",
+		},
+	})
+	s.Require().NoError(err)
+	s.Require().NotEqual(uuid.Nil, created.ID)
+	s.Equal(models.AtomEngineDocker, created.Engine, "engine should default to docker")
+
+	fetched, err := svc.Get(created.ID)
+	s.Require().NoError(err)
+	s.Equal("test-profile", fetched.Name)
+
+	list, err := svc.List(nil)
+	s.Require().NoError(err)
+	s.Len(list, 1)
+
+	newImage := "example/agent:v2"
+	updated, err := svc.Update(created.ID, &UpdateRequest{Image: &newImage})
+	s.Require().NoError(err)
+	s.Equal(newImage, updated.Image)
+
+	s.Require().NoError(svc.Delete(created.ID))
+	_, err = svc.Get(created.ID)
+	s.Error(err)
+}
+
+func (s *AgentProfileSuite) TestCreateRequiresName() {
+	svc := s.svc()
+	_, err := svc.Create(&CreateRequest{Image: "example/agent:latest"})
+	s.Require().Error(err)
+	s.ErrorIs(err, ErrInvalidProfile)
+}
+
+func (s *AgentProfileSuite) TestCreateRequiresImage() {
+	svc := s.svc()
+	_, err := svc.Create(&CreateRequest{Name: "no-image"})
+	s.Require().Error(err)
+	s.ErrorIs(err, ErrInvalidProfile)
+}
+
+func (s *AgentProfileSuite) TestCreateRejectsDuplicateName() {
+	svc := s.svc()
+	_, err := svc.Create(&CreateRequest{Name: "dup", Image: "example/agent:latest"})
+	s.Require().NoError(err)
+
+	_, err = svc.Create(&CreateRequest{Name: "dup", Image: "example/agent:latest"})
+	s.Require().Error(err)
+	s.ErrorIs(err, ErrProfileNameConflict)
+}
+
+func (s *AgentProfileSuite) TestCreateRejectsUnknownEngine() {
+	svc := s.svc()
+	_, err := svc.Create(&CreateRequest{Name: "bad-engine", Image: "img", Engine: "lxc"})
+	s.Require().Error(err)
+	s.ErrorIs(err, ErrInvalidProfile)
+}
+
+func (s *AgentProfileSuite) TestCreateRejectsMalformedSecretRef() {
+	svc := s.svc()
+	_, err := svc.Create(&CreateRequest{
+		Name:       "bad-secret",
+		Image:      "img",
+		SecretRefs: map[string]string{"key": "plaintext-not-a-uri"},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, ErrInvalidProfile)
+}
+
+func (s *AgentProfileSuite) TestCreateRejectsUnsupportedSecretProvider() {
+	svc := s.svc()
+	_, err := svc.Create(&CreateRequest{
+		Name:       "bad-provider",
+		Image:      "img",
+		SecretRefs: map[string]string{"key": "secret://ssh/host/key"},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, ErrInvalidProfile)
+}
+
+func (s *AgentProfileSuite) TestSeedDefaultsIsIdempotent() {
+	s.Require().NoError(SeedDefaults(context.Background(), s.db))
+	s.Require().NoError(SeedDefaults(context.Background(), s.db))
+
+	var profiles []models.AgentProfile
+	s.Require().NoError(s.db.Where("name = ?", DefaultTriageOnlyProfileName).Find(&profiles).Error)
+	s.Len(profiles, 1)
+}

--- a/cmd/job/lint.go
+++ b/cmd/job/lint.go
@@ -69,6 +69,9 @@ var lintCmd = &cobra.Command{
 			if err := writeLintTriggerScopeNote(cmd); err != nil {
 				return err
 			}
+			if err := writeLintRemediationScopeNote(cmd, defs); err != nil {
+				return err
+			}
 			return nil
 		}
 
@@ -93,6 +96,9 @@ var lintCmd = &cobra.Command{
 		if err := writeLintTriggerScopeNote(cmd); err != nil {
 			return err
 		}
+		if err := writeLintRemediationScopeNote(cmd, defs); err != nil {
+			return err
+		}
 		return nil
 	},
 }
@@ -114,6 +120,21 @@ func init() {
 
 func writeLintTriggerScopeNote(cmd *cobra.Command) error {
 	return writeCmdOut(cmd, "Note: trigger-cycle lint is file-scoped; cross-job cycles against persisted triggers are validated at apply.\n")
+}
+
+// writeLintRemediationScopeNote prints the offline-lint scope gap for
+// metadata.remediation: profile (an AgentProfile reference) and
+// escalation.channel (a NotificationChannel reference) name server-side
+// resources this offline pass has no database connection to verify. Only
+// emitted when at least one definition actually declares a remediation
+// block, so jobs that don't use the feature see no extra noise.
+func writeLintRemediationScopeNote(cmd *cobra.Command, defs []jobdef.Definition) error {
+	for i := range defs {
+		if defs[i].Metadata.Remediation != nil {
+			return writeCmdOut(cmd, "Note: metadata.remediation.profile / escalation.channel references are unverified offline; verified by server-side lint (POST /v1/jobdefs/lint) and at apply.\n")
+		}
+	}
+	return nil
 }
 
 func buildLintResolver() (*secret.MultiResolver, error) {

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -69,6 +69,8 @@ var endpointPolicy = map[string]models.Role{
 	"GET /v1/notifications/channels/:id":        models.RoleViewer,
 	"GET /v1/notifications/policies":            models.RoleViewer,
 	"GET /v1/notifications/policies/:id":        models.RoleViewer,
+	"GET /v1/agentprofiles":                     models.RoleViewer,
+	"GET /v1/agentprofiles/:id":                 models.RoleViewer,
 	"POST /v1/jobdefs/lint":                     models.RoleViewer,
 	"POST /v1/jobdefs/diff":                     models.RoleViewer,
 	"GET /v1/lineage/impact":                    models.RoleViewer,
@@ -102,6 +104,9 @@ var endpointPolicy = map[string]models.Role{
 	"POST /v1/notifications/policies":       models.RoleOperator,
 	"PATCH /v1/notifications/policies/:id":  models.RoleOperator,
 	"DELETE /v1/notifications/policies/:id": models.RoleOperator,
+	"POST /v1/agentprofiles":                models.RoleOperator,
+	"PATCH /v1/agentprofiles/:id":           models.RoleOperator,
+	"DELETE /v1/agentprofiles/:id":          models.RoleOperator,
 
 	// Admin
 	"PUT /v1/logs/level":            models.RoleAdmin,

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -109,6 +109,11 @@ func TestRequiredRoleBackfilledProtectedEndpoints(t *testing.T) {
 		{"POST", "/v1/notifications/policies", models.RoleOperator},
 		{"PATCH", "/v1/notifications/policies/:id", models.RoleOperator},
 		{"DELETE", "/v1/notifications/policies/:id", models.RoleOperator},
+		{"GET", "/v1/agentprofiles", models.RoleViewer},
+		{"GET", "/v1/agentprofiles/:id", models.RoleViewer},
+		{"POST", "/v1/agentprofiles", models.RoleOperator},
+		{"PATCH", "/v1/agentprofiles/:id", models.RoleOperator},
+		{"DELETE", "/v1/agentprofiles/:id", models.RoleOperator},
 		{"POST", "/v1/jobs/:id/runs/:id/replay", models.RoleRunner},
 	}
 

--- a/internal/jobdef/agent_profile_refs.go
+++ b/internal/jobdef/agent_profile_refs.go
@@ -10,15 +10,22 @@ import (
 	"gorm.io/gorm"
 )
 
-// ValidateAgentProfileRefs verifies that every metadata.remediation.profile
-// reference in the incoming definitions names an AgentProfile that exists.
-// This is the server-side half of the lint split
-// docs/design-agent-in-the-loop.md documents: pkg/jobdef's offline validation
-// (which runs with conn == nil, e.g. `caesium job lint`) can only check the
-// reference is well-formed and emits a scope note, because AgentProfile is
-// server-side state. This function closes that gap and is invoked both from
-// POST /v1/jobdefs/lint and from Importer.ValidateBatch inside the apply
+// ValidateAgentProfileRefs verifies that every server-side resource a
+// metadata.remediation block references exists: the AgentProfile named by
+// remediation.profile and the NotificationChannel named by
+// remediation.escalation.channel. This is the server-side half of the lint
+// split docs/design-agent-in-the-loop.md documents: pkg/jobdef's offline
+// validation (which runs with conn == nil, e.g. `caesium job lint`) can only
+// check the references are well-formed and emits a scope note, because these
+// are server-side state. This function closes that gap and is invoked both
+// from POST /v1/jobdefs/lint and from Importer.ValidateBatch inside the apply
 // transaction, mirroring ValidateDatasetGraph's conn-may-be-nil posture.
+//
+// The built-in models.DefaultTriageOnlyProfileName is treated as always
+// resolvable regardless of DB state: it is the shipped default jobs are
+// advertised to reference, seeded lazily/idempotently — so a job referencing
+// it must never be rejected merely because the row has not been materialized
+// on this particular server yet.
 func ValidateAgentProfileRefs(ctx context.Context, conn *gorm.DB, defs []schema.Definition) error {
 	if conn == nil {
 		return nil
@@ -27,40 +34,66 @@ func ValidateAgentProfileRefs(ctx context.Context, conn *gorm.DB, defs []schema.
 		ctx = context.Background()
 	}
 
-	names := make(map[string]struct{})
+	profiles := make(map[string]struct{})
+	channels := make(map[string]struct{})
 	for i := range defs {
 		r := defs[i].Metadata.Remediation
 		if r == nil {
 			continue
 		}
-		profile := strings.TrimSpace(r.Profile)
-		if profile == "" {
-			continue
+		if profile := strings.TrimSpace(r.Profile); profile != "" && profile != models.DefaultTriageOnlyProfileName {
+			profiles[profile] = struct{}{}
 		}
-		names[profile] = struct{}{}
-	}
-	if len(names) == 0 {
-		return nil
+		if r.Escalation != nil {
+			if channel := strings.TrimSpace(r.Escalation.Channel); channel != "" {
+				channels[channel] = struct{}{}
+			}
+		}
 	}
 
-	lookup := make([]string, 0, len(names))
-	for name := range names {
+	missing, err := findMissingNames(ctx, conn, &models.AgentProfile{}, profiles)
+	if err != nil {
+		return err
+	}
+	if missing != "" {
+		return fmt.Errorf("metadata.remediation.profile %q does not reference an existing AgentProfile", missing)
+	}
+
+	missing, err = findMissingNames(ctx, conn, &models.NotificationChannel{}, channels)
+	if err != nil {
+		return err
+	}
+	if missing != "" {
+		return fmt.Errorf("metadata.remediation.escalation.channel %q does not reference an existing notification channel", missing)
+	}
+	return nil
+}
+
+// findMissingNames returns the first name in want that has no matching row
+// (by the name column) in the given model's table, or "" if all resolve.
+func findMissingNames(ctx context.Context, conn *gorm.DB, model interface{}, want map[string]struct{}) (string, error) {
+	if len(want) == 0 {
+		return "", nil
+	}
+
+	lookup := make([]string, 0, len(want))
+	for name := range want {
 		lookup = append(lookup, name)
 	}
 
-	var rows []models.AgentProfile
-	if err := conn.WithContext(ctx).Where("name IN ?", lookup).Find(&rows).Error; err != nil {
-		return fmt.Errorf("validate agent profile references: %w", err)
+	var names []string
+	if err := conn.WithContext(ctx).Model(model).Where("name IN ?", lookup).Pluck("name", &names).Error; err != nil {
+		return "", fmt.Errorf("validate remediation references: %w", err)
 	}
-	found := make(map[string]struct{}, len(rows))
-	for _, row := range rows {
-		found[row.Name] = struct{}{}
+	found := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		found[name] = struct{}{}
 	}
 
-	for name := range names {
+	for name := range want {
 		if _, ok := found[name]; !ok {
-			return fmt.Errorf("metadata.remediation.profile %q does not reference an existing AgentProfile", name)
+			return name, nil
 		}
 	}
-	return nil
+	return "", nil
 }

--- a/internal/jobdef/agent_profile_refs.go
+++ b/internal/jobdef/agent_profile_refs.go
@@ -1,0 +1,66 @@
+package jobdef
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"gorm.io/gorm"
+)
+
+// ValidateAgentProfileRefs verifies that every metadata.remediation.profile
+// reference in the incoming definitions names an AgentProfile that exists.
+// This is the server-side half of the lint split
+// docs/design-agent-in-the-loop.md documents: pkg/jobdef's offline validation
+// (which runs with conn == nil, e.g. `caesium job lint`) can only check the
+// reference is well-formed and emits a scope note, because AgentProfile is
+// server-side state. This function closes that gap and is invoked both from
+// POST /v1/jobdefs/lint and from Importer.ValidateBatch inside the apply
+// transaction, mirroring ValidateDatasetGraph's conn-may-be-nil posture.
+func ValidateAgentProfileRefs(ctx context.Context, conn *gorm.DB, defs []schema.Definition) error {
+	if conn == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	names := make(map[string]struct{})
+	for i := range defs {
+		r := defs[i].Metadata.Remediation
+		if r == nil {
+			continue
+		}
+		profile := strings.TrimSpace(r.Profile)
+		if profile == "" {
+			continue
+		}
+		names[profile] = struct{}{}
+	}
+	if len(names) == 0 {
+		return nil
+	}
+
+	lookup := make([]string, 0, len(names))
+	for name := range names {
+		lookup = append(lookup, name)
+	}
+
+	var rows []models.AgentProfile
+	if err := conn.WithContext(ctx).Where("name IN ?", lookup).Find(&rows).Error; err != nil {
+		return fmt.Errorf("validate agent profile references: %w", err)
+	}
+	found := make(map[string]struct{}, len(rows))
+	for _, row := range rows {
+		found[row.Name] = struct{}{}
+	}
+
+	for name := range names {
+		if _, ok := found[name]; !ok {
+			return fmt.Errorf("metadata.remediation.profile %q does not reference an existing AgentProfile", name)
+		}
+	}
+	return nil
+}

--- a/internal/jobdef/agent_profile_refs_test.go
+++ b/internal/jobdef/agent_profile_refs_test.go
@@ -1,0 +1,80 @@
+package jobdef
+
+import (
+	"context"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func remediationDefinition(alias, profile string) schema.Definition {
+	return schema.Definition{
+		APIVersion: schema.APIVersionV1,
+		Kind:       schema.KindJob,
+		Metadata: schema.Metadata{
+			Alias: alias,
+			Remediation: &schema.MetadataRemediation{
+				Profile: profile,
+				Classes: []string{schema.RemediationClassUnknown},
+			},
+		},
+		Trigger: schema.Trigger{
+			Type:          schema.TriggerCron,
+			Configuration: map[string]any{"expression": "0 * * * *"},
+		},
+		Steps: []schema.Step{{Name: "extract", Image: "busybox:1.36.1"}},
+	}
+}
+
+func TestValidateAgentProfileRefs_NilConnSkipsVerification(t *testing.T) {
+	t.Parallel()
+
+	defs := []schema.Definition{remediationDefinition("j", "does-not-exist")}
+	require.NoError(t, ValidateAgentProfileRefs(context.Background(), nil, defs))
+}
+
+func TestValidateAgentProfileRefs_NoRemediationBlockIsANoOp(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	defs := []schema.Definition{{
+		APIVersion: schema.APIVersionV1,
+		Kind:       schema.KindJob,
+		Metadata:   schema.Metadata{Alias: "plain"},
+		Trigger: schema.Trigger{
+			Type:          schema.TriggerCron,
+			Configuration: map[string]any{"expression": "0 * * * *"},
+		},
+		Steps: []schema.Step{{Name: "extract", Image: "busybox:1.36.1"}},
+	}}
+	require.NoError(t, ValidateAgentProfileRefs(context.Background(), db, defs))
+}
+
+func TestValidateAgentProfileRefs_RejectsUnknownProfile(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	defs := []schema.Definition{remediationDefinition("j", "ghost-profile")}
+
+	err := ValidateAgentProfileRefs(context.Background(), db, defs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"ghost-profile"`)
+	require.Contains(t, err.Error(), "does not reference an existing AgentProfile")
+}
+
+func TestValidateAgentProfileRefs_AcceptsExistingProfile(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	require.NoError(t, db.Create(&models.AgentProfile{
+		ID:    uuid.New(),
+		Name:  "default-triage",
+		Image: "caesiumcloud/triage-agent:latest",
+	}).Error)
+
+	defs := []schema.Definition{remediationDefinition("j", "default-triage")}
+	require.NoError(t, ValidateAgentProfileRefs(context.Background(), db, defs))
+}

--- a/internal/jobdef/agent_profile_refs_test.go
+++ b/internal/jobdef/agent_profile_refs_test.go
@@ -8,6 +8,7 @@ import (
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
 )
 
 func remediationDefinition(alias, profile string) schema.Definition {
@@ -76,5 +77,62 @@ func TestValidateAgentProfileRefs_AcceptsExistingProfile(t *testing.T) {
 	}).Error)
 
 	defs := []schema.Definition{remediationDefinition("j", "default-triage")}
+	require.NoError(t, ValidateAgentProfileRefs(context.Background(), db, defs))
+}
+
+// TestValidateAgentProfileRefs_TriageOnlyAlwaysValid proves the shipped
+// default profile resolves even against a DB where no row has been seeded, so
+// lint/apply of a job referencing it never fails on a fresh server.
+func TestValidateAgentProfileRefs_TriageOnlyAlwaysValid(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	defs := []schema.Definition{remediationDefinition("j", models.DefaultTriageOnlyProfileName)}
+	require.NoError(t, ValidateAgentProfileRefs(context.Background(), db, defs))
+}
+
+func remediationDefinitionWithEscalation(alias, profile, channel string) schema.Definition {
+	def := remediationDefinition(alias, profile)
+	def.Metadata.Remediation.Escalation = &schema.RemediationEscalation{
+		Channel: channel,
+		After:   "15m",
+	}
+	return def
+}
+
+func TestValidateAgentProfileRefs_RejectsUnknownEscalationChannel(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	require.NoError(t, db.Create(&models.AgentProfile{
+		ID:    uuid.New(),
+		Name:  "default-triage",
+		Image: "caesiumcloud/triage-agent:latest",
+	}).Error)
+
+	defs := []schema.Definition{remediationDefinitionWithEscalation("j", "default-triage", "ghost-channel")}
+	err := ValidateAgentProfileRefs(context.Background(), db, defs)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `"ghost-channel"`)
+	require.Contains(t, err.Error(), "does not reference an existing notification channel")
+}
+
+func TestValidateAgentProfileRefs_AcceptsExistingEscalationChannel(t *testing.T) {
+	t.Parallel()
+
+	db := openTriggerCycleTestDB(t)
+	require.NoError(t, db.Create(&models.AgentProfile{
+		ID:    uuid.New(),
+		Name:  "default-triage",
+		Image: "caesiumcloud/triage-agent:latest",
+	}).Error)
+	require.NoError(t, db.Create(&models.NotificationChannel{
+		ID:     uuid.New(),
+		Name:   "data-oncall",
+		Type:   models.ChannelTypeWebhook,
+		Config: datatypes.JSON(`{"url":"https://example.com/hook"}`),
+	}).Error)
+
+	defs := []schema.Definition{remediationDefinitionWithEscalation("j", "default-triage", "data-oncall")}
 	require.NoError(t, ValidateAgentProfileRefs(context.Background(), db, defs))
 }

--- a/internal/jobdef/trigger_cycle.go
+++ b/internal/jobdef/trigger_cycle.go
@@ -40,7 +40,10 @@ func (i *Importer) ValidateBatch(ctx context.Context, defs []schema.Definition) 
 	if err := ValidateTriggerChains(ctx, i.db, defs); err != nil {
 		return err
 	}
-	return ValidateDatasetGraph(ctx, i.db, defs)
+	if err := ValidateDatasetGraph(ctx, i.db, defs); err != nil {
+		return err
+	}
+	return ValidateAgentProfileRefs(ctx, i.db, defs)
 }
 
 func ValidateTriggerChains(ctx context.Context, conn *gorm.DB, defs []schema.Definition) error {

--- a/internal/models/agent_profile.go
+++ b/internal/models/agent_profile.go
@@ -8,6 +8,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// DefaultTriageOnlyProfileName is the shipped zero-risk default AgentProfile:
+// tier 0 (deterministic rules only) plus escalate, so teams can adopt
+// agent-in-the-loop remediation incrementally without granting any autonomous
+// action. It is a built-in name: a job's metadata.remediation.profile may
+// reference it and server-side lint/apply treats it as always resolvable even
+// before the row is seeded, so a fresh server never rejects the advertised
+// default. See docs/design-agent-in-the-loop.md.
+const DefaultTriageOnlyProfileName = "triage-only"
+
 // AgentProfile is the server-side resource declaring how a remediation agent
 // runs: its container image/engine, resource limits, model-credential
 // secret:// references, session budgets, and the default playbook. It is

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -773,14 +773,25 @@ func validateRemediationAutonomy(a *RemediationAutonomy, defaultParams map[strin
 		}
 	}
 
-	for class, policy := range a.PerClass {
-		name := strings.TrimSpace(class)
-		if !isKnownRemediationClass(name) {
-			return fmt.Errorf("metadata.remediation.autonomy.perClass key %q is not a known failure class", class)
+	if len(a.PerClass) > 0 {
+		// Rebuild the map with trimmed/canonical keys so runtime lookups
+		// (PerClass["auth_failure"]) hit even when the YAML key carried
+		// surrounding whitespace.
+		normalized := make(map[string]RemediationClassPolicy, len(a.PerClass))
+		for class, policy := range a.PerClass {
+			name := strings.TrimSpace(class)
+			if !isKnownRemediationClass(name) {
+				return fmt.Errorf("metadata.remediation.autonomy.perClass key %q is not a known failure class", class)
+			}
+			if _, dup := normalized[name]; dup {
+				return fmt.Errorf("metadata.remediation.autonomy.perClass key %q duplicates another entry", class)
+			}
+			if err := validateRemediationActionList(fmt.Sprintf("metadata.remediation.autonomy.perClass[%q].allow", name), policy.Allow); err != nil {
+				return err
+			}
+			normalized[name] = policy
 		}
-		if err := validateRemediationActionList(fmt.Sprintf("metadata.remediation.autonomy.perClass[%q].allow", class), policy.Allow); err != nil {
-			return err
-		}
+		a.PerClass = normalized
 	}
 
 	if err := validateRemediationActionList("metadata.remediation.autonomy.requireApproval", a.RequireApproval); err != nil {

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -123,6 +123,14 @@ type Metadata struct {
 	// Datasets declares the external source datasets this job's steps consume.
 	// It is scheduling metadata for freshness and does not affect the cache hash.
 	Datasets *MetadataDatasets `yaml:"datasets,omitempty" json:"datasets,omitempty"`
+	// Remediation declares this job's opt-in to autonomous incident
+	// remediation (agent-in-the-loop-remediation Stream E): which
+	// AgentProfile to use, which failure classes are in scope, the tiered
+	// action catalog the agent (or a deterministic rule) may exercise
+	// autonomously, and the escalation fallback. It is server-enforced
+	// scheduling/policy metadata, not a step-execution input, and does not
+	// affect the cache hash.
+	Remediation *MetadataRemediation `yaml:"remediation,omitempty" json:"remediation,omitempty"`
 }
 
 // Concurrency controls admission of new runs for the same job.
@@ -285,6 +293,154 @@ type SourceDataset struct {
 // datasets the job's steps consume.
 type MetadataDatasets struct {
 	Sources []SourceDataset `yaml:"sources,omitempty" json:"sources,omitempty"`
+}
+
+// Failure class names accepted by metadata.remediation.classes and the keys
+// of metadata.remediation.autonomy.perClass. These must stay in sync with
+// internal/incident.FailureClass (the deterministic classifier, Stream A);
+// pkg/jobdef duplicates the vocabulary rather than importing internal/incident
+// so offline `caesium job lint` (and this package generally) stays free of a
+// dependency on the incident runtime.
+const (
+	RemediationClassTransientInfra  = "transient_infra"
+	RemediationClassSchemaViolation = "schema_violation"
+	RemediationClassSLARisk         = "sla_risk"
+	RemediationClassDataUnavailable = "data_unavailable"
+	RemediationClassAuthFailure     = "auth_failure"
+	RemediationClassOOM             = "oom"
+	RemediationClassQuota           = "quota"
+	RemediationClassUnknown         = "unknown"
+)
+
+// remediationClasses is the lookup set backing isKnownRemediationClass.
+var remediationClasses = map[string]struct{}{
+	RemediationClassTransientInfra:  {},
+	RemediationClassSchemaViolation: {},
+	RemediationClassSLARisk:         {},
+	RemediationClassDataUnavailable: {},
+	RemediationClassAuthFailure:     {},
+	RemediationClassOOM:             {},
+	RemediationClassQuota:           {},
+	RemediationClassUnknown:         {},
+}
+
+// Remediation action names accepted by metadata.remediation.autonomy.allow,
+// .perClass[].allow, and .requireApproval. These name the typed action
+// catalog docs/design-agent-in-the-loop.md defines for Stream B's executor
+// (tier 1/2 autonomous actions, tier-3 approval-gated producers, plus the
+// terminal `escalate`); pkg/jobdef validates job-declared policy names
+// against this list without depending on Stream B's executor package.
+const (
+	RemediationActionAutoRetryBackoff         = "auto_retry_backoff"
+	RemediationActionSnoozeUntilCron          = "snooze_until_cron"
+	RemediationActionSnoozeRetry              = "snooze_retry"
+	RemediationActionRetryFromFailure         = "retry_from_failure"
+	RemediationActionRetryCallbacks           = "retry_callbacks"
+	RemediationActionNotify                   = "notify"
+	RemediationActionQuarantineReplay         = "quarantine_replay"
+	RemediationActionRerunWithParams          = "rerun_with_params"
+	RemediationActionPauseJob                 = "pause_job"
+	RemediationActionUnpauseJob               = "unpause_job"
+	RemediationActionClearCacheEntry          = "clear_cache_entry"
+	RemediationActionSuppressDownstreamAlerts = "suppress_downstream_alerts"
+	RemediationActionExtendSLAOnce            = "extend_sla_once"
+	RemediationActionSkipTask                 = "skip_task"
+	RemediationActionOverrideSchemaGate       = "override_schema_gate"
+	RemediationActionApplyJobdefPatch         = "apply_jobdef_patch"
+	RemediationActionEscalate                 = "escalate"
+)
+
+// remediationActions is the lookup set backing isKnownRemediationAction.
+var remediationActions = map[string]struct{}{
+	RemediationActionAutoRetryBackoff:         {},
+	RemediationActionSnoozeUntilCron:          {},
+	RemediationActionSnoozeRetry:              {},
+	RemediationActionRetryFromFailure:         {},
+	RemediationActionRetryCallbacks:           {},
+	RemediationActionNotify:                   {},
+	RemediationActionQuarantineReplay:         {},
+	RemediationActionRerunWithParams:          {},
+	RemediationActionPauseJob:                 {},
+	RemediationActionUnpauseJob:               {},
+	RemediationActionClearCacheEntry:          {},
+	RemediationActionSuppressDownstreamAlerts: {},
+	RemediationActionExtendSLAOnce:            {},
+	RemediationActionSkipTask:                 {},
+	RemediationActionOverrideSchemaGate:       {},
+	RemediationActionApplyJobdefPatch:         {},
+	RemediationActionEscalate:                 {},
+}
+
+func isKnownRemediationClass(name string) bool {
+	_, ok := remediationClasses[name]
+	return ok
+}
+
+func isKnownRemediationAction(name string) bool {
+	_, ok := remediationActions[name]
+	return ok
+}
+
+// RemediationClassPolicy narrows the allowed action set for one failure class,
+// e.g. metadata.remediation.autonomy.perClass.auth_failure.allow.
+type RemediationClassPolicy struct {
+	Allow []string `yaml:"allow,omitempty" json:"allow,omitempty"`
+}
+
+// RemediationAutonomy is the tiered-autonomy policy within a remediation
+// block: which actions may execute without a human, the whitelist of
+// rerun_with_params overrides, per-class narrowing, and which actions always
+// require approval regardless of tier.
+type RemediationAutonomy struct {
+	// Allow lists the actions this job permits to run autonomously (subject
+	// to each action's own tier semantics — tier 3 always creates an
+	// ApprovalRequest no matter what allow contains).
+	Allow []string `yaml:"allow,omitempty" json:"allow,omitempty"`
+	// ParamOverrides whitelists the rerun_with_params values allowed per
+	// trigger.defaultParams key. Every key must name an existing
+	// trigger.defaultParams entry.
+	ParamOverrides map[string][]string `yaml:"paramOverrides,omitempty" json:"paramOverrides,omitempty"`
+	// PerClass optionally narrows the allow list for a specific failure class.
+	PerClass map[string]RemediationClassPolicy `yaml:"perClass,omitempty" json:"perClass,omitempty"`
+	// RequireApproval lists actions that must create an ApprovalRequest for
+	// this job even if the action's own default tier would otherwise permit
+	// autonomous execution.
+	RequireApproval []string `yaml:"requireApproval,omitempty" json:"requireApproval,omitempty"`
+}
+
+// RemediationEscalation configures the forced hand-off when remediation does
+// not resolve an incident within the wall-clock cap.
+type RemediationEscalation struct {
+	// Channel names a NotificationChannel (server-side state; unverified by
+	// offline lint, same posture as Profile).
+	Channel string `yaml:"channel,omitempty" json:"channel,omitempty"`
+	// After is the wall-clock cap, as a Go duration string, before the
+	// incident is force-escalated to Channel.
+	After string `yaml:"after,omitempty" json:"after,omitempty"`
+}
+
+// MetadataRemediation is the job-level opt-in to autonomous incident
+// remediation (docs/design-agent-in-the-loop.md "Declarative policy"). It is
+// policy metadata enforced server-side by the incident manager and executor
+// (Streams A-D); it never participates in step-execution cache identity.
+type MetadataRemediation struct {
+	// Profile references an AgentProfile by name. AgentProfile is
+	// server-side state (api/rest/controller/agentprofile), so offline
+	// `caesium job lint` cannot verify this reference — it emits a scope
+	// note instead. Server-side lint (POST /v1/jobdefs/lint) and the apply
+	// transaction both verify it.
+	Profile string `yaml:"profile" json:"profile"`
+	// Classes lists the failure classes this policy applies to.
+	Classes []string `yaml:"classes,omitempty" json:"classes,omitempty"`
+	// MaxAttempts bounds how many remediation attempts an incident may take
+	// before it force-escalates.
+	MaxAttempts int `yaml:"maxAttempts,omitempty" json:"maxAttempts,omitempty"`
+	// Autonomy declares which actions may run without a human and under what
+	// constraints.
+	Autonomy *RemediationAutonomy `yaml:"autonomy,omitempty" json:"autonomy,omitempty"`
+	// Escalation configures the forced hand-off when remediation doesn't
+	// resolve the incident within Escalation.After.
+	Escalation *RemediationEscalation `yaml:"escalation,omitempty" json:"escalation,omitempty"`
 }
 
 // Step defines an execution step.
@@ -527,6 +683,125 @@ func (d *Definition) Validate() error {
 	}
 	if err := validateDatasets(d); err != nil {
 		return err
+	}
+	if err := validateRemediation(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRemediation performs single-definition validation of the
+// metadata.remediation block: class/action names are known, maxAttempts is
+// non-negative, autonomy.paramOverrides keys exist in trigger.defaultParams,
+// autonomy.perClass keys are known classes, and escalation.after (if set)
+// parses as a positive Go duration. It deliberately cannot verify
+// Profile or Escalation.Channel — those name server-side resources
+// (AgentProfile, NotificationChannel) that do not exist at parse time; the
+// offline lint scope note (cmd/job/lint.go) names this gap, and server-side
+// lint (internal/jobdef.ValidateAgentProfileRefs, invoked from
+// POST /v1/jobdefs/lint and the apply transaction) closes it. The block is
+// policy metadata and never enters the cache identity hash.
+func validateRemediation(d *Definition) error {
+	r := d.Metadata.Remediation
+	if r == nil {
+		return nil
+	}
+
+	r.Profile = strings.TrimSpace(r.Profile)
+	if r.Profile == "" {
+		return fmt.Errorf("metadata.remediation.profile is required")
+	}
+
+	if len(r.Classes) == 0 {
+		return fmt.Errorf("metadata.remediation.classes must contain at least one entry")
+	}
+	seenClasses := make(map[string]struct{}, len(r.Classes))
+	for i, raw := range r.Classes {
+		name := strings.TrimSpace(raw)
+		if !isKnownRemediationClass(name) {
+			return fmt.Errorf("metadata.remediation.classes[%d] %q is not a known failure class", i, raw)
+		}
+		if _, dup := seenClasses[name]; dup {
+			return fmt.Errorf("metadata.remediation.classes[%d] %q duplicates another entry", i, raw)
+		}
+		seenClasses[name] = struct{}{}
+		r.Classes[i] = name
+	}
+
+	if r.MaxAttempts < 0 {
+		return fmt.Errorf("metadata.remediation.maxAttempts must be >= 0")
+	}
+
+	if r.Autonomy != nil {
+		if err := validateRemediationAutonomy(r.Autonomy, d.Trigger.DefaultParams); err != nil {
+			return err
+		}
+	}
+
+	if r.Escalation != nil {
+		r.Escalation.Channel = strings.TrimSpace(r.Escalation.Channel)
+		after := strings.TrimSpace(r.Escalation.After)
+		if r.Escalation.Channel == "" && after == "" {
+			return fmt.Errorf("metadata.remediation.escalation requires channel and/or after")
+		}
+		if after != "" {
+			dur, err := time.ParseDuration(after)
+			if err != nil {
+				return fmt.Errorf("metadata.remediation.escalation.after %q must be a valid duration: %w", after, err)
+			}
+			if dur <= 0 {
+				return fmt.Errorf("metadata.remediation.escalation.after %q must be a positive duration", after)
+			}
+		}
+		r.Escalation.After = after
+	}
+
+	return nil
+}
+
+func validateRemediationAutonomy(a *RemediationAutonomy, defaultParams map[string]string) error {
+	if err := validateRemediationActionList("metadata.remediation.autonomy.allow", a.Allow); err != nil {
+		return err
+	}
+
+	for key, values := range a.ParamOverrides {
+		if _, ok := defaultParams[key]; !ok {
+			return fmt.Errorf("metadata.remediation.autonomy.paramOverrides key %q does not match any trigger.defaultParams key", key)
+		}
+		if len(values) == 0 {
+			return fmt.Errorf("metadata.remediation.autonomy.paramOverrides[%q] must list at least one allowed value", key)
+		}
+	}
+
+	for class, policy := range a.PerClass {
+		name := strings.TrimSpace(class)
+		if !isKnownRemediationClass(name) {
+			return fmt.Errorf("metadata.remediation.autonomy.perClass key %q is not a known failure class", class)
+		}
+		if err := validateRemediationActionList(fmt.Sprintf("metadata.remediation.autonomy.perClass[%q].allow", class), policy.Allow); err != nil {
+			return err
+		}
+	}
+
+	if err := validateRemediationActionList("metadata.remediation.autonomy.requireApproval", a.RequireApproval); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateRemediationActionList(field string, actions []string) error {
+	seen := make(map[string]struct{}, len(actions))
+	for i, raw := range actions {
+		name := strings.TrimSpace(raw)
+		if !isKnownRemediationAction(name) {
+			return fmt.Errorf("%s[%d] %q is not a known remediation action", field, i, raw)
+		}
+		if _, dup := seen[name]; dup {
+			return fmt.Errorf("%s[%d] %q duplicates another entry", field, i, raw)
+		}
+		seen[name] = struct{}{}
+		actions[i] = name
 	}
 	return nil
 }

--- a/pkg/jobdef/remediation_test.go
+++ b/pkg/jobdef/remediation_test.go
@@ -1,0 +1,256 @@
+package jobdef
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/caesium-cloud/caesium/internal/cache"
+)
+
+const remediationJob = `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: vendor-x-daily
+  remediation:
+    profile: default-triage
+    classes: [data_unavailable, schema_violation, transient_infra, unknown]
+    maxAttempts: 2
+    autonomy:
+      allow: [retry_from_failure, snooze_retry, quarantine_replay, rerun_with_params, pause_job]
+      paramOverrides:
+        badRowPolicy: [quarantine]
+      perClass:
+        auth_failure:
+          allow: [pause_job, notify, escalate]
+      requireApproval: [apply_jobdef_patch, skip_task, override_schema_gate]
+    escalation:
+      channel: data-oncall
+      after: 15m
+trigger:
+  type: cron
+  configuration:
+    expression: "0 */6 * * *"
+  defaultParams:
+    badRowPolicy: quarantine
+steps:
+  - name: extract
+    image: etl:1.4
+`
+
+func TestParseRemediationSurface(t *testing.T) {
+	def, err := Parse([]byte(remediationJob))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	r := def.Metadata.Remediation
+	if r == nil {
+		t.Fatal("expected metadata.remediation to be set")
+	}
+	if r.Profile != "default-triage" {
+		t.Fatalf("unexpected profile: %q", r.Profile)
+	}
+	if len(r.Classes) != 4 {
+		t.Fatalf("expected 4 classes, got %+v", r.Classes)
+	}
+	if r.MaxAttempts != 2 {
+		t.Fatalf("unexpected maxAttempts: %d", r.MaxAttempts)
+	}
+	if r.Autonomy == nil {
+		t.Fatal("expected autonomy to be set")
+	}
+	if len(r.Autonomy.Allow) != 5 {
+		t.Fatalf("unexpected allow list: %+v", r.Autonomy.Allow)
+	}
+	if vals := r.Autonomy.ParamOverrides["badRowPolicy"]; len(vals) != 1 || vals[0] != "quarantine" {
+		t.Fatalf("unexpected paramOverrides: %+v", r.Autonomy.ParamOverrides)
+	}
+	perClass, ok := r.Autonomy.PerClass["auth_failure"]
+	if !ok || len(perClass.Allow) != 3 {
+		t.Fatalf("unexpected perClass: %+v", r.Autonomy.PerClass)
+	}
+	if len(r.Autonomy.RequireApproval) != 3 {
+		t.Fatalf("unexpected requireApproval: %+v", r.Autonomy.RequireApproval)
+	}
+	if r.Escalation == nil || r.Escalation.Channel != "data-oncall" || r.Escalation.After != "15m" {
+		t.Fatalf("unexpected escalation: %+v", r.Escalation)
+	}
+}
+
+func TestValidateRemediation_RequiresProfile(t *testing.T) {
+	y := strings.Replace(remediationJob, "profile: default-triage", "profile: \"\"", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "profile is required") {
+		t.Fatalf("expected profile-required error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_RequiresClasses(t *testing.T) {
+	y := strings.Replace(remediationJob, "classes: [data_unavailable, schema_violation, transient_infra, unknown]", "classes: []", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "classes must contain at least one entry") {
+		t.Fatalf("expected classes-required error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_UnknownClass(t *testing.T) {
+	y := strings.Replace(remediationJob, "classes: [data_unavailable, schema_violation, transient_infra, unknown]", "classes: [bogus_class]", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "not a known failure class") {
+		t.Fatalf("expected unknown-class error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_DuplicateClass(t *testing.T) {
+	y := strings.Replace(remediationJob, "classes: [data_unavailable, schema_violation, transient_infra, unknown]", "classes: [unknown, unknown]", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "duplicates another entry") {
+		t.Fatalf("expected duplicate-class error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_UnknownAction(t *testing.T) {
+	y := strings.Replace(remediationJob, "allow: [retry_from_failure, snooze_retry, quarantine_replay, rerun_with_params, pause_job]", "allow: [rm_rf_slash]", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "not a known remediation action") {
+		t.Fatalf("expected unknown-action error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_ParamOverridesMustMatchDefaultParams(t *testing.T) {
+	y := strings.Replace(remediationJob, "badRowPolicy: [quarantine]", "unknownParam: [quarantine]", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "does not match any trigger.defaultParams key") {
+		t.Fatalf("expected paramOverrides-mismatch error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_PerClassUnknownClass(t *testing.T) {
+	y := strings.Replace(remediationJob, "auth_failure:", "bogus_class:", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "perClass key") {
+		t.Fatalf("expected perClass-unknown-class error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_NegativeMaxAttempts(t *testing.T) {
+	y := strings.Replace(remediationJob, "maxAttempts: 2", "maxAttempts: -1", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "maxAttempts must be >= 0") {
+		t.Fatalf("expected maxAttempts error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_EscalationAfterMustBeDuration(t *testing.T) {
+	y := strings.Replace(remediationJob, "after: 15m", "after: not-a-duration", 1)
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "must be a valid duration") {
+		t.Fatalf("expected duration error, got %v", err)
+	}
+}
+
+func TestValidateRemediation_EscalationRequiresChannelOrAfter(t *testing.T) {
+	y := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+  remediation:
+    profile: default-triage
+    classes: [unknown]
+    escalation: {}
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+`
+	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "requires channel and/or after") {
+		t.Fatalf("expected escalation error, got %v", err)
+	}
+}
+
+func TestRemediationOptional(t *testing.T) {
+	y := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+`
+	def, err := Parse([]byte(y))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if def.Metadata.Remediation != nil {
+		t.Fatalf("expected no remediation block, got %+v", def.Metadata.Remediation)
+	}
+}
+
+// TestRemediationDoesNotAffectCacheHash proves the remediation block is
+// policy metadata: adding it to a job's metadata leaves the container spec
+// that feeds the cache identity — and thus HashInput.Compute() — byte
+// identical, mirroring TestDatasetsDoNotAffectCacheHash.
+func TestRemediationDoesNotAffectCacheHash(t *testing.T) {
+	base := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+    command: ["sh", "-c", "run"]
+`
+	withRemediation := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+  remediation:
+    profile: default-triage
+    classes: [unknown, transient_infra]
+    maxAttempts: 3
+    autonomy:
+      allow: [retry_from_failure, notify]
+      requireApproval: [apply_jobdef_patch]
+    escalation:
+      channel: data-oncall
+      after: 30m
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+    command: ["sh", "-c", "run"]
+`
+
+	hashFor := func(y string) string {
+		def, err := Parse([]byte(y))
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		step := &def.Steps[0]
+		spec, err := def.RuntimeSpecForStep(step)
+		if err != nil {
+			t.Fatalf("runtime spec: %v", err)
+		}
+		h := cache.HashInput{
+			JobAlias:             def.Metadata.Alias,
+			TaskName:             step.Name,
+			Image:                step.Image,
+			Command:              step.Command,
+			Env:                  spec.Env,
+			WorkDir:              spec.WorkDir,
+			Mounts:               spec.Mounts,
+			ResolvedVolumeMounts: spec.ResolvedVolumeMounts,
+			Kubernetes:           spec.Kubernetes,
+		}
+		return h.Compute()
+	}
+
+	if got, want := hashFor(withRemediation), hashFor(base); got != want {
+		t.Fatalf("remediation changed the cache hash: with=%s without=%s", got, want)
+	}
+}

--- a/pkg/jobdef/remediation_test.go
+++ b/pkg/jobdef/remediation_test.go
@@ -119,6 +119,39 @@ func TestValidateRemediation_ParamOverridesMustMatchDefaultParams(t *testing.T) 
 	}
 }
 
+func TestValidateRemediation_PerClassKeyCanonicalized(t *testing.T) {
+	y := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: j
+  remediation:
+    profile: default-triage
+    classes: [unknown]
+    autonomy:
+      perClass:
+        "  auth_failure  ":
+          allow: [notify, escalate]
+trigger:
+  type: cron
+  configuration: {expression: "0 * * * *"}
+steps:
+  - name: extract
+    image: etl:1.4
+`
+	def, err := Parse([]byte(y))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	pc := def.Metadata.Remediation.Autonomy.PerClass
+	if _, ok := pc["auth_failure"]; !ok {
+		t.Fatalf("expected canonical key \"auth_failure\", got keys %v", pc)
+	}
+	if _, ok := pc["  auth_failure  "]; ok {
+		t.Fatalf("expected untrimmed key to be dropped, got keys %v", pc)
+	}
+}
+
 func TestValidateRemediation_PerClassUnknownClass(t *testing.T) {
 	y := strings.Replace(remediationJob, "auth_failure:", "bogus_class:", 1)
 	if _, err := Parse([]byte(y)); err == nil || !strings.Contains(err.Error(), "perClass key") {

--- a/test/agent_profile_test.go
+++ b/test/agent_profile_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// TestAgentProfileCRUD drives the real /v1/agentprofiles REST surface
+// (agent-in-the-loop-remediation Stream E2) against the live server: create,
+// read, list, update, and delete, asserting on observed HTTP responses —
+// not an internal service-package call.
+func (s *IntegrationTestSuite) TestAgentProfileCRUD() {
+	name := fmt.Sprintf("integration-agent-profile-%d", time.Now().UnixNano())
+
+	createPayload := fmt.Sprintf(`{
+		"name": %q,
+		"image": "caesiumcloud/triage-agent:latest",
+		"engine": "docker",
+		"limits": {"cpu": "1", "memory": "512Mi"},
+		"secret_refs": {"model_api_key": "secret://env/AGENT_MODEL_API_KEY"},
+		"budgets": {"max_actions": 5},
+		"playbook": {"autonomy": {"allow": ["retry_from_failure"]}}
+	}`, name)
+
+	resp, err := s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/agentprofiles", strings.NewReader(createPayload))
+	s.Require().NoError(err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusCreated, resp.StatusCode, string(body))
+
+	var created struct {
+		ID         string            `json:"id"`
+		Name       string            `json:"name"`
+		Image      string            `json:"image"`
+		Engine     string            `json:"engine"`
+		SecretRefs map[string]string `json:"secret_refs"`
+	}
+	s.Require().NoError(json.Unmarshal(body, &created))
+	s.Require().NotEmpty(created.ID)
+	s.Equal(name, created.Name)
+	s.Equal("caesiumcloud/triage-agent:latest", created.Image)
+	s.Equal("docker", created.Engine)
+	s.Equal("secret://env/AGENT_MODEL_API_KEY", created.SecretRefs["model_api_key"])
+
+	// GET returns the same profile.
+	var fetched struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Image string `json:"image"`
+	}
+	s.getJSON("/v1/agentprofiles/"+created.ID, &fetched)
+	s.Equal(created.ID, fetched.ID)
+	s.Equal(name, fetched.Name)
+
+	// LIST includes the created profile.
+	var listed []struct {
+		ID string `json:"id"`
+	}
+	s.getJSON("/v1/agentprofiles", &listed)
+	found := false
+	for _, p := range listed {
+		if p.ID == created.ID {
+			found = true
+			break
+		}
+	}
+	s.True(found, "expected created profile %s in list response", created.ID)
+
+	// PATCH updates the image.
+	updatePayload := `{"image": "caesiumcloud/triage-agent:v2"}`
+	resp, err = s.doJSONRequest(http.MethodPatch, s.caesiumURL+"/v1/agentprofiles/"+created.ID, strings.NewReader(updatePayload))
+	s.Require().NoError(err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode, string(body))
+
+	var updated struct {
+		Image string `json:"image"`
+	}
+	s.Require().NoError(json.Unmarshal(body, &updated))
+	s.Equal("caesiumcloud/triage-agent:v2", updated.Image)
+
+	// Name conflict: creating a second profile with the same name is rejected.
+	resp, err = s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/agentprofiles", strings.NewReader(createPayload))
+	s.Require().NoError(err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Equal(http.StatusConflict, resp.StatusCode, string(body))
+
+	// DELETE removes it.
+	resp, err = s.doJSONRequest(http.MethodDelete, s.caesiumURL+"/v1/agentprofiles/"+created.ID, nil)
+	s.Require().NoError(err)
+	resp.Body.Close()
+	s.Require().Equal(http.StatusNoContent, resp.StatusCode)
+
+	resp, err = s.doJSONRequest(http.MethodGet, s.caesiumURL+"/v1/agentprofiles/"+created.ID, nil)
+	s.Require().NoError(err)
+	resp.Body.Close()
+	s.Require().Equal(http.StatusNotFound, resp.StatusCode)
+}
+
+// TestAgentProfileCreateRejectsUnsupportedSecretProvider proves the server
+// validates secret_refs syntactically (scheme + known provider) without ever
+// resolving them.
+func (s *IntegrationTestSuite) TestAgentProfileCreateRejectsUnsupportedSecretProvider() {
+	name := fmt.Sprintf("integration-agent-profile-badsecret-%d", time.Now().UnixNano())
+	payload := fmt.Sprintf(`{
+		"name": %q,
+		"image": "caesiumcloud/triage-agent:latest",
+		"secret_refs": {"model_api_key": "not-a-secret-uri"}
+	}`, name)
+
+	resp, err := s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/agentprofiles", strings.NewReader(payload))
+	s.Require().NoError(err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusBadRequest, resp.StatusCode, string(body))
+}
+
+// TestJobdefLintVerifiesRemediationProfileReference exercises the
+// server-side half of the metadata.remediation lint split
+// (docs/design-agent-in-the-loop.md): POST /v1/jobdefs/lint has a database
+// connection, so — unlike offline `caesium job lint` — it can and must
+// verify that metadata.remediation.profile names a real AgentProfile.
+func (s *IntegrationTestSuite) TestJobdefLintVerifiesRemediationProfileReference() {
+	profileName := fmt.Sprintf("integration-lint-profile-%d", time.Now().UnixNano())
+	createPayload := fmt.Sprintf(`{"name": %q, "image": "caesiumcloud/triage-agent:latest"}`, profileName)
+	resp, err := s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/agentprofiles", strings.NewReader(createPayload))
+	s.Require().NoError(err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusCreated, resp.StatusCode, string(body))
+
+	alias := fmt.Sprintf("integration-lint-remediation-%d", time.Now().UnixNano())
+
+	validDef := fmt.Sprintf(`{"definitions":[{
+		"apiVersion": "v1",
+		"kind": "Job",
+		"metadata": {"alias": %q, "remediation": {"profile": %q, "classes": ["unknown"]}},
+		"trigger": {"type": "cron", "configuration": {"expression": "0 * * * *"}},
+		"steps": [{"name": "extract", "image": "busybox:1.36.1"}]
+	}]}`, alias, profileName)
+
+	var lintResp struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	resp, err = s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/jobdefs/lint", strings.NewReader(validDef))
+	s.Require().NoError(err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode, string(body))
+	s.Require().NoError(json.Unmarshal(body, &lintResp))
+	s.Empty(lintResp.Errors, "expected no lint errors for a real profile reference, got %+v", lintResp.Errors)
+
+	missingAlias := fmt.Sprintf("integration-lint-remediation-missing-%d", time.Now().UnixNano())
+	invalidDef := fmt.Sprintf(`{"definitions":[{
+		"apiVersion": "v1",
+		"kind": "Job",
+		"metadata": {"alias": %q, "remediation": {"profile": "does-not-exist-%d", "classes": ["unknown"]}},
+		"trigger": {"type": "cron", "configuration": {"expression": "0 * * * *"}},
+		"steps": [{"name": "extract", "image": "busybox:1.36.1"}]
+	}]}`, missingAlias, time.Now().UnixNano())
+
+	resp, err = s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/jobdefs/lint", strings.NewReader(invalidDef))
+	s.Require().NoError(err)
+	body, err = io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode, string(body))
+	s.Require().NoError(json.Unmarshal(body, &lintResp))
+	s.Require().NotEmpty(lintResp.Errors, "expected a lint error for an unresolvable profile reference")
+	found := false
+	for _, e := range lintResp.Errors {
+		if strings.Contains(e.Message, "does not reference an existing AgentProfile") {
+			found = true
+			break
+		}
+	}
+	s.True(found, "expected an AgentProfile-reference error, got %+v", lintResp.Errors)
+}


### PR DESCRIPTION
## Summary

Second wave (W2-ε) of [`docs/exec-plans/active/agent-in-the-loop-remediation.md`](https://github.com/caesium-cloud/caesium/blob/master/docs/exec-plans/active/agent-in-the-loop-remediation.md) — **Stream E**, the declarative-policy surface. Builds on the Phase-0 models from #278.

- **E1 — `metadata.remediation` jobdef block** (`pkg/jobdef/definition.go`): `Metadata.Remediation` with `profile`, `classes`, `maxAttempts`, `autonomy.{allow, paramOverrides, perClass, requireApproval}`, `escalation.{channel, after}`, wired into `Validate()`. Class/action vocabularies are duplicated as constants (kept out of an `internal/` import so `pkg/jobdef` stays dependency-clean) with a must-stay-in-sync comment. Policy metadata only — it does **not** touch the engines or `internal/cache/hash.go`; `TestRemediationDoesNotAffectCacheHash` proves `HashInput.Compute()` is byte-identical with/without the block (mirrors the `datasets` precedent). `caesium job lint` prints a scope note when a remediation block references offline-unverifiable `profile`/`escalation.channel`.
- **E2 — `AgentProfile` CRUD** (`api/rest/{controller,service}/agentprofile/`): REST CRUD mirroring notification channels; validates `secret_refs` are syntactically valid `secret://` URIs with a known provider (never resolved). Lazily seeds the shipped `triage-only` default profile (idempotent via `sync.Once` + the model's unique-name index). The server-side lint half (`internal/jobdef/agent_profile_refs.go`, `conn==nil` skips like `ValidateDatasetGraph`) is wired into `ValidateBatch` (apply path) and `POST /v1/jobdefs/lint`.

## Test plan

- [x] `gofmt` clean; `go vet` (incl. `-tags=integration`) clean; `golangci-lint run` 0 issues on touched packages
- [x] `go build ./...` (dqlite-CGO; only the pre-existing `ui/embed.go`/`ui/dist` gap, unrelated)
- [x] `go test ./pkg/jobdef/... ./internal/jobdef/... ./api/rest/service/agentprofile/... ./internal/guardrails/` — green (remediation parse/validate + cache-hash stability, CRUD suite, ref lint)
- [x] **Integration test** `test/agent_profile_test.go` — real CRUD round-trip against `/v1/agentprofiles`, secret-provider rejection, and `POST /v1/jobdefs/lint` proving both a valid and a dangling `profile:` reference (per the CLAUDE.md e2e gate)
- [ ] full `just integration-test` runs in CI

## Coordination

- `pkg/jobdef/definition.go` — only this stream touches it this wave (adds `remediation` alongside the shipped `datasets` block).
- `api/rest/bind/bind.go` — additive `/agentprofiles` route block + one import, positioned away from where Streams C (`/v1/agent/*`) and D (`/v1/incidents*`) append; union-merge.
- `internal/jobdef/trigger_cycle.go` (`ValidateBatch`) — adds the agent-profile-ref check alongside the shipped dataset-graph check.
- Two new test fixtures pin `busybox:1.36.1` (image-consistency guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh)_