### PR TITLE
Add the dataset REST + CLI operator surface (freshness-scheduling W3-γ)

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -9,6 +9,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/backfill"
 	blamectrl "github.com/caesium-cloud/caesium/api/rest/controller/blame"
 	"github.com/caesium-cloud/caesium/api/rest/controller/database"
+	datasetctrl "github.com/caesium-cloud/caesium/api/rest/controller/dataset"
 	"github.com/caesium-cloud/caesium/api/rest/controller/event"
 	incidentctrl "github.com/caesium-cloud/caesium/api/rest/controller/incident"
 	"github.com/caesium-cloud/caesium/api/rest/controller/job"
@@ -129,6 +130,15 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		g.POST("/jobdefs/apply", jobdef.Apply)
 		g.POST("/jobdefs/lint", jobdef.Lint)
 		g.POST("/jobdefs/diff", jobdef.Diff)
+	}
+
+	// datasets
+	{
+		dc := datasetctrl.New()
+		g.GET("/datasets", dc.List)
+		g.GET("/datasets/:ns/:name", dc.Get)
+		g.GET("/datasets/:ns/:name/derivations", dc.Derivations)
+		g.POST("/datasets/:ns/:name/advance", dc.Advance)
 	}
 
 	// triggers

--- a/api/rest/controller/dataset/dataset.go
+++ b/api/rest/controller/dataset/dataset.go
@@ -1,0 +1,133 @@
+// Package dataset implements the freshness dataset REST surface.
+package dataset
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	svc "github.com/caesium-cloud/caesium/api/rest/service/dataset"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+// Controller serves the dataset endpoints.
+type Controller struct{}
+
+// New constructs a dataset Controller.
+func New() *Controller {
+	return &Controller{}
+}
+
+// List handles GET /v1/datasets.
+func (ctrl *Controller) List(c *echo.Context) error {
+	params := svc.ListParams{
+		Status: strings.TrimSpace(c.QueryParam("status")),
+	}
+	if err := parsePagination(c, &params.Limit, &params.Offset); err != nil {
+		return err
+	}
+
+	result, err := svc.New(c.Request().Context()).List(params)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// Get handles GET /v1/datasets/:ns/:name.
+func (ctrl *Controller) Get(c *echo.Context) error {
+	namespace, name := datasetPath(c)
+	if name == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request")
+	}
+
+	result, err := svc.New(c.Request().Context()).Get(namespace, name)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// Derivations handles GET /v1/datasets/:ns/:name/derivations.
+func (ctrl *Controller) Derivations(c *echo.Context) error {
+	namespace, name := datasetPath(c)
+	if name == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request")
+	}
+
+	params := svc.DerivationsParams{
+		Namespace: namespace,
+		Name:      name,
+	}
+	if err := parsePagination(c, &params.Limit, &params.Offset); err != nil {
+		return err
+	}
+
+	result, err := svc.New(c.Request().Context()).Derivations(params)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+type advanceRequest struct {
+	Watermark string `json:"watermark"`
+}
+
+// Advance handles POST /v1/datasets/:ns/:name/advance.
+func (ctrl *Controller) Advance(c *echo.Context) error {
+	namespace, name := datasetPath(c)
+	if name == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request")
+	}
+
+	var body advanceRequest
+	if err := json.NewDecoder(c.Request().Body).Decode(&body); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+	watermark := strings.TrimSpace(body.Watermark)
+	if watermark == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "watermark is required")
+	}
+
+	result, err := svc.New(c.Request().Context()).Advance(svc.AdvanceParams{
+		Namespace: namespace,
+		Name:      name,
+		Watermark: watermark,
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+func datasetPath(c *echo.Context) (string, string) {
+	return svc.NamespaceFromPath(c.Param("ns")), strings.TrimSpace(c.Param("name"))
+}
+
+func parsePagination(c *echo.Context, limit, offset *int) error {
+	if raw := strings.TrimSpace(c.QueryParam("limit")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid limit")
+		}
+		*limit = n
+	}
+	if raw := strings.TrimSpace(c.QueryParam("offset")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid offset")
+		}
+		*offset = n
+	}
+	return nil
+}

--- a/api/rest/service/dataset/dataset.go
+++ b/api/rest/service/dataset/dataset.go
@@ -304,39 +304,39 @@ func normalizePagination(rawLimit, rawOffset int) (int, int) {
 }
 
 func (s *Service) declarationOnlyStates(limit int) ([]models.DatasetState, int64, error) {
-	// Collapse duplicate declarations (the same dataset is commonly declared by
-	// multiple jobs) in the database via GROUP BY, so the LIMIT applies to
-	// distinct datasets and the count reflects distinct datasets rather than raw
-	// declaration rows. Grouping on COALESCE(namespace, '') keeps NULL and empty
-	// namespaces on the same logical dataset.
-	q := s.db.WithContext(s.ctx).
+	// A dataset is commonly declared by multiple jobs; we want distinct
+	// (namespace, name) datasets so the LIMIT and total reflect datasets rather
+	// than raw declaration rows. We dedup in Go rather than via a SQL GROUP BY:
+	// dqlite cannot return computed/aggregate result columns (MAX(...),
+	// COALESCE(...)) and fails such a query with "unknown data type". The
+	// declared-but-stateless set is bounded (one row per job/dataset
+	// declaration), so fetching plain columns and deduping in-process is cheap.
+	var decls []models.DatasetDeclaration
+	if err := s.db.WithContext(s.ctx).
 		Model(&models.DatasetDeclaration{}).
-		Select("COALESCE(namespace, '') AS namespace, name, MAX(created_at) AS created_at, MAX(updated_at) AS updated_at").
 		Where("direction IN ?", declarationDirections).
 		Where("NOT EXISTS (SELECT 1 FROM dataset_states ds WHERE ds.name = dataset_declarations.name AND ds.namespace = COALESCE(dataset_declarations.namespace, ''))").
-		Group("COALESCE(namespace, ''), name")
-
-	// With a GROUP BY present, gorm's Count returns the number of groups
-	// (distinct datasets), which is the total we want.
-	var total int64
-	if err := q.Count(&total).Error; err != nil {
-		return nil, 0, err
-	}
-
-	var decls []models.DatasetDeclaration
-	if err := q.
-		Order("MAX(updated_at) DESC").
-		Limit(limit).
+		Order("updated_at DESC").
 		Find(&decls).Error; err != nil {
 		return nil, 0, err
 	}
 
-	out := make([]models.DatasetState, 0, len(decls))
+	seen := make(map[string]struct{}, len(decls))
+	out := make([]models.DatasetState, 0)
 	for _, decl := range decls {
 		ns := declNamespaceValue(decl.Namespace)
-		out = append(out, unknownState(ns, decl.Name, decl.CreatedAt, decl.UpdatedAt))
+		key := ns + "\x00" + decl.Name
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		// updated_at DESC ordering means the first row for a (ns, name) is the
+		// most recently touched declaration — mirrors the old MAX(updated_at).
+		if len(out) < limit {
+			out = append(out, unknownState(ns, decl.Name, decl.CreatedAt, decl.UpdatedAt))
+		}
 	}
-	return out, total, nil
+	return out, int64(len(seen)), nil
 }
 
 func (s *Service) getState(namespace, name string) (models.DatasetState, bool, error) {

--- a/api/rest/service/dataset/dataset.go
+++ b/api/rest/service/dataset/dataset.go
@@ -235,6 +235,7 @@ func (s *Service) Derivations(p DerivationsParams) (*DerivationsResult, error) {
 	var rows []models.DatasetDerivation
 	if err := q.
 		Order("created_at DESC").
+		Order("id DESC").
 		Limit(limit).
 		Offset(offset).
 		Find(&rows).Error; err != nil {
@@ -303,11 +304,20 @@ func normalizePagination(rawLimit, rawOffset int) (int, int) {
 }
 
 func (s *Service) declarationOnlyStates(limit int) ([]models.DatasetState, int64, error) {
+	// Collapse duplicate declarations (the same dataset is commonly declared by
+	// multiple jobs) in the database via GROUP BY, so the LIMIT applies to
+	// distinct datasets and the count reflects distinct datasets rather than raw
+	// declaration rows. Grouping on COALESCE(namespace, '') keeps NULL and empty
+	// namespaces on the same logical dataset.
 	q := s.db.WithContext(s.ctx).
 		Model(&models.DatasetDeclaration{}).
+		Select("COALESCE(namespace, '') AS namespace, name, MAX(created_at) AS created_at, MAX(updated_at) AS updated_at").
 		Where("direction IN ?", declarationDirections).
-		Where("NOT EXISTS (SELECT 1 FROM dataset_states ds WHERE ds.name = dataset_declarations.name AND ds.namespace = COALESCE(dataset_declarations.namespace, ''))")
+		Where("NOT EXISTS (SELECT 1 FROM dataset_states ds WHERE ds.name = dataset_declarations.name AND ds.namespace = COALESCE(dataset_declarations.namespace, ''))").
+		Group("COALESCE(namespace, ''), name")
 
+	// With a GROUP BY present, gorm's Count returns the number of groups
+	// (distinct datasets), which is the total we want.
 	var total int64
 	if err := q.Count(&total).Error; err != nil {
 		return nil, 0, err
@@ -315,21 +325,15 @@ func (s *Service) declarationOnlyStates(limit int) ([]models.DatasetState, int64
 
 	var decls []models.DatasetDeclaration
 	if err := q.
-		Order("updated_at DESC").
+		Order("MAX(updated_at) DESC").
 		Limit(limit).
 		Find(&decls).Error; err != nil {
 		return nil, 0, err
 	}
 
-	out := make([]models.DatasetState, 0)
-	seen := make(map[string]struct{}, len(decls))
+	out := make([]models.DatasetState, 0, len(decls))
 	for _, decl := range decls {
 		ns := declNamespaceValue(decl.Namespace)
-		key := datasetKey(ns, decl.Name)
-		if _, ok := seen[key]; ok {
-			continue
-		}
-		seen[key] = struct{}{}
 		out = append(out, unknownState(ns, decl.Name, decl.CreatedAt, decl.UpdatedAt))
 	}
 	return out, total, nil
@@ -371,6 +375,7 @@ func (s *Service) latestDerivation(namespace, name string) (models.DatasetDeriva
 	q := s.db.WithContext(s.ctx).
 		Where("name = ?", strings.TrimSpace(name)).
 		Order("created_at DESC").
+		Order("id DESC").
 		Limit(1)
 	q = withDerivationNamespace(q, namespace)
 	res := q.Find(&derivation)
@@ -427,10 +432,6 @@ func declNamespaceValue(namespace *string) string {
 		return ""
 	}
 	return strings.TrimSpace(*namespace)
-}
-
-func datasetKey(namespace, name string) string {
-	return strings.TrimSpace(namespace) + "\x00" + strings.TrimSpace(name)
 }
 
 func paginateStates(rows []models.DatasetState, limit, offset int) []models.DatasetState {

--- a/api/rest/service/dataset/dataset.go
+++ b/api/rest/service/dataset/dataset.go
@@ -1,0 +1,459 @@
+// Package dataset exposes the freshness dataset read model and manual advance
+// operation used by the REST controller and operator CLI.
+package dataset
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/freshness"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+const (
+	defaultListLimit = 50
+	maxListLimit     = 200
+)
+
+var declarationDirections = []string{
+	models.DatasetDirectionProduces,
+	models.DatasetDirectionSource,
+}
+
+// Service wraps read-side dataset queries and the manual advance path.
+type Service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+// New creates a Service backed by the default DB connection.
+func New(ctx context.Context) *Service {
+	return &Service{ctx: ctx, db: db.Connection()}
+}
+
+// WithDatabase returns a copy of the Service backed by conn; used by tests.
+func (s *Service) WithDatabase(conn *gorm.DB) *Service {
+	if conn == nil {
+		return s
+	}
+	return &Service{ctx: s.ctx, db: conn}
+}
+
+// NamespaceFromPath maps the REST path convention "_" to the v1 empty
+// namespace. All other values are trimmed and used literally.
+func NamespaceFromPath(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "_" {
+		return ""
+	}
+	return raw
+}
+
+// ListParams filters and paginates the dataset feed.
+type ListParams struct {
+	Status string
+	Limit  int
+	Offset int
+}
+
+// ListResult is the paginated dataset state response.
+type ListResult struct {
+	Datasets []models.DatasetState `json:"datasets"`
+	Total    int64                 `json:"total"`
+	Limit    int                   `json:"limit"`
+	Offset   int                   `json:"offset"`
+}
+
+// SLO summarizes the declaration-level freshness contract for a dataset.
+type SLO struct {
+	Freshness     string `json:"freshness,omitempty"`
+	MaxStaleness  string `json:"max_staleness,omitempty"`
+	ExpectedEvery string `json:"expected_every,omitempty"`
+}
+
+// ProducingJob identifies the Caesium job and step that produce a dataset.
+type ProducingJob struct {
+	ID       uuid.UUID `json:"id"`
+	Alias    string    `json:"alias"`
+	StepName string    `json:"step_name,omitempty"`
+}
+
+// Detail returns the state row plus the declaration metadata operators need to
+// understand the SLO and producer.
+type Detail struct {
+	State        models.DatasetState        `json:"state"`
+	Declaration  *models.DatasetDeclaration `json:"declaration,omitempty"`
+	SLO          *SLO                       `json:"slo,omitempty"`
+	Producing    *ProducingJob              `json:"producing_job,omitempty"`
+	LastDecision *models.DatasetDerivation  `json:"last_decision,omitempty"`
+}
+
+// DerivationsParams filters and paginates the append-only derivation audit.
+type DerivationsParams struct {
+	Namespace string
+	Name      string
+	Limit     int
+	Offset    int
+}
+
+// DerivationsResult is the paginated derivation audit response.
+type DerivationsResult struct {
+	Derivations []models.DatasetDerivation `json:"derivations"`
+	Total       int64                      `json:"total"`
+	Limit       int                        `json:"limit"`
+	Offset      int                        `json:"offset"`
+}
+
+// AdvanceParams carries a manual dataset arrival.
+type AdvanceParams struct {
+	Namespace string
+	Name      string
+	Watermark string
+}
+
+// AdvanceResult is the manual advance outcome plus the resulting state row.
+type AdvanceResult struct {
+	Outcome freshness.Outcome   `json:"outcome"`
+	State   models.DatasetState `json:"state"`
+}
+
+// List returns a bounded, paginated, filtered slice of dataset states
+// newest-first. Declared-but-unobserved produced/source datasets are surfaced as
+// synthetic unknown state so operators can see the declared graph before a run
+// advances anything.
+func (s *Service) List(p ListParams) (*ListResult, error) {
+	limit, offset := normalizePagination(p.Limit, p.Offset)
+	status := strings.TrimSpace(p.Status)
+
+	if status != "" && status != models.DatasetStatusUnknown {
+		rows, total, err := s.observedStates(status, limit, offset)
+		if err != nil {
+			return nil, err
+		}
+		return &ListResult{
+			Datasets: rows,
+			Total:    total,
+			Limit:    limit,
+			Offset:   offset,
+		}, nil
+	}
+
+	fetchLimit := limit + offset
+	rows, observedTotal, err := s.observedStates(status, fetchLimit, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	declRows, declTotal, err := s.declarationOnlyStates(fetchLimit)
+	if err != nil {
+		return nil, err
+	}
+	rows = append(rows, declRows...)
+	sortStates(rows)
+
+	rows = paginateStates(rows, limit, offset)
+	return &ListResult{
+		Datasets: rows,
+		Total:    observedTotal + declTotal,
+		Limit:    limit,
+		Offset:   offset,
+	}, nil
+}
+
+// Get returns one dataset's state plus declaration metadata. A declared dataset
+// with no state row is served as unknown rather than 404.
+func (s *Service) Get(namespace, name string) (*Detail, error) {
+	name = strings.TrimSpace(name)
+	state, foundState, err := s.getState(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	decl, foundDecl, err := s.getDeclaration(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	if !foundState && !foundDecl {
+		return nil, gorm.ErrRecordNotFound
+	}
+	if !foundState {
+		state = unknownState(namespace, name, decl.CreatedAt, decl.UpdatedAt)
+	}
+
+	detail := &Detail{State: state}
+	if foundDecl {
+		detail.Declaration = &decl
+		detail.SLO = &SLO{
+			Freshness:     decl.Freshness,
+			MaxStaleness:  decl.MaxStaleness,
+			ExpectedEvery: decl.ExpectedEvery,
+		}
+		if decl.Direction == models.DatasetDirectionProduces {
+			detail.Producing = &ProducingJob{
+				ID:       decl.JobID,
+				Alias:    decl.JobAlias,
+				StepName: decl.StepName,
+			}
+		}
+	}
+	derivation, foundDerivation, err := s.latestDerivation(namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	if foundDerivation {
+		detail.LastDecision = &derivation
+	}
+	return detail, nil
+}
+
+// Derivations returns the append-only derivation audit newest-first.
+func (s *Service) Derivations(p DerivationsParams) (*DerivationsResult, error) {
+	limit, offset := normalizePagination(p.Limit, p.Offset)
+	exists, err := s.exists(p.Namespace, p.Name)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	q := s.db.WithContext(s.ctx).
+		Model(&models.DatasetDerivation{}).
+		Where("name = ?", strings.TrimSpace(p.Name))
+	q = withDerivationNamespace(q, p.Namespace)
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, err
+	}
+
+	var rows []models.DatasetDerivation
+	if err := q.
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	return &DerivationsResult{
+		Derivations: rows,
+		Total:       total,
+		Limit:       limit,
+		Offset:      offset,
+	}, nil
+}
+
+// Advance applies a manual arrival through the freshness.Store contract.
+func (s *Service) Advance(p AdvanceParams) (*AdvanceResult, error) {
+	now := time.Now().UTC()
+	result, err := freshness.NewStore(s.db).Advance(s.ctx, freshness.AdvanceInput{
+		Namespace:   namespacePtr(p.Namespace),
+		Name:        strings.TrimSpace(p.Name),
+		Watermark:   strings.TrimSpace(p.Watermark),
+		RunID:       uuid.Nil,
+		CompletedAt: now,
+		RunOrder:    now,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &AdvanceResult{Outcome: result.Outcome, State: result.State}, nil
+}
+
+func (s *Service) observedStates(status string, limit, offset int) ([]models.DatasetState, int64, error) {
+	q := s.db.WithContext(s.ctx).Model(&models.DatasetState{})
+	if status != "" {
+		q = q.Where("status = ?", status)
+	}
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var rows []models.DatasetState
+	if err := q.
+		Order("updated_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&rows).Error; err != nil {
+		return nil, 0, err
+	}
+	return rows, total, nil
+}
+
+func normalizePagination(rawLimit, rawOffset int) (int, int) {
+	limit := rawLimit
+	if limit <= 0 {
+		limit = defaultListLimit
+	}
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	offset := rawOffset
+	if offset < 0 {
+		offset = 0
+	}
+	return limit, offset
+}
+
+func (s *Service) declarationOnlyStates(limit int) ([]models.DatasetState, int64, error) {
+	q := s.db.WithContext(s.ctx).
+		Model(&models.DatasetDeclaration{}).
+		Where("direction IN ?", declarationDirections).
+		Where("NOT EXISTS (SELECT 1 FROM dataset_states ds WHERE ds.name = dataset_declarations.name AND ds.namespace = COALESCE(dataset_declarations.namespace, ''))")
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	var decls []models.DatasetDeclaration
+	if err := q.
+		Order("updated_at DESC").
+		Limit(limit).
+		Find(&decls).Error; err != nil {
+		return nil, 0, err
+	}
+
+	out := make([]models.DatasetState, 0)
+	seen := make(map[string]struct{}, len(decls))
+	for _, decl := range decls {
+		ns := declNamespaceValue(decl.Namespace)
+		key := datasetKey(ns, decl.Name)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, unknownState(ns, decl.Name, decl.CreatedAt, decl.UpdatedAt))
+	}
+	return out, total, nil
+}
+
+func (s *Service) getState(namespace, name string) (models.DatasetState, bool, error) {
+	var state models.DatasetState
+	res := s.db.WithContext(s.ctx).
+		Where("namespace = ? AND name = ?", strings.TrimSpace(namespace), strings.TrimSpace(name)).
+		Limit(1).
+		Find(&state)
+	if res.Error != nil {
+		return models.DatasetState{}, false, res.Error
+	}
+	return state, res.RowsAffected > 0, nil
+}
+
+func (s *Service) getDeclaration(namespace, name string) (models.DatasetDeclaration, bool, error) {
+	name = strings.TrimSpace(name)
+	for _, direction := range declarationDirections {
+		var decl models.DatasetDeclaration
+		q := s.db.WithContext(s.ctx).
+			Where("name = ? AND direction = ?", name, direction).
+			Limit(1)
+		q = withDeclarationNamespace(q, namespace)
+		res := q.Find(&decl)
+		if res.Error != nil {
+			return models.DatasetDeclaration{}, false, res.Error
+		}
+		if res.RowsAffected > 0 {
+			return decl, true, nil
+		}
+	}
+	return models.DatasetDeclaration{}, false, nil
+}
+
+func (s *Service) latestDerivation(namespace, name string) (models.DatasetDerivation, bool, error) {
+	var derivation models.DatasetDerivation
+	q := s.db.WithContext(s.ctx).
+		Where("name = ?", strings.TrimSpace(name)).
+		Order("created_at DESC").
+		Limit(1)
+	q = withDerivationNamespace(q, namespace)
+	res := q.Find(&derivation)
+	if res.Error != nil {
+		return models.DatasetDerivation{}, false, res.Error
+	}
+	return derivation, res.RowsAffected > 0, nil
+}
+
+func (s *Service) exists(namespace, name string) (bool, error) {
+	if _, ok, err := s.getState(namespace, name); err != nil || ok {
+		return ok, err
+	}
+	_, ok, err := s.getDeclaration(namespace, name)
+	return ok, err
+}
+
+func withDeclarationNamespace(q *gorm.DB, namespace string) *gorm.DB {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return q.Where("(namespace IS NULL OR namespace = '')")
+	}
+	return q.Where("namespace = ?", namespace)
+}
+
+func withDerivationNamespace(q *gorm.DB, namespace string) *gorm.DB {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return q.Where("(namespace IS NULL OR namespace = '')")
+	}
+	return q.Where("namespace = ?", namespace)
+}
+
+func unknownState(namespace, name string, createdAt, updatedAt time.Time) models.DatasetState {
+	return models.DatasetState{
+		Namespace: strings.TrimSpace(namespace),
+		Name:      strings.TrimSpace(name),
+		Status:    models.DatasetStatusUnknown,
+		CreatedAt: createdAt,
+		UpdatedAt: updatedAt,
+	}
+}
+
+func namespacePtr(namespace string) *string {
+	namespace = strings.TrimSpace(namespace)
+	if namespace == "" {
+		return nil
+	}
+	return &namespace
+}
+
+func declNamespaceValue(namespace *string) string {
+	if namespace == nil {
+		return ""
+	}
+	return strings.TrimSpace(*namespace)
+}
+
+func datasetKey(namespace, name string) string {
+	return strings.TrimSpace(namespace) + "\x00" + strings.TrimSpace(name)
+}
+
+func paginateStates(rows []models.DatasetState, limit, offset int) []models.DatasetState {
+	if offset >= len(rows) {
+		return []models.DatasetState{}
+	}
+	end := offset + limit
+	if end > len(rows) {
+		end = len(rows)
+	}
+	return rows[offset:end]
+}
+
+func sortStates(rows []models.DatasetState) {
+	sort.SliceStable(rows, func(i, j int) bool {
+		left := rows[i].UpdatedAt
+		right := rows[j].UpdatedAt
+		if left.Equal(right) {
+			if rows[i].Namespace == rows[j].Namespace {
+				return rows[i].Name < rows[j].Name
+			}
+			return rows[i].Namespace < rows[j].Namespace
+		}
+		return left.After(right)
+	})
+}

--- a/cmd/dataset/advance.go
+++ b/cmd/dataset/advance.go
@@ -14,7 +14,7 @@ import (
 var advanceWatermark string
 
 var advanceCmd = &cobra.Command{
-	Use:   "advance <namespace.name> --watermark <value>",
+	Use:   "advance <name> --watermark <value> [--namespace <ns>]",
 	Short: "Manually advance a freshness dataset watermark",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/dataset/advance.go
+++ b/cmd/dataset/advance.go
@@ -1,0 +1,44 @@
+package dataset
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+)
+
+var advanceWatermark string
+
+var advanceCmd = &cobra.Command{
+	Use:   "advance <namespace.name> --watermark <value>",
+	Short: "Manually advance a freshness dataset watermark",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, name, err := splitDatasetRef(args[0])
+		if err != nil {
+			return err
+		}
+		watermark := strings.TrimSpace(advanceWatermark)
+		if watermark == "" {
+			return fmt.Errorf("--watermark is required")
+		}
+
+		payload, err := json.Marshal(map[string]string{"watermark": watermark})
+		if err != nil {
+			return err
+		}
+		body, err := request(cmd, http.MethodPost, serverBase()+datasetPath(namespace, name)+"/advance", bytes.NewReader(payload))
+		if err != nil {
+			return err
+		}
+		return cliutil.WritePrettyJSON(cmd, body, "dataset advance")
+	},
+}
+
+func init() {
+	advanceCmd.Flags().StringVar(&advanceWatermark, "watermark", "", "Watermark value to record")
+}

--- a/cmd/dataset/dataset.go
+++ b/cmd/dataset/dataset.go
@@ -1,0 +1,20 @@
+package dataset
+
+import "github.com/spf13/cobra"
+
+var (
+	serverFlag string
+	apiKeyFlag string
+)
+
+// Cmd is the root `caesium dataset` command group.
+var Cmd = &cobra.Command{
+	Use:   "dataset",
+	Short: "Inspect and advance freshness datasets",
+}
+
+func init() {
+	Cmd.PersistentFlags().StringVar(&serverFlag, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "API key for authentication (prefer "+apiKeyEnvVar+"; --api-key is visible in process listings)")
+	Cmd.AddCommand(listCmd, statusCmd, advanceCmd)
+}

--- a/cmd/dataset/dataset.go
+++ b/cmd/dataset/dataset.go
@@ -3,8 +3,9 @@ package dataset
 import "github.com/spf13/cobra"
 
 var (
-	serverFlag string
-	apiKeyFlag string
+	serverFlag    string
+	apiKeyFlag    string
+	namespaceFlag string
 )
 
 // Cmd is the root `caesium dataset` command group.
@@ -16,5 +17,6 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.PersistentFlags().StringVar(&serverFlag, "server", "http://localhost:8080", "Caesium server base URL")
 	Cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "API key for authentication (prefer "+apiKeyEnvVar+"; --api-key is visible in process listings)")
+	Cmd.PersistentFlags().StringVar(&namespaceFlag, "namespace", "", "Dataset namespace (defaults to the empty namespace used in v1)")
 	Cmd.AddCommand(listCmd, statusCmd, advanceCmd)
 }

--- a/cmd/dataset/http.go
+++ b/cmd/dataset/http.go
@@ -55,20 +55,17 @@ func datasetPath(namespace, name string) string {
 	return "/v1/datasets/" + url.PathEscape(nsSegment) + "/" + url.PathEscape(name)
 }
 
+// splitDatasetRef resolves a dataset argument into (namespace, name). Dataset
+// names are free-form identifiers that routinely contain dots (e.g.
+// "raw.vendor_x"), and the namespace is a separate, distinct axis (unused in
+// v1), so the whole argument is taken as the name. A namespace, when needed, is
+// supplied explicitly via --namespace rather than parsed out of the name.
 func splitDatasetRef(raw string) (string, string, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return "", "", fmt.Errorf("dataset reference is required")
+	name := strings.TrimSpace(raw)
+	if name == "" {
+		return "", "", fmt.Errorf("dataset name is required")
 	}
-	ns, name, ok := strings.Cut(raw, ".")
-	if !ok {
-		return "", raw, nil
-	}
-	ns = strings.TrimSpace(ns)
-	name = strings.TrimSpace(name)
-	if ns == "" || name == "" {
-		return "", "", fmt.Errorf("dataset reference must be <namespace.name> or <name>")
-	}
+	ns := strings.TrimSpace(namespaceFlag)
 	if ns == "_" {
 		ns = ""
 	}

--- a/cmd/dataset/http.go
+++ b/cmd/dataset/http.go
@@ -1,0 +1,76 @@
+package dataset
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+)
+
+const apiKeyEnvVar = cliutil.APIKeyEnvVar
+
+var httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
+
+func request(cmd *cobra.Command, method, reqURL string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequestWithContext(cmd.Context(), method, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if apiKey := cliutil.ResolveAPIKey(cmd, apiKeyFlag, apiKeyEnvVar); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading dataset response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, fmt.Errorf("dataset request failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	return data, nil
+}
+
+func serverBase() string {
+	return strings.TrimSuffix(serverFlag, "/")
+}
+
+func datasetPath(namespace, name string) string {
+	nsSegment := namespace
+	if nsSegment == "" {
+		nsSegment = "_"
+	}
+	return "/v1/datasets/" + url.PathEscape(nsSegment) + "/" + url.PathEscape(name)
+}
+
+func splitDatasetRef(raw string) (string, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", fmt.Errorf("dataset reference is required")
+	}
+	ns, name, ok := strings.Cut(raw, ".")
+	if !ok {
+		return "", raw, nil
+	}
+	ns = strings.TrimSpace(ns)
+	name = strings.TrimSpace(name)
+	if ns == "" || name == "" {
+		return "", "", fmt.Errorf("dataset reference must be <namespace.name> or <name>")
+	}
+	if ns == "_" {
+		ns = ""
+	}
+	return ns, name, nil
+}

--- a/cmd/dataset/list.go
+++ b/cmd/dataset/list.go
@@ -1,0 +1,100 @@
+package dataset
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+)
+
+var (
+	listStatus string
+	listJSON   bool
+)
+
+type listResponse struct {
+	Datasets []datasetState `json:"datasets"`
+	Total    int64          `json:"total"`
+	Limit    int            `json:"limit"`
+	Offset   int            `json:"offset"`
+}
+
+type datasetState struct {
+	Namespace string    `json:"namespace,omitempty"`
+	Name      string    `json:"name"`
+	Watermark string    `json:"watermark"`
+	Status    string    `json:"status"`
+	Reason    string    `json:"reason,omitempty"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List freshness dataset states",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		params := url.Values{}
+		if status := strings.TrimSpace(listStatus); status != "" {
+			params.Set("status", status)
+		}
+		reqURL := serverBase() + "/v1/datasets"
+		if encoded := params.Encode(); encoded != "" {
+			reqURL += "?" + encoded
+		}
+
+		body, err := request(cmd, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return err
+		}
+		if listJSON {
+			return cliutil.WritePrettyJSON(cmd, body, "datasets")
+		}
+
+		var result listResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return fmt.Errorf("datasets response was not valid JSON: %w", err)
+		}
+		renderDatasetList(cmd, result.Datasets)
+		return nil
+	},
+}
+
+func renderDatasetList(cmd *cobra.Command, rows []datasetState) {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "NAMESPACE\tNAME\tSTATUS\tWATERMARK\tUPDATED\tREASON")
+	for _, row := range rows {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			displayNamespace(row.Namespace),
+			row.Name,
+			row.Status,
+			row.Watermark,
+			formatTime(row.UpdatedAt),
+			row.Reason,
+		)
+	}
+	_ = w.Flush()
+}
+
+func displayNamespace(namespace string) string {
+	if strings.TrimSpace(namespace) == "" {
+		return "_"
+	}
+	return namespace
+}
+
+func formatTime(t time.Time) string {
+	if t.IsZero() {
+		return "-"
+	}
+	return t.UTC().Format(time.RFC3339)
+}
+
+func init() {
+	listCmd.Flags().StringVar(&listStatus, "status", "", "Filter by dataset status")
+	listCmd.Flags().BoolVar(&listJSON, "json", false, "Print JSON")
+}

--- a/cmd/dataset/status.go
+++ b/cmd/dataset/status.go
@@ -1,0 +1,109 @@
+package dataset
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"text/tabwriter"
+	"time"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+var statusJSON bool
+
+type statusResponse struct {
+	State        datasetState       `json:"state"`
+	SLO          *datasetSLO        `json:"slo,omitempty"`
+	Producing    *producingJob      `json:"producing_job,omitempty"`
+	LastDecision *datasetDerivation `json:"last_decision,omitempty"`
+	Declaration  any                `json:"declaration,omitempty"`
+}
+
+type datasetSLO struct {
+	Freshness     string `json:"freshness,omitempty"`
+	MaxStaleness  string `json:"max_staleness,omitempty"`
+	ExpectedEvery string `json:"expected_every,omitempty"`
+}
+
+type producingJob struct {
+	ID       uuid.UUID `json:"id"`
+	Alias    string    `json:"alias"`
+	StepName string    `json:"step_name,omitempty"`
+}
+
+type datasetDerivation struct {
+	Decision  string    `json:"decision"`
+	Reason    string    `json:"reason,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+var statusCmd = &cobra.Command{
+	Use:   "status <namespace.name>",
+	Short: "Show one freshness dataset state",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		namespace, name, err := splitDatasetRef(args[0])
+		if err != nil {
+			return err
+		}
+
+		body, err := request(cmd, http.MethodGet, serverBase()+datasetPath(namespace, name), nil)
+		if err != nil {
+			return err
+		}
+		if statusJSON {
+			return cliutil.WritePrettyJSON(cmd, body, "dataset status")
+		}
+
+		var result statusResponse
+		if err := json.Unmarshal(body, &result); err != nil {
+			return fmt.Errorf("dataset status response was not valid JSON: %w", err)
+		}
+		renderDatasetStatus(cmd, result)
+		return nil
+	},
+}
+
+func renderDatasetStatus(cmd *cobra.Command, result statusResponse) {
+	w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+	_, _ = fmt.Fprintf(w, "NAMESPACE\t%s\n", displayNamespace(result.State.Namespace))
+	_, _ = fmt.Fprintf(w, "NAME\t%s\n", result.State.Name)
+	_, _ = fmt.Fprintf(w, "STATUS\t%s\n", result.State.Status)
+	_, _ = fmt.Fprintf(w, "WATERMARK\t%s\n", result.State.Watermark)
+	_, _ = fmt.Fprintf(w, "UPDATED\t%s\n", formatTime(result.State.UpdatedAt))
+	if result.State.Reason != "" {
+		_, _ = fmt.Fprintf(w, "REASON\t%s\n", result.State.Reason)
+	}
+	if result.SLO != nil {
+		if result.SLO.Freshness != "" {
+			_, _ = fmt.Fprintf(w, "FRESHNESS\t%s\n", result.SLO.Freshness)
+		}
+		if result.SLO.MaxStaleness != "" {
+			_, _ = fmt.Fprintf(w, "MAX STALENESS\t%s\n", result.SLO.MaxStaleness)
+		}
+		if result.SLO.ExpectedEvery != "" {
+			_, _ = fmt.Fprintf(w, "EXPECTED EVERY\t%s\n", result.SLO.ExpectedEvery)
+		}
+	}
+	if result.Producing != nil {
+		_, _ = fmt.Fprintf(w, "PRODUCER\t%s\n", result.Producing.Alias)
+		if result.Producing.StepName != "" {
+			_, _ = fmt.Fprintf(w, "PRODUCER STEP\t%s\n", result.Producing.StepName)
+		}
+	}
+	if result.LastDecision != nil {
+		_, _ = fmt.Fprintf(w, "LAST DECISION\t%s\n", result.LastDecision.Decision)
+		if result.LastDecision.Reason != "" {
+			_, _ = fmt.Fprintf(w, "LAST DECISION REASON\t%s\n", result.LastDecision.Reason)
+		}
+		_, _ = fmt.Fprintf(w, "LAST DECISION AT\t%s\n", formatTime(result.LastDecision.CreatedAt))
+	}
+	_ = w.Flush()
+}
+
+func init() {
+	statusCmd.Flags().BoolVar(&statusJSON, "json", false, "Print JSON")
+}

--- a/cmd/dataset/status.go
+++ b/cmd/dataset/status.go
@@ -41,7 +41,7 @@ type datasetDerivation struct {
 }
 
 var statusCmd = &cobra.Command{
-	Use:   "status <namespace.name>",
+	Use:   "status <name> [--namespace <ns>]",
 	Short: "Show one freshness dataset state",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -5,6 +5,7 @@ import (
 	"github.com/caesium-cloud/caesium/cmd/backfill"
 	"github.com/caesium-cloud/caesium/cmd/blame"
 	"github.com/caesium-cloud/caesium/cmd/cache"
+	"github.com/caesium-cloud/caesium/cmd/dataset"
 	"github.com/caesium-cloud/caesium/cmd/dev"
 	"github.com/caesium-cloud/caesium/cmd/event"
 	"github.com/caesium-cloud/caesium/cmd/job"
@@ -23,6 +24,7 @@ var cmds = []*cobra.Command{
 	backfill.Cmd,
 	blame.Cmd,
 	cache.Cmd,
+	dataset.Cmd,
 	dev.Cmd,
 	event.Cmd,
 	job.Cmd,

--- a/docs/exec-plans/active/freshness-scheduling.md
+++ b/docs/exec-plans/active/freshness-scheduling.md
@@ -381,19 +381,22 @@ plan's items add files and append route lines to it. The two plans' `bind.go` /
 `--json` output goes to **stdout, clean and parseable**, captured separately from
 stderr per the `CLAUDE.md` gate.
 
-- [ ] E1. Add the dataset read + advance REST: `GET /v1/datasets` (list +
+- [x] E1. Add the dataset read + advance REST: `GET /v1/datasets` (list +
       `status` filter, bounded/paginated), `GET /v1/datasets/:ns/:name` (state,
       SLO, producing job), `GET /v1/datasets/:ns/:name/derivations` (the
       `DatasetDerivation` decision audit — why/why-not), and
       `POST /v1/datasets/:ns/:name/advance` (manual arrival, auth-scoped, reusing
       the shipped API-key convention). Controller + service + the route lines in
-      `Protected()` (`api/rest/bind/bind.go:57`). The reads serve declared-graph
+      `Protected()` (`api/rest/bind/bind.go`). The reads serve declared-graph
       datasets before any run exists (`unknown` state), not just observed ones.
       Files: new `api/rest/controller/dataset/`, new
       `api/rest/service/dataset/`, `api/rest/bind/bind.go`.
       Depends on: B1 (state/derivation models) + A2 (declarations) + B2 (state
       store).
-- [ ] E2. Add the `caesium dataset` CLI group appended to the `cmds` slice in
+      Note: implemented service/controller package, ungated `Protected()` route
+      block, declared-only `unknown` reads, `/_/name` empty-namespace path
+      convention, and the manual advance path through `freshness.Store.Advance`.
+- [x] E2. Add the `caesium dataset` CLI group appended to the `cmds` slice in
       `cmd/execute.go`: `caesium dataset list [--status stale|violated|…] [--json]`,
       `caesium dataset status <namespace.name> [--json]` (state, SLO, last
       decision), and `caesium dataset advance <namespace.name> --watermark <v>`
@@ -402,6 +405,10 @@ stderr per the `CLAUDE.md` gate.
       push`/`caesium trigger events` CLI hygiene).
       Files: new `cmd/dataset/`, `cmd/execute.go`.
       Depends on: E1.
+      Note: implemented the base `cmd/dataset` group with list/status/advance,
+      `cliutil.WritePrettyJSON` for machine output, a timed HTTP client, bearer
+      API-key resolution, first-dot namespace splitting, and the `_` empty-namespace
+      path convention shared with REST.
 
 ### Stream F — Console UI: dataset board, lineage overlay, derivations panel
 

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -78,6 +78,13 @@ var endpointPolicy = map[string]models.Role{
 	"GET /v1/incidents":     models.RoleViewer,
 	"GET /v1/incidents/:id": models.RoleViewer,
 
+	// Dataset freshness operator surface (freshness-scheduling E1). Reads are
+	// viewer; the manual watermark advance is a data-plane write at runner.
+	"GET /v1/datasets":                     models.RoleViewer,
+	"GET /v1/datasets/:id/:id":             models.RoleViewer,
+	"GET /v1/datasets/:id/:id/derivations": models.RoleViewer,
+	"POST /v1/datasets/:id/:id/advance":    models.RoleRunner,
+
 	// Agent tool surface (/v1/agent/*). Reachable by an unscoped operator/admin
 	// AND by an agent-session credential minted at the runner role; the
 	// per-incident binding is enforced separately by the deny-by-default scope

--- a/test/dataset_e2e_test.go
+++ b/test/dataset_e2e_test.go
@@ -123,6 +123,24 @@ func (s *IntegrationTestSuite) TestDatasetRESTAndCLIListSurfacesManualAdvance() 
 	s.Equal("advanced", cliAdvanced.Outcome)
 	s.Equal(cliName, cliAdvanced.State.Name)
 	s.Equal(cliWatermark, cliAdvanced.State.Watermark)
+
+	// A dataset name that contains dots (e.g. "raw.vendor_x") must round-trip as
+	// a single name in the empty namespace, not be split into namespace.name.
+	dottedName := fmt.Sprintf("raw.vendor_%d", time.Now().UnixNano())
+	dottedWatermark := fmt.Sprintf("%d", time.Now().UnixNano())
+	dottedAdvanceOut, err := s.runCLIStdout("dataset", "advance", dottedName, "--watermark", dottedWatermark, "--server", s.caesiumURL)
+	s.Require().NoError(err)
+	var dottedAdvanced datasetAdvanceResponse
+	s.Require().NoError(json.Unmarshal([]byte(dottedAdvanceOut), &dottedAdvanced))
+	s.Equal(dottedName, dottedAdvanced.State.Name)
+	s.Equal("", dottedAdvanced.State.Namespace)
+
+	dottedStatusOut, err := s.runCLIStdout("dataset", "status", dottedName, "--json", "--server", s.caesiumURL)
+	s.Require().NoError(err)
+	var dottedStatus datasetDetailResponse
+	s.Require().NoError(json.Unmarshal([]byte(dottedStatusOut), &dottedStatus))
+	s.Equal(dottedName, dottedStatus.State.Name)
+	s.Equal(dottedWatermark, dottedStatus.State.Watermark)
 }
 
 func findDatasetState(rows []datasetStateResponse, namespace, name string) (datasetStateResponse, bool) {

--- a/test/dataset_e2e_test.go
+++ b/test/dataset_e2e_test.go
@@ -1,0 +1,153 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type datasetListResponse struct {
+	Datasets []datasetStateResponse `json:"datasets"`
+	Total    int64                  `json:"total"`
+}
+
+type datasetStateResponse struct {
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name"`
+	Watermark string `json:"watermark"`
+	Status    string `json:"status"`
+}
+
+type datasetAdvanceResponse struct {
+	Outcome string               `json:"outcome"`
+	State   datasetStateResponse `json:"state"`
+}
+
+type datasetDetailResponse struct {
+	State datasetStateResponse `json:"state"`
+	SLO   *datasetSLOResponse  `json:"slo,omitempty"`
+}
+
+type datasetSLOResponse struct {
+	ExpectedEvery string `json:"expected_every,omitempty"`
+}
+
+type datasetDerivationsResponse struct {
+	Derivations []json.RawMessage `json:"derivations"`
+	Total       int64             `json:"total"`
+}
+
+func (s *IntegrationTestSuite) TestDatasetRESTAndCLIListSurfacesManualAdvance() {
+	declaredName := fmt.Sprintf("declared_%d", time.Now().UnixNano())
+	alias := fmt.Sprintf("integration-dataset-declared-%d", time.Now().UnixNano())
+	dir := s.writeJobManifest(datasetDeclaredSourceManifest(alias, declaredName))
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	var declared datasetDetailResponse
+	s.getJSON("/v1/datasets/_/"+declaredName, &declared)
+	s.Equal(declaredName, declared.State.Name)
+	s.Equal("unknown", declared.State.Status)
+	s.Require().NotNil(declared.SLO)
+	s.Equal("1h", declared.SLO.ExpectedEvery)
+
+	name := fmt.Sprintf("manual_%d", time.Now().UnixNano())
+	watermark := fmt.Sprintf("%d", time.Now().UnixNano())
+	payload := fmt.Sprintf(`{"watermark":%q}`, watermark)
+
+	resp, err := s.doRequest(http.MethodPost, s.caesiumURL+"/v1/datasets/_/"+name+"/advance", strings.NewReader(payload))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode, string(body))
+
+	var advanced datasetAdvanceResponse
+	s.Require().NoError(json.Unmarshal(body, &advanced))
+	s.Equal("advanced", advanced.Outcome)
+	s.Equal("", advanced.State.Namespace)
+	s.Equal(name, advanced.State.Name)
+	s.Equal(watermark, advanced.State.Watermark)
+	s.Equal("unknown", advanced.State.Status)
+
+	var detail datasetDetailResponse
+	s.getJSON("/v1/datasets/_/"+name, &detail)
+	s.Equal(name, detail.State.Name)
+	s.Equal(watermark, detail.State.Watermark)
+	s.Equal("unknown", detail.State.Status)
+
+	var listed datasetListResponse
+	s.getJSON("/v1/datasets?status=unknown", &listed)
+	state, ok := findDatasetState(listed.Datasets, "", name)
+	s.Require().True(ok, "advanced dataset %q not found in list response: %+v", name, listed.Datasets)
+	s.Equal(watermark, state.Watermark)
+	s.Equal("unknown", state.Status)
+
+	var derivations datasetDerivationsResponse
+	s.getJSON("/v1/datasets/_/"+name+"/derivations", &derivations)
+	s.Len(derivations.Derivations, 0)
+	s.Equal(int64(0), derivations.Total)
+
+	stdout, err := s.runCLIStdout("dataset", "list", "--json", "--server", s.caesiumURL)
+	s.Require().NoError(err)
+	s.Require().True(json.Valid([]byte(stdout)), "caesium dataset list stdout was not clean JSON:\n%s", stdout)
+
+	var cliList datasetListResponse
+	s.Require().NoError(json.Unmarshal([]byte(stdout), &cliList))
+	_, ok = findDatasetState(cliList.Datasets, "", name)
+	s.Require().True(ok, "advanced dataset %q not found in CLI list response: %+v", name, cliList.Datasets)
+
+	statusOut, err := s.runCLIStdout("dataset", "status", name, "--json", "--server", s.caesiumURL)
+	s.Require().NoError(err)
+	s.Require().True(json.Valid([]byte(statusOut)), "caesium dataset status stdout was not clean JSON:\n%s", statusOut)
+
+	var cliStatus datasetDetailResponse
+	s.Require().NoError(json.Unmarshal([]byte(statusOut), &cliStatus))
+	s.Equal(name, cliStatus.State.Name)
+	s.Equal(watermark, cliStatus.State.Watermark)
+
+	cliName := fmt.Sprintf("manual_cli_%d", time.Now().UnixNano())
+	cliWatermark := fmt.Sprintf("%d", time.Now().UnixNano())
+	advanceOut, err := s.runCLIStdout("dataset", "advance", cliName, "--watermark", cliWatermark, "--server", s.caesiumURL)
+	s.Require().NoError(err)
+	s.Require().True(json.Valid([]byte(advanceOut)), "caesium dataset advance stdout was not clean JSON:\n%s", advanceOut)
+
+	var cliAdvanced datasetAdvanceResponse
+	s.Require().NoError(json.Unmarshal([]byte(advanceOut), &cliAdvanced))
+	s.Equal("advanced", cliAdvanced.Outcome)
+	s.Equal(cliName, cliAdvanced.State.Name)
+	s.Equal(cliWatermark, cliAdvanced.State.Watermark)
+}
+
+func findDatasetState(rows []datasetStateResponse, namespace, name string) (datasetStateResponse, bool) {
+	for _, row := range rows {
+		if row.Namespace == namespace && row.Name == name {
+			return row, true
+		}
+	}
+	return datasetStateResponse{}, false
+}
+
+func datasetDeclaredSourceManifest(alias, datasetName string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  datasets:
+    sources:
+      - name: %s
+        expectedEvery: 1h
+        external: true
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: noop
+    image: alpine:3.23
+    command: ["sh","-c","echo ok"]
+`, alias, datasetName)
+}


### PR DESCRIPTION
## Summary
- Adds the base **`/v1/datasets` REST family**: `GET /v1/datasets` (status filter + pagination), `GET /v1/datasets/:ns/:name`, `GET …/derivations` (decision audit), `POST …/advance` (manual arrival). Controller + service mirror the incident pattern (echo v5 pointer `*echo.Context`).
- Adds the **`caesium dataset`** CLI group (`list` / `status` / `advance`) with machine `--json` on clean stdout via `cliutil.WritePrettyJSON`, timed HTTP client, bearer API-key.
- Adds **RBAC `endpointPolicy` entries** for all four routes (reads = viewer, advance = runner) so the auth-middleware completeness test passes.
- Routes are **ungated** (no dependency on the evaluator's env flag) so the read surface serves declared-graph datasets in `unknown` state before any run.
- Owns the base `cmd/dataset/` group + `api/rest/{controller,service}/dataset/` packages (a sibling plan extends them later).

## Test plan
- [x] `just lint` — pass
- [x] `just unit-test` — pass (incl. `TestAuthMiddlewareMountedRoutesHaveRBACPolicy`)
- [ ] `just integration-test` — self-contained scenario (`POST advance` → `GET list`/`derivations`; `runCLIStdout` clean JSON) runs at the merge gate

Implemented by codex (GPT-5.5); orchestrator added the RBAC `endpointPolicy` entries pre-publish (the RBAC completeness test caught the omission).

🤖 Generated with [Claude Code](https://claude.com/claude-code)