### PR TITLE
Fix freshness evaluator reactive-read race via dataset_advanced

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -191,6 +191,10 @@ func start(cmd *cobra.Command, args []string) error {
 	}
 	if vars.FreshnessEnabled {
 		conn := db.Connection()
+		// Wire the process-wide arrival observer (used by the ingest/webhook
+		// controllers) to the bus so an accepted arrival advance publishes
+		// dataset_advanced, waking the evaluator without a timer tick.
+		freshness.DefaultArrivalObserver().SetBus(bus)
 		capturer := freshness.NewCapturer(bus, conn)
 		evaluator := freshness.NewEvaluator(freshness.Config{
 			DB:                    conn,

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -45,6 +45,14 @@ const (
 	TypeSLAMissed              Type = "sla_missed"
 	TypeFreshnessViolated      Type = "freshness_violated"
 	TypeDatasetFreshnessAtRisk Type = "dataset_freshness_at_risk"
+	// TypeDatasetAdvanced fires after a dataset's watermark is advanced or
+	// verify-refreshed — by the run-completion capturer or the arrival observer —
+	// carrying {namespace, name} in its payload. The freshness evaluator
+	// subscribes to it to reactively re-derive downstream consumers off
+	// POST-advance state. Reacting to run_completed instead would race the
+	// capturer's own Advance (the bus fans out to subscribers unordered), so the
+	// evaluator could read pre-advance state and derive a redundant producer run.
+	TypeDatasetAdvanced Type = "dataset_advanced"
 	// TypeSchemaViolationRecorded is emitted when a task's output violates its
 	// declared schema in "warn" mode — the task does NOT fail, so the incident
 	// manager would otherwise never see the violation. In "fail" mode the task

--- a/internal/freshness/arrival.go
+++ b/internal/freshness/arrival.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
+	"github.com/caesium-cloud/caesium/internal/event"
 	eventmatch "github.com/caesium-cloud/caesium/internal/eventmatch"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/db"
@@ -23,6 +25,10 @@ import (
 type ArrivalObserver struct {
 	registry *Registry
 	store    *Store
+	// bus is optional; when wired (SetBus), an accepted arrival advance publishes
+	// dataset_advanced so the freshness evaluator reacts immediately instead of
+	// waiting for its next timer tick.
+	bus event.Bus
 }
 
 // ArrivalAdvance records one source declaration matched and advanced/verified
@@ -59,6 +65,16 @@ func DefaultArrivalObserver() *ArrivalObserver {
 		defaultArrivalObserver = NewArrivalObserver(db.Connection())
 	})
 	return defaultArrivalObserver
+}
+
+// SetBus wires the observer to the event bus so an accepted arrival advance
+// publishes dataset_advanced. Call once at startup before serving; the field is
+// read on every Observe.
+func (o *ArrivalObserver) SetBus(bus event.Bus) {
+	if o == nil {
+		return
+	}
+	o.bus = bus
 }
 
 func (o *ArrivalObserver) Observe(ctx context.Context, evt *models.IngestedEvent) (ArrivalResult, error) {
@@ -126,13 +142,38 @@ func (o *ArrivalObserver) Observe(ctx context.Context, evt *models.IngestedEvent
 		})
 		log.Info("freshness: arrival matched dataset",
 			"dataset", binding.name, "event_id", evt.ID, "outcome", string(res.Outcome), "watermark", watermark)
-		if res.Outcome == OutcomeRegressionDropped || res.Outcome == OutcomeOutOfOrderDropped {
+		switch res.Outcome {
+		case OutcomeRegressionDropped, OutcomeOutOfOrderDropped:
 			log.Warn("freshness: arrival watermark write dropped",
 				"dataset", binding.name, "event_id", evt.ID, "outcome", string(res.Outcome), "watermark", watermark)
+		case OutcomeAdvanced, OutcomeVerified:
+			// An external event just advanced a source dataset. Publish
+			// dataset_advanced (RunID nil — no producing run) so the evaluator
+			// derives downstream immediately, removing the up-to-a-full-tick
+			// latency the timer-only path would otherwise impose.
+			o.publishDatasetAdvanced(binding.namespace, binding.name)
 		}
 	}
 
 	return result, nil
+}
+
+// publishDatasetAdvanced notifies the freshness evaluator that an arrival
+// advanced a source dataset. RunID is nil (no producing run) so the evaluator
+// starts downstream derivation at trigger depth 0.
+func (o *ArrivalObserver) publishDatasetAdvanced(namespace *string, name string) {
+	if o.bus == nil {
+		return
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"namespace": nsValue(namespace),
+		"name":      name,
+	})
+	o.bus.Publish(event.Event{
+		Type:      event.TypeDatasetAdvanced,
+		Timestamp: time.Now().UTC(),
+		Payload:   payload,
+	})
 }
 
 type arrivalBinding struct {

--- a/internal/freshness/evaluator.go
+++ b/internal/freshness/evaluator.go
@@ -96,7 +96,11 @@ func NewEvaluator(cfg Config) *Evaluator {
 	}
 	reactiveTypes := cfg.ReactiveSubscriberTypes
 	if len(reactiveTypes) == 0 {
-		reactiveTypes = []event.Type{event.TypeRunCompleted}
+		// React to dataset_advanced (published post-Advance by the capturer and
+		// arrival observer), NOT run_completed: the latter races the capturer's own
+		// Advance, so the evaluator could read pre-advance state and derive a
+		// redundant producer run. The timer loop remains the correctness backstop.
+		reactiveTypes = []event.Type{event.TypeDatasetAdvanced}
 	}
 	return &Evaluator{
 		db:                    cfg.DB,
@@ -179,7 +183,15 @@ func (e *Evaluator) EvaluateDatasetNames(ctx context.Context, names []string) er
 }
 
 func (e *Evaluator) EvaluateEvent(ctx context.Context, evt event.Event) error {
-	if !e.isReactiveType(evt.Type) || evt.JobID == uuid.Nil {
+	if !e.isReactiveType(evt.Type) {
+		return nil
+	}
+	// Target the dataset that just advanced (from the event payload) plus its
+	// downstream consumers, rather than everything the event's job produces. This
+	// keys off the advanced dataset's identity, so arrival advances (which have no
+	// producing job) drive derivation too.
+	id, ok := datasetIdentityFromPayload(evt.Payload)
+	if !ok {
 		return nil
 	}
 	if e.leaderCheck != nil {
@@ -197,20 +209,11 @@ func (e *Evaluator) EvaluateEvent(ctx context.Context, evt event.Event) error {
 		return err
 	}
 	graph := newRegistrySnapshot(decls)
-	produced := graph.producesByJob[evt.JobID]
-	if len(produced) == 0 {
-		return nil
-	}
 
-	start := make([]datasetIdentity, 0, len(produced))
-	targets := make(map[datasetIdentity]struct{}, len(produced))
-	for _, decl := range produced {
-		id := declarationIdentity(decl)
-		start = append(start, id)
-		targets[id] = struct{}{}
-	}
-	for _, id := range graph.downstreamOf(start) {
-		targets[id] = struct{}{}
+	start := []datasetIdentity{id}
+	targets := map[datasetIdentity]struct{}{id: {}}
+	for _, downstream := range graph.downstreamOf(start) {
+		targets[downstream] = struct{}{}
 	}
 
 	depth, err := e.runTriggerDepth(ctx, evt.RunID)
@@ -218,6 +221,26 @@ func (e *Evaluator) EvaluateEvent(ctx context.Context, evt event.Event) error {
 		return err
 	}
 	return e.evaluateWithSnapshot(ctx, graph, targets, depth)
+}
+
+// datasetIdentityFromPayload extracts the {namespace, name} dataset identity a
+// dataset_advanced event carries. Namespace is already in nsValue (nil→"") form.
+func datasetIdentityFromPayload(payload json.RawMessage) (datasetIdentity, bool) {
+	if len(payload) == 0 {
+		return datasetIdentity{}, false
+	}
+	var p struct {
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	}
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return datasetIdentity{}, false
+	}
+	name := strings.TrimSpace(p.Name)
+	if name == "" {
+		return datasetIdentity{}, false
+	}
+	return datasetIdentity{namespace: p.Namespace, name: name}, true
 }
 
 func (e *Evaluator) evaluate(ctx context.Context, targets map[datasetIdentity]struct{}, triggerDepth int) error {
@@ -377,20 +400,20 @@ func (e *Evaluator) updateStatus(ctx context.Context, namespace *string, name, s
 		ID:        uuid.New(),
 		Namespace: nsValue(namespace),
 		Name:      name,
-		Status:    models.DatasetStatusUnknown,
+		Status:    status,
+		Reason:    reason,
 	}
-	if err := e.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "namespace"}, {Name: "name"}},
-		DoNothing: true,
-	}).Create(&row).Error; err != nil {
-		return err
-	}
-	return e.db.WithContext(ctx).Model(&models.DatasetState{}).
-		Where("namespace = ? AND name = ?", nsValue(namespace), name).
-		Updates(map[string]any{
-			"status": status,
-			"reason": reason,
-		}).Error
+	// One upsert carrying the real status/reason: insert the row on first
+	// observation, otherwise update the evaluator-owned columns in place. dqlite
+	// accepts ON CONFLICT DO UPDATE for plain column assignments.
+	return e.db.WithContext(ctx).Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "namespace"}, {Name: "name"}},
+		DoUpdates: clause.Assignments(map[string]any{
+			"status":     status,
+			"reason":     reason,
+			"updated_at": e.now().UTC(),
+		}),
+	}).Create(&row).Error
 }
 
 func (e *Evaluator) upstreamReady(ctx context.Context, outputState models.DatasetState, consumes []models.DatasetDeclaration) (bool, map[string]string, string, error) {
@@ -699,6 +722,12 @@ func newRegistrySnapshot(decls []models.DatasetDeclaration) registrySnapshot {
 
 func (g registrySnapshot) downstreamOf(start []datasetIdentity) []datasetIdentity {
 	seen := make(map[datasetIdentity]struct{}, len(start))
+	// Pre-seed the start nodes so a (lint-forbidden but defensively handled)
+	// cyclic declared graph can never re-emit a start dataset as its own
+	// downstream.
+	for _, id := range start {
+		seen[id] = struct{}{}
+	}
 	queue := append([]datasetIdentity(nil), start...)
 	out := make([]datasetIdentity, 0)
 	for len(queue) > 0 {
@@ -786,16 +815,9 @@ func canonicalConsumedJSON(consumed map[string]string) datatypes.JSON {
 	if len(consumed) == 0 {
 		return datatypes.JSON([]byte(`{}`))
 	}
-	keys := make([]string, 0, len(consumed))
-	for key := range consumed {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	ordered := make(map[string]string, len(consumed))
-	for _, key := range keys {
-		ordered[key] = consumed[key]
-	}
-	blob, err := json.Marshal(ordered)
+	// encoding/json already marshals map keys in sorted order, so the output is
+	// canonical without an explicit sort-then-rebuild.
+	blob, err := json.Marshal(consumed)
 	if err != nil {
 		return datatypes.JSON([]byte(`{}`))
 	}

--- a/internal/freshness/evaluator_test.go
+++ b/internal/freshness/evaluator_test.go
@@ -284,6 +284,176 @@ func TestEvaluatorAdmissionErrorsAreRecorded(t *testing.T) {
 	}
 }
 
+// TestEvaluatorReactsToDatasetAdvancedPostState proves the reactive path keys
+// off POST-advance state: a downstream consumer only derives once its upstream's
+// watermark has actually advanced past the consumed snapshot. This is the race
+// fix — dataset_advanced is published AFTER the capturer's Advance commits, so
+// the evaluator never reads pre-advance state and derives a redundant run.
+func TestEvaluatorReactsToDatasetAdvancedPostState(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	now := t0.Add(3 * time.Hour)
+
+	p1 := seedFreshnessJob(t, db, "stage-producer")
+	p2 := seedFreshnessJob(t, db, "mart-producer")
+	seedDeclarations(t, db,
+		produceDecl(p1, "staging", "1h", ""),
+		produceDecl(p2, "mart", "1h", ""),
+		consumeDecl(p2, "staging"),
+	)
+	// mart is stale and last consumed staging="1". staging is currently fresh but
+	// still at watermark "1" (pre-advance) — equal to mart's consumed snapshot.
+	seedState(t, db, "mart", "500", now.Add(-2*time.Hour), map[string]string{"staging": "1"})
+	seedState(t, db, "staging", "1", now.Add(-30*time.Minute), nil)
+
+	admitter := &fakeRunAdmitter{t: t, db: db, handled: true}
+	eval := NewEvaluator(Config{
+		DB:                    db,
+		RunStore:              admitter,
+		MaxDerivationsPerTick: 50,
+		Now:                   func() time.Time { return now },
+	})
+
+	advanced := datasetAdvancedEvent(t, "", "staging", uuid.Nil)
+
+	// Pre-advance: staging watermark "1" == mart's consumed "1", so mart is
+	// stale-upstream (waiting) and must NOT derive a redundant producer run.
+	if err := eval.EvaluateEvent(ctx, advanced); err != nil {
+		t.Fatalf("evaluate pre-advance: %v", err)
+	}
+	if admitter.calls != 0 {
+		t.Fatalf("pre-advance derived %d runs, want 0", admitter.calls)
+	}
+	assertDerivationCount(t, db, models.DatasetDecisionSkippedUpstream, 1)
+
+	// The capturer's Advance commits before it publishes dataset_advanced. Move
+	// staging past mart's consumed snapshot.
+	if _, err := NewStore(db).Advance(ctx, AdvanceInput{
+		Name: "staging", Watermark: "2", RunID: uuid.New(), CompletedAt: now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("advance staging: %v", err)
+	}
+
+	// Post-advance: mart now sees staging advanced past its consumed snapshot and
+	// derives exactly one run.
+	if err := eval.EvaluateEvent(ctx, advanced); err != nil {
+		t.Fatalf("evaluate post-advance: %v", err)
+	}
+	if admitter.calls != 1 {
+		t.Fatalf("post-advance derived %d runs, want 1", admitter.calls)
+	}
+	assertDerivationCount(t, db, models.DatasetDecisionDerived, 1)
+}
+
+// TestArrivalAdvanceTriggersReactiveEvaluation proves the flagship external
+// event -> derive downstream flow: an arrival advance publishes dataset_advanced,
+// and feeding that event to the evaluator derives the downstream consumer
+// without waiting for a timer tick.
+func TestArrivalAdvanceTriggersReactiveEvaluation(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	now := t0.Add(3 * time.Hour)
+
+	seedArrivalSource(t, db, "raw.vendor_x", "s3:ObjectCreated", "$.key")
+	p2 := seedFreshnessJob(t, db, "arrival-mart")
+	seedDeclarations(t, db,
+		produceDecl(p2, "mart", "1h", ""),
+		consumeDecl(p2, "raw.vendor_x"),
+	)
+	// mart is stale and last consumed raw.vendor_x="v1".
+	seedState(t, db, "mart", "500", now.Add(-2*time.Hour), map[string]string{"raw.vendor_x": "v1"})
+
+	bus := event.New()
+	events, err := bus.Subscribe(ctx, event.Filter{Types: []event.Type{event.TypeDatasetAdvanced}})
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	obs := NewArrivalObserver(db)
+	obs.SetBus(bus)
+
+	ingested := &models.IngestedEvent{
+		ID:        uuid.New(),
+		Type:      "s3:ObjectCreated",
+		Data:      datatypes.JSON([]byte(`{"key":"v2"}`)),
+		CreatedAt: now.Add(-time.Minute),
+	}
+	res, err := obs.Observe(ctx, ingested)
+	if err != nil {
+		t.Fatalf("observe: %v", err)
+	}
+	if len(res.Advances) != 1 || res.Advances[0].Outcome != OutcomeAdvanced {
+		t.Fatalf("arrival advances = %+v, want one OutcomeAdvanced", res.Advances)
+	}
+
+	// The arrival advance must have published dataset_advanced for the source.
+	var advanced event.Event
+	select {
+	case advanced = <-events:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for dataset_advanced from arrival")
+	}
+	if advanced.Type != event.TypeDatasetAdvanced {
+		t.Fatalf("event type = %q, want %q", advanced.Type, event.TypeDatasetAdvanced)
+	}
+	id, ok := datasetIdentityFromPayload(advanced.Payload)
+	if !ok || id.name != "raw.vendor_x" {
+		t.Fatalf("dataset_advanced payload = %s (parsed=%+v ok=%v)", advanced.Payload, id, ok)
+	}
+
+	// Feeding the reactive event to the evaluator derives the downstream mart.
+	admitter := &fakeRunAdmitter{t: t, db: db, handled: true}
+	eval := NewEvaluator(Config{
+		DB:                    db,
+		RunStore:              admitter,
+		MaxDerivationsPerTick: 50,
+		Now:                   func() time.Time { return now },
+	})
+	if err := eval.EvaluateEvent(ctx, advanced); err != nil {
+		t.Fatalf("evaluate reactive: %v", err)
+	}
+	if admitter.calls != 1 {
+		t.Fatalf("reactive derived %d runs, want 1", admitter.calls)
+	}
+	assertDerivationCount(t, db, models.DatasetDecisionDerived, 1)
+}
+
+func datasetAdvancedEvent(t *testing.T, namespace, name string, runID uuid.UUID) event.Event {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{"namespace": namespace, "name": name})
+	if err != nil {
+		t.Fatalf("marshal dataset_advanced payload: %v", err)
+	}
+	return event.Event{Type: event.TypeDatasetAdvanced, RunID: runID, Payload: payload}
+}
+
+func seedArrivalSource(t *testing.T, db *gorm.DB, name, eventType, watermarkPath string) {
+	t.Helper()
+	binding, err := json.Marshal(map[string]any{
+		"event":     map[string]any{"type": eventType},
+		"watermark": watermarkPath,
+	})
+	if err != nil {
+		t.Fatalf("marshal arrival binding: %v", err)
+	}
+	decl := models.DatasetDeclaration{
+		ID:             uuid.New(),
+		JobID:          uuid.New(),
+		JobAlias:       "arrival-source",
+		StepName:       "",
+		Name:           name,
+		Direction:      models.DatasetDirectionSource,
+		External:       true,
+		ExpectedEvery:  "24h",
+		ArrivalBinding: datatypes.JSON(binding),
+		CreatedAt:      t0,
+		UpdatedAt:      t0,
+	}
+	if err := db.Create(&decl).Error; err != nil {
+		t.Fatalf("create arrival source: %v", err)
+	}
+}
+
 func seedFreshnessJob(t *testing.T, db *gorm.DB, alias string) uuid.UUID {
 	t.Helper()
 	now := time.Now().UTC()

--- a/internal/freshness/subscriber.go
+++ b/internal/freshness/subscriber.go
@@ -181,11 +181,38 @@ func (c *Capturer) handleRunCompleted(ctx context.Context, evt event.Event) {
 			log.Error("freshness: advance failed", "dataset", p.Name, "run_id", evt.RunID, "error", err)
 			continue
 		}
-		if res.Outcome == OutcomeRegressionDropped || res.Outcome == OutcomeOutOfOrderDropped {
+		switch res.Outcome {
+		case OutcomeRegressionDropped, OutcomeOutOfOrderDropped:
 			log.Warn("freshness: watermark write dropped",
 				"dataset", p.Name, "outcome", string(res.Outcome), "run_id", evt.RunID, "watermark", watermark)
+		case OutcomeAdvanced, OutcomeVerified:
+			// Publish AFTER the Advance commits so the evaluator reacting to this
+			// event reads post-advance state. RunID feeds the evaluator's
+			// _trigger_depth propagation. Regression/out-of-order/backfill drops
+			// leave state unchanged, so they must not wake a reactive derivation.
+			c.publishDatasetAdvanced(p.Namespace, p.Name, evt.JobID, evt.RunID)
 		}
 	}
+}
+
+// publishDatasetAdvanced notifies the freshness evaluator that a dataset's
+// watermark moved, so it can reactively re-derive downstream consumers off
+// post-advance state. Payload carries the {namespace, name} dataset identity.
+func (c *Capturer) publishDatasetAdvanced(namespace *string, name string, jobID, runID uuid.UUID) {
+	if c.bus == nil {
+		return
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"namespace": nsValue(namespace),
+		"name":      name,
+	})
+	c.bus.Publish(event.Event{
+		Type:      event.TypeDatasetAdvanced,
+		JobID:     jobID,
+		RunID:     runID,
+		Timestamp: time.Now().UTC(),
+		Payload:   payload,
+	})
 }
 
 // runTiming reports whether the run is a backfill and its effective completion


### PR DESCRIPTION
## Summary

The Stream-B **capturer** subscribes to `run_completed` and the freshness **evaluator**'s reactive path *also* defaulted to `run_completed`. The event bus fans out to independent buffered channels with **no cross-subscriber ordering**, so `EvaluateEvent` could read **pre-`Advance`** `DatasetState`, classify a dataset stale, and derive a **redundant producer run**. The `hasActiveOrQueuedRun` dedupe missed it because the pre-advance consumed-watermark snapshot differs from the post-advance one. It self-heals on the next timer tick (not data loss), but it is a wasted producer run — and **Wave-4 Stream G1 (skip-when-fresh)** will read this same state.

## Fix

- New event `TypeDatasetAdvanced = "dataset_advanced"` (`internal/event/bus.go`), payload `{namespace, name}`.
- The **capturer** publishes it after each successful `Advance` (accepted advance OR verify-only refresh), with `JobID`/`RunID` from the completed run — `RunID` feeds the existing `_trigger_depth` propagation. Regression/out-of-order/backfill drops do **not** publish.
- The **arrival observer** publishes it after its accepted `store.Advance` (`RunID` nil).
- The **evaluator** now defaults its reactive types to `{dataset_advanced}`, and `EvaluateEvent` derives its target datasets from the event payload's dataset identity (∪ `downstreamOf`) instead of `producesByJob[evt.JobID]`. The timer loop remains the correctness backstop; the per-tick derivation cap is kept.

**Rejected alternatives:** synchronous advance (inverts the run→freshness dependency the package deliberately avoids); a wait/retry ordering guard in `EvaluateEvent` (still races verify-only advances).

## Bonus (beyond the race fix)

Publishing `dataset_advanced` from the arrival observer makes the flagship **external event → derive downstream** flow reactive for the first time. Previously an arrival advance notified nothing, so the evaluator waited up to a full timer tick.

## Bundled evaluator nits (`internal/freshness/evaluator.go`)

- `updateStatus`: one `ON CONFLICT DO UPDATE` upsert carrying the real status/reason, replacing INSERT-DoNothing + a second `Updates` round-trip.
- `canonicalConsumedJSON`: drop the redundant sort-then-rebuild — `encoding/json` already marshals map keys in sorted order.
- `downstreamOf`: pre-seed `seen` with the start node(s) so a (lint-forbidden but defensively handled) cyclic declared graph can't re-emit a start dataset.

## Tests

- `TestEvaluatorReactsToDatasetAdvancedPostState` — a downstream consumer only derives once its upstream's watermark has actually advanced past the consumed snapshot (proves the reactive path reads post-advance state).
- `TestArrivalAdvanceTriggersReactiveEvaluation` — an arrival advance publishes `dataset_advanced`, and feeding that event to the evaluator derives the downstream consumer.
- Existing freshness tests stay green.

## Verify

- `just lint` — 0 issues
- `just unit-test` — pass (incl. `internal/freshness`, `internal/event`, `cmd/start`)

## Note for reviewer

This must land **before Wave-4 Stream G2**, which also edits `evaluator.go`. The arrival-reactivity improvement is a bonus beyond the race fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)