### PR TITLE
Add freshness + agent-remediation integration harnesses (agent-in-the-loop-remediation W3-η)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,10 @@ LICENSE
 
 docs
 build
+# Re-include the triage-agent script: build/ is ignored, but the fake-agent
+# image (build/Dockerfile.triage-agent, built with the repo root as context)
+# COPYs this file, so it must remain in the build context.
+!build/triage-agent.sh
 tools
 **/*_test.go
 caesium

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,23 @@ jobs:
       - name: Distributed integration tests (amd64)
         run: CAESIUM_EVENT_INGEST_API_KEY=integration-test-key just tag=${{ env.IMAGE_TAG }}-amd64 integration-test-distributed
 
+  build-and-integration-test-agent-auth:
+    needs: builder
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@just
+      - uses: docker/setup-docker-action@v5
+      - uses: actions/download-artifact@v8
+        with:
+          name: builder-amd64
+          path: /tmp
+      - name: Load builder images
+        run: gunzip -c /tmp/builder-amd64.tar.gz | docker load
+      - name: Agent auth integration tests (amd64)
+        run: CAESIUM_EVENT_INGEST_API_KEY=integration-test-key just tag=${{ env.IMAGE_TAG }}-amd64 integration-test-agent
+
   build-and-integration-test-arm64:
     needs: builder-arm64
     runs-on: ubuntu-24.04-arm
@@ -245,6 +262,7 @@ jobs:
             -e CAESIUM_MANUAL_TRIGGER_API_KEY=e2e-test-key \
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+            -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -307,6 +325,7 @@ jobs:
             -e CAESIUM_AUTH_REQUIRE_TLS=false \
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+            -e CAESIUM_FRESHNESS_ENABLED=true \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
           tries=0
@@ -485,6 +504,7 @@ jobs:
             -e CAESIUM_LOG_LEVEL=debug \
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+            -e CAESIUM_FRESHNESS_ENABLED=true \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
       - name: Extract caesium CLI
@@ -522,6 +542,7 @@ jobs:
       - ui-e2e-auth
       - build-and-integration-test
       - build-and-integration-test-distributed
+      - build-and-integration-test-agent-auth
       - build-and-integration-test-arm64
       - helm-lint
       - helm-integration-test

--- a/build/Dockerfile.triage-agent
+++ b/build/Dockerfile.triage-agent
@@ -1,0 +1,10 @@
+FROM alpine:3.23
+
+RUN apk add --no-cache ca-certificates curl jq && \
+    adduser -D -H -u 10001 triage
+
+COPY build/triage-agent.sh /usr/local/bin/triage-agent
+RUN chmod 0755 /usr/local/bin/triage-agent
+
+USER 10001:10001
+ENTRYPOINT ["/usr/local/bin/triage-agent"]

--- a/build/triage-agent.sh
+++ b/build/triage-agent.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+fail() {
+  echo "triage-agent: $*" >&2
+  exit 1
+}
+
+api_url="${CAESIUM_API_URL:-http://127.0.0.1:8080}"
+api_url="${api_url%/}"
+
+incident_id="${CAESIUM_INCIDENT_ID:-}"
+if [ -z "$incident_id" ]; then
+  incident_id="${CAESIUM_AGENT_INCIDENT_ID:-}"
+fi
+
+[ -n "$incident_id" ] || fail "CAESIUM_INCIDENT_ID is required"
+[ -n "${CAESIUM_AGENT_TOKEN:-}" ] || fail "CAESIUM_AGENT_TOKEN is required"
+
+bundle_file="$(mktemp)"
+note_file="$(mktemp)"
+action_file="$(mktemp)"
+trap 'rm -f "$bundle_file" "$note_file" "$action_file"' EXIT
+
+auth_header="Authorization: Bearer ${CAESIUM_AGENT_TOKEN}"
+
+curl -fsS \
+  -H "$auth_header" \
+  "${api_url}/v1/agent/incidents/${incident_id}/bundle" \
+  -o "$bundle_file" || fail "bundle fetch failed"
+
+jq -e --arg incident_id "$incident_id" '
+  .incident.id == $incident_id and
+  (.incident.job_id | type == "string" and length > 0) and
+  (.incident.status | type == "string" and length > 0) and
+  (.classification.class | type == "string" and length > 0) and
+  (.failure.log_tail_scrubbed | type == "boolean") and
+  (.job.alias | type == "string" and length > 0) and
+  (.job.tasks | type == "array" and length > 0) and
+  (.run_history | type == "array") and
+  (.lineage_impact.allowed_jobs | type == "array") and
+  (.lineage_impact.frozen == true) and
+  (.generated_at | type == "string" and length > 0)
+' "$bundle_file" >/dev/null || fail "bundle shape assertion failed"
+
+post_json() {
+  url="$1"
+  payload="$2"
+  out="$3"
+  status="$(curl -sS -o "$out" -w "%{http_code}" \
+    -X POST \
+    -H "$auth_header" \
+    -H "Content-Type: application/json" \
+    -d "$payload" \
+    "$url")" || fail "POST $url failed"
+  case "$status" in
+    200|201|202)
+      ;;
+    *)
+      echo "triage-agent: unexpected status ${status} from ${url}" >&2
+      cat "$out" >&2 || true
+      exit 1
+      ;;
+  esac
+}
+
+task_name="$(jq -r '.incident.task_name // (.job.tasks[0].name // "")' "$bundle_file")"
+if [ -z "$task_name" ] || [ "$task_name" = "null" ]; then
+  task_name="unknown"
+fi
+
+note_payload="$(jq -nc --arg task_name "$task_name" \
+  '{text: ("fake triage agent validated bundle shape for task " + $task_name)}')"
+post_json "${api_url}/v1/agent/incidents/${incident_id}/notes" "$note_payload" "$note_file"
+jq -e '.id and .type == "note" and .status == "executed"' "$note_file" >/dev/null ||
+  fail "note response shape assertion failed"
+
+action_payload="$(jq -nc --arg task_name "$task_name" \
+  '{type: "skip_task", params: {task_name: $task_name}}')"
+post_json "${api_url}/v1/agent/incidents/${incident_id}/actions" "$action_payload" "$action_file"
+jq -e '.disposition and .action.id and .action.type == "skip_task"' "$action_file" >/dev/null ||
+  fail "action response shape assertion failed"
+
+echo "triage-agent: completed scripted triage for incident ${incident_id}"

--- a/build/triage-agent.sh
+++ b/build/triage-agent.sh
@@ -17,10 +17,14 @@ fi
 [ -n "$incident_id" ] || fail "CAESIUM_INCIDENT_ID is required"
 [ -n "${CAESIUM_AGENT_TOKEN:-}" ] || fail "CAESIUM_AGENT_TOKEN is required"
 
+bundle_file=""
+note_file=""
+action_file=""
+trap 'rm -f "${bundle_file:-}" "${note_file:-}" "${action_file:-}"' EXIT
+
 bundle_file="$(mktemp)"
 note_file="$(mktemp)"
 action_file="$(mktemp)"
-trap 'rm -f "$bundle_file" "$note_file" "$action_file"' EXIT
 
 auth_header="Authorization: Bearer ${CAESIUM_AGENT_TOKEN}"
 
@@ -78,7 +82,16 @@ jq -e '.id and .type == "note" and .status == "executed"' "$note_file" >/dev/nul
 action_payload="$(jq -nc --arg task_name "$task_name" \
   '{type: "skip_task", params: {task_name: $task_name}}')"
 post_json "${api_url}/v1/agent/incidents/${incident_id}/actions" "$action_payload" "$action_file"
-jq -e '.disposition and .action.id and .action.type == "skip_task"' "$action_file" >/dev/null ||
-  fail "action response shape assertion failed"
+# skip_task is a tier-3 (approval-gated) action: it is recorded and routed to the
+# approval gate, never auto-executed. A correct disposition is therefore
+# "proposed" (audit-spine stub, or executor pending approval) or
+# "awaiting_approval" — but never "executed"/"failed"/absent, which would signal
+# a contract violation or a silent remediation error slipping past the lane.
+jq -e '
+  .action.id and
+  .action.type == "skip_task" and
+  (.disposition == "proposed" or .disposition == "awaiting_approval")
+' "$action_file" >/dev/null ||
+  fail "action disposition assertion failed (skip_task is tier-3; expected proposed or awaiting_approval)"
 
 echo "triage-agent: completed scripted triage for incident ${incident_id}"

--- a/docs/exec-plans/active/agent-in-the-loop-remediation.md
+++ b/docs/exec-plans/active/agent-in-the-loop-remediation.md
@@ -170,7 +170,7 @@ Streams F, G, U (+ H-1, N-1) remain for later waves.
 | F | MCP surface — `/v1/agent/mcp` JSON-RPC/streamable-HTTP over the same handlers | P2 | Not started |
 | G | CLI — `caesium incident …` + `caesium agent profile …` | P2 | Not started |
 | U | Console incidents surface — feed, triage timeline, approval cards, run/task ribbons, agent activity, fleet analytics | P1 | Not started |
-| H-1 | Harness — deterministic fake agent image + integration server gate wiring | — | Not started |
+| H-1 | Harness — deterministic fake agent image + integration server gate wiring | — | **Shipped** (W3-eta: fake image + auth lane) |
 | N-1 | Docs — roadmap §3.5 flip, design banner, schema reference (`remediation` block), examples, README | — | Not started |
 
 ## Streams
@@ -577,7 +577,7 @@ primary evidence — nothing is prose-only.
 
 ## Harness Strengthening
 
-- [ ] H-1. Build the deterministic **fake agent image** (`build/`) — the linchpin
+- [x] H-1. Build the deterministic **fake agent image** (`build/`) — W3-eta note: pinned fake image, dedicated auth lane, and bearer-aware helpers landed — the linchpin
       of the integration suite: a small script image that reads the triage bundle,
       asserts its shape, and emits a **scripted action sequence** via the real
       `/v1/agent/*` API (and, once Stream F lands, an MCP protocol-level test

--- a/docs/exec-plans/active/freshness-scheduling.md
+++ b/docs/exec-plans/active/freshness-scheduling.md
@@ -139,7 +139,7 @@ sequenced last so scheduling behavior only changes after the substrate is proven
 | E | Dataset REST + CLI operator surface — `GET /v1/datasets*`, `POST …/advance`, `caesium dataset list/status/advance` | **P0** | Not started |
 | F | Console UI — dataset freshness board, lineage freshness overlay, "why did/didn't this run" derivations panel | P1 | Not started |
 | G | Scheduling behavior — skip-when-fresh (P1) + `trigger: {type: freshness}` (P2) | P1 → P2 | Not started |
-| H-1 | Integration harness — `CAESIUM_FRESHNESS_ENABLED=true` on the live integration server | — | Not started |
+| H-1 | Integration harness — `CAESIUM_FRESHNESS_ENABLED=true` on the live integration server | — | **Shipped** (W3-eta: just/CI/helm env mirrors) |
 | N-1 | Docs — roadmap Phase 4 flip, design banner, schema references, examples, README | — | Not started |
 
 ## Streams
@@ -459,7 +459,7 @@ from day one so the later extension does not require a migration rewrite.
 
 ## Harness Strengthening
 
-- [ ] H-1. Ensure the integration server exercises the real freshness path: set
+- [x] H-1. Ensure the integration server exercises the real freshness path (W3-eta note: shared/distributed/UI/podman/helm env mirrors set): set
       `CAESIUM_FRESHNESS_ENABLED=true` on the `just integration-up` /
       `just integration-test` server (mirroring the lineage
       `CAESIUM_OPEN_LINEAGE_ENABLED` precedent the `CLAUDE.md` gate calls out —

--- a/helm/caesium/ci/test-values-k8s.yaml
+++ b/helm/caesium/ci/test-values-k8s.yaml
@@ -30,6 +30,9 @@ config:
       value: "true"
     - name: CAESIUM_OPEN_LINEAGE_TRANSPORT
       value: console
+    # Enable freshness so dataset-state integration scenarios exercise the live evaluator.
+    - name: CAESIUM_FRESHNESS_ENABLED
+      value: "true"
 
 kubernetes:
   engine:

--- a/justfile
+++ b/justfile
@@ -225,7 +225,7 @@ integration-test-agent:
     {{ container_cli }} rm -f "$cli_ctr" >/dev/null 2>&1 || true; \
     admin_key=""; \
     tries=0; \
-    until admin_key="$({{ container_cli }} logs {{ agent_it_container }} 2>&1 | awk '/csk_/ { for (i = 1; i <= NF; i++) if ($i ~ /^csk_/) { print $i; exit } }')" && [ -n "$admin_key" ]; do \
+    until admin_key="$({{ container_cli }} logs {{ agent_it_container }} 2>&1 | awk '/csk_/ { for (i = 1; i <= NF; i++) if ($i ~ /^csk_/) { print $i; exit } }' | tr -d '\r')" && [ -n "$admin_key" ]; do \
         tries=$((tries + 1)); \
         if [ "$tries" -gt 30 ]; then \
             echo "Agent auth bootstrap admin key did not appear in server logs"; \

--- a/justfile
+++ b/justfile
@@ -13,6 +13,7 @@ target_arch := if platform == "linux/arm64" { "arm64" } else if platform == "lin
 bld_dir := "/bld/caesium"
 repo_dir := `pwd`
 it_container := "caesium-server-test"
+agent_it_container := "caesium-server-agent-test"
 uid := `id -u`
 
 # Podman support: set CAESIUM_PODMAN=true to use podman and localhost-prefixed local image refs.
@@ -24,12 +25,16 @@ podman_sock := if xdg_runtime_dir != "" { xdg_runtime_dir + "/podman/podman.sock
 default_sock := if podman == "true" { podman_sock } else { "/var/run/docker.sock" }
 local_image_ref := if podman == "true" { "localhost/" + repo + "/" + image } else { repo + "/" + image }
 local_builder_ref := if podman == "true" { "localhost/" + repo + "/" + builder_image } else { repo + "/" + builder_image }
+triage_agent_image := repo + "/triage-agent"
+local_triage_agent_ref := if podman == "true" { "localhost/" + triage_agent_image } else { triage_agent_image }
 publish_image_ref := repo + "/" + image
 publish_builder_ref := repo + "/" + builder_image
 sock := env("CAESIUM_SOCK", default_sock)
 port := env("CAESIUM_PORT", "8080")
 auth_mode := env("CAESIUM_AUTH_MODE", "none")
 event_ingest_api_key := env("CAESIUM_EVENT_INGEST_API_KEY", "integration-test-key")
+agent_integration_run := env("CAESIUM_AGENT_INTEGRATION_RUN", "TestIntegrationTestSuite/TestAgent")
+agent_api_external_url := env("CAESIUM_AGENT_API_EXTERNAL_URL", "http://172.17.0.1:" + port)
 
 # Local Docker registry used by `just k8s-distributed` to push freshly-built
 # images into the cluster's containerd. Port 5050 sidesteps the macOS
@@ -109,6 +114,12 @@ build-test: builder
         --target test \
         -t {{ local_image_ref }}:{{ tag }}-test \
         -f {{ dockerfile }} .
+
+build-triage-agent: validate-platform
+    {{ container_cli }} build --platform {{ platform }} \
+        -t {{ local_triage_agent_ref }}:{{ tag }} \
+        -t {{ triage_agent_image }}:latest \
+        -f build/Dockerfile.triage-agent .
 
 push:
     docker push {{ publish_image_ref }}:{{ tag }}
@@ -202,8 +213,68 @@ integration-test-distributed:
       exit 1; \
     fi
 
+integration-test-agent:
+    just tag={{ tag }} integration-up-agent
+    @cli_dir={{ repo_dir }}/.tmp/caesium-cli; \
+    rm -rf "$cli_dir"; \
+    mkdir -p "$cli_dir"; \
+    cli_ctr=$({{ container_cli }} create --platform {{ platform }} {{ local_image_ref }}:{{ tag }}-test true); \
+    trap '{{ container_cli }} rm -f "$cli_ctr" >/dev/null 2>&1 || true; rm -rf "$cli_dir"' EXIT; \
+    {{ container_cli }} cp "$cli_ctr":/bin/caesium "$cli_dir/caesium"; \
+    chmod +x "$cli_dir/caesium"; \
+    {{ container_cli }} rm -f "$cli_ctr" >/dev/null 2>&1 || true; \
+    admin_key=""; \
+    tries=0; \
+    until admin_key="$({{ container_cli }} logs {{ agent_it_container }} 2>&1 | awk '/csk_/ { for (i = 1; i <= NF; i++) if ($i ~ /^csk_/) { print $i; exit } }')" && [ -n "$admin_key" ]; do \
+        tries=$((tries + 1)); \
+        if [ "$tries" -gt 30 ]; then \
+            echo "Agent auth bootstrap admin key did not appear in server logs"; \
+            {{ container_cli }} logs {{ agent_it_container }} || true; \
+            {{ container_cli }} rm -f {{ agent_it_container }} >/dev/null 2>&1 || true; \
+            exit 1; \
+        fi; \
+        sleep 1; \
+    done; \
+    printf '::add-mask::%s\n' "$admin_key"; \
+    tries=0; \
+    until curl -fsS -H "Authorization: Bearer $admin_key" http://127.0.0.1:{{ port }}/v1/agentprofiles >/dev/null; do \
+        tries=$((tries + 1)); \
+        if [ "$tries" -gt 30 ]; then \
+            echo "Agent auth lane did not become ready or seed the default profile"; \
+            {{ container_cli }} logs {{ agent_it_container }} || true; \
+            {{ container_cli }} rm -f {{ agent_it_container }} >/dev/null 2>&1 || true; \
+            exit 1; \
+        fi; \
+        sleep 1; \
+    done; \
+    if {{ container_cli }} run --rm --platform {{ platform }} \
+        -v {{ repo_dir }}:{{ bld_dir }} \
+        -v {{ sock }}:/var/run/docker.sock \
+        -e CAESIUM_CLI_PATH={{ bld_dir }}/.tmp/caesium-cli/caesium \
+        -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
+        -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
+        -e CAESIUM_AUTH_ADMIN_KEY="$admin_key" \
+        -e CAESIUM_API_KEY="$admin_key" \
+        -e CAESIUM_AGENT_AUTH_LANE=true \
+        -e CAESIUM_TRIAGE_AGENT_IMAGE={{ triage_agent_image }}:latest \
+        -e DOCKER_HOST=unix:///var/run/docker.sock \
+        --network=container:{{ agent_it_container }} \
+        -w {{ bld_dir }} \
+        {{ local_builder_ref }}:{{ tag }}-full \
+        sh -c 'mkdir -p ui/dist && touch ui/dist/index.html && go test ./test/ -tags=integration -run "{{ agent_integration_run }}" -timeout 10m'; then \
+      {{ container_cli }} rm -f {{ agent_it_container }} >/dev/null 2>&1 || true; \
+    else \
+      echo "agent auth integration tests failed; caesium server logs:"; \
+      {{ container_cli }} logs {{ agent_it_container }} || true; \
+      {{ container_cli }} rm -f {{ agent_it_container }} >/dev/null 2>&1 || true; \
+      exit 1; \
+    fi
+
 integration-down:
     {{ container_cli }} rm -f {{ it_container }}
+
+integration-down-agent:
+    {{ container_cli }} rm -f {{ agent_it_container }}
 
 # Run integration tests against a Caesium server using the Podman engine.
 # Requires Podman to be installed and the Podman socket to be active
@@ -222,6 +293,7 @@ integration-test-podman: build
         -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
         -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
         -e CAESIUM_LOG_LEVEL=debug \
+        -e CAESIUM_FRESHNESS_ENABLED=true \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
     if docker run --rm --platform {{ platform }} \
@@ -262,6 +334,7 @@ integration-up: build-test
         -e CAESIUM_DATABASE_SHARDS=4 \
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+        -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_RATE_LIMIT_PRUNER_ENABLED=true \
         -e CAESIUM_RATE_LIMIT_PRUNE_INTERVAL=500ms \
@@ -285,6 +358,7 @@ integration-up-distributed: build-test
         -e CAESIUM_DATABASE_SHARDS=4 \
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+        -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_EXECUTION_MODE=distributed \
         -e CAESIUM_NODE_ADDRESS=127.0.0.1:9001 \
@@ -304,6 +378,34 @@ integration-up-distributed: build-test
         -e CAESIUM_RUN_QUEUE_ENABLED=true \
         -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
         -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
+        {{ local_image_ref }}:{{ tag }}-test start
+
+integration-up-agent: build-test build-triage-agent
+    {{ container_cli }} rm -f {{ agent_it_container }} >/dev/null 2>&1 || true
+    {{ container_cli }} run -d --platform {{ platform }} \
+        --name {{ agent_it_container }} \
+        --privileged \
+        -p {{ port }}:8080 \
+        -v {{ sock }}:/var/run/docker.sock \
+        -e DOCKER_HOST=unix:///var/run/docker.sock \
+        --user 0:0 \
+        -e CAESIUM_MANUAL_TRIGGER_API_KEY=integration-test-key \
+        -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
+        -e CAESIUM_LOG_LEVEL=debug \
+        -e CAESIUM_DATABASE_SHARDS=4 \
+        -e CAESIUM_AUTH_MODE=api-key \
+        -e CAESIUM_AUTH_KEY_HASH_SECRET=agent-integration-auth-key-hash-secret-000001 \
+        -e CAESIUM_AUTH_REQUIRE_TLS=false \
+        -e CAESIUM_AGENT_REMEDIATION_ENABLED=true \
+        -e CAESIUM_AGENT_DEFAULT_PROFILE=triage-only \
+        -e CAESIUM_AGENT_MAX_CONCURRENT_SESSIONS=1 \
+        -e CAESIUM_AGENT_SESSION_TIMEOUT=45s \
+        -e CAESIUM_AGENT_INCIDENT_COOLDOWN=1s \
+        -e CAESIUM_API_EXTERNAL_URL={{ agent_api_external_url }} \
+        -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
+        -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+        -e CAESIUM_FRESHNESS_ENABLED=true \
+        -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         {{ local_image_ref }}:{{ tag }}-test start
 
 lint: builder-full
@@ -341,6 +443,7 @@ ui-e2e: build-release
             -e CAESIUM_MANUAL_TRIGGER_API_KEY=e2e-test-key \
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+            -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -377,6 +480,7 @@ ui-e2e-auth: build-release
         -e CAESIUM_AUTH_REQUIRE_TLS=false \
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
+        -e CAESIUM_FRESHNESS_ENABLED=true \
         --user 0:0 {{ local_image_ref }}:{{ tag }} start >/dev/null
     tries=0
     until node -e "fetch('http://127.0.0.1:{{ port }}/health').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"; do
@@ -457,6 +561,8 @@ k8s-distributed: build-release k8s-registry-up
             --set image.pullPolicy=Always \
             --set config.extraEnv[0].name=CAESIUM_EXECUTION_MODE \
             --set config.extraEnv[0].value=distributed \
+            --set config.extraEnv[1].name=CAESIUM_FRESHNESS_ENABLED \
+            --set-string config.extraEnv[1].value=true \
             --set kubernetes.engine.enabled=true \
             --set persistence.enabled=false \
             --wait

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -35,6 +35,7 @@ type IntegrationTestSuite struct {
 	engineType          string // "docker", "podman", or "kubernetes"
 	manualTriggerAPIKey string
 	eventIngestAPIKey   string
+	authAPIKey          string
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
@@ -72,6 +73,12 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.eventIngestAPIKey = os.Getenv("CAESIUM_EVENT_INGEST_API_KEY")
 	if s.eventIngestAPIKey == "" {
 		s.eventIngestAPIKey = "integration-test-key"
+	}
+	for _, envName := range []string{"CAESIUM_API_KEY", "CAESIUM_AUTH_ADMIN_KEY", "CAESIUM_OPERATOR_BEARER_TOKEN"} {
+		if token := strings.TrimSpace(os.Getenv(envName)); token != "" {
+			s.authAPIKey = token
+			break
+		}
 	}
 
 	client := &http.Client{Timeout: 2 * time.Second}
@@ -351,9 +358,17 @@ func (s *IntegrationTestSuite) doRequest(method, target string, body io.Reader) 
 	if err != nil {
 		return nil, err
 	}
+	s.authorize(req)
 
 	//nolint:bodyclose // Response body ownership is transferred to the caller.
 	return http.DefaultClient.Do(req)
+}
+
+func (s *IntegrationTestSuite) authorize(req *http.Request) {
+	if s.authAPIKey == "" || req.Header.Get("Authorization") != "" {
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+s.authAPIKey)
 }
 
 func (s *IntegrationTestSuite) doManualTriggerRequest(method, target string, body io.Reader) (*http.Response, error) {
@@ -361,6 +376,7 @@ func (s *IntegrationTestSuite) doManualTriggerRequest(method, target string, bod
 	if err != nil {
 		return nil, err
 	}
+	s.authorize(req)
 	req.Header.Set("X-Caesium-API-Key", s.manualTriggerAPIKey)
 	return http.DefaultClient.Do(req)
 }
@@ -370,6 +386,7 @@ func (s *IntegrationTestSuite) doEventIngestRequest(method, target string, body 
 	if err != nil {
 		return nil, err
 	}
+	s.authorize(req)
 	req.Header.Set("X-Caesium-API-Key", s.eventIngestAPIKey)
 	req.Header.Set("Content-Type", "application/json")
 	return http.DefaultClient.Do(req)

--- a/test/job_test.go
+++ b/test/job_test.go
@@ -452,6 +452,7 @@ func (s *IntegrationTestSuite) doJSONRequest(method, target string, body io.Read
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	s.authorize(req)
 
 	//nolint:bodyclose // Response body ownership is transferred to the caller.
 	return http.DefaultClient.Do(req)


### PR DESCRIPTION
## Summary
Lands both plans' deferred H-1 integration harnesses.

**Freshness H-1** — adds `CAESIUM_FRESHNESS_ENABLED=true` to the integration server across `integration-up`, `integration-up-distributed`, `ui-e2e`, the helm test values, and CI (inherited via the justfile). Inert until the evaluator (Stream C) ships the env field; harmless meanwhile.

**Agent H-1** — a deterministic fake triage-agent image (`build/Dockerfile.triage-agent` + `build/triage-agent.sh`, pinned `alpine:3.23`), and a **separate** auth-enabled lane: `caesium-server-agent-test` via `integration-up-agent` / `integration-test-agent`, plus a new `build-and-integration-test-agent-auth` CI job (`needs: builder`). The lane scrapes the `csk_` bootstrap admin key from server logs and runs the `TestAgent*` scenario subset under `AUTH_MODE=api-key` + `AGENT_REMEDIATION_ENABLED`.

**Landmine avoided (verified):** auth is NOT flipped on the shared `integration-up` — that would 401 the entire existing suite (and remediation refuses to boot under no-auth). The suite's new `authorize()` helper only attaches a bearer token when an auth key env is present, so it's a **no-op on the shared no-auth lane** and active only on the agent lane.

## Test plan
- [x] justfile parses (`just --list`)
- [x] ci.yml valid YAML
- [x] `just lint` — 0 issues
- [ ] `just integration-test` (standard lane, confirms the authorize() change doesn't break the shared suite) — runs at merge gate
- [ ] `just integration-test-agent` (auth-lane infra: fake image builds, auth server boots, key scrape + profile seed) — runs at merge gate

Implemented by codex (GPT-5.5) under the Wave 3 exec-plan orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)