### PR TITLE
Add agent runtime: scoped token, session supervisor, triage bundle, /v1/agent tool surface (agent-in-the-loop-remediation W2-γ)

### DIFF
--- a/api/middleware/auth_agent_scope_test.go
+++ b/api/middleware/auth_agent_scope_test.go
@@ -1,0 +1,153 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/stretchr/testify/require"
+)
+
+// mintAgentKey mints a scoped agent-session credential bound to incidentID and
+// returns its plaintext.
+func mintAgentKey(t *testing.T, svc *auth.Service, incidentID uuid.UUID, allowlist []string) string {
+	t.Helper()
+	resp, err := svc.MintAgentSessionKey(incidentID, allowlist, time.Hour)
+	require.NoError(t, err)
+	return resp.Plaintext
+}
+
+// TestAgentTokenReachesOwnIncidentAgentRoute proves an agent token is accepted on
+// its own incident's agent route AND that the frozen allowlist is injected for
+// the context handlers.
+func TestAgentTokenReachesOwnIncidentAgentRoute(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	incidentID := uuid.New()
+	key := mintAgentKey(t, svc, incidentID, []string{"alpha", "beta"})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent/incidents/"+incidentID.String()+"/bundle", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	var aliases []string
+	rec, err := callMiddleware(
+		t, svc, auditor, limiter, req,
+		&echo.RouteInfo{Path: "/v1/agent/incidents/:id/bundle", Method: http.MethodGet},
+		echo.PathValues{{Name: "id", Value: incidentID.String()}},
+		func(c *echo.Context) error {
+			aliases = authmw.GetAllowedJobAliases(c)
+			return c.String(http.StatusOK, "ok")
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, []string{"alpha", "beta"}, aliases)
+}
+
+// TestAgentTokenDeniedOnOtherIncident proves the cross-incident boundary: a token
+// minted for incident X is 403'd on incident Y's agent routes.
+func TestAgentTokenDeniedOnOtherIncident(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	incidentX := uuid.New()
+	incidentY := uuid.New()
+	key := mintAgentKey(t, svc, incidentX, []string{"alpha"})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent/incidents/"+incidentY.String()+"/bundle", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	_, err := callMiddleware(
+		t, svc, auditor, limiter, req,
+		&echo.RouteInfo{Path: "/v1/agent/incidents/:id/bundle", Method: http.MethodGet},
+		echo.PathValues{{Name: "id", Value: incidentY.String()}},
+		nil,
+	)
+	require.Error(t, err)
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+	require.Equal(t, authmw.AgentScopeDenyMessage, he.Message)
+}
+
+// TestAgentTokenDeniedOnActionsOfOtherIncident proves the boundary holds for the
+// mutating action route too (not just reads).
+func TestAgentTokenDeniedOnActionsOfOtherIncident(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	incidentX := uuid.New()
+	incidentY := uuid.New()
+	key := mintAgentKey(t, svc, incidentX, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/incidents/"+incidentY.String()+"/actions", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	_, err := callMiddleware(
+		t, svc, auditor, limiter, req,
+		&echo.RouteInfo{Path: "/v1/agent/incidents/:id/actions", Method: http.MethodPost},
+		echo.PathValues{{Name: "id", Value: incidentY.String()}},
+		nil,
+	)
+	require.Error(t, err)
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+// TestAgentTokenDeniedOnNonAgentRoutes proves the cross-route boundary: an agent
+// token can never act as a general principal. It is 403'd on ordinary job/stats
+// routes and — critically — on the global lineage-impact route (the frozen
+// snapshot in the bundle is the only lineage view an agent gets).
+func TestAgentTokenDeniedOnNonAgentRoutes(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	incidentID := uuid.New()
+	key := mintAgentKey(t, svc, incidentID, []string{"alpha"})
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"jobs list", http.MethodGet, "/v1/jobs"},
+		{"stats", http.MethodGet, "/v1/stats"},
+		{"lineage impact", http.MethodGet, "/v1/lineage/impact"},
+		{"events", http.MethodGet, "/v1/events"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+key)
+			_, err := callMiddleware(
+				t, svc, auditor, limiter, req,
+				&echo.RouteInfo{Path: tc.path, Method: tc.method},
+				nil, nil,
+			)
+			require.Error(t, err)
+			he, ok := err.(*echo.HTTPError)
+			require.True(t, ok)
+			require.Equal(t, http.StatusForbidden, he.Code, "agent token must be 403'd off %s", tc.path)
+			require.Equal(t, authmw.AgentScopeDenyMessage, he.Message)
+		})
+	}
+}
+
+// TestAgentTokenReachesContextRoute proves the wildcard context passthrough is
+// reachable for the token's own incident.
+func TestAgentTokenReachesContextRoute(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	incidentID := uuid.New()
+	key := mintAgentKey(t, svc, incidentID, []string{"alpha"})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/agent/incidents/"+incidentID.String()+"/context/history", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+
+	rec, err := callMiddleware(
+		t, svc, auditor, limiter, req,
+		&echo.RouteInfo{Path: "/v1/agent/incidents/:id/context/*", Method: http.MethodGet},
+		echo.PathValues{{Name: "id", Value: incidentID.String()}, {Name: "*", Value: "history"}},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}

--- a/api/middleware/auth_scope.go
+++ b/api/middleware/auth_scope.go
@@ -27,6 +27,16 @@ const LineageImpactScopedDenyMessage = "lineage impact is a global cross-job que
 // must resolve to one run owner before any events are streamed.
 const EventsScopedDenyMessage = "event stream requires an in-scope run_id for scoped principals"
 
+// AgentRoutePrefix is the only route prefix an agent-session credential may
+// reach. Everything outside it is denied outright for agent tokens.
+const AgentRoutePrefix = "/v1/agent/"
+
+// AgentScopeDenyMessage is the 403 reason returned when an agent-session token
+// is used on any route outside its incident's /v1/agent/* tool surface (a
+// non-agent route, or a different incident's agent route). Exported so the auth
+// and integration tests assert against the single source of truth.
+const AgentScopeDenyMessage = "agent session token is scoped to its own incident's /v1/agent/* tool surface"
+
 type scopeAuditContext struct {
 	jobAliases []string
 }
@@ -45,6 +55,20 @@ func GetAllowedJobAliases(c *echo.Context) []string {
 }
 
 func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routePath string) (*scopeAuditContext, error) {
+	// Agent-session credentials are intercepted FIRST and are fully
+	// self-contained: an agent token is valid only for its own incident's
+	// /v1/agent/* routes and nothing else. This check must precede the
+	// job-scope path because an agent key carries an empty job list — treating
+	// it as "unrestricted" (the len==0 branch below) would be a privilege
+	// escalation, letting an agent token reach every unscoped route.
+	agentClaim, err := auth.DecodeAgentClaim(scopeJSON)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+	}
+	if agentClaim != nil {
+		return authorizeAgentScope(c, agentClaim, routePath)
+	}
+
 	scopeJobs, err := auth.ScopeJobs(scopeJSON)
 	if err != nil {
 		return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
@@ -132,6 +156,46 @@ func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routeP
 	}
 
 	return nil, echo.NewHTTPError(http.StatusForbidden, "insufficient permissions")
+}
+
+// authorizeAgentScope enforces an agent-session credential's incident binding.
+// The token is valid ONLY for /v1/agent/incidents/:id/* routes whose :id equals
+// the incident the token was minted for. Two negative properties are the whole
+// point of this arm:
+//
+//   - Cross-route denial: any route outside /v1/agent/* (a normal job route, the
+//     approval routes, /v1/lineage/impact, /v1/database/*) is 403'd — an agent
+//     token can never act as a general principal.
+//   - Cross-incident denial: an agent token minted for incident X hitting
+//     incident Y's agent routes is 403'd — the incident id in the path must match
+//     the frozen claim exactly.
+//
+// On success the frozen job allowlist is injected into the request context so the
+// read-only context handlers can gate which jobs' logs/why/history the agent may
+// pull. Server-side enforcement here is the security boundary; the agent's
+// prompt is not.
+func authorizeAgentScope(c *echo.Context, claim *auth.AgentClaimView, routePath string) (*scopeAuditContext, error) {
+	if !strings.HasPrefix(routePath, AgentRoutePrefix) {
+		return nil, echo.NewHTTPError(http.StatusForbidden, AgentScopeDenyMessage)
+	}
+
+	incParam := strings.TrimSpace(c.Param("id"))
+	if incParam == "" {
+		// An agent route with no incident id in scope is not part of the
+		// per-incident tool surface an agent token may reach.
+		return nil, echo.NewHTTPError(http.StatusForbidden, AgentScopeDenyMessage)
+	}
+	incID, err := uuid.Parse(incParam)
+	if err != nil {
+		return nil, echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	}
+	if incID != claim.IncidentID {
+		return nil, echo.NewHTTPError(http.StatusForbidden, AgentScopeDenyMessage)
+	}
+
+	allowed := append([]string(nil), claim.Jobs...)
+	c.Set(ContextKeyAllowedJobAliases, allowed)
+	return &scopeAuditContext{jobAliases: allowed}, nil
 }
 
 func resolveScopedJobAlias(c *echo.Context, svc *auth.Service, routePath string) (string, error) {

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -2,6 +2,7 @@ package bind
 
 import (
 	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	agentctrl "github.com/caesium-cloud/caesium/api/rest/controller/agent"
 	"github.com/caesium-cloud/caesium/api/rest/controller/atom"
 	authctrl "github.com/caesium-cloud/caesium/api/rest/controller/auth"
 	"github.com/caesium-cloud/caesium/api/rest/controller/backfill"
@@ -189,6 +190,16 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 	// lineage impact (data-plane-memory C2)
 	{
 		g.GET("/lineage/impact", lineagectrl.Impact)
+	}
+
+	// agent tool surface (agent-in-the-loop-remediation Stream C). All routes are
+	// gated by the auth middleware's agent-scope switch, which restricts an
+	// agent-session token to exactly its own incident's /v1/agent/* routes.
+	{
+		g.GET("/agent/incidents/:id/bundle", agentctrl.Bundle)
+		g.GET("/agent/incidents/:id/context/*", agentctrl.Context)
+		g.POST("/agent/incidents/:id/actions", agentctrl.Actions)
+		g.POST("/agent/incidents/:id/notes", agentctrl.Notes)
 	}
 }
 

--- a/api/rest/controller/agent/actions.go
+++ b/api/rest/controller/agent/actions.go
@@ -1,0 +1,53 @@
+package agent
+
+import (
+	"errors"
+	"net/http"
+
+	agentsvc "github.com/caesium-cloud/caesium/api/rest/service/agent"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+// Actions handles POST /v1/agent/incidents/:id/actions — propose/execute a typed
+// remediation action. The action is validated and executed by Stream B's
+// server-side action executor (the agent never gets shell/SQL/generic HTTP);
+// until that executor is wired the action is recorded as `proposed` for the
+// audit spine. Tier-3 actions always route to a human approval, never
+// auto-execute — that boundary is enforced server-side by the executor, not here.
+func Actions(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	}
+
+	var req agentsvc.ActionRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	svc := agentsvc.New(c.Request().Context())
+	inc, err := svc.Incident(id)
+	if err != nil {
+		if errors.Is(err, agentsvc.ErrIncidentNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	result, err := svc.ProposeAction(inc, req)
+	if err != nil {
+		if errors.Is(err, agentsvc.ErrUnknownActionType) {
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	// A proposed (not yet executed) action is accepted for later resolution; an
+	// executed/terminal one is a completed mutation.
+	status := http.StatusOK
+	if result.Disposition == "proposed" || result.Disposition == "awaiting_approval" {
+		status = http.StatusAccepted
+	}
+	return c.JSON(status, result)
+}

--- a/api/rest/controller/agent/bundle.go
+++ b/api/rest/controller/agent/bundle.go
@@ -1,0 +1,33 @@
+// Package agent implements the scoped /v1/agent/* tool surface controllers: the
+// triage bundle, read-only context passthroughs, typed-action proposals, and
+// timeline notes. Every route is gated by the auth middleware's agent-scope
+// switch (api/middleware/auth_scope.go), which 403s an agent-session token on
+// any incident but the one its credential was minted for.
+package agent
+
+import (
+	"errors"
+	"net/http"
+
+	agentsvc "github.com/caesium-cloud/caesium/api/rest/service/agent"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+// Bundle handles GET /v1/agent/incidents/:id/bundle — the JSON triage document
+// the agent fetches once at startup.
+func Bundle(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	}
+
+	b, err := agentsvc.New(c.Request().Context()).Bundle(id)
+	if err != nil {
+		if errors.Is(err, agentsvc.ErrIncidentNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, b)
+}

--- a/api/rest/controller/agent/context.go
+++ b/api/rest/controller/agent/context.go
@@ -1,0 +1,78 @@
+package agent
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	agentsvc "github.com/caesium-cloud/caesium/api/rest/service/agent"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+// Context handles GET /v1/agent/incidents/:id/context/* — the read-only
+// passthroughs (logs, why, run history) scoped to the incident's frozen job
+// allowlist. The wildcard subpath selects the passthrough. Cross-job reads are
+// gated against the allowlist injected by the auth middleware.
+func Context(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	}
+
+	svc := agentsvc.New(c.Request().Context())
+	inc, err := svc.Incident(id)
+	if err != nil {
+		if errors.Is(err, agentsvc.ErrIncidentNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	allowed := authmw.GetAllowedJobAliases(c)
+	sub := strings.Trim(c.Param("*"), "/")
+
+	switch sub {
+	case "logs":
+		text, ok, err := svc.FailingLog(inc)
+		if err != nil {
+			return mapContextError(err)
+		}
+		return c.JSON(http.StatusOK, map[string]any{"log_tail": text, "available": ok, "scrubbed": true})
+
+	case "history":
+		runs, err := svc.History(inc, strings.TrimSpace(c.QueryParam("job")), allowed)
+		if err != nil {
+			return mapContextError(err)
+		}
+		return c.JSON(http.StatusOK, map[string]any{"runs": runs})
+
+	case "why":
+		task := strings.TrimSpace(c.QueryParam("task"))
+		if task == "" {
+			return echo.NewHTTPError(http.StatusBadRequest, "task query parameter is required")
+		}
+		explanation, err := svc.Why(inc, task)
+		if err != nil {
+			return mapContextError(err)
+		}
+		return c.JSON(http.StatusOK, explanation)
+
+	default:
+		return echo.NewHTTPError(http.StatusNotFound, "unknown context passthrough")
+	}
+}
+
+func mapContextError(err error) error {
+	switch {
+	case errors.Is(err, agentsvc.ErrForbiddenJob):
+		return echo.NewHTTPError(http.StatusForbidden, agentsvc.ErrForbiddenJob.Error())
+	case errors.Is(err, agentsvc.ErrNoFailingRun), errors.Is(err, gorm.ErrRecordNotFound), errors.Is(err, runstorage.ErrTaskRunNotFound):
+		return echo.ErrNotFound
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+}

--- a/api/rest/controller/agent/notes.go
+++ b/api/rest/controller/agent/notes.go
@@ -1,0 +1,49 @@
+package agent
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	agentsvc "github.com/caesium-cloud/caesium/api/rest/service/agent"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+)
+
+// noteBody is the POST /v1/agent/incidents/:id/notes request body.
+type noteBody struct {
+	Text string `json:"text"`
+}
+
+// Notes handles POST /v1/agent/incidents/:id/notes — append a free-text finding
+// to the incident timeline (recorded as a tier-0 AgentAction of type "note").
+func Notes(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	}
+
+	var body noteBody
+	if err := c.Bind(&body); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+	body.Text = strings.TrimSpace(body.Text)
+	if body.Text == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "text is required")
+	}
+
+	svc := agentsvc.New(c.Request().Context())
+	inc, err := svc.Incident(id)
+	if err != nil {
+		if errors.Is(err, agentsvc.ErrIncidentNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	action, err := svc.Note(inc, body.Text)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusCreated, action)
+}

--- a/api/rest/service/agent/actions.go
+++ b/api/rest/service/agent/actions.go
@@ -1,0 +1,93 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+)
+
+// ActionRequest is a typed remediation action proposed/executed by the agent
+// through POST /v1/agent/incidents/:id/actions. The incident id comes from the
+// route (and is scope-checked by the middleware); the agent supplies the action
+// type and its params.
+type ActionRequest struct {
+	IncidentID uuid.UUID       `json:"-"`
+	Type       string          `json:"type"`
+	Params     json.RawMessage `json:"params,omitempty"`
+}
+
+// ActionResult is what the actions endpoint returns: the recorded AgentAction
+// row and a coarse disposition (proposed | executed | failed | awaiting_approval).
+type ActionResult struct {
+	Action      *models.AgentAction `json:"action"`
+	Disposition string              `json:"disposition"`
+}
+
+// ErrUnknownActionType is returned when the action type is empty/unrecognized at
+// the surface level (deep validation is the executor's job).
+var ErrUnknownActionType = errors.New("agent: action type is required")
+
+// ActionExecutor is Stream B's server-side action executor. It validates a typed
+// action against the effective playbook, executes tier-1/2 actions, routes
+// tier-3 through the approval gate, and records the AgentAction audit row with
+// the correct actor/tier/status.
+//
+// CROSS-PR SEAM: Stream B (internal/incident/executor.go) ships this in a
+// sibling PR; the orchestrator sequences B before C at merge. Until an executor
+// is registered via SetActionExecutor, ProposeAction degrades to recording a
+// `proposed` AgentAction row (the audit spine) and returning it — the tool
+// surface is live and auditable, and B's executor takes over the execution
+// semantics when wired.
+type ActionExecutor interface {
+	ExecuteAgentAction(ctx context.Context, req ActionRequest) (*ActionResult, error)
+}
+
+// executor is the process-wide registered action executor (nil until Stream B
+// wires one at startup).
+var executor ActionExecutor
+
+// SetActionExecutor registers Stream B's action executor. Wired once at startup.
+func SetActionExecutor(e ActionExecutor) { executor = e }
+
+// ProposeAction records/executes a typed action for an incident. When Stream B's
+// executor is registered it delegates entirely (execution + audit). Otherwise it
+// records a `proposed` AgentAction row so the timeline and audit spine work and
+// the endpoint is exercisable end-to-end; the executor supersedes this.
+func (s *Service) ProposeAction(inc *models.Incident, req ActionRequest) (*ActionResult, error) {
+	req.Type = strings.TrimSpace(req.Type)
+	if req.Type == "" {
+		return nil, ErrUnknownActionType
+	}
+	req.IncidentID = inc.ID
+
+	if executor != nil {
+		return executor.ExecuteAgentAction(s.ctx, req)
+	}
+
+	now := time.Now().UTC()
+	var params datatypes.JSON
+	if len(req.Params) > 0 {
+		params = datatypes.JSON(req.Params)
+	}
+	action := &models.AgentAction{
+		ID:         uuid.New(),
+		Namespace:  inc.Namespace,
+		IncidentID: inc.ID,
+		Type:       req.Type,
+		Params:     params,
+		Status:     models.AgentActionStatusProposed,
+		Actor:      models.AgentActionActorAgent,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.db.WithContext(s.ctx).Create(action).Error; err != nil {
+		return nil, err
+	}
+	return &ActionResult{Action: action, Disposition: string(models.AgentActionStatusProposed)}, nil
+}

--- a/api/rest/service/agent/agent.go
+++ b/api/rest/service/agent/agent.go
@@ -1,0 +1,93 @@
+// Package agent implements the service layer behind the scoped /v1/agent/* tool
+// surface: the triage bundle, the read-only context passthroughs, timeline
+// notes, and the typed-action proposal path that delegates to Stream B's action
+// executor. Every method here is reached only through the auth middleware's
+// agent-scope switch, which 403s an agent token on any incident but its own.
+package agent
+
+import (
+	"context"
+	"errors"
+
+	iincident "github.com/caesium-cloud/caesium/internal/incident"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ErrIncidentNotFound is returned when the addressed incident does not exist.
+var ErrIncidentNotFound = errors.New("agent: incident not found")
+
+// Service wraps the incident package for the REST controllers, mirroring the
+// thin service pattern used by lineage/why (a context + a *gorm.DB, with a
+// WithDatabase override for tests).
+type Service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+// New creates a Service with the default DB connection.
+func New(ctx context.Context) *Service {
+	return &Service{ctx: ctx, db: db.Connection()}
+}
+
+// WithDatabase returns a copy of the Service using the given connection.
+func (s *Service) WithDatabase(conn *gorm.DB) *Service {
+	if conn == nil {
+		return s
+	}
+	return &Service{ctx: s.ctx, db: conn}
+}
+
+// Incident loads the addressed incident, translating not-found.
+func (s *Service) Incident(id uuid.UUID) (*models.Incident, error) {
+	var inc models.Incident
+	if err := s.db.WithContext(s.ctx).First(&inc, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrIncidentNotFound
+		}
+		return nil, err
+	}
+	return &inc, nil
+}
+
+// Bundle assembles the triage bundle for an incident. The effective profile
+// (whose playbook is surfaced) is resolved best-effort from the bootstrap
+// default-profile env; the remediation-block → profile resolution lands with
+// Stream E's declarative policy and supersedes this once available.
+func (s *Service) Bundle(id uuid.UUID) (*iincident.Bundle, error) {
+	profile := s.defaultProfile()
+	b, err := iincident.BuildBundle(s.ctx, s.db, id, profile)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrIncidentNotFound
+		}
+		return nil, err
+	}
+	return b, nil
+}
+
+// AllowedJobs returns the incident's frozen agent read-scope allowlist.
+func (s *Service) AllowedJobs(id uuid.UUID) ([]string, error) {
+	return iincident.NewStore(s.db).AllowedJobsForIncident(s.ctx, id)
+}
+
+// Note appends a free-text finding to the incident timeline.
+func (s *Service) Note(inc *models.Incident, text string) (*models.AgentAction, error) {
+	return iincident.RecordNote(s.ctx, s.db, inc.ID, nil, inc.Namespace, text)
+}
+
+// defaultProfile resolves the bootstrap default agent profile by name, or nil.
+func (s *Service) defaultProfile() *models.AgentProfile {
+	name := env.Variables().AgentDefaultProfile
+	if name == "" {
+		return nil
+	}
+	var profile models.AgentProfile
+	if err := s.db.WithContext(s.ctx).First(&profile, "name = ?", name).Error; err != nil {
+		return nil
+	}
+	return &profile
+}

--- a/api/rest/service/agent/agent_test.go
+++ b/api/rest/service/agent/agent_test.go
@@ -1,0 +1,116 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	iincident "github.com/caesium-cloud/caesium/internal/incident"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func seedJob(t *testing.T, db *gorm.DB, alias string) uuid.UUID {
+	t.Helper()
+	now := time.Now().UTC()
+	trigger := uuid.New()
+	require.NoError(t, db.Create(&models.Trigger{ID: trigger, Type: models.TriggerTypeCron, Configuration: `{"cron":"0 * * * *"}`, CreatedAt: now, UpdatedAt: now}).Error)
+	jobID := uuid.New()
+	require.NoError(t, db.Create(&models.Job{ID: jobID, Alias: alias, TriggerID: trigger, CreatedAt: now, UpdatedAt: now}).Error)
+	return jobID
+}
+
+func seedIncident(t *testing.T, db *gorm.DB, jobID uuid.UUID) *models.Incident {
+	t.Helper()
+	inc, _, err := iincident.NewStore(db).OpenOrAppend(context.Background(), iincident.OpenParams{
+		JobID: jobID, TaskName: "extract", Class: iincident.ClassUnknown,
+	})
+	require.NoError(t, err)
+	return inc
+}
+
+func TestProposeActionRecordsProposedWhenNoExecutor(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	t.Cleanup(func() { SetActionExecutor(nil) })
+	SetActionExecutor(nil)
+
+	jobID := seedJob(t, db, "vendor-x")
+	inc := seedIncident(t, db, jobID)
+
+	svc := &Service{ctx: context.Background(), db: db}
+	res, err := svc.ProposeAction(inc, ActionRequest{Type: "retry_from_failure", Params: []byte(`{"run_id":"x"}`)})
+	require.NoError(t, err)
+	require.Equal(t, "proposed", res.Disposition)
+	require.Equal(t, models.AgentActionStatusProposed, res.Action.Status)
+	require.Equal(t, models.AgentActionActorAgent, res.Action.Actor)
+
+	var count int64
+	require.NoError(t, db.Model(&models.AgentAction{}).Where("incident_id = ?", inc.ID).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}
+
+func TestProposeActionRequiresType(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	t.Cleanup(func() { SetActionExecutor(nil) })
+
+	jobID := seedJob(t, db, "vendor-x")
+	inc := seedIncident(t, db, jobID)
+
+	svc := &Service{ctx: context.Background(), db: db}
+	_, err := svc.ProposeAction(inc, ActionRequest{Type: "  "})
+	require.ErrorIs(t, err, ErrUnknownActionType)
+}
+
+// fakeExecutor stands in for Stream B's executor and records delegation.
+type fakeExecutor struct{ called bool }
+
+func (f *fakeExecutor) ExecuteAgentAction(_ context.Context, req ActionRequest) (*ActionResult, error) {
+	f.called = true
+	return &ActionResult{Action: &models.AgentAction{IncidentID: req.IncidentID, Type: req.Type, Status: models.AgentActionStatusExecuted}, Disposition: "executed"}, nil
+}
+
+func TestProposeActionDelegatesToRegisteredExecutor(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	t.Cleanup(func() { SetActionExecutor(nil) })
+
+	jobID := seedJob(t, db, "vendor-x")
+	inc := seedIncident(t, db, jobID)
+
+	exec := &fakeExecutor{}
+	SetActionExecutor(exec)
+
+	svc := &Service{ctx: context.Background(), db: db}
+	res, err := svc.ProposeAction(inc, ActionRequest{Type: "retry_from_failure"})
+	require.NoError(t, err)
+	require.True(t, exec.called)
+	require.Equal(t, "executed", res.Disposition)
+}
+
+func TestHistoryEnforcesAllowlist(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	jobID := seedJob(t, db, "vendor-x")
+	seedJob(t, db, "other-job")
+	inc := seedIncident(t, db, jobID)
+
+	svc := &Service{ctx: context.Background(), db: db}
+
+	// A cross-job read for a job NOT in the frozen allowlist is refused.
+	_, err := svc.History(inc, "other-job", []string{"vendor-x"})
+	require.ErrorIs(t, err, ErrForbiddenJob)
+
+	// The incident's own job (default) is always readable.
+	_, err = svc.History(inc, "", []string{"vendor-x"})
+	require.NoError(t, err)
+
+	// A job within the allowlist is readable.
+	_, err = svc.History(inc, "vendor-x", []string{"vendor-x"})
+	require.NoError(t, err)
+}

--- a/api/rest/service/agent/agent_test.go
+++ b/api/rest/service/agent/agent_test.go
@@ -114,3 +114,29 @@ func TestHistoryEnforcesAllowlist(t *testing.T) {
 	_, err = svc.History(inc, "vendor-x", []string{"vendor-x"})
 	require.NoError(t, err)
 }
+
+// TestHistoryEmptyAllowlistDeniesCrossJob is the security regression for the
+// "empty means unrestricted" footgun: an agent token whose frozen allowlist is
+// EMPTY may read only its own incident's job, never any other job's history.
+func TestHistoryEmptyAllowlistDeniesCrossJob(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	jobID := seedJob(t, db, "vendor-x")
+	seedJob(t, db, "other-job")
+	inc := seedIncident(t, db, jobID)
+
+	svc := &Service{ctx: context.Background(), db: db}
+
+	// Empty allowlist must NOT open every job — a cross-job read is refused.
+	_, err := svc.History(inc, "other-job", nil)
+	require.ErrorIs(t, err, ErrForbiddenJob)
+	_, err = svc.History(inc, "other-job", []string{})
+	require.ErrorIs(t, err, ErrForbiddenJob)
+
+	// The incident's own job stays readable even with an empty allowlist.
+	_, err = svc.History(inc, "vendor-x", nil)
+	require.NoError(t, err)
+	_, err = svc.History(inc, "", nil)
+	require.NoError(t, err)
+}

--- a/api/rest/service/agent/context.go
+++ b/api/rest/service/agent/context.go
@@ -1,0 +1,113 @@
+package agent
+
+import (
+	"errors"
+	"time"
+
+	whysvc "github.com/caesium-cloud/caesium/api/rest/service/why"
+	iincident "github.com/caesium-cloud/caesium/internal/incident"
+	"github.com/caesium-cloud/caesium/internal/models"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// ErrForbiddenJob is returned when a context read targets a job outside the
+// incident's frozen allowlist. The controller maps it to 403.
+var ErrForbiddenJob = errors.New("agent: job is outside the incident's frozen allowlist")
+
+// ErrNoFailingRun is returned when the incident has no addressable failing run.
+var ErrNoFailingRun = errors.New("agent: incident has no failing run")
+
+// RunSummary is one run in the read-only context history passthrough.
+type RunSummary struct {
+	ID          uuid.UUID  `json:"id"`
+	Status      string     `json:"status"`
+	Error       string     `json:"error,omitempty"`
+	StartedAt   time.Time  `json:"started_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	DurationMS  int64      `json:"duration_ms,omitempty"`
+}
+
+// FailingLog returns the scrubbed log tail of the incident's failing task. The
+// A5 scrubber's high-entropy heuristic strips credential-shaped tokens; exact
+// secret-value removal is not available post-hoc (resolved secrets are never
+// persisted).
+func (s *Service) FailingLog(inc *models.Incident) (string, bool, error) {
+	if inc.RunID == nil || inc.TaskID == nil {
+		return "", false, ErrNoFailingRun
+	}
+	var tr models.TaskRun
+	if err := s.db.WithContext(s.ctx).
+		Where("job_run_id = ? AND task_id = ?", *inc.RunID, *inc.TaskID).
+		First(&tr).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return "", false, ErrNoFailingRun
+		}
+		return "", false, err
+	}
+	return iincident.NewScrubber(nil).Scrub(tr.LogText), true, nil
+}
+
+// History returns recent runs for the incident's own job, or — when jobAlias is
+// supplied — for that job PROVIDED it is within the incident's frozen allowlist.
+// A request for an out-of-allowlist job is refused (ErrForbiddenJob), which is
+// the read-scope boundary for agent tokens.
+func (s *Service) History(inc *models.Incident, jobAlias string, allowed []string) ([]RunSummary, error) {
+	jobID := inc.JobID
+	if jobAlias != "" {
+		if !jobInAllowlist(jobAlias, allowed) {
+			return nil, ErrForbiddenJob
+		}
+		var job models.Job
+		if err := s.db.WithContext(s.ctx).Select("id").First(&job, "alias = ?", jobAlias).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				return nil, ErrForbiddenJob
+			}
+			return nil, err
+		}
+		jobID = job.ID
+	}
+
+	var runs []models.JobRun
+	if err := s.db.WithContext(s.ctx).
+		Where("job_id = ?", jobID).
+		Order("created_at DESC").
+		Limit(50).
+		Find(&runs).Error; err != nil {
+		return nil, err
+	}
+	out := make([]RunSummary, 0, len(runs))
+	for i := range runs {
+		r := runs[i]
+		rs := RunSummary{ID: r.ID, Status: r.Status, Error: r.Error, StartedAt: r.StartedAt, CompletedAt: r.CompletedAt}
+		if r.CompletedAt != nil && !r.StartedAt.IsZero() {
+			rs.DurationMS = r.CompletedAt.Sub(r.StartedAt).Milliseconds()
+		}
+		out = append(out, rs)
+	}
+	return out, nil
+}
+
+// Why returns the causal explanation for a task in the incident's failing run.
+func (s *Service) Why(inc *models.Incident, task string) (*runstorage.WhyExplanation, error) {
+	if inc.RunID == nil {
+		return nil, ErrNoFailingRun
+	}
+	return whysvc.New(s.ctx).WithDatabase(s.db).Why(*inc.RunID, task)
+}
+
+// jobInAllowlist reports whether jobAlias is within the frozen allowlist. An
+// empty allowlist (no scoped principal, e.g. an unscoped operator or auth
+// disabled) imposes no restriction; a non-empty allowlist restricts strictly.
+func jobInAllowlist(jobAlias string, allowed []string) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	for _, a := range allowed {
+		if a == jobAlias {
+			return true
+		}
+	}
+	return false
+}

--- a/api/rest/service/agent/context.go
+++ b/api/rest/service/agent/context.go
@@ -56,7 +56,15 @@ func (s *Service) FailingLog(inc *models.Incident) (string, bool, error) {
 func (s *Service) History(inc *models.Incident, jobAlias string, allowed []string) ([]RunSummary, error) {
 	jobID := inc.JobID
 	if jobAlias != "" {
-		if !jobInAllowlist(jobAlias, allowed) {
+		// The incident's own job is always readable; ANY other job must be
+		// explicitly listed in the frozen allowlist. An empty allowlist therefore
+		// permits ONLY the incident's own job — empty is never "allow any" (the
+		// same "empty means unrestricted" footgun closed in authorizeAgentScope).
+		ownAlias, err := s.incidentJobAlias(inc.JobID)
+		if err != nil {
+			return nil, err
+		}
+		if jobAlias != ownAlias && !jobInAllowlist(jobAlias, allowed) {
 			return nil, ErrForbiddenJob
 		}
 		var job models.Job
@@ -97,13 +105,21 @@ func (s *Service) Why(inc *models.Incident, task string) (*runstorage.WhyExplana
 	return whysvc.New(s.ctx).WithDatabase(s.db).Why(*inc.RunID, task)
 }
 
-// jobInAllowlist reports whether jobAlias is within the frozen allowlist. An
-// empty allowlist (no scoped principal, e.g. an unscoped operator or auth
-// disabled) imposes no restriction; a non-empty allowlist restricts strictly.
-func jobInAllowlist(jobAlias string, allowed []string) bool {
-	if len(allowed) == 0 {
-		return true
+// incidentJobAlias resolves the alias of the incident's own job (always readable
+// through the context passthroughs regardless of the frozen allowlist).
+func (s *Service) incidentJobAlias(jobID uuid.UUID) (string, error) {
+	var job models.Job
+	if err := s.db.WithContext(s.ctx).Select("alias").First(&job, "id = ?", jobID).Error; err != nil {
+		return "", err
 	}
+	return job.Alias, nil
+}
+
+// jobInAllowlist reports whether jobAlias is EXPLICITLY within the frozen
+// allowlist. An empty allowlist matches nothing — it is never treated as
+// "unrestricted", so a scoped agent token with an empty frozen list can read no
+// cross-job context (only the incident's own job, handled by the caller).
+func jobInAllowlist(jobAlias string, allowed []string) bool {
 	for _, a := range allowed {
 		if a == jobAlias {
 			return true

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -470,6 +470,27 @@ func start(cmd *cobra.Command, args []string) error {
 			log.Info("launching incident timer sweeper")
 			timerSweeper.Run(ctx)
 		})
+
+		// --- Agent session supervisor (Stream C: agent runtime) ---
+		//
+		// The supervisor drives a profile image through the existing atom.Engine
+		// as an AgentSession (deliberately NOT a JobRun), minting a scoped,
+		// short-lived credential per session and enforcing the concurrent-session
+		// caps against the shared store (leader-node placement in v1). It is
+		// registered process-wide; the incident manager / action executor (Streams
+		// B, E) obtain it to dispatch a triage session once a playbook admits one.
+		sessionSupervisor := incident.NewSupervisor(incConn, authSvc, incident.DefaultEngineFactory, incident.SupervisorConfig{
+			APIBaseURL:               strings.TrimSpace(vars.APIExternalURL),
+			SessionTimeout:           vars.AgentSessionTimeout,
+			MaxConcurrentSessions:    vars.AgentMaxConcurrentSessions,
+			PerJobConcurrentSessions: 1,
+		})
+		incident.SetSessionSupervisor(sessionSupervisor)
+		log.Info("agent session supervisor ready",
+			"max_concurrent_sessions", vars.AgentMaxConcurrentSessions,
+			"session_timeout", vars.AgentSessionTimeout,
+			"default_profile", vars.AgentDefaultProfile,
+		)
 	}
 
 	importer := jobdef.NewImporter(db.Connection())

--- a/internal/auth/agentkey.go
+++ b/internal/auth/agentkey.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"errors"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+)
+
+// AgentSessionKeyRole is the RBAC role an agent-session credential is minted
+// with. It is the minimum role that satisfies the /v1/agent/* route policy
+// (read context at viewer level, propose/execute actions and append notes at
+// runner level). The credential is additionally scope-locked to a single
+// incident's agent routes by its AgentClaim, so the role alone never grants
+// reach beyond that incident — RBAC and scope both gate every request.
+const AgentSessionKeyRole = models.RoleRunner
+
+// ErrAgentKeyIncidentRequired is returned when a mint is attempted without a
+// bound incident.
+var ErrAgentKeyIncidentRequired = errors.New("mint agent session key: incident id required")
+
+// MintAgentSessionKey creates a scoped, short-lived API key bound to a single
+// incident's /v1/agent/* tool surface. It is the credential-minting site the
+// incident manager (an unscoped, server-side principal) calls once per agent
+// session: the caller supplies the FROZEN job allowlist snapshotted at incident
+// open, and the returned key can never widen it. The plaintext is returned once
+// (to be injected into the agent container) and only its hash is persisted.
+//
+// The key:
+//   - carries an AgentClaim, so the deny-by-default route-scope switch treats it
+//     as valid ONLY for this incident's agent routes and 403s everything else;
+//   - is minted at the runner role (the minimum the agent routes require);
+//   - expires after ttl, so the credential dies with the session even if the
+//     supervisor never gets to revoke it explicitly.
+func (s *Service) MintAgentSessionKey(incidentID uuid.UUID, allowlist []string, ttl time.Duration) (*CreateKeyResponse, error) {
+	if incidentID == uuid.Nil {
+		return nil, ErrAgentKeyIncidentRequired
+	}
+	if ttl <= 0 {
+		ttl = time.Hour
+	}
+	expiry := s.nowUTC().Add(ttl)
+
+	scope := &models.KeyScope{
+		Agent: &models.AgentClaim{
+			IncidentID: incidentID,
+			Jobs:       normalizeAllowlist(allowlist),
+		},
+	}
+
+	return s.CreateKey(&CreateKeyRequest{
+		Description: "agent session " + incidentID.String(),
+		Role:        AgentSessionKeyRole,
+		Scope:       scope,
+		CreatedBy:   "incident-manager",
+		ExpiresAt:   &expiry,
+	})
+}
+
+// normalizeAllowlist trims, de-duplicates, and sorts the frozen job allowlist so
+// the persisted claim is deterministic.
+func normalizeAllowlist(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, a := range in {
+		a = strings.TrimSpace(a)
+		if a == "" {
+			continue
+		}
+		if _, ok := seen[a]; ok {
+			continue
+		}
+		seen[a] = struct{}{}
+		out = append(out, a)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/auth/agentkey_test.go
+++ b/internal/auth/agentkey_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMintAgentSessionKeyScopeAndExpiry(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	svc := NewService(db)
+
+	incidentID := uuid.New()
+	before := time.Now().UTC()
+	resp, err := svc.MintAgentSessionKey(incidentID, []string{"beta", "alpha", "alpha", " "}, 30*time.Minute)
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Plaintext)
+	require.NotNil(t, resp.Key)
+
+	// Runner role — the minimum the agent routes require.
+	require.Equal(t, models.RoleRunner, resp.Key.Role)
+
+	// Short-lived: expires within the ttl window.
+	require.NotNil(t, resp.Key.ExpiresAt)
+	require.True(t, resp.Key.ExpiresAt.After(before))
+	require.True(t, resp.Key.ExpiresAt.Before(before.Add(31*time.Minute)))
+
+	// The stored scope carries the agent claim with a normalized (deduped,
+	// sorted, whitespace-stripped) allowlist and NO plain job scope.
+	claim, err := DecodeAgentClaim(resp.Key.Scope)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	require.Equal(t, incidentID, claim.IncidentID)
+	require.Equal(t, []string{"alpha", "beta"}, claim.Jobs)
+
+	jobs, err := ScopeJobs(resp.Key.Scope)
+	require.NoError(t, err)
+	require.Empty(t, jobs, "agent key must not carry a plain job scope")
+}
+
+func TestMintAgentSessionKeyRequiresIncident(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	svc := NewService(db)
+
+	_, err := svc.MintAgentSessionKey(uuid.Nil, nil, time.Hour)
+	require.ErrorIs(t, err, ErrAgentKeyIncidentRequired)
+}
+
+func TestDecodeAgentClaimNonAgentScope(t *testing.T) {
+	// A plain job scope is not an agent claim.
+	claim, err := DecodeAgentClaim([]byte(`{"jobs":["alpha"]}`))
+	require.NoError(t, err)
+	require.Nil(t, claim)
+
+	// Empty / nil scope is not an agent claim.
+	claim, err = DecodeAgentClaim(nil)
+	require.NoError(t, err)
+	require.Nil(t, claim)
+
+	// An agent claim with a nil incident id is rejected (not a valid binding).
+	claim, err = DecodeAgentClaim([]byte(`{"agent":{"incident_id":"00000000-0000-0000-0000-000000000000"}}`))
+	require.NoError(t, err)
+	require.Nil(t, claim)
+}
+
+func TestMintedAgentKeyValidatesAndIsScoped(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	svc := NewService(db)
+
+	incidentID := uuid.New()
+	resp, err := svc.MintAgentSessionKey(incidentID, []string{"alpha"}, time.Hour)
+	require.NoError(t, err)
+
+	// The minted plaintext validates and round-trips its agent claim.
+	key, err := svc.ValidateKey(resp.Plaintext)
+	require.NoError(t, err)
+	claim, err := DecodeAgentClaim(key.Scope)
+	require.NoError(t, err)
+	require.NotNil(t, claim)
+	require.Equal(t, incidentID, claim.IncidentID)
+}

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -73,6 +73,17 @@ var endpointPolicy = map[string]models.Role{
 	"POST /v1/jobdefs/diff":                     models.RoleViewer,
 	"GET /v1/lineage/impact":                    models.RoleViewer,
 
+	// Agent tool surface (/v1/agent/*). Reachable by an unscoped operator/admin
+	// AND by an agent-session credential minted at the runner role; the
+	// per-incident binding is enforced separately by the deny-by-default scope
+	// switch (api/middleware/auth_scope.go), which 403s an agent token on any
+	// route outside its own incident. Reads sit at viewer, mutating tool calls
+	// (propose/execute an action, append a note) at runner.
+	"GET /v1/agent/incidents/:id/bundle":    models.RoleViewer,
+	"GET /v1/agent/incidents/:id/context/*": models.RoleViewer,
+	"POST /v1/agent/incidents/:id/actions":  models.RoleRunner,
+	"POST /v1/agent/incidents/:id/notes":    models.RoleRunner,
+
 	// Runner
 	"POST /v1/jobs/:id/run":                      models.RoleRunner,
 	"POST /v1/jobs/:id/runs/:id/replay":          models.RoleRunner,

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -45,6 +45,48 @@ func DecodeScope(scopeJSON []byte) (*models.KeyScope, error) {
 	return &scope, nil
 }
 
+// AgentClaimView is the normalized, package-local view of an agent-session
+// claim returned to callers (the auth middleware) so they need not import the
+// models package to enforce the incident binding.
+type AgentClaimView struct {
+	IncidentID uuid.UUID
+	Jobs       []string
+}
+
+// DecodeAgentClaim returns the agent-session claim carried by a scope payload,
+// or nil when the key is not an agent-session credential. It deliberately does
+// NOT run the job-normalization early-return that DecodeScope applies (a scope
+// with an agent claim and no Jobs is a valid, maximally-restricted agent key,
+// not an unrestricted key), so callers MUST check for an agent claim before
+// treating an empty ScopeJobs result as "unrestricted".
+func DecodeAgentClaim(scopeJSON []byte) (*AgentClaimView, error) {
+	if len(scopeJSON) == 0 {
+		return nil, nil
+	}
+	var scope models.KeyScope
+	if err := json.Unmarshal(scopeJSON, &scope); err != nil {
+		return nil, err
+	}
+	if scope.Agent == nil || scope.Agent.IncidentID == uuid.Nil {
+		return nil, nil
+	}
+	seen := make(map[string]struct{}, len(scope.Agent.Jobs))
+	jobs := make([]string, 0, len(scope.Agent.Jobs))
+	for _, alias := range scope.Agent.Jobs {
+		alias = strings.TrimSpace(alias)
+		if alias == "" {
+			continue
+		}
+		if _, ok := seen[alias]; ok {
+			continue
+		}
+		seen[alias] = struct{}{}
+		jobs = append(jobs, alias)
+	}
+	sort.Strings(jobs)
+	return &AgentClaimView{IncidentID: scope.Agent.IncidentID, Jobs: jobs}, nil
+}
+
 // ScopeJobs returns the normalized scoped job aliases or nil when unrestricted.
 func ScopeJobs(scopeJSON []byte) ([]string, error) {
 	scope, err := DecodeScope(scopeJSON)

--- a/internal/incident/allowlist.go
+++ b/internal/incident/allowlist.go
@@ -1,0 +1,112 @@
+package incident
+
+import (
+	"context"
+	"sort"
+
+	"github.com/caesium-cloud/caesium/internal/lineage"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// FreezeAllowlist computes the static job allowlist that scopes an agent's read
+// surface for one incident. It is the failing job itself PLUS every job
+// transitively downstream of the failing job's output datasets in the lineage
+// graph — but the seed datasets deliberately EXCLUDE any output rows produced by
+// the failing run itself. That exclusion is the security property: a failing
+// task can emit arbitrary `##caesium::output` markers, which materialize as
+// lineage dataset rows; if those poisoned edges seeded the impact walk, an
+// attacker who controls the failing task could widen the agent's read scope to
+// jobs it should never see. Seeding only from the job's TRUSTED historical
+// outputs (other runs) closes that hole.
+//
+// The incident manager (an unscoped, server-side principal) calls this at
+// incident open; the result is frozen onto the incident and every agent-session
+// token minted for the incident carries a copy. The agent can never widen it.
+//
+// FreezeAllowlist is best-effort with respect to lineage availability: if the
+// lineage graph is empty or unavailable (e.g. OpenLineage disabled), it returns
+// just the failing job's own alias rather than failing incident open.
+func FreezeAllowlist(ctx context.Context, db *gorm.DB, jobID uuid.UUID, failingRunID *uuid.UUID) []string {
+	allow := map[string]struct{}{}
+
+	// The incident's own job is always in scope.
+	var job models.Job
+	if err := db.WithContext(ctx).Select("alias").First(&job, "id = ?", jobID).Error; err == nil {
+		if job.Alias != "" {
+			allow[job.Alias] = struct{}{}
+		}
+	} else {
+		log.Debug("incident: freeze allowlist could not resolve job alias", "job_id", jobID, "error", err)
+	}
+
+	// Seed the impact walk from the failing job's TRUSTED output datasets —
+	// every output row for the job EXCEPT those produced by the failing run.
+	seeds, err := trustedOutputDatasets(ctx, db, jobID, failingRunID)
+	if err != nil {
+		// Lineage tables may be absent/empty when OpenLineage is disabled; degrade
+		// to the job's own alias rather than blocking incident open.
+		log.Debug("incident: freeze allowlist could not read trusted output datasets", "job_id", jobID, "error", err)
+		return sortedKeys(allow)
+	}
+
+	for _, seed := range seeds {
+		impact, err := lineage.QueryImpact(ctx, db, seed.namespace, seed.name, 0)
+		if err != nil {
+			log.Debug("incident: freeze allowlist impact query failed", "dataset", seed.name, "error", err)
+			continue
+		}
+		for _, node := range impact.Downstream {
+			if node.JobAlias != "" {
+				allow[node.JobAlias] = struct{}{}
+			}
+		}
+	}
+
+	return sortedKeys(allow)
+}
+
+type datasetSeed struct {
+	namespace string
+	name      string
+}
+
+// trustedOutputDatasets returns the distinct (namespace, name) output datasets
+// the job has produced across its runs, EXCLUDING any produced by failingRunID.
+func trustedOutputDatasets(ctx context.Context, db *gorm.DB, jobID uuid.UUID, failingRunID *uuid.UUID) ([]datasetSeed, error) {
+	type row struct {
+		Namespace string
+		Name      string
+	}
+	var rows []row
+
+	q := db.WithContext(ctx).
+		Table("lineage_datasets ld").
+		Select("DISTINCT ld.namespace, ld.name").
+		Joins("JOIN task_runs tr ON tr.id = ld.task_run_id").
+		Joins("JOIN job_runs jr ON jr.id = tr.job_run_id").
+		Where("jr.job_id = ? AND ld.direction = ?", jobID, "output")
+	if failingRunID != nil {
+		q = q.Where("jr.id <> ?", *failingRunID)
+	}
+	if err := q.Scan(&rows).Error; err != nil {
+		return nil, err
+	}
+
+	seeds := make([]datasetSeed, 0, len(rows))
+	for _, r := range rows {
+		seeds = append(seeds, datasetSeed{namespace: r.Namespace, name: r.Name})
+	}
+	return seeds, nil
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/incident/allowlist_test.go
+++ b/internal/incident/allowlist_test.go
@@ -1,0 +1,174 @@
+package incident
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func mkTrigger(t *testing.T, db *gorm.DB) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.Trigger{
+		ID:            id,
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"cron":"0 * * * *"}`,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}).Error)
+	return id
+}
+
+func mkJob(t *testing.T, db *gorm.DB, triggerID uuid.UUID, alias string) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.Job{
+		ID:        id,
+		Alias:     alias,
+		TriggerID: triggerID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	return id
+}
+
+func mkRun(t *testing.T, db *gorm.DB, jobID, triggerID uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID:        id,
+		JobID:     jobID,
+		TriggerID: triggerID,
+		Status:    "succeeded",
+		StartedAt: now,
+		CreatedAt: now,
+	}).Error)
+	return id
+}
+
+func mkTaskRun(t *testing.T, db *gorm.DB, runID uuid.UUID) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID:        id,
+		JobRunID:  runID,
+		TaskID:    uuid.New(),
+		AtomID:    uuid.New(),
+		Engine:    models.AtomEngineDocker,
+		Image:     "busybox",
+		Command:   "echo",
+		Status:    "succeeded",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+	return id
+}
+
+func mkDataset(t *testing.T, db *gorm.DB, taskRunID uuid.UUID, dir, ns, name string) {
+	t.Helper()
+	require.NoError(t, db.Create(&models.LineageDataset{
+		ID:        uuid.New(),
+		TaskRunID: taskRunID,
+		Namespace: ns,
+		Name:      name,
+		Direction: dir,
+		CreatedAt: time.Now().UTC(),
+	}).Error)
+}
+
+// TestFreezeAllowlistExcludesFailingRunOutputs is the security property: the
+// frozen allowlist is seeded only from the failing job's TRUSTED historical
+// outputs, never from the failing run's own outputs. A downstream job reachable
+// only through an attacker-crafted output of the failing run must NOT appear.
+func TestFreezeAllowlistExcludesFailingRunOutputs(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+
+	// job-a: a trusted prior run produces D1; a FAILING run produces the poisoned
+	// output "devil".
+	jobA := mkJob(t, db, tr, "job-a")
+	trustedRun := mkRun(t, db, jobA, tr)
+	trustedTaskRun := mkTaskRun(t, db, trustedRun)
+	mkDataset(t, db, trustedTaskRun, "output", "ns", "D1")
+
+	failRun := mkRun(t, db, jobA, tr)
+	failTaskRun := mkTaskRun(t, db, failRun)
+	mkDataset(t, db, failTaskRun, "output", "ns", "devil")
+
+	// job-b consumes the trusted D1 (legitimately downstream).
+	jobB := mkJob(t, db, tr, "job-b")
+	runB := mkRun(t, db, jobB, tr)
+	taskB := mkTaskRun(t, db, runB)
+	mkDataset(t, db, taskB, "input", "ns", "D1")
+	mkDataset(t, db, taskB, "output", "ns", "D2")
+
+	// job-c consumes ONLY the poisoned "devil" output — reachable only via the
+	// failing run.
+	jobC := mkJob(t, db, tr, "job-c")
+	runC := mkRun(t, db, jobC, tr)
+	taskC := mkTaskRun(t, db, runC)
+	mkDataset(t, db, taskC, "input", "ns", "devil")
+	mkDataset(t, db, taskC, "output", "ns", "D3")
+
+	// Excluding the failing run: allowlist is {job-a, job-b}; job-c is NOT
+	// reachable because the poisoned edge is excluded.
+	frozen := FreezeAllowlist(ctx, db, jobA, &failRun)
+	require.ElementsMatch(t, []string{"job-a", "job-b"}, frozen)
+	require.NotContains(t, frozen, "job-c")
+
+	// Contrast: if the failing run's outputs were NOT excluded, job-c leaks in —
+	// this is exactly the widening the exclusion prevents.
+	leaky := FreezeAllowlist(ctx, db, jobA, nil)
+	require.Contains(t, leaky, "job-c")
+}
+
+// TestFreezeAllowlistDegradesToOwnJob proves the best-effort degradation: with no
+// lineage graph the allowlist is just the incident's own job.
+func TestFreezeAllowlistDegradesToOwnJob(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobA := mkJob(t, db, tr, "solo")
+
+	frozen := FreezeAllowlist(ctx, db, jobA, nil)
+	require.Equal(t, []string{"solo"}, frozen)
+}
+
+// TestOpenOrAppendFreezesAllowlist proves the freeze happens at incident open and
+// is persisted on the incident row.
+func TestOpenOrAppendFreezesAllowlist(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobA := mkJob(t, db, tr, "frozen-job")
+
+	store := NewStore(db)
+	inc, outcome, err := store.OpenOrAppend(ctx, OpenParams{
+		JobID:    jobA,
+		TaskName: "extract",
+		Class:    ClassUnknown,
+	})
+	require.NoError(t, err)
+	require.Equal(t, OutcomeOpened, outcome)
+
+	got, err := store.AllowedJobsForIncident(ctx, inc.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"frozen-job"}, got)
+}

--- a/internal/incident/allowlist_test.go
+++ b/internal/incident/allowlist_test.go
@@ -65,7 +65,7 @@ func mkTaskRun(t *testing.T, db *gorm.DB, runID uuid.UUID) uuid.UUID {
 		TaskID:    uuid.New(),
 		AtomID:    uuid.New(),
 		Engine:    models.AtomEngineDocker,
-		Image:     "busybox",
+		Image:     "busybox:1.36.1",
 		Command:   "echo",
 		Status:    "succeeded",
 		CreatedAt: now,

--- a/internal/incident/bundle.go
+++ b/internal/incident/bundle.go
@@ -1,0 +1,280 @@
+package incident
+
+import (
+	"context"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// Bundle is the JSON triage document an agent fetches once at session startup
+// (GET /v1/agent/incidents/:id/bundle). Env injection cannot carry it — log
+// tails alone exceed the ~128 KiB per-variable limit — so it is served over the
+// scoped tool surface. It bundles everything the agent needs to plan within
+// policy: the incident + classification, the failing task's error/scrubbed
+// log/violations, the job + DAG, recent run history, the FROZEN lineage-impact
+// allowlist, and the effective playbook. All attacker-influenced free text
+// (the log tail) is scrubbed before it enters the bundle.
+type Bundle struct {
+	Incident       BundleIncident   `json:"incident"`
+	Classification BundleClass      `json:"classification"`
+	Failure        BundleFailure    `json:"failure"`
+	Job            BundleJob        `json:"job"`
+	RunHistory     []BundleRun      `json:"run_history"`
+	LineageImpact  BundleImpact     `json:"lineage_impact"`
+	Playbook       datatypes.JSON   `json:"playbook,omitempty"`
+	Notes          []BundleNoteHint `json:"notes,omitempty"`
+	GeneratedAt    time.Time        `json:"generated_at"`
+}
+
+// BundleIncident is the incident header the agent triages.
+type BundleIncident struct {
+	ID              uuid.UUID  `json:"id"`
+	JobID           uuid.UUID  `json:"job_id"`
+	RunID           *uuid.UUID `json:"run_id,omitempty"`
+	TaskName        string     `json:"task_name,omitempty"`
+	Status          string     `json:"status"`
+	OccurrenceCount int        `json:"occurrence_count"`
+	Attempt         int        `json:"attempt"`
+	OpenedAt        time.Time  `json:"opened_at"`
+}
+
+// BundleClass carries the deterministic classification + its evidence.
+type BundleClass struct {
+	Class    string         `json:"class"`
+	Evidence datatypes.JSON `json:"evidence,omitempty"`
+}
+
+// BundleFailure carries the failing task's diagnostic signals. LogTail is
+// scrubbed; SchemaViolations and ExitCode come straight from the TaskRun.
+type BundleFailure struct {
+	Error            string         `json:"error,omitempty"`
+	LogTail          string         `json:"log_tail,omitempty"`
+	LogTailScrubbed  bool           `json:"log_tail_scrubbed"`
+	SchemaViolations datatypes.JSON `json:"schema_violations,omitempty"`
+	ExitCode         *int           `json:"exit_code,omitempty"`
+	Image            string         `json:"image,omitempty"`
+	Result           string         `json:"result,omitempty"`
+}
+
+// BundleJob is the job definition + DAG topology.
+type BundleJob struct {
+	Alias            string          `json:"alias"`
+	Paused           bool            `json:"paused"`
+	SchemaValidation string          `json:"schema_validation,omitempty"`
+	Tasks            []BundleTask    `json:"tasks"`
+	Edges            []BundleDAGEdge `json:"edges"`
+}
+
+// BundleTask is one step in the DAG.
+type BundleTask struct {
+	Name        string `json:"name"`
+	TriggerRule string `json:"trigger_rule,omitempty"`
+	Retries     int    `json:"retries"`
+	ReplaySafe  bool   `json:"replay_safe"`
+}
+
+// BundleDAGEdge is one from→to dependency edge (by task name).
+type BundleDAGEdge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// BundleRun is one recent run with its duration for history-based reasoning
+// (e.g. "this vendor has been late 4 of the last 30 days").
+type BundleRun struct {
+	ID          uuid.UUID  `json:"id"`
+	Status      string     `json:"status"`
+	Error       string     `json:"error,omitempty"`
+	StartedAt   time.Time  `json:"started_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+	DurationMS  int64      `json:"duration_ms,omitempty"`
+}
+
+// BundleImpact is the FROZEN lineage-impact snapshot: the static job allowlist
+// the incident manager computed at open (excluding the failing run's own
+// outputs). The agent reads this instead of the live /v1/lineage/impact route,
+// from which its scoped token is 403'd.
+type BundleImpact struct {
+	AllowedJobs []string `json:"allowed_jobs"`
+	Frozen      bool     `json:"frozen"`
+}
+
+// BundleNoteHint surfaces prior timeline notes so a resumed session has context.
+type BundleNoteHint struct {
+	CreatedAt time.Time `json:"created_at"`
+	Text      string    `json:"text"`
+}
+
+const bundleRunHistoryLimit = 20
+
+// BuildBundle assembles the triage bundle for an incident. profile is the
+// effective agent profile (may be nil), whose Playbook is surfaced so the agent
+// plans within policy; when nil the Playbook is omitted. The failing task's log
+// tail is scrubbed by the A5 scrubber before it enters the bundle.
+func BuildBundle(ctx context.Context, db *gorm.DB, incidentID uuid.UUID, profile *models.AgentProfile) (*Bundle, error) {
+	var inc models.Incident
+	if err := db.WithContext(ctx).First(&inc, "id = ?", incidentID).Error; err != nil {
+		return nil, err
+	}
+
+	b := &Bundle{
+		Incident: BundleIncident{
+			ID:              inc.ID,
+			JobID:           inc.JobID,
+			RunID:           inc.RunID,
+			TaskName:        inc.TaskName,
+			Status:          string(inc.Status),
+			OccurrenceCount: inc.OccurrenceCount,
+			Attempt:         inc.Attempt,
+			OpenedAt:        inc.OpenedAt,
+		},
+		Classification: BundleClass{Class: inc.Class, Evidence: inc.Evidence},
+		Failure:        BundleFailure{Error: inc.LastError},
+		LineageImpact: BundleImpact{
+			AllowedJobs: unmarshalAllowlist(inc.AllowedJobs),
+			Frozen:      true,
+		},
+		GeneratedAt: time.Now().UTC(),
+	}
+	if profile != nil {
+		b.Playbook = profile.Playbook
+	}
+
+	// Failing task detail (scrubbed log tail).
+	if inc.RunID != nil && inc.TaskID != nil {
+		var tr models.TaskRun
+		if err := db.WithContext(ctx).
+			Where("job_run_id = ? AND task_id = ?", *inc.RunID, *inc.TaskID).
+			First(&tr).Error; err == nil {
+			// The resolved secret env of the run is not persisted (secrets are
+			// never stored), so exact secret-value removal is not available
+			// post-hoc; the high-entropy token heuristic still strips
+			// credential-shaped tokens from the free text. This is the honest
+			// degradation of the A5 scrubber on the bundle read path.
+			scrubber := NewScrubber(nil)
+			b.Failure.LogTail = scrubber.Scrub(tr.LogText)
+			b.Failure.LogTailScrubbed = true
+			b.Failure.SchemaViolations = tr.SchemaViolations
+			b.Failure.ExitCode = tr.ExitCode
+			b.Failure.Image = tr.Image
+			b.Failure.Result = tr.Result
+			if tr.Error != "" {
+				b.Failure.Error = tr.Error
+			}
+		}
+	}
+
+	// Job + DAG topology.
+	job, tasks, edges, err := loadJobTopology(ctx, db, inc.JobID)
+	if err != nil {
+		return nil, err
+	}
+	b.Job = BundleJob{
+		Alias:            job.Alias,
+		Paused:           job.Paused,
+		SchemaValidation: job.SchemaValidation,
+		Tasks:            tasks,
+		Edges:            edges,
+	}
+
+	// Recent run history + durations.
+	b.RunHistory, err = loadRunHistory(ctx, db, inc.JobID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prior timeline notes (for resumed sessions).
+	b.Notes = loadNoteHints(ctx, db, inc.ID)
+
+	return b, nil
+}
+
+func loadJobTopology(ctx context.Context, db *gorm.DB, jobID uuid.UUID) (models.Job, []BundleTask, []BundleDAGEdge, error) {
+	var job models.Job
+	if err := db.WithContext(ctx).First(&job, "id = ?", jobID).Error; err != nil {
+		return job, nil, nil, err
+	}
+
+	var taskRows []models.Task
+	if err := db.WithContext(ctx).
+		Where("job_id = ?", jobID).
+		Order("position ASC").
+		Find(&taskRows).Error; err != nil {
+		return job, nil, nil, err
+	}
+	nameByID := make(map[uuid.UUID]string, len(taskRows))
+	tasks := make([]BundleTask, 0, len(taskRows))
+	for i := range taskRows {
+		t := taskRows[i]
+		nameByID[t.ID] = t.Name
+		tasks = append(tasks, BundleTask{
+			Name:        t.Name,
+			TriggerRule: t.TriggerRule,
+			Retries:     t.Retries,
+			ReplaySafe:  t.ReplaySafe,
+		})
+	}
+
+	var edgeRows []models.TaskEdge
+	if err := db.WithContext(ctx).Where("job_id = ?", jobID).Find(&edgeRows).Error; err != nil {
+		return job, nil, nil, err
+	}
+	edges := make([]BundleDAGEdge, 0, len(edgeRows))
+	for i := range edgeRows {
+		e := edgeRows[i]
+		edges = append(edges, BundleDAGEdge{From: nameByID[e.FromTaskID], To: nameByID[e.ToTaskID]})
+	}
+
+	return job, tasks, edges, nil
+}
+
+func loadRunHistory(ctx context.Context, db *gorm.DB, jobID uuid.UUID) ([]BundleRun, error) {
+	var runs []models.JobRun
+	if err := db.WithContext(ctx).
+		Where("job_id = ?", jobID).
+		Order("created_at DESC").
+		Limit(bundleRunHistoryLimit).
+		Find(&runs).Error; err != nil {
+		return nil, err
+	}
+	out := make([]BundleRun, 0, len(runs))
+	for i := range runs {
+		r := runs[i]
+		br := BundleRun{
+			ID:          r.ID,
+			Status:      r.Status,
+			Error:       r.Error,
+			StartedAt:   r.StartedAt,
+			CompletedAt: r.CompletedAt,
+		}
+		if r.CompletedAt != nil && !r.StartedAt.IsZero() {
+			br.DurationMS = r.CompletedAt.Sub(r.StartedAt).Milliseconds()
+		}
+		out = append(out, br)
+	}
+	return out, nil
+}
+
+// loadNoteHints returns prior agent notes recorded on the incident timeline
+// (AgentAction rows of type "note"), best-effort.
+func loadNoteHints(ctx context.Context, db *gorm.DB, incidentID uuid.UUID) []BundleNoteHint {
+	var actions []models.AgentAction
+	if err := db.WithContext(ctx).
+		Where("incident_id = ? AND type = ?", incidentID, AgentActionTypeNote).
+		Order("created_at ASC").
+		Find(&actions).Error; err != nil {
+		return nil
+	}
+	hints := make([]BundleNoteHint, 0, len(actions))
+	for i := range actions {
+		hints = append(hints, BundleNoteHint{
+			CreatedAt: actions[i].CreatedAt,
+			Text:      noteTextFromParams(actions[i].Params),
+		})
+	}
+	return hints
+}

--- a/internal/incident/bundle.go
+++ b/internal/incident/bundle.go
@@ -226,7 +226,14 @@ func loadJobTopology(ctx context.Context, db *gorm.DB, jobID uuid.UUID) (models.
 	edges := make([]BundleDAGEdge, 0, len(edgeRows))
 	for i := range edgeRows {
 		e := edgeRows[i]
-		edges = append(edges, BundleDAGEdge{From: nameByID[e.FromTaskID], To: nameByID[e.ToTaskID]})
+		// Skip an edge whose endpoint task is missing (e.g. soft-deleted) so a
+		// dangling reference can't produce an edge with an empty task name.
+		from, fromOK := nameByID[e.FromTaskID]
+		to, toOK := nameByID[e.ToTaskID]
+		if !fromOK || !toOK {
+			continue
+		}
+		edges = append(edges, BundleDAGEdge{From: from, To: to})
 	}
 
 	return job, tasks, edges, nil

--- a/internal/incident/bundle_test.go
+++ b/internal/incident/bundle_test.go
@@ -1,0 +1,108 @@
+package incident
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+)
+
+func TestBuildBundleAssemblesAndScrubs(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	runID := mkRun(t, db, jobID, tr)
+
+	// A failing task run whose log carries a high-entropy credential-shaped token
+	// the scrubber must strip before it enters the bundle.
+	taskID := uuid.New()
+	secret := "AKIAIOSFODNN7EXAMPLEkey9s3cr3tV4lue"
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.TaskRun{
+		ID:        uuid.New(),
+		JobRunID:  runID,
+		TaskID:    taskID,
+		AtomID:    uuid.New(),
+		Engine:    models.AtomEngineDocker,
+		Image:     "vendor/extract:1.2",
+		Command:   "extract",
+		Status:    "failed",
+		Error:     "auth failed",
+		LogText:   "connecting with token " + secret + " ... 401 unauthorized",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error)
+
+	store := NewStore(db)
+	incTaskID := taskID
+	incRunID := runID
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{
+		JobID:     jobID,
+		RunID:     &incRunID,
+		TaskID:    &incTaskID,
+		TaskName:  "extract",
+		Class:     ClassAuthFailure,
+		LastError: "auth failed",
+	})
+	require.NoError(t, err)
+
+	profile := &models.AgentProfile{
+		ID:       uuid.New(),
+		Name:     "triage",
+		Image:    "caesium/triage:latest",
+		Engine:   models.AtomEngineDocker,
+		Playbook: datatypes.JSON([]byte(`{"allow":["retry_from_failure"]}`)),
+	}
+	require.NoError(t, db.Create(profile).Error)
+
+	bundle, err := BuildBundle(ctx, db, inc.ID, profile)
+	require.NoError(t, err)
+
+	require.Equal(t, inc.ID, bundle.Incident.ID)
+	require.Equal(t, string(ClassAuthFailure), bundle.Classification.Class)
+	require.Equal(t, "vendor-x", bundle.Job.Alias)
+
+	// The log tail is present, scrubbed, and no longer contains the secret token.
+	require.True(t, bundle.Failure.LogTailScrubbed)
+	require.NotContains(t, bundle.Failure.LogTail, secret)
+	require.Contains(t, bundle.Failure.LogTail, Redacted)
+	require.Equal(t, "vendor/extract:1.2", bundle.Failure.Image)
+
+	// The frozen allowlist and the effective playbook ride along.
+	require.Equal(t, []string{"vendor-x"}, bundle.LineageImpact.AllowedJobs)
+	require.True(t, bundle.LineageImpact.Frozen)
+	require.JSONEq(t, `{"allow":["retry_from_failure"]}`, string(bundle.Playbook))
+
+	// Run history includes the seeded run.
+	require.NotEmpty(t, bundle.RunHistory)
+}
+
+func TestBuildBundleIncludesPriorNotes(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	store := NewStore(db)
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "extract", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	_, err = RecordNote(ctx, db, inc.ID, nil, nil, "vendor file late again")
+	require.NoError(t, err)
+
+	bundle, err := BuildBundle(ctx, db, inc.ID, nil)
+	require.NoError(t, err)
+	require.Len(t, bundle.Notes, 1)
+	require.Equal(t, "vendor file late again", bundle.Notes[0].Text)
+	require.True(t, strings.TrimSpace(string(bundle.Playbook)) == "", "no profile → no playbook")
+}

--- a/internal/incident/note.go
+++ b/internal/incident/note.go
@@ -1,0 +1,62 @@
+package incident
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+// AgentActionTypeNote is the AgentAction.Type used for free-text agent findings
+// appended to the incident timeline. A note is a tier-0, actor=agent,
+// status=executed row — it mutates nothing, it is evidence.
+const AgentActionTypeNote = "note"
+
+// noteParams is the JSON params shape for a note action.
+type noteParams struct {
+	Text string `json:"text"`
+}
+
+// RecordNote appends a free-text finding to the incident timeline as an
+// AgentAction row. sessionID is optional (nil for a note recorded outside a
+// session). It returns the recorded row.
+func RecordNote(ctx context.Context, db *gorm.DB, incidentID uuid.UUID, sessionID *uuid.UUID, namespace *string, text string) (*models.AgentAction, error) {
+	params, err := json.Marshal(noteParams{Text: text})
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	action := &models.AgentAction{
+		ID:         uuid.New(),
+		Namespace:  namespace,
+		IncidentID: incidentID,
+		SessionID:  sessionID,
+		Type:       AgentActionTypeNote,
+		Params:     datatypes.JSON(params),
+		Tier:       0,
+		Status:     models.AgentActionStatusExecuted,
+		Actor:      models.AgentActionActorAgent,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := db.WithContext(ctx).Create(action).Error; err != nil {
+		return nil, err
+	}
+	return action, nil
+}
+
+// noteTextFromParams extracts the note text from an AgentAction.Params blob.
+func noteTextFromParams(raw datatypes.JSON) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var p noteParams
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return ""
+	}
+	return p.Text
+}

--- a/internal/incident/session.go
+++ b/internal/incident/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sync"
 	"time"
 
 	"github.com/caesium-cloud/caesium/internal/atom"
@@ -103,6 +104,14 @@ type Supervisor struct {
 	creds     AgentCredentialManager
 	newEngine EngineFactory
 	cfg       SupervisorConfig
+
+	// dispatchMu serializes the cap-check → slot-reservation critical section so
+	// concurrent Dispatch calls cannot both pass the cap and overshoot
+	// MaxConcurrentSessions. It is held only across counting + creating the
+	// pending session row (the point at which the slot becomes visible to the
+	// next dispatcher's count), never across the long-running engine execution,
+	// so genuinely-concurrent sessions still run in parallel up to the cap.
+	dispatchMu sync.Mutex
 }
 
 // sessionSupervisor is the process-wide session supervisor, set at startup
@@ -130,44 +139,71 @@ func NewSupervisor(db *gorm.DB, creds AgentCredentialManager, factory EngineFact
 	}
 }
 
-// Dispatch enforces the concurrent-session caps against the shared store, then
-// launches a session for the incident. It returns ErrGlobalSessionCap /
-// ErrJobSessionCap without launching when a cap is already reached — the caller
-// leaves the incident open to queue for later triage rather than dropping it.
+// Dispatch enforces the concurrent-session caps and launches a session for the
+// incident. The cap-check and the slot reservation (creating the pending
+// session row) are performed atomically under dispatchMu, so concurrent
+// dispatches cannot both pass the cap and overshoot MaxConcurrentSessions. It
+// returns ErrGlobalSessionCap / ErrJobSessionCap without launching when a cap
+// is already reached — the caller leaves the incident open to queue for later
+// triage rather than dropping it.
 func (s *Supervisor) Dispatch(ctx context.Context, inc *models.Incident, profile *models.AgentProfile) (*models.AgentSession, error) {
 	if profile == nil {
 		return nil, ErrNoProfile
 	}
 
-	globalActive, err := s.store.CountActiveAgentSessions(ctx)
+	session, minted, err := s.reserveWithCaps(ctx, inc, profile)
 	if err != nil {
 		return nil, err
 	}
-	if globalActive >= int64(s.cfg.MaxConcurrentSessions) {
-		return nil, ErrGlobalSessionCap
-	}
-
-	jobActive, err := s.store.CountActiveAgentSessionsForJob(ctx, inc.JobID)
-	if err != nil {
-		return nil, err
-	}
-	if jobActive >= int64(s.cfg.PerJobConcurrentSessions) {
-		return nil, ErrJobSessionCap
-	}
-
-	return s.Run(ctx, inc, profile)
+	return s.execute(ctx, session, minted, inc, profile), nil
 }
 
-// Run mints a scoped token, records the AgentSession, launches the profile image
-// through the engine, waits under a wall-clock budget, persists the container
-// log, stops the container, sets the terminal state, and revokes the token so it
-// never outlives the session. It is synchronous (the caller owns goroutine
-// lifecycle) and cap enforcement is the caller's job via Dispatch.
+// Run launches a session WITHOUT cap enforcement (used by callers that gate
+// concurrency elsewhere, and by tests). It reserves a slot (mint + create the
+// pending session row) then drives the container to a terminal state.
 func (s *Supervisor) Run(ctx context.Context, inc *models.Incident, profile *models.AgentProfile) (*models.AgentSession, error) {
 	if profile == nil {
 		return nil, ErrNoProfile
 	}
+	session, minted, err := s.reserve(ctx, inc, profile)
+	if err != nil {
+		return nil, err
+	}
+	return s.execute(ctx, session, minted, inc, profile), nil
+}
 
+// reserveWithCaps performs the cap-check → slot-reservation critical section
+// under dispatchMu. The pending session row it creates counts toward
+// CountActiveAgentSessions, so once this returns (lock released) the next
+// dispatcher observes the reserved slot and is refused if that pushed it to the
+// cap. The lock is NOT held across the engine execution.
+func (s *Supervisor) reserveWithCaps(ctx context.Context, inc *models.Incident, profile *models.AgentProfile) (*models.AgentSession, *auth.CreateKeyResponse, error) {
+	s.dispatchMu.Lock()
+	defer s.dispatchMu.Unlock()
+
+	globalActive, err := s.store.CountActiveAgentSessions(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if globalActive >= int64(s.cfg.MaxConcurrentSessions) {
+		return nil, nil, ErrGlobalSessionCap
+	}
+
+	jobActive, err := s.store.CountActiveAgentSessionsForJob(ctx, inc.JobID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if jobActive >= int64(s.cfg.PerJobConcurrentSessions) {
+		return nil, nil, ErrJobSessionCap
+	}
+
+	return s.reserve(ctx, inc, profile)
+}
+
+// reserve mints the scoped credential and creates the pending AgentSession row.
+// It is the "slot reservation" step: after it returns, the session counts as
+// active. Callers that enforce caps (reserveWithCaps) hold dispatchMu around it.
+func (s *Supervisor) reserve(ctx context.Context, inc *models.Incident, profile *models.AgentProfile) (*models.AgentSession, *auth.CreateKeyResponse, error) {
 	allowlist := unmarshalAllowlist(inc.AllowedJobs)
 
 	// Mint a scoped credential valid slightly past the wall-clock budget so a
@@ -175,13 +211,12 @@ func (s *Supervisor) Run(ctx context.Context, inc *models.Incident, profile *mod
 	// regardless.
 	minted, err := s.creds.MintAgentSessionKey(inc.ID, allowlist, s.cfg.SessionTimeout+time.Minute)
 	if err != nil {
-		return nil, fmt.Errorf("incident: mint agent session key: %w", err)
+		return nil, nil, fmt.Errorf("incident: mint agent session key: %w", err)
 	}
-	var tokenID *uuid.UUID
-	if minted.Key != nil {
-		id := minted.Key.ID
-		tokenID = &id
+	if minted == nil || minted.Key == nil {
+		return nil, nil, errors.New("incident: mint agent session key returned no key")
 	}
+	tokenID := minted.Key.ID
 
 	engineType := profile.Engine
 	if engineType == "" {
@@ -195,21 +230,30 @@ func (s *Supervisor) Run(ctx context.Context, inc *models.Incident, profile *mod
 		IncidentID: inc.ID,
 		ProfileID:  &profile.ID,
 		Engine:     engineType,
-		TokenID:    tokenID,
+		TokenID:    &tokenID,
 		State:      models.AgentSessionStatePending,
 		CreatedAt:  now,
 		UpdatedAt:  now,
 	}
 	if err := s.db.WithContext(ctx).Create(session).Error; err != nil {
-		s.revoke(tokenID)
-		return nil, fmt.Errorf("incident: create agent session: %w", err)
+		s.revoke(&tokenID)
+		return nil, nil, fmt.Errorf("incident: create agent session: %w", err)
 	}
+	return session, minted, nil
+}
 
-	// From here on, always finalize the session and revoke the token.
-	engine, err := s.newEngine(ctx, engineType)
+// execute drives a reserved session's container to a terminal state: launches
+// the profile image, waits under the wall-clock budget, persists the log, stops
+// the container, and finalizes (terminal state + token revocation). It always
+// finalizes, even on error, so no reserved slot leaks a live token.
+func (s *Supervisor) execute(ctx context.Context, session *models.AgentSession, minted *auth.CreateKeyResponse, inc *models.Incident, profile *models.AgentProfile) *models.AgentSession {
+	tokenID := session.TokenID
+
+	engine, err := s.newEngine(ctx, session.Engine)
 	if err != nil {
-		s.finalize(ctx, session, models.AgentSessionStateFailed, "", tokenID)
-		return session, fmt.Errorf("incident: resolve engine: %w", err)
+		log.Error("incident: resolve agent engine", "session_id", session.ID, "error", err)
+		s.finalize(session, models.AgentSessionStateFailed, "", tokenID)
+		return session
 	}
 
 	spec := container.Spec{Env: s.sessionEnv(inc, minted.Plaintext, profile)}
@@ -219,8 +263,9 @@ func (s *Supervisor) Run(ctx context.Context, inc *models.Incident, profile *mod
 		Spec:  spec,
 	})
 	if err != nil {
-		s.finalize(ctx, session, models.AgentSessionStateFailed, "", tokenID)
-		return session, fmt.Errorf("incident: create agent container: %w", err)
+		log.Error("incident: create agent container", "session_id", session.ID, "error", err)
+		s.finalize(session, models.AgentSessionStateFailed, "", tokenID)
+		return session
 	}
 
 	// Mark running with the container/atom identity for the UI.
@@ -254,8 +299,8 @@ func (s *Supervisor) Run(ctx context.Context, inc *models.Incident, profile *mod
 	}
 
 	state := terminalState(final.Result(), waitErr, waitCtx.Err())
-	s.finalize(ctx, session, state, logText, tokenID)
-	return session, nil
+	s.finalize(session, state, logText, tokenID)
+	return session
 }
 
 // sessionEnv builds the container environment. The scoped token, the incident
@@ -292,8 +337,15 @@ func (s *Supervisor) captureLogs(engine atom.Engine, atomID string, since time.T
 }
 
 // finalize writes the terminal state + session log and revokes the scoped token
-// so the credential dies with the session.
-func (s *Supervisor) finalize(ctx context.Context, session *models.AgentSession, state models.AgentSessionState, logText string, tokenID *uuid.UUID) {
+// so the credential dies with the session. It runs on a DETACHED context (not
+// the caller's, which may be cancelled by shutdown or a client disconnect) so
+// termination and — critically — token revocation always complete: a cancelled
+// parent context must never leave the session non-terminal or leak a live
+// agent credential.
+func (s *Supervisor) finalize(session *models.AgentSession, state models.AgentSessionState, logText string, tokenID *uuid.UUID) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
 	completed := time.Now().UTC()
 	session.State = state
 	session.SessionLog = logText

--- a/internal/incident/session.go
+++ b/internal/incident/session.go
@@ -1,0 +1,349 @@
+package incident
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/atom"
+	"github.com/caesium-cloud/caesium/internal/atom/docker"
+	"github.com/caesium-cloud/caesium/internal/atom/kubernetes"
+	"github.com/caesium-cloud/caesium/internal/atom/podman"
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/container"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// Errors the dispatcher returns when a session cannot be launched under the
+// configured caps. They are sentinel values so callers (and tests) can branch.
+var (
+	// ErrGlobalSessionCap is returned when the global concurrent-session cap is
+	// already reached. The incident stays open and queues for later triage.
+	ErrGlobalSessionCap = errors.New("incident: global agent-session cap reached")
+	// ErrJobSessionCap is returned when the per-job concurrent-session cap is
+	// already reached. A different-key failure on a job with an active session
+	// still opens its own incident, which queues rather than being dropped.
+	ErrJobSessionCap = errors.New("incident: per-job agent-session cap reached")
+	// ErrNoProfile is returned when a session is requested without a profile.
+	ErrNoProfile = errors.New("incident: agent session requires a profile")
+)
+
+// AgentCredentialManager mints and revokes the scoped, short-lived credential a
+// session runs with. auth.Service satisfies it. It is an interface so the
+// supervisor can be unit-tested without the full auth service.
+type AgentCredentialManager interface {
+	MintAgentSessionKey(incidentID uuid.UUID, allowlist []string, ttl time.Duration) (*auth.CreateKeyResponse, error)
+	RevokeKey(id uuid.UUID) error
+}
+
+// EngineFactory resolves an atom.Engine for an engine type. Injectable so tests
+// can supply a fake engine without a container runtime.
+type EngineFactory func(ctx context.Context, engineType models.AtomEngine) (atom.Engine, error)
+
+// DefaultEngineFactory selects the concrete engine for a profile, mirroring the
+// worker's runtime executor.
+func DefaultEngineFactory(ctx context.Context, engineType models.AtomEngine) (atom.Engine, error) {
+	switch engineType {
+	case models.AtomEngineDocker, "":
+		return docker.NewEngine(ctx), nil
+	case models.AtomEngineKubernetes:
+		return kubernetes.NewEngine(ctx), nil
+	case models.AtomEnginePodman:
+		return podman.NewEngine(ctx), nil
+	default:
+		return nil, fmt.Errorf("incident: unsupported agent engine type: %v", engineType)
+	}
+}
+
+// SupervisorConfig carries the supervisor's operational limits (from env).
+type SupervisorConfig struct {
+	// APIBaseURL is the Caesium API base URL injected into the agent container so
+	// it can reach its scoped tool surface. Falls back to a sane localhost value.
+	APIBaseURL string
+	// SessionTimeout is the wall-clock budget a session may run before being
+	// forcibly stopped and marked timed_out.
+	SessionTimeout time.Duration
+	// MaxConcurrentSessions caps globally-active sessions (<=0 means 1).
+	MaxConcurrentSessions int
+	// PerJobConcurrentSessions caps active sessions per job (<=0 means 1).
+	PerJobConcurrentSessions int
+}
+
+func (c SupervisorConfig) normalized() SupervisorConfig {
+	if c.SessionTimeout <= 0 {
+		c.SessionTimeout = 10 * time.Minute
+	}
+	if c.MaxConcurrentSessions <= 0 {
+		c.MaxConcurrentSessions = 1
+	}
+	if c.PerJobConcurrentSessions <= 0 {
+		c.PerJobConcurrentSessions = 1
+	}
+	if c.APIBaseURL == "" {
+		c.APIBaseURL = "http://127.0.0.1:8080"
+	}
+	return c
+}
+
+// Supervisor drives a single agent container through the existing atom.Engine
+// (create → wait → logs → stop) with wall-clock enforcement and persisted
+// session logs, materializing an AgentSession record — deliberately NOT a
+// JobRun/TaskRun (a session as a run would pollute the quarantine-filtered run
+// stats and feed its own exhaust into the incident bus). It runs on the leader
+// node in v1 and enforces the concurrent-session caps against the shared store,
+// not per-process, so an N-node cluster does not multiply them.
+type Supervisor struct {
+	db        *gorm.DB
+	store     *Store
+	creds     AgentCredentialManager
+	newEngine EngineFactory
+	cfg       SupervisorConfig
+}
+
+// sessionSupervisor is the process-wide session supervisor, set at startup
+// behind the master gate. The incident manager / executor (Streams B, E) obtain
+// it here to dispatch a triage session; it is nil when the feature is disabled.
+var sessionSupervisor *Supervisor
+
+// SetSessionSupervisor registers the process-wide session supervisor.
+func SetSessionSupervisor(s *Supervisor) { sessionSupervisor = s }
+
+// SessionSupervisor returns the registered session supervisor, or nil.
+func SessionSupervisor() *Supervisor { return sessionSupervisor }
+
+// NewSupervisor constructs a session supervisor.
+func NewSupervisor(db *gorm.DB, creds AgentCredentialManager, factory EngineFactory, cfg SupervisorConfig) *Supervisor {
+	if factory == nil {
+		factory = DefaultEngineFactory
+	}
+	return &Supervisor{
+		db:        db,
+		store:     NewStore(db),
+		creds:     creds,
+		newEngine: factory,
+		cfg:       cfg.normalized(),
+	}
+}
+
+// Dispatch enforces the concurrent-session caps against the shared store, then
+// launches a session for the incident. It returns ErrGlobalSessionCap /
+// ErrJobSessionCap without launching when a cap is already reached — the caller
+// leaves the incident open to queue for later triage rather than dropping it.
+func (s *Supervisor) Dispatch(ctx context.Context, inc *models.Incident, profile *models.AgentProfile) (*models.AgentSession, error) {
+	if profile == nil {
+		return nil, ErrNoProfile
+	}
+
+	globalActive, err := s.store.CountActiveAgentSessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if globalActive >= int64(s.cfg.MaxConcurrentSessions) {
+		return nil, ErrGlobalSessionCap
+	}
+
+	jobActive, err := s.store.CountActiveAgentSessionsForJob(ctx, inc.JobID)
+	if err != nil {
+		return nil, err
+	}
+	if jobActive >= int64(s.cfg.PerJobConcurrentSessions) {
+		return nil, ErrJobSessionCap
+	}
+
+	return s.Run(ctx, inc, profile)
+}
+
+// Run mints a scoped token, records the AgentSession, launches the profile image
+// through the engine, waits under a wall-clock budget, persists the container
+// log, stops the container, sets the terminal state, and revokes the token so it
+// never outlives the session. It is synchronous (the caller owns goroutine
+// lifecycle) and cap enforcement is the caller's job via Dispatch.
+func (s *Supervisor) Run(ctx context.Context, inc *models.Incident, profile *models.AgentProfile) (*models.AgentSession, error) {
+	if profile == nil {
+		return nil, ErrNoProfile
+	}
+
+	allowlist := unmarshalAllowlist(inc.AllowedJobs)
+
+	// Mint a scoped credential valid slightly past the wall-clock budget so a
+	// clean shutdown never races the token expiry. It is revoked on completion
+	// regardless.
+	minted, err := s.creds.MintAgentSessionKey(inc.ID, allowlist, s.cfg.SessionTimeout+time.Minute)
+	if err != nil {
+		return nil, fmt.Errorf("incident: mint agent session key: %w", err)
+	}
+	var tokenID *uuid.UUID
+	if minted.Key != nil {
+		id := minted.Key.ID
+		tokenID = &id
+	}
+
+	engineType := profile.Engine
+	if engineType == "" {
+		engineType = models.AtomEngineDocker
+	}
+
+	now := time.Now().UTC()
+	session := &models.AgentSession{
+		ID:         uuid.New(),
+		Namespace:  inc.Namespace,
+		IncidentID: inc.ID,
+		ProfileID:  &profile.ID,
+		Engine:     engineType,
+		TokenID:    tokenID,
+		State:      models.AgentSessionStatePending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.db.WithContext(ctx).Create(session).Error; err != nil {
+		s.revoke(tokenID)
+		return nil, fmt.Errorf("incident: create agent session: %w", err)
+	}
+
+	// From here on, always finalize the session and revoke the token.
+	engine, err := s.newEngine(ctx, engineType)
+	if err != nil {
+		s.finalize(ctx, session, models.AgentSessionStateFailed, "", tokenID)
+		return session, fmt.Errorf("incident: resolve engine: %w", err)
+	}
+
+	spec := container.Spec{Env: s.sessionEnv(inc, minted.Plaintext, profile)}
+	a, err := engine.Create(&atom.EngineCreateRequest{
+		Name:  "caesium-agent-" + session.ID.String(),
+		Image: profile.Image,
+		Spec:  spec,
+	})
+	if err != nil {
+		s.finalize(ctx, session, models.AgentSessionStateFailed, "", tokenID)
+		return session, fmt.Errorf("incident: create agent container: %w", err)
+	}
+
+	// Mark running with the container/atom identity for the UI.
+	started := time.Now().UTC()
+	session.State = models.AgentSessionStateRunning
+	session.ContainerID = a.ID()
+	session.StartedAt = &started
+	session.UpdatedAt = started
+	s.persist(ctx, session, map[string]any{
+		"state":        session.State,
+		"container_id": session.ContainerID,
+		"started_at":   session.StartedAt,
+		"updated_at":   session.UpdatedAt,
+	})
+
+	// Wall-clock budget: the wait context is bounded so a runaway agent is
+	// forcibly stopped and recorded timed_out rather than burning tokens forever.
+	waitCtx, cancel := context.WithTimeout(ctx, s.cfg.SessionTimeout)
+	defer cancel()
+
+	final, waitErr := engine.Wait(&atom.EngineWaitRequest{ID: a.ID(), Context: waitCtx})
+	if final == nil {
+		final = a
+	}
+
+	logText := s.captureLogs(engine, a.ID(), started)
+
+	// Stop the container before reading terminal disposition; best-effort.
+	if stopErr := engine.Stop(&atom.EngineStopRequest{ID: a.ID(), Force: true}); stopErr != nil {
+		log.Warn("incident: failed to stop agent container", "session_id", session.ID, "atom_id", a.ID(), "error", stopErr)
+	}
+
+	state := terminalState(final.Result(), waitErr, waitCtx.Err())
+	s.finalize(ctx, session, state, logText, tokenID)
+	return session, nil
+}
+
+// sessionEnv builds the container environment. The scoped token, the incident
+// id, and the API base URL are injected so the agent can fetch its bundle and
+// call its tool surface. The bundle itself is fetched over HTTP (env injection
+// cannot carry a 1 MiB log tail), per the design.
+func (s *Supervisor) sessionEnv(inc *models.Incident, token string, profile *models.AgentProfile) map[string]string {
+	env := map[string]string{
+		"CAESIUM_API_URL":     s.cfg.APIBaseURL,
+		"CAESIUM_AGENT_TOKEN": token,
+		"CAESIUM_INCIDENT_ID": inc.ID.String(),
+	}
+	// NOTE: model-credential secret:// refs declared on the profile are resolved
+	// and injected by the deployment's secret machinery (BYO model key), not by
+	// Caesium's API — deliberately not surfaced here. See profile.SecretRefs.
+	_ = profile
+	return env
+}
+
+func (s *Supervisor) captureLogs(engine atom.Engine, atomID string, since time.Time) string {
+	logs, err := engine.Logs(&atom.EngineLogsRequest{ID: atomID, Since: since})
+	if err != nil || logs == nil {
+		return ""
+	}
+	defer func() { _ = logs.Close() }()
+	// Bound the read so a chatty agent cannot exhaust memory; the UI streams the
+	// live view separately.
+	const maxSessionLog = 1 << 20 // 1 MiB
+	buf, err := io.ReadAll(io.LimitReader(logs, maxSessionLog))
+	if err != nil {
+		return string(buf)
+	}
+	return string(buf)
+}
+
+// finalize writes the terminal state + session log and revokes the scoped token
+// so the credential dies with the session.
+func (s *Supervisor) finalize(ctx context.Context, session *models.AgentSession, state models.AgentSessionState, logText string, tokenID *uuid.UUID) {
+	completed := time.Now().UTC()
+	session.State = state
+	session.SessionLog = logText
+	session.CompletedAt = &completed
+	session.UpdatedAt = completed
+	s.persist(ctx, session, map[string]any{
+		"state":        state,
+		"session_log":  logText,
+		"completed_at": session.CompletedAt,
+		"updated_at":   session.UpdatedAt,
+	})
+	s.revoke(tokenID)
+}
+
+func (s *Supervisor) persist(ctx context.Context, session *models.AgentSession, updates map[string]any) {
+	if err := s.db.WithContext(ctx).
+		Model(&models.AgentSession{}).
+		Where("id = ?", session.ID).
+		Updates(updates).Error; err != nil {
+		log.Warn("incident: failed to persist agent session", "session_id", session.ID, "error", err)
+	}
+}
+
+func (s *Supervisor) revoke(tokenID *uuid.UUID) {
+	if tokenID == nil || s.creds == nil {
+		return
+	}
+	if err := s.creds.RevokeKey(*tokenID); err != nil {
+		log.Warn("incident: failed to revoke agent session token", "token_id", *tokenID, "error", err)
+	}
+}
+
+// terminalState maps the engine's terminal Result plus any wait/timeout error to
+// the AgentSession terminal state.
+func terminalState(result atom.Result, waitErr, ctxErr error) models.AgentSessionState {
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return models.AgentSessionStateTimedOut
+	}
+	if errors.Is(ctxErr, context.Canceled) {
+		return models.AgentSessionStateCancelled
+	}
+	if waitErr != nil {
+		return models.AgentSessionStateFailed
+	}
+	switch result {
+	case atom.Success:
+		return models.AgentSessionStateSucceeded
+	case atom.ResourceFailure, atom.Killed, atom.Terminated:
+		return models.AgentSessionStateTimedOut
+	default:
+		return models.AgentSessionStateFailed
+	}
+}

--- a/internal/incident/session.go
+++ b/internal/incident/session.go
@@ -172,32 +172,65 @@ func (s *Supervisor) Run(ctx context.Context, inc *models.Incident, profile *mod
 	return s.execute(ctx, session, minted, inc, profile), nil
 }
 
-// reserveWithCaps performs the cap-check → slot-reservation critical section
-// under dispatchMu. The pending session row it creates counts toward
-// CountActiveAgentSessions, so once this returns (lock released) the next
-// dispatcher observes the reserved slot and is refused if that pushed it to the
-// cap. The lock is NOT held across the engine execution.
+// reserveWithCaps enforces the concurrent-session caps and reserves a slot. The
+// cap-check and the pending-row insert are atomic AT THE DATABASE (a single
+// conditional INSERT-SELECT-WHERE via Store.ReserveAgentSession), so the cap
+// holds across processes and nodes — an in-process mutex cannot serialize two
+// supervisors on different nodes, nor a leader-failover split-brain window.
+// dispatchMu is kept purely as a cheap intra-process fast path; correctness now
+// comes from the DB conditional write, not the mutex.
+//
+// The token is minted only AFTER the slot is reserved, so a cap rejection never
+// leaves a minted credential behind.
 func (s *Supervisor) reserveWithCaps(ctx context.Context, inc *models.Incident, profile *models.AgentProfile) (*models.AgentSession, *auth.CreateKeyResponse, error) {
 	s.dispatchMu.Lock()
 	defer s.dispatchMu.Unlock()
 
-	globalActive, err := s.store.CountActiveAgentSessions(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	if globalActive >= int64(s.cfg.MaxConcurrentSessions) {
-		return nil, nil, ErrGlobalSessionCap
+	engineType := profile.Engine
+	if engineType == "" {
+		engineType = models.AtomEngineDocker
 	}
 
-	jobActive, err := s.store.CountActiveAgentSessionsForJob(ctx, inc.JobID)
+	now := time.Now().UTC()
+	session := &models.AgentSession{
+		ID:         uuid.New(),
+		Namespace:  inc.Namespace,
+		IncidentID: inc.ID,
+		ProfileID:  &profile.ID,
+		Engine:     engineType,
+		State:      models.AgentSessionStatePending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	capHit, err := s.store.ReserveAgentSession(ctx, session, inc.JobID, s.cfg.MaxConcurrentSessions, s.cfg.PerJobConcurrentSessions)
 	if err != nil {
 		return nil, nil, err
 	}
-	if jobActive >= int64(s.cfg.PerJobConcurrentSessions) {
+	switch capHit {
+	case CapGlobal:
+		return nil, nil, ErrGlobalSessionCap
+	case CapPerJob:
 		return nil, nil, ErrJobSessionCap
 	}
 
-	return s.reserve(ctx, inc, profile)
+	// Slot reserved (the pending row exists and counts as active). Now mint the
+	// scoped credential and attach it. If minting fails, finalize the reserved
+	// session as failed so the slot is released rather than stuck pending.
+	minted, err := s.creds.MintAgentSessionKey(inc.ID, unmarshalAllowlist(inc.AllowedJobs), s.cfg.SessionTimeout+time.Minute)
+	if err != nil {
+		s.finalize(session, models.AgentSessionStateFailed, "", nil)
+		return nil, nil, fmt.Errorf("incident: mint agent session key: %w", err)
+	}
+	if minted == nil || minted.Key == nil {
+		s.finalize(session, models.AgentSessionStateFailed, "", nil)
+		return nil, nil, errors.New("incident: mint agent session key returned no key")
+	}
+	tokenID := minted.Key.ID
+	session.TokenID = &tokenID
+	s.persist(ctx, session, map[string]any{"token_id": tokenID, "updated_at": time.Now().UTC()})
+
+	return session, minted, nil
 }
 
 // reserve mints the scoped credential and creates the pending AgentSession row.

--- a/internal/incident/session_test.go
+++ b/internal/incident/session_test.go
@@ -156,6 +156,42 @@ func TestSupervisorDispatchEnforcesGlobalCap(t *testing.T) {
 	require.ErrorIs(t, err, ErrGlobalSessionCap)
 }
 
+// TestSupervisorDispatchEnforcesPerJobCap proves the per-job cap is enforced by
+// the DB reservation (and diagnosed to the ErrJobSessionCap sentinel) even when
+// the global cap has headroom.
+func TestSupervisorDispatchEnforcesPerJobCap(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	store := NewStore(db)
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "extract", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	// One running session for this job's incident occupies the per-job slot.
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.AgentSession{
+		ID:         uuid.New(),
+		IncidentID: inc.ID,
+		State:      models.AgentSessionStateRunning,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}).Error)
+
+	profile := &models.AgentProfile{ID: uuid.New(), Name: "triage", Image: "x", Engine: models.AtomEngineDocker}
+	require.NoError(t, db.Create(profile).Error)
+
+	// Global cap has headroom (5); only the per-job cap (1) is binding.
+	sup := NewSupervisor(db, &fakeCreds{}, func(context.Context, models.AtomEngine) (atom.Engine, error) {
+		return &fakeEngine{result: atom.Success}, nil
+	}, SupervisorConfig{MaxConcurrentSessions: 5, PerJobConcurrentSessions: 1})
+
+	_, err = sup.Dispatch(ctx, inc, profile)
+	require.ErrorIs(t, err, ErrJobSessionCap)
+}
+
 func TestSupervisorRunTimeoutMarksTimedOut(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })
@@ -215,9 +251,14 @@ func (e *blockingEngine) Logs(*atom.EngineLogsRequest) (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader("")), nil
 }
 
-// TestSupervisorDispatchCapRaceNeverOvershoots proves the cap-check → slot
-// reservation is atomic: N concurrent dispatches against a cap of 1 admit
-// exactly one session and reject the rest, and exactly one session row exists.
+// TestSupervisorDispatchCapRaceNeverOvershoots proves the cap holds ACROSS
+// SUPERVISOR INSTANCES — the cross-process property an in-process mutex cannot
+// provide. It constructs N separate Supervisor structs (each with its own
+// mutex and its own credential minter) that SHARE ONE DATABASE, then dispatches
+// them concurrently against a global cap of 1. Correctness must come from the
+// DB-atomic conditional reservation, not the mutex: exactly one is admitted,
+// N-1 get ErrGlobalSessionCap, exactly one session row exists, and exactly one
+// token is minted (no leaked live credentials).
 func TestSupervisorDispatchCapRaceNeverOvershoots(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })
@@ -232,33 +273,41 @@ func TestSupervisorDispatchCapRaceNeverOvershoots(t *testing.T) {
 	profile := &models.AgentProfile{ID: uuid.New(), Name: "triage", Image: "x", Engine: models.AtomEngineDocker}
 	require.NoError(t, db.Create(profile).Error)
 
-	engine := &blockingEngine{release: make(chan struct{})}
-	sup := NewSupervisor(db, &fakeCreds{}, func(context.Context, models.AtomEngine) (atom.Engine, error) {
-		return engine, nil
-	}, SupervisorConfig{MaxConcurrentSessions: 1, PerJobConcurrentSessions: 1, SessionTimeout: time.Minute})
-
 	const n = 8
+	release := make(chan struct{})
+
+	// N distinct supervisors (distinct mutexes, distinct minters), one shared DB.
+	supers := make([]*Supervisor, n)
+	credsList := make([]*fakeCreds, n)
+	for i := 0; i < n; i++ {
+		credsList[i] = &fakeCreds{}
+		supers[i] = NewSupervisor(db, credsList[i], func(context.Context, models.AtomEngine) (atom.Engine, error) {
+			return &blockingEngine{release: release}, nil
+		}, SupervisorConfig{MaxConcurrentSessions: 1, PerJobConcurrentSessions: 1, SessionTimeout: time.Minute})
+	}
+
 	type outcome struct {
 		session *models.AgentSession
 		err     error
 	}
 	results := make(chan outcome, n)
 	for i := 0; i < n; i++ {
+		sup := supers[i]
 		go func() {
 			sess, err := sup.Dispatch(ctx, inc, profile)
 			results <- outcome{session: sess, err: err}
 		}()
 	}
 
-	// The winner blocks in Wait until released; the losers reject immediately.
-	// Collect the n-1 cap rejections first, then release the winner.
+	// The lone winner blocks in Wait until released; the losers reject at the DB
+	// reservation. Collect the n-1 cap rejections first, then release the winner.
 	capRejections := 0
 	for capRejections < n-1 {
 		r := <-results
 		require.ErrorIs(t, r.err, ErrGlobalSessionCap)
 		capRejections++
 	}
-	close(engine.release)
+	close(release)
 
 	winner := <-results
 	require.NoError(t, winner.err)
@@ -268,6 +317,13 @@ func TestSupervisorDispatchCapRaceNeverOvershoots(t *testing.T) {
 	var count int64
 	require.NoError(t, db.Model(&models.AgentSession{}).Count(&count).Error)
 	require.Equal(t, int64(1), count)
+
+	// Exactly one token was minted across all supervisors — no extra live creds.
+	totalMinted := 0
+	for _, c := range credsList {
+		totalMinted += len(c.minted)
+	}
+	require.Equal(t, 1, totalMinted)
 }
 
 // cancelEngine signals once it has ENTERED Wait — i.e. after the supervisor's

--- a/internal/incident/session_test.go
+++ b/internal/incident/session_test.go
@@ -1,0 +1,192 @@
+package incident
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/atom"
+	"github.com/caesium-cloud/caesium/internal/auth"
+	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// --- fakes ---------------------------------------------------------------
+
+type fakeAtom struct {
+	id     string
+	result atom.Result
+}
+
+func (f *fakeAtom) ID() string           { return f.id }
+func (f *fakeAtom) State() atom.State    { return atom.Stopped }
+func (f *fakeAtom) Result() atom.Result  { return f.result }
+func (f *fakeAtom) ExitCode() *int       { return nil }
+func (f *fakeAtom) CreatedAt() time.Time { return time.Now() }
+func (f *fakeAtom) StartedAt() time.Time { return time.Now() }
+func (f *fakeAtom) StoppedAt() time.Time { return time.Now() }
+func (f *fakeAtom) Engine() atom.Engine  { return nil }
+
+type fakeEngine struct {
+	result     atom.Result
+	logs       string
+	createdEnv map[string]string
+	stopped    bool
+}
+
+func (e *fakeEngine) Get(*atom.EngineGetRequest) (atom.Atom, error)     { return nil, nil }
+func (e *fakeEngine) List(*atom.EngineListRequest) ([]atom.Atom, error) { return nil, nil }
+func (e *fakeEngine) Create(req *atom.EngineCreateRequest) (atom.Atom, error) {
+	e.createdEnv = req.Spec.Env
+	return &fakeAtom{id: "atom-" + req.Name, result: e.result}, nil
+}
+func (e *fakeEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
+	return &fakeAtom{id: req.ID, result: e.result}, nil
+}
+func (e *fakeEngine) Stop(*atom.EngineStopRequest) error { e.stopped = true; return nil }
+func (e *fakeEngine) Logs(*atom.EngineLogsRequest) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader(e.logs)), nil
+}
+
+type fakeCreds struct {
+	minted  []mintCall
+	revoked []uuid.UUID
+}
+
+type mintCall struct {
+	incidentID uuid.UUID
+	allowlist  []string
+}
+
+func (c *fakeCreds) MintAgentSessionKey(incidentID uuid.UUID, allowlist []string, ttl time.Duration) (*auth.CreateKeyResponse, error) {
+	c.minted = append(c.minted, mintCall{incidentID: incidentID, allowlist: allowlist})
+	return &auth.CreateKeyResponse{
+		Plaintext: "csk_live_faketoken",
+		Key:       &models.APIKey{ID: uuid.New()},
+	}, nil
+}
+
+func (c *fakeCreds) RevokeKey(id uuid.UUID) error {
+	c.revoked = append(c.revoked, id)
+	return nil
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestSupervisorRunRecordsSessionMintsAndRevokes(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	store := NewStore(db)
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "extract", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	profile := &models.AgentProfile{ID: uuid.New(), Name: "triage", Image: "caesium/triage:latest", Engine: models.AtomEngineDocker}
+	require.NoError(t, db.Create(profile).Error)
+
+	creds := &fakeCreds{}
+	engine := &fakeEngine{result: atom.Success, logs: "agent booted\nplan: retry\n"}
+	sup := NewSupervisor(db, creds, func(context.Context, models.AtomEngine) (atom.Engine, error) {
+		return engine, nil
+	}, SupervisorConfig{SessionTimeout: time.Minute})
+
+	session, err := sup.Run(ctx, inc, profile)
+	require.NoError(t, err)
+	require.NotNil(t, session)
+
+	// Reload the persisted session.
+	var got models.AgentSession
+	require.NoError(t, db.First(&got, "id = ?", session.ID).Error)
+	require.Equal(t, models.AgentSessionStateSucceeded, got.State)
+	require.Equal(t, inc.ID, got.IncidentID)
+	require.NotNil(t, got.TokenID)
+	require.Contains(t, got.SessionLog, "agent booted")
+	require.NotNil(t, got.CompletedAt)
+
+	// A scoped token was minted with the incident's FROZEN allowlist.
+	require.Len(t, creds.minted, 1)
+	require.Equal(t, inc.ID, creds.minted[0].incidentID)
+	require.Equal(t, []string{"vendor-x"}, creds.minted[0].allowlist)
+
+	// The container received the scoped token + incident id, and the token was
+	// revoked so it never outlives the session.
+	require.Equal(t, "csk_live_faketoken", engine.createdEnv["CAESIUM_AGENT_TOKEN"])
+	require.Equal(t, inc.ID.String(), engine.createdEnv["CAESIUM_INCIDENT_ID"])
+	require.True(t, engine.stopped)
+	require.Len(t, creds.revoked, 1)
+	require.Equal(t, *got.TokenID, creds.revoked[0])
+}
+
+func TestSupervisorDispatchEnforcesGlobalCap(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	store := NewStore(db)
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "extract", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	// Seed an already-running session to occupy the single global slot.
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.AgentSession{
+		ID:         uuid.New(),
+		IncidentID: inc.ID,
+		State:      models.AgentSessionStateRunning,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}).Error)
+
+	profile := &models.AgentProfile{ID: uuid.New(), Name: "triage", Image: "x", Engine: models.AtomEngineDocker}
+	require.NoError(t, db.Create(profile).Error)
+
+	sup := NewSupervisor(db, &fakeCreds{}, func(context.Context, models.AtomEngine) (atom.Engine, error) {
+		return &fakeEngine{result: atom.Success}, nil
+	}, SupervisorConfig{MaxConcurrentSessions: 1, PerJobConcurrentSessions: 1})
+
+	_, err = sup.Dispatch(ctx, inc, profile)
+	require.ErrorIs(t, err, ErrGlobalSessionCap)
+}
+
+func TestSupervisorRunTimeoutMarksTimedOut(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	store := NewStore(db)
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "extract", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	profile := &models.AgentProfile{ID: uuid.New(), Name: "triage", Image: "x", Engine: models.AtomEngineDocker}
+	require.NoError(t, db.Create(profile).Error)
+
+	// A wait that respects the deadline: block until ctx is done, then report the
+	// deadline error via the returned atom being nil + ctx error.
+	engine := &slowEngine{}
+	sup := NewSupervisor(db, &fakeCreds{}, func(context.Context, models.AtomEngine) (atom.Engine, error) {
+		return engine, nil
+	}, SupervisorConfig{SessionTimeout: 50 * time.Millisecond})
+
+	session, err := sup.Run(ctx, inc, profile)
+	require.NoError(t, err)
+	var got models.AgentSession
+	require.NoError(t, db.First(&got, "id = ?", session.ID).Error)
+	require.Equal(t, models.AgentSessionStateTimedOut, got.State)
+}
+
+type slowEngine struct{ fakeEngine }
+
+func (e *slowEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
+	<-req.Context.Done()
+	return nil, req.Context.Err()
+}

--- a/internal/incident/session_test.go
+++ b/internal/incident/session_test.go
@@ -190,3 +190,152 @@ func (e *slowEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
 	<-req.Context.Done()
 	return nil, req.Context.Err()
 }
+
+// blockingEngine keeps every session "running" until release is closed, so a
+// batch of concurrent dispatches genuinely overlap and exercise the cap.
+type blockingEngine struct {
+	release chan struct{}
+}
+
+func (e *blockingEngine) Get(*atom.EngineGetRequest) (atom.Atom, error)     { return nil, nil }
+func (e *blockingEngine) List(*atom.EngineListRequest) ([]atom.Atom, error) { return nil, nil }
+func (e *blockingEngine) Create(req *atom.EngineCreateRequest) (atom.Atom, error) {
+	return &fakeAtom{id: "atom-" + req.Name, result: atom.Success}, nil
+}
+func (e *blockingEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
+	select {
+	case <-e.release:
+		return &fakeAtom{id: req.ID, result: atom.Success}, nil
+	case <-req.Context.Done():
+		return nil, req.Context.Err()
+	}
+}
+func (e *blockingEngine) Stop(*atom.EngineStopRequest) error { return nil }
+func (e *blockingEngine) Logs(*atom.EngineLogsRequest) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+// TestSupervisorDispatchCapRaceNeverOvershoots proves the cap-check → slot
+// reservation is atomic: N concurrent dispatches against a cap of 1 admit
+// exactly one session and reject the rest, and exactly one session row exists.
+func TestSupervisorDispatchCapRaceNeverOvershoots(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	ctx := context.Background()
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	store := NewStore(db)
+	inc, _, err := store.OpenOrAppend(ctx, OpenParams{JobID: jobID, TaskName: "extract", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	profile := &models.AgentProfile{ID: uuid.New(), Name: "triage", Image: "x", Engine: models.AtomEngineDocker}
+	require.NoError(t, db.Create(profile).Error)
+
+	engine := &blockingEngine{release: make(chan struct{})}
+	sup := NewSupervisor(db, &fakeCreds{}, func(context.Context, models.AtomEngine) (atom.Engine, error) {
+		return engine, nil
+	}, SupervisorConfig{MaxConcurrentSessions: 1, PerJobConcurrentSessions: 1, SessionTimeout: time.Minute})
+
+	const n = 8
+	type outcome struct {
+		session *models.AgentSession
+		err     error
+	}
+	results := make(chan outcome, n)
+	for i := 0; i < n; i++ {
+		go func() {
+			sess, err := sup.Dispatch(ctx, inc, profile)
+			results <- outcome{session: sess, err: err}
+		}()
+	}
+
+	// The winner blocks in Wait until released; the losers reject immediately.
+	// Collect the n-1 cap rejections first, then release the winner.
+	capRejections := 0
+	for capRejections < n-1 {
+		r := <-results
+		require.ErrorIs(t, r.err, ErrGlobalSessionCap)
+		capRejections++
+	}
+	close(engine.release)
+
+	winner := <-results
+	require.NoError(t, winner.err)
+	require.NotNil(t, winner.session)
+
+	// Exactly one session row ever existed — the cap was never overshot.
+	var count int64
+	require.NoError(t, db.Model(&models.AgentSession{}).Count(&count).Error)
+	require.Equal(t, int64(1), count)
+}
+
+// cancelEngine signals when Create runs, then blocks in Wait on the context so
+// the test can cancel the parent mid-session.
+type cancelEngine struct {
+	created chan struct{}
+	stopped bool
+}
+
+func (e *cancelEngine) Get(*atom.EngineGetRequest) (atom.Atom, error)     { return nil, nil }
+func (e *cancelEngine) List(*atom.EngineListRequest) ([]atom.Atom, error) { return nil, nil }
+func (e *cancelEngine) Create(req *atom.EngineCreateRequest) (atom.Atom, error) {
+	e.created <- struct{}{}
+	return &fakeAtom{id: "atom-" + req.Name, result: atom.Success}, nil
+}
+func (e *cancelEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
+	<-req.Context.Done()
+	return nil, req.Context.Err()
+}
+func (e *cancelEngine) Stop(*atom.EngineStopRequest) error { e.stopped = true; return nil }
+func (e *cancelEngine) Logs(*atom.EngineLogsRequest) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+
+// TestSupervisorFinalizeOnCancelledContext proves that a cancelled parent
+// context still drives the session to a terminal state AND revokes the scoped
+// token — a cancelled ctx must never leak a live credential.
+func TestSupervisorFinalizeOnCancelledContext(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	tr := mkTrigger(t, db)
+	jobID := mkJob(t, db, tr, "vendor-x")
+	store := NewStore(db)
+	inc, _, err := store.OpenOrAppend(context.Background(), OpenParams{JobID: jobID, TaskName: "extract", Class: ClassUnknown})
+	require.NoError(t, err)
+
+	profile := &models.AgentProfile{ID: uuid.New(), Name: "triage", Image: "x", Engine: models.AtomEngineDocker}
+	require.NoError(t, db.Create(profile).Error)
+
+	creds := &fakeCreds{}
+	engine := &cancelEngine{created: make(chan struct{}, 1)}
+	sup := NewSupervisor(db, creds, func(context.Context, models.AtomEngine) (atom.Engine, error) {
+		return engine, nil
+	}, SupervisorConfig{SessionTimeout: time.Hour})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan *models.AgentSession, 1)
+	go func() {
+		sess, _ := sup.Run(ctx, inc, profile)
+		done <- sess
+	}()
+
+	// Cancel only once the container is up and the supervisor is blocked in Wait.
+	<-engine.created
+	cancel()
+
+	session := <-done
+	require.NotNil(t, session)
+
+	// The session is terminal (cancelled) and persisted despite the cancelled ctx.
+	var got models.AgentSession
+	require.NoError(t, db.First(&got, "id = ?", session.ID).Error)
+	require.Equal(t, models.AgentSessionStateCancelled, got.State)
+	require.NotNil(t, got.CompletedAt)
+
+	// The scoped token was revoked — no leaked live credential.
+	require.Len(t, creds.revoked, 1)
+	require.NotNil(t, got.TokenID)
+	require.Equal(t, *got.TokenID, creds.revoked[0])
+}

--- a/internal/incident/session_test.go
+++ b/internal/incident/session_test.go
@@ -270,20 +270,26 @@ func TestSupervisorDispatchCapRaceNeverOvershoots(t *testing.T) {
 	require.Equal(t, int64(1), count)
 }
 
-// cancelEngine signals when Create runs, then blocks in Wait on the context so
-// the test can cancel the parent mid-session.
+// cancelEngine signals once it has ENTERED Wait — i.e. after the supervisor's
+// "mark running" persist has already completed on the healthy parent context —
+// then blocks on the context so the test can cancel the parent mid-session. By
+// signalling from Wait rather than Create, no DB write ever executes on the
+// cancelled context (the single-connection in-memory SQLite would otherwise
+// evict the poisoned connection and drop the schema); only the ctx-wait here and
+// finalize's DETACHED persist are exercised by the cancellation — which is
+// exactly the production property under test.
 type cancelEngine struct {
-	created chan struct{}
+	waiting chan struct{}
 	stopped bool
 }
 
 func (e *cancelEngine) Get(*atom.EngineGetRequest) (atom.Atom, error)     { return nil, nil }
 func (e *cancelEngine) List(*atom.EngineListRequest) ([]atom.Atom, error) { return nil, nil }
 func (e *cancelEngine) Create(req *atom.EngineCreateRequest) (atom.Atom, error) {
-	e.created <- struct{}{}
 	return &fakeAtom{id: "atom-" + req.Name, result: atom.Success}, nil
 }
 func (e *cancelEngine) Wait(req *atom.EngineWaitRequest) (atom.Atom, error) {
+	e.waiting <- struct{}{}
 	<-req.Context.Done()
 	return nil, req.Context.Err()
 }
@@ -309,7 +315,7 @@ func TestSupervisorFinalizeOnCancelledContext(t *testing.T) {
 	require.NoError(t, db.Create(profile).Error)
 
 	creds := &fakeCreds{}
-	engine := &cancelEngine{created: make(chan struct{}, 1)}
+	engine := &cancelEngine{waiting: make(chan struct{}, 1)}
 	sup := NewSupervisor(db, creds, func(context.Context, models.AtomEngine) (atom.Engine, error) {
 		return engine, nil
 	}, SupervisorConfig{SessionTimeout: time.Hour})
@@ -321,8 +327,10 @@ func TestSupervisorFinalizeOnCancelledContext(t *testing.T) {
 		done <- sess
 	}()
 
-	// Cancel only once the container is up and the supervisor is blocked in Wait.
-	<-engine.created
+	// Cancel only once the supervisor has recorded the session running and is
+	// blocked in Wait — so the cancellation lands on the ctx-wait and finalize's
+	// detached persist, never on a live DB write.
+	<-engine.waiting
 	cancel()
 
 	session := <-done

--- a/internal/incident/store.go
+++ b/internal/incident/store.go
@@ -2,6 +2,7 @@ package incident
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -87,6 +88,15 @@ func (s *Store) OpenOrAppend(ctx context.Context, p OpenParams) (*models.Inciden
 		}
 	}
 
+	// Freeze the agent read-scope allowlist at open. Computed by this
+	// leader-gated incident manager (an unscoped server principal) from the
+	// lineage-impact graph, EXCLUDING edges derived from the failing run's own
+	// outputs. On a fold-in (append) the existing incident keeps its already
+	// frozen value; the value computed here is only persisted when this insert
+	// wins the atomic conditional create below, so the allowlist is truly frozen
+	// at FIRST open. Best-effort: an empty result degrades to the job's own alias.
+	allowedJobs := marshalAllowlist(FreezeAllowlist(ctx, s.db, p.JobID, p.RunID))
+
 	activeKey := key
 	inc := &models.Incident{
 		ID:                     uuid.New(),
@@ -102,6 +112,7 @@ func (s *Store) OpenOrAppend(ctx context.Context, p OpenParams) (*models.Inciden
 		OccurrenceCount:        1,
 		BackfillID:             p.BackfillID,
 		RemediationTargetRunID: p.RemediationTargetRunID,
+		AllowedJobs:            allowedJobs,
 		LastError:              p.LastError,
 		Evidence:               p.Evidence,
 		OpenedAt:               now,
@@ -340,4 +351,72 @@ func (s *Store) ClaimTimer(ctx context.Context, id uuid.UUID) (bool, error) {
 		return false, res.Error
 	}
 	return res.RowsAffected == 1, nil
+}
+
+// AllowedJobsForIncident returns the frozen agent read-scope allowlist for an
+// incident (the job aliases the incident manager snapshotted at open). The
+// incident's own job alias is guaranteed present when it was resolvable at open.
+func (s *Store) AllowedJobsForIncident(ctx context.Context, incidentID uuid.UUID) ([]string, error) {
+	var inc models.Incident
+	if err := s.db.WithContext(ctx).Select("allowed_jobs").First(&inc, "id = ?", incidentID).Error; err != nil {
+		return nil, err
+	}
+	return unmarshalAllowlist(inc.AllowedJobs), nil
+}
+
+// CountActiveAgentSessions returns the number of non-terminal agent sessions
+// (pending or running) across all incidents. The leader-gated dispatcher uses
+// this to enforce the global concurrent-session cap.
+func (s *Store) CountActiveAgentSessions(ctx context.Context) (int64, error) {
+	var n int64
+	err := s.db.WithContext(ctx).
+		Model(&models.AgentSession{}).
+		Where("state IN ?", []models.AgentSessionState{
+			models.AgentSessionStatePending,
+			models.AgentSessionStateRunning,
+		}).
+		Count(&n).Error
+	return n, err
+}
+
+// CountActiveAgentSessionsForJob returns the number of non-terminal agent
+// sessions bound to incidents of the given job. The dispatcher uses this to
+// enforce the per-job concurrent-session cap (default 1).
+func (s *Store) CountActiveAgentSessionsForJob(ctx context.Context, jobID uuid.UUID) (int64, error) {
+	var n int64
+	err := s.db.WithContext(ctx).
+		Model(&models.AgentSession{}).
+		Joins("JOIN incidents ON incidents.id = agent_sessions.incident_id").
+		Where("incidents.job_id = ? AND agent_sessions.state IN ?", jobID, []models.AgentSessionState{
+			models.AgentSessionStatePending,
+			models.AgentSessionStateRunning,
+		}).
+		Count(&n).Error
+	return n, err
+}
+
+// marshalAllowlist encodes a frozen job allowlist as JSON for persistence. An
+// empty list is stored as an empty JSON array so the column is unambiguously
+// "frozen, and empty" rather than "not yet computed" (NULL).
+func marshalAllowlist(jobs []string) datatypes.JSON {
+	if jobs == nil {
+		jobs = []string{}
+	}
+	b, err := json.Marshal(jobs)
+	if err != nil {
+		return nil
+	}
+	return datatypes.JSON(b)
+}
+
+// unmarshalAllowlist decodes a persisted allowlist, tolerating NULL/empty.
+func unmarshalAllowlist(raw datatypes.JSON) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var jobs []string
+	if err := json.Unmarshal(raw, &jobs); err != nil {
+		return nil
+	}
+	return jobs
 }

--- a/internal/incident/store.go
+++ b/internal/incident/store.go
@@ -395,6 +395,89 @@ func (s *Store) CountActiveAgentSessionsForJob(ctx context.Context, jobID uuid.U
 	return n, err
 }
 
+// CapExceeded distinguishes which concurrent-session cap a reservation failed.
+type CapExceeded int
+
+const (
+	// CapNone means the reservation succeeded (no cap exceeded).
+	CapNone CapExceeded = iota
+	// CapGlobal means the global concurrent-session cap was already reached.
+	CapGlobal
+	// CapPerJob means the per-job concurrent-session cap was already reached.
+	CapPerJob
+)
+
+// ReserveAgentSession atomically reserves a slot for a new agent session AT THE
+// DATABASE, so the concurrent-session caps hold across processes and nodes — an
+// in-process mutex cannot serialize two supervisors on different nodes (or a
+// leader-failover split-brain window). It conditionally inserts the pending
+// session row in a SINGLE statement, guarded by both the global and per-job
+// active-session counts; the count and the insert therefore evaluate atomically
+// under SQLite/dqlite's serialized-writer semantics, so two concurrent
+// reservations cannot both observe "under cap" and both insert.
+//
+// The active-session predicate (state IN pending|running) matches
+// CountActiveAgentSessions / CountActiveAgentSessionsForJob EXACTLY, so the
+// reservation and the counters always agree on what "active" means.
+//
+// It returns which cap (if any) blocked the reservation. On CapNone the pending
+// row identified by session.ID exists and counts as active.
+func (s *Store) ReserveAgentSession(ctx context.Context, session *models.AgentSession, jobID uuid.UUID, globalCap, perJobCap int) (CapExceeded, error) {
+	pending := string(models.AgentSessionStatePending)
+	running := string(models.AgentSessionStateRunning)
+
+	var tokenID any
+	if session.TokenID != nil {
+		tokenID = *session.TokenID
+	}
+	var profileID any
+	if session.ProfileID != nil {
+		profileID = *session.ProfileID
+	}
+	var namespace any
+	if session.Namespace != nil {
+		namespace = *session.Namespace
+	}
+
+	// Single-statement conditional insert. SQLite/dqlite serializes writers, so
+	// the COUNT subqueries and the INSERT are atomic relative to any concurrent
+	// reservation on the same database, across processes.
+	const q = `
+INSERT INTO agent_sessions (id, namespace, incident_id, profile_id, engine, token_id, state, actions_used, tokens_used, created_at, updated_at)
+SELECT ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, ?
+WHERE (SELECT COUNT(*) FROM agent_sessions WHERE state IN (?, ?)) < ?
+  AND (
+    SELECT COUNT(*) FROM agent_sessions ss
+    JOIN incidents ii ON ii.id = ss.incident_id
+    WHERE ii.job_id = ? AND ss.state IN (?, ?)
+  ) < ?`
+
+	res := s.db.WithContext(ctx).Exec(q,
+		session.ID, namespace, session.IncidentID, profileID, string(session.Engine), tokenID, string(session.State), session.CreatedAt, session.UpdatedAt,
+		pending, running, globalCap,
+		jobID, pending, running, perJobCap,
+	)
+	if res.Error != nil {
+		return CapNone, res.Error
+	}
+	if res.RowsAffected == 1 {
+		return CapNone, nil
+	}
+
+	// The insert was refused by the guard. Diagnose which cap blocked it so the
+	// caller can return the right sentinel. This is post-hoc and purely
+	// informational — correctness (no overshoot) already came from the atomic
+	// insert above, not from these counts.
+	globalActive, err := s.CountActiveAgentSessions(ctx)
+	if err != nil {
+		return CapGlobal, nil //nolint:nilerr // best-effort diagnosis; reservation already failed
+	}
+	if globalActive >= int64(globalCap) {
+		return CapGlobal, nil
+	}
+	return CapPerJob, nil
+}
+
 // marshalAllowlist encodes a frozen job allowlist as JSON for persistence. An
 // empty list is stored as an empty JSON array so the column is unambiguously
 // "frozen, and empty" rather than "not yet computed" (NULL).

--- a/internal/models/api_key.go
+++ b/internal/models/api_key.go
@@ -72,6 +72,28 @@ func (k *APIKey) IsExpired() bool {
 }
 
 // KeyScope represents optional resource scoping for an API key.
+//
+// A key carries at most one kind of restriction. Jobs restricts a normal
+// principal to a set of job aliases (checked by the deny-by-default route-scope
+// switch). Agent, when present, marks the key as a short-lived agent-session
+// credential bound to exactly one incident's /v1/agent/* tool surface; an agent
+// key is valid for nothing else, regardless of its Jobs field.
 type KeyScope struct {
+	Jobs  []string    `json:"jobs,omitempty"`
+	Agent *AgentClaim `json:"agent,omitempty"`
+}
+
+// AgentClaim binds an API key to a single incident's agent tool surface. It is
+// minted by the incident manager (an unscoped, server-side principal) for one
+// agent session and expires with that session. The read scope is FROZEN at
+// incident open: Jobs is the static job allowlist the incident manager
+// snapshotted from the lineage-impact graph (excluding edges derived from the
+// failing run's own outputs). The agent cannot widen it — server-side
+// enforcement is the boundary, not the prompt.
+type AgentClaim struct {
+	// IncidentID is the only incident whose /v1/agent/* routes this key may call.
+	IncidentID uuid.UUID `json:"incident_id"`
+	// Jobs is the frozen job allowlist governing which jobs' read-only context
+	// (logs, why, run history) the agent may pull through the context routes.
 	Jobs []string `json:"jobs,omitempty"`
 }

--- a/internal/models/incident.go
+++ b/internal/models/incident.go
@@ -79,6 +79,15 @@ type Incident struct {
 	// remediated. It advances when a new occurrence folds in.
 	RemediationTargetRunID *uuid.UUID `gorm:"type:uuid" json:"remediation_target_run_id,omitempty"`
 
+	// AllowedJobs is the FROZEN job allowlist that scopes the agent's read
+	// surface for this incident, computed by the incident manager (an unscoped
+	// server principal) from the lineage-impact graph at open time — excluding
+	// edges derived from the failing run's own outputs so attacker-crafted
+	// ##caesium::output refs cannot widen it. It is a JSON array of job aliases.
+	// The agent's scoped token carries a copy; this column is the durable source
+	// of truth the session supervisor mints from and the bundle reports.
+	AllowedJobs datatypes.JSON `gorm:"type:json" json:"allowed_jobs,omitempty"`
+
 	// LastError is the failing task's error text captured at open, for the feed.
 	LastError string `gorm:"type:text" json:"last_error,omitempty"`
 	// ResolutionSummary is a short human/agent summary written at close.

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -286,6 +286,16 @@ type Environment struct {
 	// same (job, task, class) key within this window after the previous one
 	// closed, damping flapping. Default 15m.
 	AgentIncidentCooldown time.Duration `envconfig:"AGENT_INCIDENT_COOLDOWN" default:"15m"`
+	// CAESIUM_AGENT_MAX_CONCURRENT_SESSIONS caps globally-active agent sessions,
+	// enforced by the leader-gated session dispatcher (not per-process, which an
+	// N-node cluster would multiply). Default 1.
+	AgentMaxConcurrentSessions int `envconfig:"AGENT_MAX_CONCURRENT_SESSIONS" default:"1"`
+	// CAESIUM_AGENT_SESSION_TIMEOUT is the wall-clock budget a single agent
+	// session may run before it is forcibly stopped and marked timed_out.
+	AgentSessionTimeout time.Duration `envconfig:"AGENT_SESSION_TIMEOUT" default:"10m"`
+	// CAESIUM_AGENT_DEFAULT_PROFILE optionally names a bootstrap AgentProfile the
+	// session supervisor launches and whose playbook the triage bundle surfaces.
+	AgentDefaultProfile string `envconfig:"AGENT_DEFAULT_PROFILE" default:""`
 }
 
 // SSOEnabled reports whether any SSO provider is configured.


### PR DESCRIPTION
## Summary

Second wave (W2-γ) of [`docs/exec-plans/active/agent-in-the-loop-remediation.md`](https://github.com/caesium-cloud/caesium/blob/master/docs/exec-plans/active/agent-in-the-loop-remediation.md) — **Stream C**, the agent runtime. Builds on the Phase-0 substrate (#278); everything is behind the default-off master flag.

- **C1 — scoped short-lived agent credential**: a real `models.APIKey` carrying a new `KeyScope.Agent` claim (`AgentClaim{IncidentID, Jobs}`), minted at the **runner** role with a hard expiry via the existing `GenerateKey`/`HashKey` constant-time path (nothing stubbed). Enforced in `api/middleware/auth_scope.go`: the claim is intercepted **before** the job-scope path — an agent key carries an empty `Jobs` list, so falling through to the existing `len==0 → unrestricted` branch would be a privilege-escalation hole. `authorizeAgentScope` then **403s any route outside `/v1/agent/*`** (incl. `/v1/lineage/impact`, approval routes, job routes) and **403s cross-incident access** (`:id` ≠ claim incident), injecting only the frozen job allowlist into the request context.
- **Frozen read allowlist**: seeded at incident open (`store.OpenOrAppend` → `FreezeAllowlist`) from the job's *trusted historical* output datasets, **excluding the failing run's own outputs** (`jr.id <> failingRunID`), so an attacker-crafted `##caesium::output` cannot widen the agent's scope. Persisted on `Incident.AllowedJobs`.
- **C2 — session supervisor** (`internal/incident/session.go`): drives a profile image through `atom.Engine` as an `AgentSession` (not a `JobRun`), with concurrency cap + timeout, behind the flag.
- **C3 — triage bundle** + `GET /v1/agent/incidents/:id/bundle`: incident + classification + scrubbed log tail + why/run-diff signals, served to the scoped token.
- **C4 — `/v1/agent/*` tool surface**: context passthroughs (allowlist-gated), an actions endpoint that delegates to Stream B's executor via a registered `ActionExecutor` interface, and notes.

### RBAC + tests
The four `/v1/agent/*` routes are added to `endpointPolicy` (reads = viewer, mutations = runner); `TestAuthMiddlewareMountedRoutesHaveRBACPolicy` passes. Scope enforcement is proven against the **real `Auth` middleware with a real minted token**: accepts its own incident's routes, 403s another incident's routes and `/v1/jobs` `/v1/stats` `/v1/lineage/impact` `/v1/events`. `allowlist_test.go` proves the failing-run-output exclusion. Plus session mint→launch→revoke/cap/timeout and bundle scrub/assembly tests.

## Test plan

- [x] `gofmt` / `go vet` / `golangci-lint` (0 issues) on touched packages + `api/middleware` + `internal/auth` + `internal/incident`
- [x] `go build ./...` (dqlite-CGO; only the unrelated `ui/embed.go` gap)
- [x] `go test ./internal/auth/... ./internal/incident/... ./api/middleware/... ./api/rest/service/agent/... ./internal/models/... ./pkg/env/...` + the RBAC route-completeness test — green
- [ ] full `just integration-test` in CI. **Honest limit:** no `test/` scenario minting a live agent token — that needs H-1's deterministic fake-agent image (a deferred item); scope enforcement is proven end-to-end against the real middleware instead.

## Coordination (merge-time; sequences B→C→D→E)

- **`auth_scope.go`** — C1 establishes the agent-scope arm (`authorizeAgentScope`, claim key `"agent"`); D1 appends its approval-route rejection (which probes the same `"agent"` key — seam confirmed). Union-merge, C1 before D1.
- **C4→executor seam** — the actions endpoint calls Stream B's executor via `agentsvc.SetActionExecutor`; until B is merged the endpoint records a `proposed` `AgentAction` and returns 202. B merges before C.
- `bind.go` (agent route block), `cmd/start/start.go` (C2 supervisor block; D3 appends the ai_agent sender), `internal/auth/rbac.go` (agent policies), `pkg/env/env.go` (3 agent fields; D owns the `validate()` precondition) — all additive union-merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GFo6w8ogxJbbtmag71qyeh)_