### PR TITLE
Open one incident per failing run (dedup the run-level twin)

### DIFF
--- a/internal/incident/subscriber.go
+++ b/internal/incident/subscriber.go
@@ -177,7 +177,45 @@ func (s *Subscriber) resolveContext(ctx context.Context, evt event.Event) failur
 	return fc
 }
 
+// runHasFailedTask reports whether the run has at least one task_run in the
+// terminal failed state. Task runs finalize to their terminal state BEFORE the
+// run itself finalizes, so a failed task is already visible in task_runs when
+// the run_failed event is processed. Keying on the DB task_runs status (not the
+// incidents table) avoids racing the concurrent task-attributed incident open.
+func (s *Subscriber) runHasFailedTask(ctx context.Context, runID uuid.UUID) bool {
+	var n int64
+	if err := s.db.WithContext(ctx).
+		Model(&models.TaskRun{}).
+		// "failed" is the terminal task_run status the run store writes on task
+		// failure (run.TaskStatusFailed); referenced as a literal here to avoid an
+		// internal/run → internal/incident import cycle.
+		Where("job_run_id = ? AND status = ?", runID, "failed").
+		Count(&n).Error; err != nil {
+		log.Warn("incident: could not check for failed task runs", "run_id", runID, "error", err)
+		return false
+	}
+	return n > 0
+}
+
 func (s *Subscriber) handleFailure(ctx context.Context, evt event.Event) {
+	// A failing run publishes BOTH task_failed (carrying the failing TaskID) and
+	// run_failed (no TaskID). Both route here, but taskName only resolves for the
+	// task-bearing event, so they produce two distinct dedupe keys
+	// (job|task|class vs job||class) and open two incidents for one failure —
+	// double-counting the failure as two remediation-dispatch candidates and
+	// showing a phantom "task unknown" incident. Suppress the redundant run-level
+	// twin: when a run_failed carries no task attribution and the run already has
+	// a failed task_run, the task_failed event already opened the task-attributed
+	// incident. Genuinely run-level failures with no failed task (infra/setup
+	// errors), and run_timed_out / sla_missed, are preserved and still open a
+	// run-level incident.
+	if evt.Type == event.TypeRunFailed && evt.TaskID == uuid.Nil && evt.RunID != uuid.Nil {
+		if s.runHasFailedTask(ctx, evt.RunID) {
+			log.Debug("incident: suppressing redundant run-level failure; run has a failed task", "run_id", evt.RunID)
+			return
+		}
+	}
+
 	fc := s.resolveContext(ctx, evt)
 	if fc.jobID == uuid.Nil {
 		log.Warn("incident: could not resolve job for failure event", "type", evt.Type, "run_id", evt.RunID)

--- a/internal/incident/subscriber.go
+++ b/internal/incident/subscriber.go
@@ -177,21 +177,30 @@ func (s *Subscriber) resolveContext(ctx context.Context, evt event.Event) failur
 	return fc
 }
 
-// runHasFailedTask reports whether the run has at least one task_run in the
-// terminal failed state. Task runs finalize to their terminal state BEFORE the
-// run itself finalizes, so a failed task is already visible in task_runs when
-// the run_failed event is processed. Keying on the DB task_runs status (not the
-// incidents table) avoids racing the concurrent task-attributed incident open.
-func (s *Subscriber) runHasFailedTask(ctx context.Context, runID uuid.UUID) bool {
+// runHasTaskAttributedIncident reports whether a task-attributed incident (one
+// carrying a resolved TaskID) already exists for the run — i.e. the task_failed
+// event already opened the task incident. Suppression keys on this INCIDENT, not
+// on the task_runs table, so a task_failed that was dropped (bus buffer
+// overflow) or never handled does NOT silently swallow the run failure: with no
+// task incident, the run_failed still opens one, preserving remediation dispatch
+// and operator visibility. A missed incident is worse than a rare duplicate.
+//
+// Race-safety: the incident subscriber drains the bus on a single FIFO goroutine
+// and task_failed is published before run_failed — the owner finalizes the run
+// via store.Complete only AFTER CompleteTaskOwner has committed and published the
+// task terminal event (internal/run/owner_manager.go) — so the task-attributed
+// incident is already committed and visible by the time run_failed is processed.
+//
+// On a query error it FAILS OPEN (returns false → the run-level incident opens):
+// a rare transient error yielding a rare duplicate is a safer degradation than a
+// rare missed incident.
+func (s *Subscriber) runHasTaskAttributedIncident(ctx context.Context, runID uuid.UUID) bool {
 	var n int64
 	if err := s.db.WithContext(ctx).
-		Model(&models.TaskRun{}).
-		// "failed" is the terminal task_run status the run store writes on task
-		// failure (run.TaskStatusFailed); referenced as a literal here to avoid an
-		// internal/run → internal/incident import cycle.
-		Where("job_run_id = ? AND status = ?", runID, "failed").
+		Model(&models.Incident{}).
+		Where("run_id = ? AND task_id IS NOT NULL", runID).
 		Count(&n).Error; err != nil {
-		log.Warn("incident: could not check for failed task runs", "run_id", runID, "error", err)
+		log.Warn("incident: could not check for task-attributed incident; opening run-level incident", "run_id", runID, "error", err)
 		return false
 	}
 	return n > 0
@@ -204,14 +213,17 @@ func (s *Subscriber) handleFailure(ctx context.Context, evt event.Event) {
 	// (job|task|class vs job||class) and open two incidents for one failure —
 	// double-counting the failure as two remediation-dispatch candidates and
 	// showing a phantom "task unknown" incident. Suppress the redundant run-level
-	// twin: when a run_failed carries no task attribution and the run already has
-	// a failed task_run, the task_failed event already opened the task-attributed
-	// incident. Genuinely run-level failures with no failed task (infra/setup
-	// errors), and run_timed_out / sla_missed, are preserved and still open a
-	// run-level incident.
+	// twin: when a run_failed carries no task attribution and a task-attributed
+	// incident already exists for the run, the task_failed event already opened
+	// it. Keying on the incident (not on the failed task_run) means a dropped or
+	// unhandled task_failed leaves no incident to suppress against, so the
+	// run_failed still opens one — no silently missed incident. Genuinely
+	// run-level failures with no task incident (infra/setup errors), and
+	// run_timed_out / sla_missed, are preserved and still open a run-level
+	// incident.
 	if evt.Type == event.TypeRunFailed && evt.TaskID == uuid.Nil && evt.RunID != uuid.Nil {
-		if s.runHasFailedTask(ctx, evt.RunID) {
-			log.Debug("incident: suppressing redundant run-level failure; run has a failed task", "run_id", evt.RunID)
+		if s.runHasTaskAttributedIncident(ctx, evt.RunID) {
+			log.Debug("incident: suppressing redundant run-level failure; task-attributed incident exists", "run_id", evt.RunID)
 			return
 		}
 	}

--- a/internal/incident/subscriber_test.go
+++ b/internal/incident/subscriber_test.go
@@ -150,6 +150,36 @@ func TestSubscriberOpensRunLevelIncidentWithNoFailedTask(t *testing.T) {
 	require.Nil(t, inc.TaskID)
 }
 
+// TestSubscriberOpensRunLevelIncidentWhenTaskFailedDropped guards against a
+// silently missed incident: a failed task_run is committed, but its task_failed
+// event never reaches the subscriber (bus overflow / crash between publish and
+// handle), so NO task-attributed incident was opened. The run_failed must still
+// open exactly one incident. This is precisely why suppression keys on the
+// incident, not on the task_runs table — a committed failed task_run with no
+// incident behind it must not swallow the run failure.
+func TestSubscriberOpensRunLevelIncidentWhenTaskFailedDropped(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+	startSubscriber(t, bus, db, 0)
+
+	// The failed task_run exists, but we publish ONLY run_failed (the task_failed
+	// event was "dropped").
+	jobID, runID, _ := seedFailedTask(t, db, "Error: permission denied reading /secure")
+
+	bus.Publish(event.Event{Type: event.TypeRunFailed, JobID: jobID, RunID: runID, Timestamp: time.Now()})
+	waitForIncidents(t, db, 1)
+
+	var inc models.Incident
+	require.NoError(t, db.First(&inc).Error)
+	require.Equal(t, models.IncidentStatusOpen, inc.Status)
+	require.NotNil(t, inc.RunID)
+	require.Equal(t, runID, *inc.RunID)
+	// The run-level incident (no task attribution) was correctly opened.
+	require.Equal(t, "", inc.TaskName)
+	require.Nil(t, inc.TaskID)
+}
+
 func TestSubscriberAppendsOccurrenceNoTwin(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })

--- a/internal/incident/subscriber_test.go
+++ b/internal/incident/subscriber_test.go
@@ -82,6 +82,74 @@ func TestSubscriberOpensClassifiedIncident(t *testing.T) {
 	require.Equal(t, 1, inc.OccurrenceCount)
 }
 
+// TestSubscriberDedupesRunLevelTwin drives the dual-event path a real failing
+// run produces: it publishes BOTH task_failed (task-attributed) and run_failed
+// (no TaskID) for one run. Before the fix these routed to two distinct dedupe
+// keys (job|task|class and job||class) and opened two incidents. Exactly one
+// incident — the task-attributed one — must remain.
+func TestSubscriberDedupesRunLevelTwin(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+	startSubscriber(t, bus, db, 0)
+
+	jobID, runID, taskID := seedFailedTask(t, db, "Error: permission denied reading /secure")
+
+	bus.Publish(event.Event{Type: event.TypeTaskFailed, JobID: jobID, RunID: runID, TaskID: taskID, Timestamp: time.Now()})
+	bus.Publish(event.Event{Type: event.TypeRunFailed, JobID: jobID, RunID: runID, Timestamp: time.Now()})
+
+	// Sentinel: an independent failure published after the run_failed above. A
+	// single subscriber goroutine drains the bus FIFO, so once the sentinel's
+	// incident exists the run_failed has already been handled — making the
+	// "exactly one incident for the run" assertion deterministic rather than a
+	// race against an unprocessed event.
+	jobID2, runID2, taskID2 := seedFailedTask(t, db, "Error: permission denied reading /other")
+	bus.Publish(event.Event{Type: event.TypeTaskFailed, JobID: jobID2, RunID: runID2, TaskID: taskID2, Timestamp: time.Now()})
+
+	require.Eventually(t, func() bool {
+		var n int64
+		if err := db.Model(&models.Incident{}).Where("job_id = ?", jobID2).Count(&n).Error; err != nil {
+			return false
+		}
+		return n == 1
+	}, 3*time.Second, 10*time.Millisecond)
+
+	// Exactly one incident for the first run, and it is the task-attributed one.
+	var incidents []models.Incident
+	require.NoError(t, db.Where("job_id = ?", jobID).Find(&incidents).Error)
+	require.Len(t, incidents, 1)
+	require.Equal(t, "extract", incidents[0].TaskName)
+	require.NotNil(t, incidents[0].TaskID)
+	require.Equal(t, taskID, *incidents[0].TaskID)
+}
+
+// TestSubscriberOpensRunLevelIncidentWithNoFailedTask guards the preserve case:
+// a run_failed with NO failed task_run (an infra/setup failure that never
+// produced a failing task) is genuinely run-level and must still open one
+// incident.
+func TestSubscriberOpensRunLevelIncidentWithNoFailedTask(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+	bus := event.New()
+	startSubscriber(t, bus, db, 0)
+
+	now := time.Now().UTC()
+	jobID := uuid.New()
+	runID := uuid.New()
+	require.NoError(t, db.Create(&models.JobRun{
+		ID: runID, JobID: jobID, Status: "failed", StartedAt: now, CreatedAt: now, UpdatedAt: now,
+	}).Error)
+
+	bus.Publish(event.Event{Type: event.TypeRunFailed, JobID: jobID, RunID: runID, Timestamp: time.Now()})
+	waitForIncidents(t, db, 1)
+
+	var inc models.Incident
+	require.NoError(t, db.First(&inc).Error)
+	require.Equal(t, models.IncidentStatusOpen, inc.Status)
+	require.Equal(t, "", inc.TaskName)
+	require.Nil(t, inc.TaskID)
+}
+
 func TestSubscriberAppendsOccurrenceNoTwin(t *testing.T) {
 	db := testutil.OpenTestDB(t)
 	t.Cleanup(func() { testutil.CloseDB(db) })

--- a/ui/e2e/auth/incidents.spec.ts
+++ b/ui/e2e/auth/incidents.spec.ts
@@ -74,6 +74,15 @@ test("incidents board filters a live failure and opens the detail timeline", asy
   await waitForFailedRun(request, job.id, run.id, authHeaders(keys.viewer));
   const incident = await waitForIncident(request, job.id, run.id, authHeaders(keys.viewer));
 
+  // One failing run opens exactly one incident. A run publishes both task_failed
+  // and run_failed; the classifier dedupes the run-level twin so operators never
+  // see a phantom "task unknown" incident and remediation isn't dispatched twice.
+  // waitForFailedRun above guarantees the run finalized (both events emitted).
+  const runIncidents = await incidentsForRun(request, job.id, run.id, authHeaders(keys.viewer));
+  expect(runIncidents).toHaveLength(1);
+  expect(runIncidents[0].id).toBe(incident.id);
+  expect(runIncidents[0].task_name).toBeTruthy();
+
   await loginAtUrl(page, `/incidents?job_id=${job.id}`, keys.viewer);
   await expect(page.getByRole("heading", { name: "Incidents", exact: true })).toBeVisible({
     timeout: 30_000,
@@ -83,17 +92,16 @@ test("incidents board filters a live failure and opens the detail timeline", asy
   await page.getByTestId("incident-status-filter").selectOption(incident.status);
   await page.getByTestId("incident-class-filter").selectOption(incident.class);
 
-  // Target the specific incident row by id: the classifier can open more than one
-  // incident for a single failing run (a minimal one plus the task-attributed one),
-  // so filtering by alias + .first() can select a different incident than
-  // waitForIncident returned and then navigate to the wrong detail URL.
+  // Target the specific incident row by id (robust even if an unrelated run's
+  // incident shares the filtered board): filtering by alias + .first() could
+  // select a different incident than waitForIncident returned and navigate to the
+  // wrong detail URL.
   const row = page.locator(`a[data-testid="incident-row"][href$="/incidents/${incident.id}"]`);
   await expect(row).toBeVisible({ timeout: 30_000 });
-  // The classifier opens a minimal incident and attributes the failing task_name
-  // asynchronously, so the board row can still show the pre-enrichment task
-  // (shortId fallback) within this window even though the incident API already
-  // reports it. Task attribution is verified below on the detail timeline
-  // (refetched per-incident), so we don't assert the exact row task text here.
+  // The board row may briefly render a shortId task fallback before the incident
+  // list query resolves the task_name, so we don't assert the exact row task text
+  // here; task attribution is verified below on the detail timeline (refetched
+  // per-incident).
   await expect(row).toContainText(incident.class.replaceAll("_", " "));
   await row.click();
 
@@ -230,9 +238,9 @@ async function waitForIncident(
       return `HTTP ${response.status()}`;
     }
     const body = (await response.json()) as IncidentListResponse;
-    latest =
-      body.incidents.find((candidate) => candidate.run_id === runId && candidate.task_name) ??
-      body.incidents.find((candidate) => candidate.run_id === runId);
+    // One failing run now opens exactly one incident (the task-attributed one),
+    // so no task_name-preference fallback is needed — take the run's incident.
+    latest = body.incidents.find((candidate) => candidate.run_id === runId);
     return latest?.id ?? "";
   }, {
     timeout: 60_000,
@@ -242,6 +250,22 @@ async function waitForIncident(
     throw new Error(`incident not found for run ${runId}`);
   }
   return latest;
+}
+
+// incidentsForRun returns the incidents attributed to a single run, filtering the
+// job-scoped list client-side (the list API filters by job_id, not run_id).
+async function incidentsForRun(
+  request: APIRequestContext,
+  jobId: string,
+  runId: string,
+  headers: Record<string, string>,
+): Promise<E2EIncident[]> {
+  const response = await request.get(`/v1/incidents?job_id=${jobId}&limit=20`, { headers });
+  if (!response.ok()) {
+    throw new Error(`failed to list incidents: ${response.status()} ${await response.text()}`);
+  }
+  const body = (await response.json()) as IncidentListResponse;
+  return body.incidents.filter((candidate) => candidate.run_id === runId);
 }
 
 function envString(name: string): string | null {


### PR DESCRIPTION
## Problem

A single failing run opened **two** incidents — one task-attributed and one run-level with an empty `task_name`. This double-counted every failure as two remediation-dispatch candidates (able to double agent-session spend against the caps) and showed operators a phantom "task unknown" incident.

## Root cause

A failing run publishes BOTH `task_failed` (`internal/run/store.go`, carrying the failing `TaskID`) and `run_failed` (no `TaskID`). Both types are in the classifier's open set and route to `handleFailure` (`internal/incident/subscriber.go`). The dedupe key is `job_id|task_name|class`, but `taskName` only resolves when the event carries a `TaskID`. So:

- `task_failed` → key `job|task|class`
- `run_failed` → key `job||class`

Two distinct `active_dedupe_key`s → two winning conditional inserts → two incidents. (The "async task_name" appearance was an illusion: `TaskName` is written only at insert; the task-less row is the second, run-level incident, which the `opened_at DESC` list sorts first.)

## Fix

In `handleFailure`, suppress the redundant run-level twin: when the event is a `run_failed` with `TaskID == uuid.Nil` **and a task-attributed incident already exists for the run**, the `task_failed` event already opened it, so skip opening a second one.

- **Suppression keys on the incident, not `task_runs`.** `runHasTaskAttributedIncident` queries the incidents table for an incident with this `run_id` and a non-nil `task_id`. Keying on the incident (rather than on a committed failed `task_run`) means a `task_failed` that was **dropped** (bus buffer overflow) or never handled leaves no incident to suppress against — so the `run_failed` still opens one, and a failed run is never left with **zero** incidents (a missed incident is worse than a duplicate). *(This is the fix for greptile P1.)*
- **Race-safe under FIFO.** The incident subscriber drains the bus on a single goroutine, and `task_failed` is published before `run_failed` — the owner calls `store.Complete` (→ `run_failed`) only after `CompleteTaskOwner` commits and publishes the task terminal event (`internal/run/owner_manager.go`). So the task-attributed incident is committed and visible by the time `run_failed` is processed.
- **Fails open on query error.** If the incidents query errors, `runHasTaskAttributedIncident` logs and returns `false`, opening the run-level incident — a rare duplicate is a safer degradation than a rare missed incident. *(This is the fix for greptile P2.)*
- **Preserved run-level failure modes:** `run_timed_out` / `sla_missed`, and a `run_failed` where the run has **no** task-attributed incident (an infra/setup failure), still open a run-level incident. Only the redundant twin — `run_failed` when a task incident exists — is suppressed.

## Test coverage

- **Unit (`internal/incident/subscriber_test.go`):**
  - `TestSubscriberDedupesRunLevelTwin` — publishes BOTH `task_failed` and `run_failed` for one run and asserts **exactly one** incident, task-attributed (a sentinel event makes the assertion deterministic against FIFO processing).
  - `TestSubscriberOpensRunLevelIncidentWithNoFailedTask` — a `run_failed` with **no** failed task still opens one run-level incident (preserve case).
  - `TestSubscriberOpensRunLevelIncidentWhenTaskFailedDropped` — a failed `task_run` is committed but only `run_failed` is published (`task_failed` "dropped") → exactly one run-level incident opens (guards the P1 missed-incident gap).
- **E2E (`ui/e2e/auth/incidents.spec.ts`):** tightened now that one run = one incident. After `waitForIncident`, asserts the job-scoped list has exactly one incident for the run (filtered client-side by `run_id`, since the list API filters by `job_id`). Simplified `waitForIncident`'s `task_name`-preference fallback. By-id row targeting and the timeline assertions are unchanged.

## Verification

- `just lint` — 0 issues
- `just unit-test` — full race suite, exit 0, 0 failures (all subscriber tests PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)