### PR TITLE
Stabilize three pre-existing flaky tests (QW-2)

### DIFF
--- a/internal/incident/subscriber_remediation_test.go
+++ b/internal/incident/subscriber_remediation_test.go
@@ -38,17 +38,22 @@ func seedTransientInfraFailure(t *testing.T, db *gorm.DB) (jobID, runID, taskID 
 	return jobID, runID, taskID
 }
 
+// waitForAction blocks until the deterministic AgentAction row exists AND has
+// reached a terminal status. The row is first written as "proposed" and then
+// asynchronously updated to its terminal status by the executor; returning on
+// the intermediate "proposed" state races that update (and cancelling the test
+// ctx mid-update yields a "context canceled" warn), so poll until terminal.
 func waitForAction(t *testing.T, db *gorm.DB) models.AgentAction {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		var a models.AgentAction
-		if err := db.First(&a).Error; err == nil {
+		if err := db.First(&a).Error; err == nil && a.Status != models.AgentActionStatusProposed {
 			return a
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatal("expected a deterministic AgentAction row, got none")
+	t.Fatal("expected a deterministic AgentAction row in a terminal status, got none")
 	return models.AgentAction{}
 }
 

--- a/internal/trigger/event/router_test.go
+++ b/internal/trigger/event/router_test.go
@@ -202,9 +202,15 @@ func TestLifecycleBridgeRoutesRunCompletedWithJobAliasAndDepth(t *testing.T) {
 	require.NoError(t, router.Reload(ctx))
 
 	bus := eventstore.New()
+	// Subscribe SYNCHRONOUSLY so the publish below can't race the bridge's
+	// bus.Subscribe landing (an async StartLifecycleBridge occasionally loses
+	// the single publish under -race). Then run the bridge loop in the
+	// background and publish exactly once; Eventually only polls the DB.
+	events, err := router.SubscribeLifecycleBridge(ctx, bus)
+	require.NoError(t, err)
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- router.StartLifecycleBridge(ctx, bus)
+		errCh <- router.RunLifecycleBridge(ctx, events)
 	}()
 	t.Cleanup(func() {
 		cancel()
@@ -212,14 +218,14 @@ func TestLifecycleBridgeRoutesRunCompletedWithJobAliasAndDepth(t *testing.T) {
 	})
 
 	runID := uuid.New()
-	require.Eventually(t, func() bool {
-		bus.Publish(eventstore.Event{
-			Type:    eventstore.TypeRunCompleted,
-			JobID:   upstreamJob.ID,
-			RunID:   runID,
-			Payload: []byte(`{"params":{"_trigger_depth":"1"}}`),
-		})
+	bus.Publish(eventstore.Event{
+		Type:    eventstore.TypeRunCompleted,
+		JobID:   upstreamJob.ID,
+		RunID:   runID,
+		Payload: []byte(`{"params":{"_trigger_depth":"1"}}`),
+	})
 
+	require.Eventually(t, func() bool {
 		var count int64
 		if err := db.Model(&models.JobRun{}).Where("job_id = ?", downstreamJob.ID).Count(&count).Error; err != nil {
 			return false
@@ -263,17 +269,22 @@ func TestEventTriggerFireRejectsDepthExceeded(t *testing.T) {
 
 func openEventRouterTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	// Private in-memory DB (no cache=shared): shared-cache uses a process-wide
+	// lock, so one test's concurrent bridge writes contend with — and can stall —
+	// sibling t.Parallel() tests. A private in-memory DB is isolated per test.
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory"), &gorm.Config{})
 	require.NoError(t, err)
-	require.NoError(t, db.AutoMigrate(models.All...))
 	sqlDB, err := db.DB()
 	require.NoError(t, err)
-	// Serialize all access through a single connection: the lifecycle-bridge test
-	// writes (Route) concurrently with the test's reads on this cache=shared in-mem
-	// DB, and concurrent shared-cache access deadlocks (and via the process-wide
-	// shared-cache lock hangs sibling tests' gorm.Open). One connection serializes
-	// it without contention.
+	// Pin to a single connection so the private in-memory DB survives across
+	// calls (a mode=memory DB lives only as long as its connection) and to
+	// serialize the lifecycle-bridge test's concurrent Route writes with the
+	// test's reads without contention.
 	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	sqlDB.SetConnMaxLifetime(0)
+	sqlDB.SetConnMaxIdleTime(0)
+	require.NoError(t, db.AutoMigrate(models.All...))
 	t.Cleanup(func() { _ = sqlDB.Close() })
 	return db
 }


### PR DESCRIPTION
## Summary

Test-only stabilization of three pre-existing flaky tests. No production race exists.

### 1. `TestLifecycleBridgeRoutesRunCompletedWithJobAliasAndDepth` (`internal/trigger/event/router_test.go`)
The test started `StartLifecycleBridge` in a goroutine and published inside a ~1s `require.Eventually`. Until the bridge's `bus.Subscribe` landed, publishes matched no subscriber and vanished; success then required subscribe + a full DB `Route` within the window — occasionally missed under `-race`.

**Fix:** use the already-split API — subscribe synchronously via `SubscribeLifecycleBridge`, then `go RunLifecycleBridge(ctx, events)`, publish exactly once, and let `Eventually` poll only the DB.

### 2. `TestRouterRouteAfterSharedTriggerJobDeleteFiresSibling` (`openEventRouterTestDB`)
Cross-test coupling: both flaky tests are `t.Parallel()` over a `cache=shared` in-memory SQLite DB, whose process-wide shared-cache lock let test 1's concurrent bridge stall siblings.

**Fix:** drop `cache=shared` so each test keeps a private in-memory DB, and pin the single connection (`SetMaxOpenConns/MaxIdleConns(1)`, `ConnMaxLifetime/IdleTime(0)`) so the in-memory DB survives.

### 3. `TestSubscriberDeterministicRuleOnOpen` (`internal/incident/subscriber_remediation_test.go`)
Flaked asserting status `"executed"` but getting `"proposed"` — the AgentAction row is written as `proposed` then asynchronously updated to its terminal status by the executor, and `waitForAction` returned on the intermediate state.

**Fix:** `waitForAction` now polls until the action reaches a terminal (non-`proposed`) status. The assertion still requires `executed`.

## Verification

- `just lint` — 0 issues
- `just unit-test` — green (`internal/trigger/event`, `internal/incident` pass)
- Stress (builder image, `-race -count=30`):
  - `go test -race -count=30 -run 'TestLifecycleBridgeRoutesRunCompletedWithJobAliasAndDepth|TestRouterRouteAfterSharedTriggerJobDeleteFiresSibling' ./internal/trigger/event/` → **ok**
  - `go test -race -count=30 -run TestSubscriberDeterministicRuleOnOpen ./internal/incident/` → **ok**

🤖 Generated with [Claude Code](https://claude.com/claude-code)