### PR TITLE
Harden exec-plan-wave: plan-slug branches, codex exec dispatch, remote-branch cleanup

### DIFF
--- a/.claude/skills/exec-plan-wave/PLAYBOOK.md
+++ b/.claude/skills/exec-plan-wave/PLAYBOOK.md
@@ -167,17 +167,18 @@ If the wave invocation specifies codex sub-agents (e.g. "use the codex plugin"),
   **Fix (use this as the default for codex waves) — dispatch `codex exec` directly, NOT the `codex-companion` background job manager.** The companion's `task --background` spawns a detached job-worker that, on the current codex-cli, dies instantly with `failed to load configuration: No such file or directory (os error 2)` — while the interactive `codex exec` path is unaffected (this is NOT a codex-cli version regression; the same error is recorded against much older plugin versions — see the § "codex-companion background dispatch" note below). Drive `codex exec` yourself, one detached run per stream, via a `Bash` `run_in_background` call — no `Agent` wrapper, no forwarder, no detached companion worker, nothing to auto-clean:
 
   ```sh
+  scratch=$(mktemp -d)                                                   # scratch dir for the per-stream prompt + log files
   wt="$REPO_ROOT/.claude/worktrees/agent-<plan-slug>-<wave>-<stream>"     # ALWAYS include the plan slug — a bare agent-<wave>-<stream> collides with a prior plan's branch on the remote; keep the agent-* prefix so Phase 7.5b prunes it
   git worktree add "$wt" -b "worktree-agent-<plan-slug>-<wave>-<stream>" master   # orchestrator owns this worktree
-  pf="$SCRATCH/codex-<stream>-prompt.md"                                  # write the filled stream-agent-prompt-codex.md body to a scratch file (Write tool)
+  pf="$scratch/codex-<stream>-prompt.md"                                 # write the filled stream-agent-prompt-codex.md body here (Write tool)
   # ...then run EACH stream as its OWN Bash run_in_background call. ⚠️ cd INTO the worktree first —
   # a missing cd runs codex in the MAIN checkout (it edits master's tree, not the branch):
-  #   cd "$wt" && cat "$pf" | codex exec --skip-git-repo-check > "$SCRATCH/codex-<stream>.log" 2>&1
+  #   cd "$wt" && cat "$pf" | codex exec --skip-git-repo-check > "$scratch/codex-<stream>.log" 2>&1
   ```
 
   `codex exec` reads the prompt from stdin and runs the agent to completion in the worktree cwd (with the user's configured model/effort). You get one background-task completion notification per stream; on completion, inspect the worktree `git status --short` + the log's final report, then verify + publish in Phase 4.5. Confirm each run's cwd once right after dispatch (`lsof -a -p <pid> -d cwd` or `git -C "$wt" status`) — a mis-targeted run is the one dispatch failure mode left. The companion-specific guidance below (`status`/`resume`/hung-job/pid) applies ONLY if you fall back to the companion; with `codex exec`, the harness's background-task lifecycle replaces it.
 
-  Do all streams' `git worktree add` + detached spawns in one Bash batch. Poll the codex state dir for `$wt` (enumerate the newest `~/.claude/plugins/data/codex-openai-codex/state/agent-*` dirs after dispatch and read their `state.json`, or `cd "$wt" && node "$companion" status <job-id> --json`). The PR branch is the `worktree-agent-<plan-slug>-<wave>-<stream>` you created; Phase 4.5 publishes straight from `$wt`; Phase 7.5b prunes `agent-*` worktrees by PR state. On this path there is **no forwarder and no premature task-completion notification** — the `state.json` poll (pid alive + `phase`/`updatedAt`) is the only completion signal.
+  **(Companion fallback only — the `codex exec` default above needs none of this.)** If you fall back to `codex-companion`, resolve its path (`companion=$(ls ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | sort -V | tail -1)`), do all streams' `git worktree add` + `node "$companion" task --background` spawns in one Bash batch, then poll the codex state dir for `$wt` (enumerate the newest `~/.claude/plugins/data/codex-openai-codex/state/agent-*` dirs and read their `state.json`, or `cd "$wt" && node "$companion" status <job-id> --json`) — on that path there is **no completion notification**, so the `state.json` poll (pid alive + `phase`/`updatedAt`) is the only signal. Either way the PR branch is the `worktree-agent-<plan-slug>-<wave>-<stream>` you created; Phase 4.5 publishes from `$wt`; Phase 7.5b prunes `agent-*` worktrees by PR state.
 
 - **codex-rescue is a thin forwarder.** It dispatches one codex job via `codex-companion task --background --write` and exits, regardless of "stay alive and poll" instructions. The orchestrator MUST poll codex job status itself. Resolve the companion path at runtime: `companion=$(ls ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | sort -V | tail -1)`. Job state lives at `~/.claude/plugins/data/codex-openai-codex/state/agent-<id>-<hash>/state.json`; read those directly for `status`/`phase`/`updatedAt`. `cancel <job-id>` from the worktree cwd to stop a stuck job.
 
@@ -643,16 +644,21 @@ Also prune `/private/tmp/caesium-*-bridge` and `/private/tmp/caesium-agent-*-imp
 
 ```sh
 git remote prune origin
-git branch -r | sed 's|.*origin/||' | grep '^worktree-agent-' | sort -u | while IFS= read -r b; do
+git branch -r | grep -E '^[[:space:]]*origin/worktree-agent-' | sed 's|^[[:space:]]*origin/||' | sort -u | while IFS= read -r b; do
   [ -z "$b" ] && continue
-  # NEVER delete a branch with an open PR (an in-flight concurrent wave)
-  [ "$(gh pr list --head "$b" --state open --json number --jq 'length')" = "0" ] || { echo "SKIP $b (open PR)"; continue; }
-  git push origin --delete "$b" && echo "deleted remote $b"
+  # Delete ONLY branches whose PR is MERGED. A closed-but-unmerged PR, a paused-wave
+  # branch, or a recovery branch (any non-MERGED state, INCLUDING no PR at all) may
+  # carry commits that are not on master — deleting it would lose that work.
+  state=$(gh pr list --head "$b" --state all --json state --jq '.[0].state // "NO_PR"')
+  case "$state" in
+    MERGED) git push origin --delete "$b" </dev/null && echo "deleted remote $b" ;;
+    *)      echo "SKIP $b ($state)" ;;
+  esac
 done
 git remote prune origin
 ```
 
-Deleting a squash-merged branch is safe — the content is in `master` and the PR preserves the head SHA. Do a per-branch open-PR check (above) rather than a blind bulk delete, and never sweep non-`worktree-agent-*` branches (`sync-*`, `claude/*`) here. Note: a single multi-ref `git push origin --delete a b c …` aborts if any ref is already gone from the remote — delete per-branch after `git remote prune origin`, not in one batch.
+Deleting a squash-MERGED branch is safe — the content is in `master` and the PR preserves the head SHA. The `MERGED`-only guard (not "no open PR") protects closed-unmerged / paused / recovery branches; `</dev/null` stops `git push` from consuming the loop's stdin; the anchored `origin/worktree-agent-` grep avoids matching a differently-named remote. Never sweep non-`worktree-agent-*` branches (`sync-*`, `claude/*`) here, and delete per-branch after `git remote prune origin` — a single multi-ref `git push origin --delete a b c …` aborts if any one ref is already gone from the remote.
 
 ### Step 7.5d: Do NOT prune
 

--- a/.claude/skills/exec-plan-wave/PLAYBOOK.md
+++ b/.claude/skills/exec-plan-wave/PLAYBOOK.md
@@ -164,20 +164,20 @@ If the wave invocation specifies codex sub-agents (e.g. "use the codex plugin"),
 
 - **⚠️ Worktree-auto-clean race — dispatch codex into an orchestrator-owned worktree, NOT `Agent(isolation: "worktree")`.** When you spawn codex via `Agent({subagent_type: "codex:codex-rescue", isolation: "worktree"})`, the worktree is owned by the spawned *forwarder* agent. That forwarder dispatches the detached codex job and then completes within seconds-to-minutes — and when it completes, the harness **auto-cleans its worktree if it looks unchanged**. The detached codex job frequently hasn't staged anything that early, so the worktree (judged unchanged) is removed out from under the still-starting job; the job then dies with zero work or self-rescues by copying to `/private/tmp/caesium-agent-<id>-impl`. This is a **dispatch-time race**.
 
-  **Fix (use this as the default for codex waves):** the orchestrator creates the worktree itself and dispatches `codex-companion` directly into it — no `Agent` wrapper, so there is no forwarder and nothing to auto-clean:
+  **Fix (use this as the default for codex waves) — dispatch `codex exec` directly, NOT the `codex-companion` background job manager.** The companion's `task --background` spawns a detached job-worker that, on the current codex-cli, dies instantly with `failed to load configuration: No such file or directory (os error 2)` — while the interactive `codex exec` path is unaffected (this is NOT a codex-cli version regression; the same error is recorded against much older plugin versions — see the § "codex-companion background dispatch" note below). Drive `codex exec` yourself, one detached run per stream, via a `Bash` `run_in_background` call — no `Agent` wrapper, no forwarder, no detached companion worker, nothing to auto-clean:
 
   ```sh
-  companion=$(ls ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | sort -V | tail -1)
-  wt="$REPO_ROOT/.claude/worktrees/agent-<wave>-<stream>"   # e.g. agent-w3-beta; keep the agent-* prefix so Phase 7.5b prunes it
-  git worktree add "$wt" -b "worktree-agent-<wave>-<stream>" master       # orchestrator owns this worktree → never auto-cleaned
-  pf=$(mktemp)                                                            # write the filled prompt to a file to avoid shell-quoting hell
-  cat > "$pf" <<'PROMPT'
-  <filled-in stream-agent-prompt-codex.md body>
-  PROMPT
-  ( cd "$wt" && node "$companion" task --background --write -- "$(cat "$pf")" )   # prints the job id; codex runs detached and survives this Bash call
+  wt="$REPO_ROOT/.claude/worktrees/agent-<plan-slug>-<wave>-<stream>"     # ALWAYS include the plan slug — a bare agent-<wave>-<stream> collides with a prior plan's branch on the remote; keep the agent-* prefix so Phase 7.5b prunes it
+  git worktree add "$wt" -b "worktree-agent-<plan-slug>-<wave>-<stream>" master   # orchestrator owns this worktree
+  pf="$SCRATCH/codex-<stream>-prompt.md"                                  # write the filled stream-agent-prompt-codex.md body to a scratch file (Write tool)
+  # ...then run EACH stream as its OWN Bash run_in_background call. ⚠️ cd INTO the worktree first —
+  # a missing cd runs codex in the MAIN checkout (it edits master's tree, not the branch):
+  #   cd "$wt" && cat "$pf" | codex exec --skip-git-repo-check > "$SCRATCH/codex-<stream>.log" 2>&1
   ```
 
-  Do all streams' `git worktree add` + detached spawns in one Bash batch. Poll the codex state dir for `$wt` (enumerate the newest `~/.claude/plugins/data/codex-openai-codex/state/agent-*` dirs after dispatch and read their `state.json`, or `cd "$wt" && node "$companion" status <job-id> --json`). The PR branch is the `worktree-agent-<wave>-<stream>` you created; Phase 4.5 publishes straight from `$wt`; Phase 7.5b prunes `agent-*` worktrees by PR state. On this path there is **no forwarder and no premature task-completion notification** — the `state.json` poll (pid alive + `phase`/`updatedAt`) is the only completion signal.
+  `codex exec` reads the prompt from stdin and runs the agent to completion in the worktree cwd (with the user's configured model/effort). You get one background-task completion notification per stream; on completion, inspect the worktree `git status --short` + the log's final report, then verify + publish in Phase 4.5. Confirm each run's cwd once right after dispatch (`lsof -a -p <pid> -d cwd` or `git -C "$wt" status`) — a mis-targeted run is the one dispatch failure mode left. The companion-specific guidance below (`status`/`resume`/hung-job/pid) applies ONLY if you fall back to the companion; with `codex exec`, the harness's background-task lifecycle replaces it.
+
+  Do all streams' `git worktree add` + detached spawns in one Bash batch. Poll the codex state dir for `$wt` (enumerate the newest `~/.claude/plugins/data/codex-openai-codex/state/agent-*` dirs after dispatch and read their `state.json`, or `cd "$wt" && node "$companion" status <job-id> --json`). The PR branch is the `worktree-agent-<plan-slug>-<wave>-<stream>` you created; Phase 4.5 publishes straight from `$wt`; Phase 7.5b prunes `agent-*` worktrees by PR state. On this path there is **no forwarder and no premature task-completion notification** — the `state.json` poll (pid alive + `phase`/`updatedAt`) is the only completion signal.
 
 - **codex-rescue is a thin forwarder.** It dispatches one codex job via `codex-companion task --background --write` and exits, regardless of "stay alive and poll" instructions. The orchestrator MUST poll codex job status itself. Resolve the companion path at runtime: `companion=$(ls ~/.claude/plugins/cache/openai-codex/codex/*/scripts/codex-companion.mjs | sort -V | tail -1)`. Job state lives at `~/.claude/plugins/data/codex-openai-codex/state/agent-<id>-<hash>/state.json`; read those directly for `status`/`phase`/`updatedAt`. `cancel <job-id>` from the worktree cwd to stop a stuck job.
 
@@ -637,13 +637,30 @@ git worktree prune
 
 Also prune `/private/tmp/caesium-*-bridge` and `/private/tmp/caesium-agent-*-impl` (codex sandbox fallback worktrees), and any `.claude/worktrees/agent-*` whose `git -C ... status` errors (rsync-recovery shells, post-publish).
 
-### Step 7.5c: Do NOT prune
+### Step 7.5c: Delete merged remote branches
+
+`gh pr merge --delete-branch` does NOT reliably delete the remote branch when the local branch is worktree-locked (see the "Common gotchas" note), so `worktree-agent-*` branches accumulate on origin and — because the codex path names branches deterministically — collide with a later wave's same-named branch. After the merge train, delete this wave's remote branches and sweep prior waves' strays:
+
+```sh
+git remote prune origin
+git branch -r | sed 's|.*origin/||' | grep '^worktree-agent-' | sort -u | while IFS= read -r b; do
+  [ -z "$b" ] && continue
+  # NEVER delete a branch with an open PR (an in-flight concurrent wave)
+  [ "$(gh pr list --head "$b" --state open --json number --jq 'length')" = "0" ] || { echo "SKIP $b (open PR)"; continue; }
+  git push origin --delete "$b" && echo "deleted remote $b"
+done
+git remote prune origin
+```
+
+Deleting a squash-merged branch is safe — the content is in `master` and the PR preserves the head SHA. Do a per-branch open-PR check (above) rather than a blind bulk delete, and never sweep non-`worktree-agent-*` branches (`sync-*`, `claude/*`) here. Note: a single multi-ref `git push origin --delete a b c …` aborts if any ref is already gone from the remote — delete per-branch after `git remote prune origin`, not in one batch.
+
+### Step 7.5d: Do NOT prune
 
 - Worktrees the operator created manually (e.g. a sibling clone like `../caesium-<feature>/` outside `$REPO_ROOT`) — user-owned. Surface their existence in the final report if disk pressure remains; never auto-prune without explicit consent.
 - Active claude-code chat worktrees (`.claude/worktrees/<adjective-name>/` like `adoring-pascal` — not `agent-*`).
 - The main checkout (`$REPO_ROOT/`).
 
-### Step 7.5d: Verify reclaim
+### Step 7.5e: Verify reclaim
 
 ```sh
 du -sh $REPO_ROOT/.claude/worktrees
@@ -716,7 +733,7 @@ Use the format from `SKILL.md` § Output. Be terse. Include all PR URLs and call
 
 ## Common gotchas
 
-- **`gh pr merge --delete-branch` exit code 1**: the remote branch IS deleted; only local-branch deletion failed (worktree using it). The merge IS done. Do not retry.
+- **`gh pr merge --delete-branch` exit code 1**: the merge IS done — do not retry — but do NOT assume the remote branch was deleted. When the local branch is checked out in a worktree, `gh` often fails the local delete AND skips the remote delete, so `worktree-agent-*` branches pile up on origin (this wave left 49). Verify with `git ls-remote --heads origin <branch>` and clean leftovers in Phase 7.5c. The worktree-directory cleanup (Phase 7.5a) is separate and always needed.
 - **`gh pr view <pr> --json merged`**: `merged` is not a valid field; use `mergedAt` (truthy when merged).
 - **Sleeping after a push before retrying merge**: GitHub's `mergeStateStatus` doesn't update instantly. After a conflict-resolution push, sleep ~5s before re-attempting `gh pr merge`.
 - **`UNSTABLE` `mergeStateStatus`**: normal for "mergeable but at least one non-required check failed" — caesium has no required checks, so a squash-merge succeeds anyway (subject to the CODEOWNER review gate).
@@ -726,6 +743,7 @@ Use the format from `SKILL.md` § Output. Be terse. Include all PR URLs and call
 - **arch-specific failures**: check both `unit-test` and `unit-test-arm64` (and both `build-and-integration-test` jobs). An arm64-only failure is real, not a flake.
 - **builder is the CI root**: if `builder`/`builder-arm64` fails, every dependent job is skipped — diagnose the builder job first; downstream "failures" may just be "skipped".
 - **Codex publish + verify is the orchestrator's job by default**: codex sandbox blocks DNS for github.com AND has no Docker, so it can run none of caesium's verify chain. The codex stream prompt tells the agent to gofmt + stage + STOP; Phase 4.5 runs `just lint` + `just unit-test` and publishes. Three worktree shapes to handle: standard, `/private/tmp/caesium-agent-<id>-impl` (on `master`), and already-committed.
+- **§ codex-companion background dispatch is unreliable — use `codex exec`**: `node codex-companion.mjs task --background` spawns a detached job-worker that dies at thread start with `failed to load configuration: No such file or directory (os error 2)` (~440ms after dispatch), while `codex exec` from the same shell works. It is NOT a codex-cli version regression (the identical error is recorded against much older plugin versions in `~/.claude/plugins/data/codex-openai-codex/state/`); the trigger is the detached-worker environment inherited from a sandboxed sub-agent shell. Dispatch codex streams via `codex exec` piped from a prompt file inside a `Bash run_in_background` call (Phase 3 § codex), and rely on the harness's background-task completion notifications for status instead of `codex-companion status`. `codex exec` respects the user's `~/.codex/config.toml` (model/effort/sandbox), so the model is set by config, not a per-dispatch flag.
 - **Worktrees share a git stash store**: a `git stash` from one worktree can be popped into a sibling, silently corrupting foreign work. Stream agents commit WIP (`git add -A && git commit -m "wip" --no-verify`, then `git reset HEAD~1`) instead. Codified in the stream prompts.
 - **Security stub-on-merge is a P0**: an agent stubbing `validateSignature` / `ValidateKey` / `HasRole` / `CheckScope` / a `subtle.ConstantTimeCompare` / the SAML `recordAssertion` / the OIDC nonce check AND merging ships a forgery / privilege-escalation / replay hole. Treat these as merge-blocking; re-dispatch as a fix-forward (sonnet → opus) before Phase 7. Verify any "dep would conflict" stub-justification against `go.mod`/`go.sum` first.
 - **`docs/roadmap.md` is lowercase**: there is NO `ROADMAP.md`. A dashboard sync that edits "ROADMAP.md" creates a duplicate file. Always edit `docs/roadmap.md`.

--- a/.claude/skills/exec-plan-wave/PLAYBOOK.md
+++ b/.claude/skills/exec-plan-wave/PLAYBOOK.md
@@ -239,9 +239,11 @@ For each codex stream:
 
 ### Step 4.5a: Locate the worktree
 
+**With the `codex exec` default (Phase 3), the worktree is the standard `agent-<plan-slug>-<wave>-<stream>` you created — the first row below.** The `/private/tmp/caesium-agent-<id>-impl` and rsync-recovery shapes are `codex-companion`-fallback artifacts (codex making its own copy when the sandbox can't reach the worktree's git metadata) and do NOT occur with `codex exec`; the `<id>` in those rows is the codex *job* id, not the worktree name.
+
 | Symptom | Worktree location | How to detect |
 |---|---|---|
-| Standard | `$REPO_ROOT/.claude/worktrees/agent-<id>/` | `git -C .claude/worktrees/agent-<id> status --short` lists modified/untracked files |
+| Standard (`codex exec`) | `$REPO_ROOT/.claude/worktrees/agent-<plan-slug>-<wave>-<stream>/` | `git -C "$wt" status --short` lists modified/untracked files |
 | /private/tmp fallback | `/private/tmp/caesium-agent-<id>-impl/` | The orchestrator's worktree is clean/absent; `ls -d /private/tmp/caesium-agent-<id>*` finds the temp clone (on `master`) |
 | Already committed locally | Same as above, but `git log master..HEAD` is non-empty | Codex's `git commit` succeeded but the push failed; commit is preserved |
 | Worktree never materialized (rsync recovery) | `.claude/worktrees/agent-<id>/` exists as a plain dir (not a git worktree) | `git worktree list` lacks `agent-<id>`; `git -C <path> status` errors; the dir is a flat copy of the repo minus `.git/` |
@@ -267,7 +269,7 @@ If they pass: codex's work is credible enough to publish.
 Standard worktree case:
 
 ```sh
-cd $REPO_ROOT/.claude/worktrees/agent-<id>
+cd $REPO_ROOT/.claude/worktrees/agent-<plan-slug>-<wave>-<stream>
 git add -A
 git status --short
 git commit -m "$(cat <<'EOF'
@@ -553,7 +555,7 @@ After each merge:
 
 If `gh pr merge` returns `Pull Request has merge conflicts`:
 
-1. cd to the PR's worktree (`$REPO_ROOT/.claude/worktrees/agent-<id>`).
+1. cd to the PR's worktree (`$REPO_ROOT/.claude/worktrees/agent-<id>` for general-purpose streams, `agent-<plan-slug>-<wave>-<stream>` for codex streams).
 2. `git fetch origin master && git merge --no-commit --no-ff origin/master`
 3. `grep -n "<<<<<<< \|>>>>>>> \|^=======$" <conflicted_files>` to find conflict regions.
 4. Resolve via `Read` + `Edit`. Common caesium patterns:

--- a/.claude/skills/exec-plan-wave/SKILL.md
+++ b/.claude/skills/exec-plan-wave/SKILL.md
@@ -73,12 +73,18 @@ These are baked into the skill (do not deviate):
   `$REPO_ROOT/.claude/worktrees/agent-<id>` (do not spawn
   fresh worktrees because the branch is checked out there). **Codex streams
   in a parallel wave are the exception**: do NOT use `isolation: "worktree"`
-  for them — the forwarder agent's worktree gets auto-cleaned out from under
-  the detached codex job (see `PLAYBOOK.md` Phase 3 § codex
-  "Worktree-auto-clean race"). The orchestrator creates
-  `.claude/worktrees/agent-<wave>-<stream>` itself (branch
-  `worktree-agent-<wave>-<stream>`) and dispatches `codex-companion task
-  --background` directly into it.
+  for them (the forwarder agent's worktree gets auto-cleaned out from under a
+  detached job). The orchestrator creates the worktree itself —
+  `.claude/worktrees/agent-<plan-slug>-<wave>-<stream>`, branch
+  `worktree-agent-<plan-slug>-<wave>-<stream>` (**always include the plan slug**:
+  a bare `<wave>-<stream>` name — e.g. `worktree-agent-w3-alpha` — collides with
+  an earlier plan's same-named branch still on the remote, and the collision only
+  surfaces as a rejected push at publish time) — and dispatches **`codex exec`**
+  into it via a `Bash` `run_in_background` call (NOT `codex-companion task
+  --background`, whose detached job-worker fails to start on current codex-cli —
+  see `PLAYBOOK.md` Phase 3 § codex). `codex exec` runs the agent in-process in
+  the worktree cwd; the orchestrator gets a background-task completion
+  notification, then verifies + publishes in Phase 4.5.
 - **PR title format**: `<Imperative subject> (<plan-slug> <wave>-<stream>)` —
   e.g. `Add event-trigger evaluation engine (event-triggers W1-α)`. GitHub
   appends `(#NNN)` on squash-merge (caesium's house style is a plain


### PR DESCRIPTION
Three hardening fixes for the `exec-plan-wave` skill, each learned from a concrete failure during the Wave 3 run of the freshness-scheduling + agent-in-the-loop-remediation plans (7 streams, all merged).

## 1. Plan-slug branch names (collision fix)
The codex path named branches `worktree-agent-<wave>-<stream>` with **no plan slug**, so `worktree-agent-w3-alpha`/`beta` collided with the event-trigger-routing wave's merged branches of the same name (#260/#261) — surfacing only as a rejected `git push` at publish time, mid-wave. Convention is now `worktree-agent-<plan-slug>-<wave>-<stream>` (SKILL.md + PLAYBOOK Phase 3).

## 2. `codex exec` dispatch (reliability fix)
`codex-companion task --background` spawns a detached job-worker that dies ~440ms in with `failed to load configuration: No such file or directory (os error 2)` on the current codex-cli, while `codex exec` from the same shell works. It is **not** a version regression (the identical error is recorded against much older plugin versions) — the trigger is the detached-worker environment inherited from a sandboxed sub-agent shell. The codex dispatch lane now drives `codex exec` piped from a prompt file in a `Bash run_in_background` call; the companion `status`/`resume`/hung-job guidance is retained as a labeled fallback. Adds a warning to `cd` into the worktree before `codex exec` (a missing `cd` runs it against the main checkout).

## 3. Remote-branch cleanup (the false gotcha)
The playbook claimed `gh pr merge --delete-branch` exit-1 means "the remote branch IS deleted; only local failed." **False** — when the local branch is worktree-locked, `gh` skips the remote delete too, so `worktree-agent-*` branches pile up (this wave left **49** on origin, which is what caused #1 to recur across waves). Corrects the gotcha and adds **Phase 7.5c** — a per-branch, open-PR-guarded remote sweep after `git remote prune origin` (noting that a single multi-ref `--delete` aborts on the first already-gone ref).

Docs-only change to `.claude/skills/exec-plan-wave/`. No code, no guardrail surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)