### PR TITLE
Add agent remediation CLI commands (agent-in-the-loop-remediation W3-ε)

### DIFF
--- a/cmd/agentprofile/agentprofile.go
+++ b/cmd/agentprofile/agentprofile.go
@@ -107,10 +107,11 @@ var applyCmd = &cobra.Command{
 			return err
 		}
 
+		// Only an explicit --id selects PATCH (update by ID). A file-embedded
+		// `id` must NOT force an update: a profile document copied across
+		// environments would otherwise clobber an existing profile with the same
+		// ID instead of creating a new one (greptile P1, #286).
 		id := strings.TrimSpace(applyID)
-		if id == "" {
-			id = strings.TrimSpace(profile.ID)
-		}
 
 		method := http.MethodPost
 		wantStatus := http.StatusCreated

--- a/cmd/agentprofile/agentprofile.go
+++ b/cmd/agentprofile/agentprofile.go
@@ -1,0 +1,237 @@
+package agentprofile
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+const agentProfileAPIKeyEnvVar = "CAESIUM_AGENTPROFILE_API_KEY"
+
+var (
+	serverFlag string
+	apiKeyFlag string
+	jsonFlag   bool
+
+	listLimit   int
+	listOffset  int
+	listOrderBy string
+
+	applyPath string
+	applyID   string
+
+	httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
+)
+
+// Cmd is the `caesium agentprofile` command group.
+var Cmd = &cobra.Command{
+	Use:   "agentprofile",
+	Short: "Manage agent remediation profiles",
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List agent profiles",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		params := url.Values{}
+		if listLimit < 0 {
+			return fmt.Errorf("--limit must be greater than or equal to 0")
+		}
+		if listLimit > 0 {
+			params.Set("limit", strconv.Itoa(listLimit))
+		}
+		if listOffset < 0 {
+			return fmt.Errorf("--offset must be greater than or equal to 0")
+		}
+		if listOffset > 0 {
+			params.Set("offset", strconv.Itoa(listOffset))
+		}
+		if orderBy := strings.TrimSpace(listOrderBy); orderBy != "" {
+			params.Set("order_by", orderBy)
+		}
+
+		reqURL := strings.TrimSuffix(serverFlag, "/") + "/v1/agentprofiles"
+		if qs := params.Encode(); qs != "" {
+			reqURL += "?" + qs
+		}
+
+		body, err := doRequest(cmd, http.MethodGet, reqURL, nil, http.StatusOK, "agentprofile list")
+		if err != nil {
+			return err
+		}
+		return cliutil.WritePrettyJSON(cmd, body, "agentprofile list")
+	},
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get an agent profile",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := strings.TrimSpace(args[0])
+		if id == "" {
+			return fmt.Errorf("agent profile id is required")
+		}
+
+		reqURL := strings.TrimSuffix(serverFlag, "/") + "/v1/agentprofiles/" + url.PathEscape(id)
+		body, err := doRequest(cmd, http.MethodGet, reqURL, nil, http.StatusOK, "agentprofile get")
+		if err != nil {
+			return err
+		}
+		return cliutil.WritePrettyJSON(cmd, body, "agentprofile get")
+	},
+}
+
+var applyCmd = &cobra.Command{
+	Use:   "apply --path <file|-|stdin>",
+	Short: "Create or update an agent profile",
+	Long: "Create an AgentProfile from a YAML or JSON document. " +
+		"Use --id to update an existing profile by ID; updates are sent with PATCH.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		profile, err := readProfileFile(applyPath)
+		if err != nil {
+			return err
+		}
+		payload, err := json.Marshal(profile.toRequest())
+		if err != nil {
+			return err
+		}
+
+		id := strings.TrimSpace(applyID)
+		if id == "" {
+			id = strings.TrimSpace(profile.ID)
+		}
+
+		method := http.MethodPost
+		wantStatus := http.StatusCreated
+		reqURL := strings.TrimSuffix(serverFlag, "/") + "/v1/agentprofiles"
+		label := "agentprofile apply"
+		if id != "" {
+			method = http.MethodPatch
+			wantStatus = http.StatusOK
+			reqURL += "/" + url.PathEscape(id)
+			label = "agentprofile patch"
+		}
+
+		body, err := doRequest(cmd, method, reqURL, bytes.NewReader(payload), wantStatus, label)
+		if err != nil {
+			return err
+		}
+		return cliutil.WritePrettyJSON(cmd, body, label)
+	},
+}
+
+type profileFile struct {
+	ID         string                 `json:"id,omitempty" yaml:"id,omitempty"`
+	Name       *string                `json:"name,omitempty" yaml:"name,omitempty"`
+	Image      *string                `json:"image,omitempty" yaml:"image,omitempty"`
+	Engine     *string                `json:"engine,omitempty" yaml:"engine,omitempty"`
+	Limits     map[string]interface{} `json:"limits,omitempty" yaml:"limits,omitempty"`
+	SecretRefs map[string]string      `json:"secret_refs,omitempty" yaml:"secret_refs,omitempty"`
+	Budgets    map[string]interface{} `json:"budgets,omitempty" yaml:"budgets,omitempty"`
+	Playbook   map[string]interface{} `json:"playbook,omitempty" yaml:"playbook,omitempty"`
+}
+
+type profileRequest struct {
+	Name       *string                `json:"name,omitempty"`
+	Image      *string                `json:"image,omitempty"`
+	Engine     *string                `json:"engine,omitempty"`
+	Limits     map[string]interface{} `json:"limits,omitempty"`
+	SecretRefs map[string]string      `json:"secret_refs,omitempty"`
+	Budgets    map[string]interface{} `json:"budgets,omitempty"`
+	Playbook   map[string]interface{} `json:"playbook,omitempty"`
+}
+
+func (p profileFile) toRequest() profileRequest {
+	return profileRequest{
+		Name:       p.Name,
+		Image:      p.Image,
+		Engine:     p.Engine,
+		Limits:     p.Limits,
+		SecretRefs: p.SecretRefs,
+		Budgets:    p.Budgets,
+		Playbook:   p.Playbook,
+	}
+}
+
+func readProfileFile(path string) (*profileFile, error) {
+	path = strings.TrimSpace(path)
+	var (
+		data []byte
+		err  error
+	)
+	if path == "" || path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, err
+	}
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 {
+		return nil, fmt.Errorf("agent profile input is empty")
+	}
+
+	var profile profileFile
+	if err := yaml.Unmarshal(data, &profile); err != nil {
+		if path == "" || path == "-" {
+			return nil, fmt.Errorf("stdin: %w", err)
+		}
+		return nil, fmt.Errorf("%s: %w", path, err)
+	}
+	return &profile, nil
+}
+
+func doRequest(cmd *cobra.Command, method, reqURL string, body io.Reader, wantStatus int, label string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(cmd.Context(), method, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if k := cliutil.ResolveAPIKey(cmd, apiKeyFlag, agentProfileAPIKeyEnvVar, cliutil.APIKeyEnvVar); k != "" {
+		req.Header.Set("Authorization", "Bearer "+k)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s response: %w", label, err)
+	}
+	if resp.StatusCode != wantStatus {
+		return nil, fmt.Errorf("%s failed (%d): %s", label, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return respBody, nil
+}
+
+func init() {
+	Cmd.PersistentFlags().StringVar(&serverFlag, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "AgentProfile API key for authentication (prefer "+agentProfileAPIKeyEnvVar+"; --api-key is visible in process listings)")
+	Cmd.PersistentFlags().BoolVar(&jsonFlag, "json", false, "Print machine-readable JSON")
+
+	listCmd.Flags().IntVar(&listLimit, "limit", 0, "Maximum agent profiles to return")
+	listCmd.Flags().IntVar(&listOffset, "offset", 0, "Agent profile list offset")
+	listCmd.Flags().StringVar(&listOrderBy, "order-by", "", "Order by clause passed to the API")
+
+	applyCmd.Flags().StringVar(&applyPath, "path", "-", "Path to a YAML/JSON agent profile, or - for stdin")
+	applyCmd.Flags().StringVar(&applyID, "id", "", "Existing agent profile ID to update with PATCH")
+
+	Cmd.AddCommand(listCmd, getCmd, applyCmd)
+}

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/caesium-cloud/caesium/cmd/agentprofile"
 	"github.com/caesium-cloud/caesium/cmd/auth"
 	"github.com/caesium-cloud/caesium/cmd/backfill"
 	"github.com/caesium-cloud/caesium/cmd/blame"
@@ -8,6 +9,7 @@ import (
 	"github.com/caesium-cloud/caesium/cmd/dataset"
 	"github.com/caesium-cloud/caesium/cmd/dev"
 	"github.com/caesium-cloud/caesium/cmd/event"
+	"github.com/caesium-cloud/caesium/cmd/incident"
 	"github.com/caesium-cloud/caesium/cmd/job"
 	"github.com/caesium-cloud/caesium/cmd/receipt"
 	"github.com/caesium-cloud/caesium/cmd/run"
@@ -20,6 +22,7 @@ import (
 )
 
 var cmds = []*cobra.Command{
+	agentprofile.Cmd,
 	auth.Cmd,
 	backfill.Cmd,
 	blame.Cmd,
@@ -27,6 +30,7 @@ var cmds = []*cobra.Command{
 	dataset.Cmd,
 	dev.Cmd,
 	event.Cmd,
+	incident.Cmd,
 	job.Cmd,
 	receipt.Cmd,
 	run.Cmd,

--- a/cmd/incident/incident.go
+++ b/cmd/incident/incident.go
@@ -1,0 +1,207 @@
+package incident
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+)
+
+const incidentAPIKeyEnvVar = "CAESIUM_INCIDENT_API_KEY"
+
+var (
+	serverFlag string
+	apiKeyFlag string
+	jsonFlag   bool
+
+	listStatus        string
+	listClass         string
+	listNeedsApproval bool
+	listJobID         string
+	listLimit         int
+	listOffset        int
+
+	approvalID    string
+	approveReason string
+	rejectReason  string
+
+	httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
+)
+
+// Cmd is the `caesium incident` command group.
+var Cmd = &cobra.Command{
+	Use:   "incident",
+	Short: "Inspect and decide agent-remediation incidents",
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List incidents",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		params := url.Values{}
+		if status := strings.TrimSpace(listStatus); status != "" {
+			params.Set("status", status)
+		}
+		if class := strings.TrimSpace(listClass); class != "" {
+			params.Set("class", class)
+		}
+		if cmd.Flags().Changed("needs-approval") {
+			params.Set("needs_approval", strconv.FormatBool(listNeedsApproval))
+		}
+		if jobID := strings.TrimSpace(listJobID); jobID != "" {
+			params.Set("job_id", jobID)
+		}
+		if listLimit < 0 {
+			return fmt.Errorf("--limit must be greater than or equal to 0")
+		}
+		if listLimit > 0 {
+			params.Set("limit", strconv.Itoa(listLimit))
+		}
+		if listOffset < 0 {
+			return fmt.Errorf("--offset must be greater than or equal to 0")
+		}
+		if listOffset > 0 {
+			params.Set("offset", strconv.Itoa(listOffset))
+		}
+
+		reqURL := strings.TrimSuffix(serverFlag, "/") + "/v1/incidents"
+		if qs := params.Encode(); qs != "" {
+			reqURL += "?" + qs
+		}
+
+		body, err := doRequest(cmd, http.MethodGet, reqURL, nil, http.StatusOK, "incident list")
+		if err != nil {
+			return err
+		}
+		return cliutil.WritePrettyJSON(cmd, body, "incident list")
+	},
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <id>",
+	Short: "Get an incident timeline",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := strings.TrimSpace(args[0])
+		if id == "" {
+			return fmt.Errorf("incident id is required")
+		}
+
+		reqURL := strings.TrimSuffix(serverFlag, "/") + "/v1/incidents/" + url.PathEscape(id)
+		body, err := doRequest(cmd, http.MethodGet, reqURL, nil, http.StatusOK, "incident get")
+		if err != nil {
+			return err
+		}
+		return cliutil.WritePrettyJSON(cmd, body, "incident get")
+	},
+}
+
+var approveCmd = &cobra.Command{
+	Use:   "approve <id> --approval <approval-id>",
+	Short: "Approve a pending incident action",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return decide(cmd, strings.TrimSpace(args[0]), true, approveReason)
+	},
+}
+
+var rejectCmd = &cobra.Command{
+	Use:   "reject <id> --approval <approval-id> [--reason <reason>]",
+	Short: "Reject a pending incident action",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return decide(cmd, strings.TrimSpace(args[0]), false, rejectReason)
+	},
+}
+
+func decide(cmd *cobra.Command, incidentID string, approve bool, reason string) error {
+	if incidentID == "" {
+		return fmt.Errorf("incident id is required")
+	}
+	approval := strings.TrimSpace(approvalID)
+	if approval == "" {
+		return fmt.Errorf("--approval is required")
+	}
+
+	action := "reject"
+	if approve {
+		action = "approve"
+	}
+	reqURL := strings.TrimSuffix(serverFlag, "/") +
+		"/v1/incidents/" + url.PathEscape(incidentID) +
+		"/approvals/" + url.PathEscape(approval) +
+		"/" + action
+
+	var body io.Reader
+	if trimmed := strings.TrimSpace(reason); trimmed != "" {
+		payload, err := json.Marshal(map[string]string{"reason": trimmed})
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(payload)
+	}
+
+	respBody, err := doRequest(cmd, http.MethodPost, reqURL, body, http.StatusOK, "incident "+action)
+	if err != nil {
+		return err
+	}
+	return cliutil.WritePrettyJSON(cmd, respBody, "incident "+action)
+}
+
+func doRequest(cmd *cobra.Command, method, reqURL string, body io.Reader, wantStatus int, label string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(cmd.Context(), method, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if k := cliutil.ResolveAPIKey(cmd, apiKeyFlag, incidentAPIKeyEnvVar, cliutil.APIKeyEnvVar); k != "" {
+		req.Header.Set("Authorization", "Bearer "+k)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s response: %w", label, err)
+	}
+	if resp.StatusCode != wantStatus {
+		return nil, fmt.Errorf("%s failed (%d): %s", label, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return respBody, nil
+}
+
+func init() {
+	Cmd.PersistentFlags().StringVar(&serverFlag, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "Incident API key for authentication (prefer "+incidentAPIKeyEnvVar+"; --api-key is visible in process listings)")
+	Cmd.PersistentFlags().BoolVar(&jsonFlag, "json", false, "Print machine-readable JSON")
+
+	listCmd.Flags().StringVar(&listStatus, "status", "", "Filter incidents by status")
+	listCmd.Flags().StringVar(&listClass, "class", "", "Filter incidents by class")
+	listCmd.Flags().BoolVar(&listNeedsApproval, "needs-approval", false, "Filter incidents that need approval")
+	listCmd.Flags().StringVar(&listJobID, "job-id", "", "Filter incidents by job ID")
+	listCmd.Flags().IntVar(&listLimit, "limit", 0, "Maximum incidents to return")
+	listCmd.Flags().IntVar(&listOffset, "offset", 0, "Incident list offset")
+
+	approveCmd.Flags().StringVar(&approvalID, "approval", "", "Approval request ID (required)")
+	approveCmd.Flags().StringVar(&approveReason, "reason", "", "Optional approval reason")
+	_ = approveCmd.MarkFlagRequired("approval")
+
+	rejectCmd.Flags().StringVar(&approvalID, "approval", "", "Approval request ID (required)")
+	rejectCmd.Flags().StringVar(&rejectReason, "reason", "", "Optional rejection reason")
+	_ = rejectCmd.MarkFlagRequired("approval")
+
+	Cmd.AddCommand(listCmd, getCmd, approveCmd, rejectCmd)
+}

--- a/docs/exec-plans/active/agent-in-the-loop-remediation.md
+++ b/docs/exec-plans/active/agent-in-the-loop-remediation.md
@@ -508,7 +508,7 @@ stream owns the job-schema addition and the server-side profile resource.
 
 ### Stream G — CLI
 
-- [ ] G1. Add the `caesium incident` command group: `list [--status] [--class]`,
+- [x] G1. Add the `caesium incident` command group: `list [--status] [--class]`,
       `get <id>` (timeline: observations, actions, evidence), `approve <id>
       --approval <id>`, `reject <id> --approval <id> [--reason]`, `escalate <id>`
       (force hand-off, close the agent session). Machine output (`--json`) goes to
@@ -516,10 +516,18 @@ stream owns the job-schema addition and the server-side profile resource.
       integration gate; append the group to the `cmds` slice in `cmd/execute.go`.
       Files: new `cmd/incident/`, `cmd/execute.go`.
       Depends on: D1 + D2.
-- [ ] G2. Add the `caesium agent profile` command group: `list`, `get`, `apply`,
+      W3-ε note: shipped `list/get/approve/reject` against the verified
+      `/v1/incidents` routes; no `escalate` command was added because no REST
+      endpoint exists. Added a stdout-clean integration check for `incident list
+      --json` in the remediation-enabled auth lane.
+- [x] G2. Add the `caesium agent profile` command group: `list`, `get`, `apply`,
       appended to `cmd/execute.go`. `--json` to clean stdout.
       Files: new `cmd/agent/`, `cmd/execute.go`.
       Depends on: E2.
+      W3-ε note: shipped `caesium agentprofile` against `/v1/agentprofiles`;
+      `apply` creates with POST or updates by ID with PATCH. Added a
+      stdout-clean integration check for the bare-array `agentprofile list
+      --json` response.
 
 ### Stream U — Console incidents surface
 

--- a/test/agent_remediation_cli_test.go
+++ b/test/agent_remediation_cli_test.go
@@ -1,0 +1,63 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+func (s *IntegrationTestSuite) TestAgentProfileCLIListJSONStdout() {
+	profileArgs := []string{"agentprofile", "list", "--json", "--server", s.caesiumURL}
+	if key := firstEnv("CAESIUM_AGENTPROFILE_API_KEY", "CAESIUM_API_KEY", "CAESIUM_E2E_AUTH_ADMIN_KEY"); key != "" {
+		profileArgs = append(profileArgs, "--api-key", key)
+	}
+	profileOut, err := s.runCLIStdout(profileArgs...)
+	s.Require().NoError(err, "caesium agentprofile list --json failed:\n%s", profileOut)
+	s.Require().True(json.Valid([]byte(profileOut)), "caesium agentprofile list --json stdout was not clean JSON:\n%s", profileOut)
+
+	var profiles []map[string]interface{}
+	s.Require().NoError(json.Unmarshal([]byte(profileOut), &profiles))
+}
+
+func (s *IntegrationTestSuite) TestIncidentCLIListJSONStdout() {
+	if !envBool("CAESIUM_AGENT_REMEDIATION_ENABLED") {
+		s.T().Skip("incident CLI stdout check requires the remediation-enabled auth integration lane")
+	}
+
+	args := []string{"incident", "list", "--json", "--server", s.caesiumURL}
+	if key := firstEnv("CAESIUM_INCIDENT_API_KEY", "CAESIUM_API_KEY", "CAESIUM_E2E_AUTH_ADMIN_KEY"); key != "" {
+		args = append(args, "--api-key", key)
+	}
+	incidentOut, err := s.runCLIStdout(args...)
+	s.Require().NoError(err, "caesium incident list --json failed:\n%s", incidentOut)
+	s.Require().True(json.Valid([]byte(incidentOut)), "caesium incident list --json stdout was not clean JSON:\n%s", incidentOut)
+
+	var incidents struct {
+		Incidents []map[string]interface{} `json:"incidents"`
+		Total     int                      `json:"total"`
+		Limit     int                      `json:"limit"`
+		Offset    int                      `json:"offset"`
+	}
+	s.Require().NoError(json.Unmarshal([]byte(incidentOut), &incidents))
+	s.Require().NotNil(incidents.Incidents, "incident list JSON must include incidents array")
+}
+
+func envBool(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func firstEnv(names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary
- Adds `caesium incident` (list / get / approve / reject) driving the shipped `/v1/incidents*` routes.
- Adds `caesium agentprofile` (list / get / apply) driving `/v1/agentprofiles` (POST create, PATCH update-by-id).
- Machine `--json` output goes through `cliutil.WritePrettyJSON` so stdout stays clean and parseable.
- Adds `test/agent_remediation_cli_test.go` integration coverage using `runCLIStdout` (separate stdout capture) for both response shapes.
- Ticks Stream G (G1/G2) in the plan.

Scope corrections applied vs. the plan text (verified against HEAD): there is **no** `escalate` REST endpoint (built list/get/approve/reject only); the profile route is `/v1/agentprofiles` (one word, not `/v1/agent/profiles`) and update is **PATCH**.

## Test plan
- [x] `just lint` (orchestrator) — pass
- [x] `just unit-test` (orchestrator) — pass, all packages ok
- [ ] `just integration-test` — runs at the pre-merge gate against the auth-enabled agent lane (incident routes require `AGENT_REMEDIATION_ENABLED`; harness stream W3-η stands that lane up)

Implemented by codex (GPT-5.5) under the Wave 3 exec-plan orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)