### PR TITLE
Add the agent MCP tool surface (agent-in-the-loop-remediation W3-δ)

### DIFF
--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -235,6 +235,7 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		g.GET("/agent/incidents/:id/context/*", agentctrl.Context)
 		g.POST("/agent/incidents/:id/actions", agentctrl.Actions)
 		g.POST("/agent/incidents/:id/notes", agentctrl.Notes)
+		g.POST("/agent/incidents/:id/mcp", agentctrl.MCP)
 	}
 }
 

--- a/api/rest/controller/agent/mcp.go
+++ b/api/rest/controller/agent/mcp.go
@@ -1,0 +1,191 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	agentsvc "github.com/caesium-cloud/caesium/api/rest/service/agent"
+	"github.com/caesium-cloud/caesium/internal/mcp"
+	"github.com/caesium-cloud/caesium/internal/models"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+// MCP handles POST /v1/agent/incidents/:id/mcp: a synchronous JSON-RPC 2.0 MCP
+// endpoint for the same incident-scoped agent tool surface as the REST routes.
+// The incident id is read only from the route, so the auth middleware's
+// per-incident agent-token confinement applies before JSON-RPC dispatch.
+func MCP(c *echo.Context) error {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid incident id")
+	}
+
+	svc := agentsvc.New(c.Request().Context())
+	inc, err := svc.Incident(id)
+	if err != nil {
+		if errors.Is(err, agentsvc.ErrIncidentNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	allowed := authmw.GetAllowedJobAliases(c)
+	dispatcher := mcp.Dispatcher{
+		Tools:               mcp.AgentTools,
+		ReservedParamFields: []string{"incident_id", "incidentId", "incidentID"},
+		CallTool: func(name string, arguments json.RawMessage) (any, *mcp.Error) {
+			return callMCPAgentTool(svc, inc, allowed, name, arguments)
+		},
+	}
+
+	return c.JSON(http.StatusOK, mcp.Handle(c.Request().Body, dispatcher))
+}
+
+type getContextArgs struct {
+	Kind string `json:"kind"`
+	Job  string `json:"job,omitempty"`
+	Task string `json:"task,omitempty"`
+}
+
+type proposeActionArgs struct {
+	Type   string          `json:"type"`
+	Params json.RawMessage `json:"params,omitempty"`
+}
+
+type addNoteArgs struct {
+	Text string `json:"text"`
+}
+
+func callMCPAgentTool(svc *agentsvc.Service, inc *models.Incident, allowed []string, name string, arguments json.RawMessage) (any, *mcp.Error) {
+	switch name {
+	case "get_bundle":
+		var args struct{}
+		if rpcErr := decodeMCPToolArguments(arguments, &args); rpcErr != nil {
+			return nil, rpcErr
+		}
+		bundle, err := svc.Bundle(inc.ID)
+		if err != nil {
+			return nil, mapMCPAgentError(err)
+		}
+		return bundle, nil
+
+	case "get_context":
+		var args getContextArgs
+		if rpcErr := decodeMCPToolArguments(arguments, &args); rpcErr != nil {
+			return nil, rpcErr
+		}
+		switch strings.TrimSpace(args.Kind) {
+		case "logs":
+			text, ok, err := svc.FailingLog(inc)
+			if err != nil {
+				return nil, mapMCPAgentError(err)
+			}
+			return map[string]any{"log_tail": text, "available": ok, "scrubbed": true}, nil
+		case "history":
+			runs, err := svc.History(inc, strings.TrimSpace(args.Job), allowed)
+			if err != nil {
+				return nil, mapMCPAgentError(err)
+			}
+			return map[string]any{"runs": runs}, nil
+		case "why":
+			task := strings.TrimSpace(args.Task)
+			if task == "" {
+				return nil, mcp.InvalidParams("task is required for why context")
+			}
+			explanation, err := svc.Why(inc, task)
+			if err != nil {
+				return nil, mapMCPAgentError(err)
+			}
+			return explanation, nil
+		default:
+			return nil, mcp.InvalidParams("unknown context kind")
+		}
+
+	case "propose_action":
+		var args proposeActionArgs
+		if rpcErr := decodeMCPToolArguments(arguments, &args); rpcErr != nil {
+			return nil, rpcErr
+		}
+		result, err := svc.ProposeAction(inc, agentsvc.ActionRequest{
+			Type:   strings.TrimSpace(args.Type),
+			Params: args.Params,
+		})
+		if err != nil {
+			return nil, mapMCPAgentError(err)
+		}
+		return result, nil
+
+	case "add_note":
+		var args addNoteArgs
+		if rpcErr := decodeMCPToolArguments(arguments, &args); rpcErr != nil {
+			return nil, rpcErr
+		}
+		text := strings.TrimSpace(args.Text)
+		if text == "" {
+			return nil, mcp.InvalidParams("text is required")
+		}
+		action, err := svc.Note(inc, text)
+		if err != nil {
+			return nil, mapMCPAgentError(err)
+		}
+		return action, nil
+
+	default:
+		return nil, mcp.NotFound("unknown tool")
+	}
+}
+
+func decodeMCPToolArguments(raw json.RawMessage, target any) *mcp.Error {
+	if hasIncidentIDArgument(raw) {
+		return mcp.InvalidParams("incident id must be supplied in the URL path, not MCP arguments")
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		raw = json.RawMessage("{}")
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(target); err != nil {
+		return mcp.InvalidParams("invalid tool arguments")
+	}
+	var extra any
+	if err := dec.Decode(&extra); err == nil || !errors.Is(err, io.EOF) {
+		return mcp.InvalidParams("invalid tool arguments")
+	}
+	return nil
+}
+
+func hasIncidentIDArgument(raw json.RawMessage) bool {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return false
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return false
+	}
+	_, snake := fields["incident_id"]
+	_, lowerCamel := fields["incidentId"]
+	_, upperCamel := fields["incidentID"]
+	return snake || lowerCamel || upperCamel
+}
+
+func mapMCPAgentError(err error) *mcp.Error {
+	switch {
+	case errors.Is(err, agentsvc.ErrUnknownActionType):
+		return mcp.InvalidParams(err.Error())
+	case errors.Is(err, agentsvc.ErrForbiddenJob):
+		return mcp.Forbidden(agentsvc.ErrForbiddenJob.Error())
+	case errors.Is(err, agentsvc.ErrIncidentNotFound), errors.Is(err, agentsvc.ErrNoFailingRun), errors.Is(err, gorm.ErrRecordNotFound), errors.Is(err, runstorage.ErrTaskRunNotFound):
+		return mcp.NotFound("not found")
+	default:
+		return mcp.InternalError()
+	}
+}

--- a/api/rest/controller/agent/mcp.go
+++ b/api/rest/controller/agent/mcp.go
@@ -46,7 +46,12 @@ func MCP(c *echo.Context) error {
 		},
 	}
 
-	return c.JSON(http.StatusOK, mcp.Handle(c.Request().Body, dispatcher))
+	resp, respond := mcp.Handle(c.Request().Body, dispatcher)
+	if !respond {
+		// JSON-RPC notifications carry no id and MUST NOT receive a response.
+		return c.NoContent(http.StatusAccepted)
+	}
+	return c.JSON(http.StatusOK, resp)
 }
 
 type getContextArgs struct {

--- a/docs/exec-plans/active/agent-in-the-loop-remediation.md
+++ b/docs/exec-plans/active/agent-in-the-loop-remediation.md
@@ -167,7 +167,7 @@ Streams F, G, U (+ H-1, N-1) remain for later waves.
 | C | Agent runtime — session supervisor (atom.Engine), triage bundle, scoped short-lived token, `/v1/agent/*` REST tool surface | P1 | **Shipped** (Wave 2, #284) |
 | D | Approval gates + incident REST reads + `ai_agent` dispatch channel | P1 | **Shipped** (Wave 2, #283) |
 | E | Declarative policy — jobdef `metadata.remediation` block + `AgentProfile` CRUD + offline/server lint | P1 | **Shipped** (Wave 2, #282) |
-| F | MCP surface — `/v1/agent/mcp` JSON-RPC/streamable-HTTP over the same handlers | P2 | Not started |
+| F | MCP surface — `/v1/agent/incidents/:id/mcp` JSON-RPC over the same service layer | P2 | **Shipped** (Wave 3, W3-δ) |
 | G | CLI — `caesium incident …` + `caesium agent profile …` | P2 | Not started |
 | U | Console incidents surface — feed, triage timeline, approval cards, run/task ribbons, agent activity, fleet analytics | P1 | Not started |
 | H-1 | Harness — deterministic fake agent image + integration server gate wiring | — | **Shipped** (W3-eta: fake image + auth lane) |
@@ -494,17 +494,24 @@ stream owns the job-schema addition and the server-side profile resource.
 
 ### Stream F — MCP surface
 
-- [ ] F1. Expose the same tool surface over MCP's streamable-HTTP transport at
-      `/v1/agent/mcp` (POST-carried JSON-RPC 2.0 with an optional SSE channel) so
-      off-the-shelf agents (Claude Code, Agent SDK apps) connect without glue code.
+- [x] F1. Expose the same tool surface over MCP's streamable-HTTP transport at
+      `/v1/agent/incidents/:id/mcp` (POST-carried JSON-RPC 2.0, one synchronous
+      response per call) so off-the-shelf agents connect without glue code.
       Honest cost: Caesium has no JSON-RPC/MCP dependency today, so this is a small
       vendored MCP server layer or hand-rolled JSON-RPC 2.0 inside Echo over the
-      **same handler layer** as Stream C, plus **exempting the route from the
-      server's 30s write timeout**. REST ships first (Stream C); MCP follows.
+      **same service layer** as Stream C. The incident id stays in the path so the
+      existing agent-token incident confinement applies; the endpoint is
+      synchronous and stays under the server's existing 30s write timeout.
       Files: new `api/rest/controller/agent/mcp.go`, new `internal/mcp/`
-      (JSON-RPC layer), `api/rest/bind/bind.go`, `api/api.go` (write-timeout
-      exemption for the MCP route).
+      (JSON-RPC layer), `api/rest/bind/bind.go`, `internal/auth/rbac.go`, and
+      `test/agent_mcp_test.go`.
       Depends on: C4.
+      W3-delta note (2026-07-04): implemented as synchronous JSON-RPC 2.0 at
+      `POST /v1/agent/incidents/:id/mcp`, reusing `api/rest/service/agent`
+      directly. The incident id is path-only (not accepted in JSON-RPC params),
+      no SSE/write-timeout exemption was added, and the route is registered in
+      `endpointPolicy` at `RoleRunner` because MCP multiplexes read and write
+      tools over one POST.
 
 ### Stream G — CLI
 
@@ -625,7 +632,7 @@ primary evidence — nothing is prose-only.
   prerequisite for B4 and U3.
 - **Stream E**: E1 (jobdef block) is independent of the runtime (leaf); E2
   (AgentProfile CRUD) depends on A1.
-- **Stream F** (MCP) depends on C4 (reuses the same handler layer).
+- **Stream F** (MCP) depends on C4 (reuses the same service layer).
 - **Stream G**: G1 depends on D1 + D2; G2 depends on E2.
 - **Stream U** (UI): U1 depends on D2; U2→U1; U3 depends on U2 + D1; U4→U2; U5→U1.
 - **H-1** is largely independent (build image + justfile/CI + test harness) but
@@ -681,7 +688,8 @@ E1 standalone; E2 after A1. U1 → U2 → (U3, U4); U5 after U1.
 - `cmd/execute.go` — G1 + G2 append command groups (additive, both W3).
 - `internal/event/bus.go` — A2 (`schema_violation_recorded`) and D2 (the four SSE
   incident event types) both add event types. A2 (W1) before D2 (W2); additive.
-- `api/api.go` — only F1 (W3) touches it (write-timeout exemption); no conflict.
+- `api/api.go` — F1 no longer touches it; MCP is synchronous under the existing
+  write timeout.
 - `ui/src/router.tsx`, `ui/src/lib/api.ts`, `ui/src/components/layout/Sidebar.tsx`
   — U1–U5 append (same stream U); additive list edits.
 
@@ -757,8 +765,8 @@ The plan is done when **all** of these hold:
    lint verifies profile references inside the apply transaction, and `AgentProfile`
    CRUD + the shipped `triage-only` default profile exist. Closed by a lint
    scenario + an AgentProfile CRUD scenario.
-6. **Stream F — the MCP surface** exposes the tool set at `/v1/agent/mcp` over
-   JSON-RPC/streamable-HTTP with the write-timeout exemption. Closed by an MCP
+6. **Stream F — the MCP surface** exposes the tool set at
+   `/v1/agent/incidents/:id/mcp` over synchronous JSON-RPC 2.0. Closed by an MCP
    protocol-level integration test.
 7. **Stream G — the CLI** ships `caesium incident …` and `caesium agent profile …`
    driving the real endpoints, asserted via `runCLIStdout` (clean, parseable stdout

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -90,11 +90,13 @@ var endpointPolicy = map[string]models.Role{
 	// per-incident binding is enforced separately by the deny-by-default scope
 	// switch (api/middleware/auth_scope.go), which 403s an agent token on any
 	// route outside its own incident. Reads sit at viewer, mutating tool calls
-	// (propose/execute an action, append a note) at runner.
+	// (propose/execute an action, append a note) at runner. MCP multiplexes both
+	// read and write tools over one POST, so it is agent/runner-only.
 	"GET /v1/agent/incidents/:id/bundle":    models.RoleViewer,
 	"GET /v1/agent/incidents/:id/context/*": models.RoleViewer,
 	"POST /v1/agent/incidents/:id/actions":  models.RoleRunner,
 	"POST /v1/agent/incidents/:id/notes":    models.RoleRunner,
+	"POST /v1/agent/incidents/:id/mcp":      models.RoleRunner,
 
 	// Runner
 	"POST /v1/jobs/:id/run":                      models.RoleRunner,

--- a/internal/mcp/dispatcher.go
+++ b/internal/mcp/dispatcher.go
@@ -1,0 +1,108 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+const protocolVersion = "2024-11-05"
+
+// ToolHandler executes one named MCP tool and returns the structured payload for
+// the MCP tools/call result.
+type ToolHandler func(name string, arguments json.RawMessage) (any, *Error)
+
+// Dispatcher handles MCP's JSON-RPC methods over one synchronous HTTP POST.
+type Dispatcher struct {
+	Tools               []Tool
+	CallTool            ToolHandler
+	ReservedParamFields []string
+}
+
+// Dispatch handles initialize, tools/list, and tools/call.
+func (d Dispatcher) Dispatch(req Request) Response {
+	if field := findReservedField(req.Params, d.ReservedParamFields); field != "" {
+		return ErrorResponse(req.ID, InvalidParams(field+" is not accepted in MCP params"))
+	}
+
+	switch req.Method {
+	case "initialize":
+		return SuccessResponse(req.ID, InitializeResult{
+			ProtocolVersion: protocolVersion,
+			Capabilities:    Capabilities{Tools: map[string]any{}},
+			ServerInfo:      ServerInfo{Name: "caesium-agent-tools", Version: "0.1.0"},
+		})
+	case "tools/list":
+		return SuccessResponse(req.ID, ListToolsResult{Tools: d.Tools})
+	case "tools/call":
+		result, rpcErr := d.dispatchToolCall(req.Params)
+		if rpcErr != nil {
+			return ErrorResponse(req.ID, rpcErr)
+		}
+		return SuccessResponse(req.ID, result)
+	default:
+		return ErrorResponse(req.ID, &Error{Code: CodeMethodNotFound, Message: "method not found"})
+	}
+}
+
+func (d Dispatcher) dispatchToolCall(params json.RawMessage) (ToolCallResult, *Error) {
+	if d.CallTool == nil {
+		return ToolCallResult{}, &Error{Code: CodeMethodNotFound, Message: "method not found"}
+	}
+	if field := findReservedField(params, d.ReservedParamFields); field != "" {
+		return ToolCallResult{}, InvalidParams(field + " is not accepted in MCP params")
+	}
+
+	var call ToolCallParams
+	if err := decodeObject(params, &call); err != nil {
+		return ToolCallResult{}, InvalidParams("invalid tools/call params")
+	}
+	if call.Name == "" {
+		return ToolCallResult{}, InvalidParams("tool name is required")
+	}
+	if len(call.Arguments) == 0 {
+		call.Arguments = json.RawMessage("{}")
+	}
+
+	payload, rpcErr := d.CallTool(call.Name, call.Arguments)
+	if rpcErr != nil {
+		return ToolCallResult{}, rpcErr
+	}
+	result, err := NewToolCallResult(payload)
+	if err != nil {
+		return ToolCallResult{}, InternalError()
+	}
+	return result, nil
+}
+
+func findReservedField(raw json.RawMessage, fields []string) string {
+	if len(fields) == 0 || len(bytes.TrimSpace(raw)) == 0 {
+		return ""
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return ""
+	}
+	for _, field := range fields {
+		if _, ok := object[field]; ok {
+			return field
+		}
+	}
+	return ""
+}
+
+func decodeObject(raw json.RawMessage, target any) error {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		raw = json.RawMessage("{}")
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	if err := dec.Decode(target); err != nil {
+		return err
+	}
+	var extra any
+	if err := dec.Decode(&extra); err == nil || !errors.Is(err, io.EOF) {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -43,13 +43,25 @@ type Error struct {
 	Message string `json:"message"`
 }
 
-// Handle decodes one JSON-RPC request from r and dispatches it.
-func Handle(r io.Reader, d Dispatcher) Response {
+// IsNotification reports whether the request is a JSON-RPC 2.0 notification: a
+// request with no "id" member. Notifications MUST NOT receive a response.
+func (r Request) IsNotification() bool {
+	return len(r.ID) == 0
+}
+
+// Handle decodes one JSON-RPC request from r and dispatches it. The returned
+// bool reports whether a response should be written back to the client:
+// JSON-RPC notifications (requests without an "id") MUST NOT receive a
+// response, so callers must suppress the response body when it is false.
+func Handle(r io.Reader, d Dispatcher) (Response, bool) {
 	req, rpcErr := decodeRequest(r)
 	if rpcErr != nil {
-		return ErrorResponse(nil, rpcErr)
+		return ErrorResponse(nil, rpcErr), true
 	}
-	return d.Dispatch(req)
+	if req.IsNotification() {
+		return Response{}, false
+	}
+	return d.Dispatch(req), true
 }
 
 // SuccessResponse builds a JSON-RPC success envelope.
@@ -83,6 +95,9 @@ func InternalError() *Error {
 }
 
 func decodeRequest(r io.Reader) (Request, *Error) {
+	if r == nil {
+		return Request{}, &Error{Code: CodeParseError, Message: "parse error"}
+	}
 	dec := json.NewDecoder(r)
 
 	var req Request

--- a/internal/mcp/jsonrpc.go
+++ b/internal/mcp/jsonrpc.go
@@ -1,0 +1,109 @@
+package mcp
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+)
+
+const (
+	// JSON-RPC 2.0 well-known error codes.
+	CodeParseError     = -32700
+	CodeInvalidRequest = -32600
+	CodeMethodNotFound = -32601
+	CodeInvalidParams  = -32602
+	CodeInternalError  = -32603
+
+	// Application error codes live in the JSON-RPC server error range.
+	CodeForbidden = -32003
+	CodeNotFound  = -32004
+)
+
+var nullID = json.RawMessage("null")
+
+// Request is the JSON-RPC 2.0 envelope accepted by the MCP endpoint.
+type Request struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// Response is the JSON-RPC 2.0 envelope returned by the MCP endpoint.
+type Response struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *Error          `json:"error,omitempty"`
+}
+
+// Error is the JSON-RPC 2.0 error object.
+type Error struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Handle decodes one JSON-RPC request from r and dispatches it.
+func Handle(r io.Reader, d Dispatcher) Response {
+	req, rpcErr := decodeRequest(r)
+	if rpcErr != nil {
+		return ErrorResponse(nil, rpcErr)
+	}
+	return d.Dispatch(req)
+}
+
+// SuccessResponse builds a JSON-RPC success envelope.
+func SuccessResponse(id json.RawMessage, result any) Response {
+	return Response{JSONRPC: "2.0", ID: responseID(id), Result: result}
+}
+
+// ErrorResponse builds a JSON-RPC error envelope.
+func ErrorResponse(id json.RawMessage, err *Error) Response {
+	return Response{JSONRPC: "2.0", ID: responseID(id), Error: err}
+}
+
+// InvalidParams returns a JSON-RPC invalid-params error.
+func InvalidParams(message string) *Error {
+	return &Error{Code: CodeInvalidParams, Message: message}
+}
+
+// Forbidden returns a JSON-RPC forbidden application error.
+func Forbidden(message string) *Error {
+	return &Error{Code: CodeForbidden, Message: message}
+}
+
+// NotFound returns a JSON-RPC not-found application error.
+func NotFound(message string) *Error {
+	return &Error{Code: CodeNotFound, Message: message}
+}
+
+// InternalError returns a JSON-RPC internal-error response with a stable message.
+func InternalError() *Error {
+	return &Error{Code: CodeInternalError, Message: "internal server error"}
+}
+
+func decodeRequest(r io.Reader) (Request, *Error) {
+	dec := json.NewDecoder(r)
+
+	var req Request
+	if err := dec.Decode(&req); err != nil {
+		return Request{}, &Error{Code: CodeParseError, Message: "parse error"}
+	}
+
+	var extra any
+	if err := dec.Decode(&extra); err == nil || !errors.Is(err, io.EOF) {
+		return Request{}, &Error{Code: CodeParseError, Message: "parse error"}
+	}
+
+	if req.JSONRPC != "2.0" || req.Method == "" {
+		return req, &Error{Code: CodeInvalidRequest, Message: "invalid request"}
+	}
+	return req, nil
+}
+
+func responseID(id json.RawMessage) json.RawMessage {
+	if len(id) == 0 {
+		return nullID
+	}
+	return id
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1,0 +1,137 @@
+package mcp
+
+import "encoding/json"
+
+// Tool is an MCP tool descriptor.
+type Tool struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"inputSchema"`
+}
+
+// InitializeResult is the MCP initialize response payload.
+type InitializeResult struct {
+	ProtocolVersion string       `json:"protocolVersion"`
+	Capabilities    Capabilities `json:"capabilities"`
+	ServerInfo      ServerInfo   `json:"serverInfo"`
+}
+
+// Capabilities advertises supported MCP server capabilities.
+type Capabilities struct {
+	Tools map[string]any `json:"tools"`
+}
+
+// ServerInfo identifies this MCP server surface.
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// ListToolsResult is the tools/list response payload.
+type ListToolsResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+// ToolCallParams is the tools/call params payload.
+type ToolCallParams struct {
+	Name      string          `json:"name"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// ToolCallResult is the MCP tools/call result payload.
+type ToolCallResult struct {
+	Content           []ToolContent `json:"content"`
+	StructuredContent any           `json:"structuredContent,omitempty"`
+}
+
+// ToolContent is one MCP content item.
+type ToolContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// NewToolCallResult returns both structured JSON and a text JSON representation
+// for MCP clients that only consume content[].
+func NewToolCallResult(payload any) (ToolCallResult, error) {
+	if payload == nil {
+		payload = map[string]any{}
+	}
+	text, err := json.Marshal(payload)
+	if err != nil {
+		return ToolCallResult{}, err
+	}
+	return ToolCallResult{
+		Content: []ToolContent{
+			{Type: "text", Text: string(text)},
+		},
+		StructuredContent: payload,
+	}, nil
+}
+
+// AgentTools are the four Caesium agent tools exposed over MCP. The incident id
+// is intentionally absent: it comes only from /v1/agent/incidents/:id/mcp.
+var AgentTools = []Tool{
+	{
+		Name:        "get_bundle",
+		Description: "Fetch the incident triage bundle for this agent session.",
+		InputSchema: objectSchema(nil, nil),
+	},
+	{
+		Name:        "get_context",
+		Description: "Fetch scoped incident context: failing logs, run history, or why output.",
+		InputSchema: objectSchema(map[string]any{
+			"kind": map[string]any{
+				"type":        "string",
+				"description": "Context kind to fetch.",
+				"enum":        []string{"logs", "history", "why"},
+			},
+			"job": map[string]any{
+				"type":        "string",
+				"description": "Optional job alias for history; must be in the incident allowlist unless it is the incident job.",
+			},
+			"task": map[string]any{
+				"type":        "string",
+				"description": "Task name for why context.",
+			},
+		}, []string{"kind"}),
+	},
+	{
+		Name:        "propose_action",
+		Description: "Propose or execute a typed remediation action through Caesium's server-side executor.",
+		InputSchema: objectSchema(map[string]any{
+			"type": map[string]any{
+				"type":        "string",
+				"description": "Typed remediation action name.",
+			},
+			"params": map[string]any{
+				"type":        "object",
+				"description": "Action-specific parameters.",
+			},
+		}, []string{"type"}),
+	},
+	{
+		Name:        "add_note",
+		Description: "Append a free-text finding to the incident timeline.",
+		InputSchema: objectSchema(map[string]any{
+			"text": map[string]any{
+				"type":        "string",
+				"description": "Timeline note text.",
+			},
+		}, []string{"text"}),
+	},
+}
+
+func objectSchema(properties map[string]any, required []string) map[string]any {
+	if properties == nil {
+		properties = map[string]any{}
+	}
+	schema := map[string]any{
+		"type":                 "object",
+		"properties":           properties,
+		"additionalProperties": false,
+	}
+	if len(required) > 0 {
+		schema["required"] = required
+	}
+	return schema
+}

--- a/test/agent_mcp_test.go
+++ b/test/agent_mcp_test.go
@@ -1,0 +1,175 @@
+//go:build integration
+
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
+	iauth "github.com/caesium-cloud/caesium/internal/auth"
+	iincident "github.com/caesium-cloud/caesium/internal/incident"
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/env"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+func (s *IntegrationTestSuite) TestAgentMCPToolsListBundleAndIncidentScope() {
+	s.Require().NoError(env.Process())
+	vars := env.Variables()
+	if vars.AuthMode != "api-key" || !vars.AgentRemediationEnabled {
+		s.T().Skip("agent MCP integration requires the auth-enabled remediation lane")
+	}
+
+	conn := db.Connection()
+	incX, aliasX := seedMCPIncident(s.T(), conn, "x")
+	incY, _ := seedMCPIncident(s.T(), conn, "y")
+
+	authSvc := iauth.NewService(conn, iauth.WithKeyHashSecret(vars.AuthKeyHashSecret))
+	key, err := authSvc.MintAgentSessionKey(incX.ID, []string{aliasX}, time.Hour)
+	s.Require().NoError(err)
+
+	status, body := s.postAgentMCP(key.Plaintext, incX.ID, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+	})
+	s.Require().Equal(http.StatusOK, status, string(body))
+
+	var listResp mcpListResponse
+	s.Require().NoError(json.Unmarshal(body, &listResp))
+	s.Require().Nil(listResp.Error)
+	s.Equal("2.0", listResp.JSONRPC)
+	var toolNames []string
+	for _, tool := range listResp.Result.Tools {
+		toolNames = append(toolNames, tool.Name)
+	}
+	s.ElementsMatch([]string{"get_bundle", "get_context", "propose_action", "add_note"}, toolNames)
+
+	status, body = s.postAgentMCP(key.Plaintext, incX.ID, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "bundle",
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      "get_bundle",
+			"arguments": map[string]any{},
+		},
+	})
+	s.Require().Equal(http.StatusOK, status, string(body))
+
+	var bundleResp mcpBundleResponse
+	s.Require().NoError(json.Unmarshal(body, &bundleResp))
+	s.Require().Nil(bundleResp.Error)
+	s.Equal("2.0", bundleResp.JSONRPC)
+	s.Equal(incX.ID.String(), bundleResp.Result.StructuredContent.Incident.ID)
+	s.NotEmpty(bundleResp.Result.Content)
+
+	status, body = s.postAgentMCP(key.Plaintext, incY.ID, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/list",
+	})
+	s.Require().Equal(http.StatusForbidden, status, string(body))
+	s.Contains(string(body), authmw.AgentScopeDenyMessage)
+}
+
+type mcpErrorResponse struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type mcpListResponse struct {
+	JSONRPC string            `json:"jsonrpc"`
+	Error   *mcpErrorResponse `json:"error,omitempty"`
+	Result  struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	} `json:"result"`
+}
+
+type mcpBundleResponse struct {
+	JSONRPC string            `json:"jsonrpc"`
+	Error   *mcpErrorResponse `json:"error,omitempty"`
+	Result  struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		StructuredContent struct {
+			Incident struct {
+				ID string `json:"id"`
+			} `json:"incident"`
+		} `json:"structuredContent"`
+	} `json:"result"`
+}
+
+func (s *IntegrationTestSuite) postAgentMCP(token string, incidentID uuid.UUID, payload any) (int, []byte) {
+	s.T().Helper()
+
+	body, err := json.Marshal(payload)
+	s.Require().NoError(err)
+	req, err := http.NewRequestWithContext(
+		s.T().Context(),
+		http.MethodPost,
+		fmt.Sprintf("%s/v1/agent/incidents/%s/mcp", s.caesiumURL, incidentID),
+		bytes.NewReader(body),
+	)
+	s.Require().NoError(err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	out, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	return resp.StatusCode, out
+}
+
+func seedMCPIncident(t *testing.T, conn *gorm.DB, suffix string) (*models.Incident, string) {
+	t.Helper()
+
+	now := time.Now().UTC()
+	triggerID := uuid.New()
+	if err := conn.Create(&models.Trigger{
+		ID:            triggerID,
+		Type:          models.TriggerTypeCron,
+		Configuration: `{"cron":"0 * * * *"}`,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}).Error; err != nil {
+		t.Fatalf("seed MCP trigger: %v", err)
+	}
+
+	alias := fmt.Sprintf("agent-mcp-%s-%d", suffix, now.UnixNano())
+	jobID := uuid.New()
+	if err := conn.Create(&models.Job{
+		ID:        jobID,
+		Alias:     alias,
+		TriggerID: triggerID,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}).Error; err != nil {
+		t.Fatalf("seed MCP job: %v", err)
+	}
+
+	inc, _, err := iincident.NewStore(conn).OpenOrAppend(t.Context(), iincident.OpenParams{
+		JobID:     jobID,
+		TaskName:  "extract-" + suffix,
+		Class:     iincident.ClassUnknown,
+		LastError: "mcp integration seed",
+	})
+	if err != nil {
+		t.Fatalf("seed MCP incident: %v", err)
+	}
+	return inc, alias
+}


### PR DESCRIPTION
## Summary
- Exposes the 4 shipped agent tools (`get_bundle` / `get_context` / `propose_action` / `add_note`) over **MCP JSON-RPC 2.0** (`initialize` / `tools/list` / `tools/call`), hand-rolled in `internal/mcp` over the **same service layer** as the REST agent handlers (no new dependency).
- **Secure route shape**: `POST /v1/agent/incidents/:id/mcp` — the incident id is read from the URL path, so the shipped per-incident scope confinement (`authorizeAgentScope`) applies unchanged; a body/params-carried incident id is **actively rejected** (closes the cross-incident privilege-escalation vector a flat `/v1/agent/mcp` would open).
- Registered at `RoleRunner` with a matching `internal/auth/rbac.go` `endpointPolicy` entry (passes `TestAuthMiddlewareMountedRoutesHaveRBACPolicy`).
- Synchronous request/response keeps each call under the global 30s write timeout (verified there is no per-route exemption). Surfaces `ProposeAction`'s real disposition (proposed/awaiting_approval/executed) faithfully.

## Test plan
- [x] `just lint` — pass
- [x] `just unit-test` — pass (incl. RBAC completeness)
- [ ] `just integration-test-agent` — MCP `tools/list` + `tools/call` with a real agent-session token, and a cross-incident 403, run on the auth lane at the merge gate

Implemented by codex (GPT-5.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)