### PR TITLE
Add freshness scheduling behavior: skip-when-fresh + freshness trigger (freshness-scheduling W4-β)

### DIFF
--- a/api/rest/service/trigger/trigger_test.go
+++ b/api/rest/service/trigger/trigger_test.go
@@ -225,6 +225,22 @@ func (s *TriggerSuite) TestCreateRejectsDuplicateAlias() {
 	s.True(errors.Is(err, ErrTriggerAliasConflict))
 }
 
+func (s *TriggerSuite) TestCreateRejectsBareFreshnessTrigger() {
+	// The trigger API has no job-definition context, so it cannot verify a
+	// freshness trigger's required consumed/produced datasets. A freshness trigger
+	// must be declared on a job definition (the apply path), so creating one
+	// through the trigger API is rejected even with the feature gate enabled.
+	s.T().Setenv("CAESIUM_FRESHNESS_ENABLED", "true")
+	_, err := s.svc().Create(&CreateRequest{
+		Alias:         "bare-freshness",
+		Type:          string(models.TriggerTypeFreshness),
+		Configuration: map[string]interface{}{},
+	})
+	s.Require().Error(err)
+	s.True(errors.Is(err, ErrInvalidTriggerRequest))
+	s.Contains(err.Error(), "cannot be created via the trigger API")
+}
+
 func (s *TriggerSuite) TestUpdateHTTPConfigurationRefreshesNormalizedPath() {
 	created := s.createHTTPTrigger("webhook", "/hooks/original")
 

--- a/docs/exec-plans/active/freshness-scheduling.md
+++ b/docs/exec-plans/active/freshness-scheduling.md
@@ -483,7 +483,7 @@ observe. Sequenced last and gated behind `CAESIUM_FRESHNESS_ENABLED` so a green
 substrate is proven before any tick is skipped or any job drops cron. Touches
 the trigger/executor loop, distinct files from the evaluator.
 
-- [ ] G1. **P1 — skip-when-fresh:** a cron tick consults dataset state and
+- [x] G1. **P1 — skip-when-fresh:** a cron tick consults dataset state and
       **skips** when every produced dataset is fresh and no consumed watermark
       advanced since the last run, recording `skipped_fresh` on
       `DatasetDerivation` (visible, opt-out per job via
@@ -495,7 +495,10 @@ the trigger/executor loop, distinct files from the evaluator.
       `internal/freshness/` (skip decision), `pkg/jobdef/definition.go`
       (`skipWhenFresh` metadata flag).
       Depends on: C1 (state machine) + A1 (metadata surface).
-- [ ] G2. **P2 — `trigger: {type: freshness}`:** a purely data-derived job may
+      Note: W4-beta added the env-gated cron/catchup skip helper, persists the
+      `skipWhenFresh` default on declarations, and records `skipped_fresh` only
+      after fresh outputs plus unchanged consumed watermarks are proven.
+- [x] G2. **P2 — `trigger: {type: freshness}`:** a purely data-derived job may
       drop cron entirely and declare a freshness trigger; the evaluator owns its
       cadence (cron demoted to optional heartbeat). Add `TriggerTypeFreshness` +
       type-specific validation in `pkg/jobdef/definition.go` `ValidateTriggerSpec`
@@ -505,6 +508,9 @@ the trigger/executor loop, distinct files from the evaluator.
       (`ValidateTriggerSpec`), `internal/freshness/evaluator.go`.
       Depends on: C3 (derivation must exist for a freshness-only job to ever run)
       + G1.
+      Note: W4-beta added the `freshness` trigger type, feature-flag/schema
+      validation, and evaluator admission only for persisted freshness-triggered
+      jobs.
 
 #### Deferred — partition-level freshness
 

--- a/internal/freshness/evaluator.go
+++ b/internal/freshness/evaluator.go
@@ -392,6 +392,13 @@ func (e *Evaluator) statusFor(decl models.DatasetDeclaration, state models.Datas
 }
 
 func (e *Evaluator) updateStatus(ctx context.Context, namespace *string, name, status, reason string) error {
+	return e.updateStatusTx(ctx, e.db, namespace, name, status, reason)
+}
+
+// updateStatusTx is updateStatus bound to an explicit connection (a caller's
+// transaction or e.db). It threads the *gorm.DB rather than reassigning e.db so
+// a shared evaluator stays safe under concurrent ticks.
+func (e *Evaluator) updateStatusTx(ctx context.Context, db *gorm.DB, namespace *string, name, status, reason string) error {
 	name = strings.TrimSpace(name)
 	if name == "" {
 		return errEmptyDatasetName
@@ -406,7 +413,7 @@ func (e *Evaluator) updateStatus(ctx context.Context, namespace *string, name, s
 	// One upsert carrying the real status/reason: insert the row on first
 	// observation, otherwise update the evaluator-owned columns in place. dqlite
 	// accepts ON CONFLICT DO UPDATE for plain column assignments.
-	return e.db.WithContext(ctx).Clauses(clause.OnConflict{
+	return db.WithContext(ctx).Clauses(clause.OnConflict{
 		Columns: []clause.Column{{Name: "namespace"}, {Name: "name"}},
 		DoUpdates: clause.Assignments(map[string]any{
 			"status":     status,
@@ -502,9 +509,12 @@ func (e *Evaluator) freshnessTriggerIDForJob(ctx context.Context, jobID uuid.UUI
 		TriggerID   uuid.UUID
 		TriggerType models.TriggerType
 	}
+	// Filter GORM soft-deletes on both sides of the raw join: a plain Joins does
+	// not apply the deleted_at scope, so a soft-deleted trigger could otherwise
+	// still match an active job's trigger_id.
 	err := e.db.WithContext(ctx).Table("jobs").
 		Select("jobs.trigger_id AS trigger_id, triggers.type AS trigger_type").
-		Joins("JOIN triggers ON triggers.id = jobs.trigger_id").
+		Joins("JOIN triggers ON triggers.id = jobs.trigger_id AND triggers.deleted_at IS NULL").
 		Where("jobs.id = ? AND jobs.deleted_at IS NULL", jobID).
 		Take(&row).Error
 	if err != nil {
@@ -605,11 +615,18 @@ func sameDerivationParams(a, b map[string]string) bool {
 }
 
 func (e *Evaluator) recordDerivation(ctx context.Context, decl models.DatasetDeclaration, decision, reason string, consumed map[string]string, runID *uuid.UUID) error {
+	return e.recordDerivationTx(ctx, e.db, decl, decision, reason, consumed, runID)
+}
+
+// recordDerivationTx is recordDerivation bound to an explicit connection so a
+// batch of skip decisions can commit atomically. It threads the *gorm.DB rather
+// than reassigning e.db so a shared evaluator stays safe under concurrent ticks.
+func (e *Evaluator) recordDerivationTx(ctx context.Context, db *gorm.DB, decl models.DatasetDeclaration, decision, reason string, consumed map[string]string, runID *uuid.UUID) error {
 	if strings.TrimSpace(decision) == "" {
 		return nil
 	}
 	metrics.DatasetDerivationsTotal.WithLabelValues(datasetParamName(decl.Namespace, decl.Name), decision).Inc()
-	return e.db.WithContext(ctx).Create(&models.DatasetDerivation{
+	return db.WithContext(ctx).Create(&models.DatasetDerivation{
 		ID:                 uuid.New(),
 		Namespace:          decl.Namespace,
 		Name:               decl.Name,

--- a/internal/freshness/evaluator.go
+++ b/internal/freshness/evaluator.go
@@ -332,9 +332,9 @@ func (e *Evaluator) evaluateProducedDataset(ctx context.Context, graph registryS
 		if !upstreamReady {
 			return e.recordDerivation(ctx, decl, models.DatasetDecisionSkippedUpstream, reason, consumed, nil)
 		}
-		return e.derive(ctx, decl, reason, consumed, triggerDepth, budget)
+		return e.deriveIfFreshnessTriggered(ctx, decl, reason, consumed, triggerDepth, budget)
 	case models.DatasetStatusStale:
-		return e.derive(ctx, decl, reason, consumed, triggerDepth, budget)
+		return e.deriveIfFreshnessTriggered(ctx, decl, reason, consumed, triggerDepth, budget)
 	case models.DatasetStatusQuarantined:
 		return e.recordDerivation(ctx, decl, models.DatasetDecisionSkippedAdmission, "dataset quarantined", consumed, nil)
 	default:
@@ -486,7 +486,41 @@ func watermarkAdvancedPast(previous, current string) bool {
 	return true
 }
 
-func (e *Evaluator) derive(ctx context.Context, decl models.DatasetDeclaration, reason string, consumed map[string]string, triggerDepth int, budget *int) error {
+func (e *Evaluator) deriveIfFreshnessTriggered(ctx context.Context, decl models.DatasetDeclaration, reason string, consumed map[string]string, triggerDepth int, budget *int) error {
+	triggerID, ok, err := e.freshnessTriggerIDForJob(ctx, decl.JobID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return e.recordDerivation(ctx, decl, models.DatasetDecisionSkippedAdmission, "job trigger is not freshness; waiting for scheduler", consumed, nil)
+	}
+	return e.derive(ctx, decl, triggerID, reason, consumed, triggerDepth, budget)
+}
+
+func (e *Evaluator) freshnessTriggerIDForJob(ctx context.Context, jobID uuid.UUID) (*uuid.UUID, bool, error) {
+	var row struct {
+		TriggerID   uuid.UUID
+		TriggerType models.TriggerType
+	}
+	err := e.db.WithContext(ctx).Table("jobs").
+		Select("jobs.trigger_id AS trigger_id, triggers.type AS trigger_type").
+		Joins("JOIN triggers ON triggers.id = jobs.trigger_id").
+		Where("jobs.id = ? AND jobs.deleted_at IS NULL", jobID).
+		Take(&row).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	if row.TriggerType != models.TriggerTypeFreshness || row.TriggerID == uuid.Nil {
+		return nil, false, nil
+	}
+	id := row.TriggerID
+	return &id, true, nil
+}
+
+func (e *Evaluator) derive(ctx context.Context, decl models.DatasetDeclaration, triggerID *uuid.UUID, reason string, consumed map[string]string, triggerDepth int, budget *int) error {
 	if budget != nil && *budget <= 0 {
 		return e.recordDerivation(ctx, decl, models.DatasetDecisionSkippedAdmission, "freshness derivation cap reached", consumed, nil)
 	}
@@ -514,7 +548,7 @@ func (e *Evaluator) derive(ctx context.Context, decl models.DatasetDeclaration, 
 		return e.recordDerivation(ctx, decl, models.DatasetDecisionSkippedActiveRun, "producer already has an active or queued run for the consumed watermarks", consumed, nil)
 	}
 
-	runRecord, handled, err := e.runStore.AdmitRun(decl.JobID, nil, runstorage.WithStartParams(params))
+	runRecord, handled, err := e.runStore.AdmitRun(decl.JobID, triggerID, runstorage.WithStartParams(params))
 	if err != nil {
 		if errors.Is(err, runstorage.ErrRunSkipped) || errors.Is(err, runstorage.ErrRunQueued) || errors.Is(err, runstorage.ErrMaxConcurrentRunsReached) {
 			return e.recordDerivation(ctx, decl, models.DatasetDecisionSkippedAdmission, err.Error(), consumed, nil)

--- a/internal/freshness/evaluator_test.go
+++ b/internal/freshness/evaluator_test.go
@@ -283,6 +283,42 @@ func TestEvaluatorDoesNotDeriveCronTriggeredJob(t *testing.T) {
 	assertDerivationCount(t, db, models.DatasetDecisionDerived, 0)
 }
 
+func TestEvaluatorSkipsJobWithSoftDeletedFreshnessTrigger(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	now := t0.Add(3 * time.Hour)
+	jobID := seedFreshnessJobWithTriggerType(t, db, "soft-deleted", models.TriggerTypeFreshness)
+	seedDeclarations(t, db, produceDecl(jobID, "out", "1h", ""))
+	seedState(t, db, "out", "100", now.Add(-2*time.Hour), nil)
+
+	// Soft-delete the job's freshness trigger. A plain join would still match it;
+	// the deleted_at filter must exclude it so the job is no longer treated as
+	// freshness-triggered and derives nothing.
+	var job models.Job
+	if err := db.First(&job, "id = ?", jobID).Error; err != nil {
+		t.Fatalf("load job: %v", err)
+	}
+	if err := db.Delete(&models.Trigger{}, "id = ?", job.TriggerID).Error; err != nil {
+		t.Fatalf("soft-delete trigger: %v", err)
+	}
+
+	admitter := &fakeRunAdmitter{t: t, db: db, handled: true}
+	eval := NewEvaluator(Config{
+		DB:                    db,
+		RunStore:              admitter,
+		MaxDerivationsPerTick: 50,
+		Now:                   func() time.Time { return now },
+	})
+	if err := eval.EvaluateOnce(ctx); err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if admitter.calls != 0 {
+		t.Fatalf("soft-deleted-trigger job admitted %d runs, want 0", admitter.calls)
+	}
+	assertDerivationCount(t, db, models.DatasetDecisionSkippedAdmission, 1)
+	assertDerivationCount(t, db, models.DatasetDecisionDerived, 0)
+}
+
 func TestEvaluatorAdmissionErrorsAreRecorded(t *testing.T) {
 	db := openRegistryDB(t)
 	ctx := context.Background()

--- a/internal/freshness/evaluator_test.go
+++ b/internal/freshness/evaluator_test.go
@@ -258,6 +258,31 @@ func TestEvaluatorFanInDerivesOneRunAndDedupesActiveWatermarks(t *testing.T) {
 	assertDerivationCount(t, db, models.DatasetDecisionSkippedActiveRun, 1)
 }
 
+func TestEvaluatorDoesNotDeriveCronTriggeredJob(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	now := t0.Add(3 * time.Hour)
+	jobID := seedFreshnessJobWithTriggerType(t, db, "cron-owned", models.TriggerTypeCron)
+	seedDeclarations(t, db, produceDecl(jobID, "out", "1h", ""))
+	seedState(t, db, "out", "100", now.Add(-2*time.Hour), nil)
+
+	admitter := &fakeRunAdmitter{t: t, db: db, handled: true}
+	eval := NewEvaluator(Config{
+		DB:                    db,
+		RunStore:              admitter,
+		MaxDerivationsPerTick: 50,
+		Now:                   func() time.Time { return now },
+	})
+	if err := eval.EvaluateOnce(ctx); err != nil {
+		t.Fatalf("evaluate: %v", err)
+	}
+	if admitter.calls != 0 {
+		t.Fatalf("cron-triggered job admitted %d runs, want 0", admitter.calls)
+	}
+	assertDerivationCount(t, db, models.DatasetDecisionSkippedAdmission, 1)
+	assertDerivationCount(t, db, models.DatasetDecisionDerived, 0)
+}
+
 func TestEvaluatorAdmissionErrorsAreRecorded(t *testing.T) {
 	db := openRegistryDB(t)
 	ctx := context.Background()
@@ -455,13 +480,17 @@ func seedArrivalSource(t *testing.T, db *gorm.DB, name, eventType, watermarkPath
 }
 
 func seedFreshnessJob(t *testing.T, db *gorm.DB, alias string) uuid.UUID {
+	return seedFreshnessJobWithTriggerType(t, db, alias, models.TriggerTypeFreshness)
+}
+
+func seedFreshnessJobWithTriggerType(t *testing.T, db *gorm.DB, alias string, triggerType models.TriggerType) uuid.UUID {
 	t.Helper()
 	now := time.Now().UTC()
 	triggerID := uuid.New()
 	trigger := models.Trigger{
 		ID:            triggerID,
 		Alias:         alias + "-trigger",
-		Type:          models.TriggerTypeCron,
+		Type:          triggerType,
 		Configuration: `{"expression":"0 0 31 2 *"}`,
 		CreatedAt:     now,
 		UpdatedAt:     now,

--- a/internal/freshness/registry.go
+++ b/internal/freshness/registry.go
@@ -45,6 +45,8 @@ func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string)
 	}
 
 	decls := make([]models.DatasetDeclaration, 0)
+	skipWhenFresh := schema.SkipWhenFreshEnabled(def.Metadata.Datasets)
+	skipWhenFreshPtr := boolPtr(skipWhenFresh)
 
 	if def.Metadata.Datasets != nil {
 		for i := range def.Metadata.Datasets.Sources {
@@ -66,6 +68,7 @@ func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string)
 				ExpectedEvery:  strings.TrimSpace(src.ExpectedEvery),
 				External:       src.External,
 				ArrivalBinding: binding,
+				SkipWhenFresh:  skipWhenFreshPtr,
 			})
 		}
 	}
@@ -86,15 +89,16 @@ func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string)
 				watermarkKey = strings.TrimSpace(p.Watermark.Key)
 			}
 			decls = append(decls, models.DatasetDeclaration{
-				ID:           uuid.New(),
-				JobID:        jobID,
-				JobAlias:     alias,
-				StepName:     step.Name,
-				Name:         name,
-				Direction:    models.DatasetDirectionProduces,
-				Freshness:    strings.TrimSpace(p.Freshness),
-				MaxStaleness: strings.TrimSpace(p.MaxStaleness),
-				WatermarkKey: watermarkKey,
+				ID:            uuid.New(),
+				JobID:         jobID,
+				JobAlias:      alias,
+				StepName:      step.Name,
+				Name:          name,
+				Direction:     models.DatasetDirectionProduces,
+				Freshness:     strings.TrimSpace(p.Freshness),
+				MaxStaleness:  strings.TrimSpace(p.MaxStaleness),
+				WatermarkKey:  watermarkKey,
+				SkipWhenFresh: skipWhenFreshPtr,
 			})
 		}
 		for _, raw := range step.Datasets.Consumes {
@@ -103,17 +107,23 @@ func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string)
 				continue
 			}
 			decls = append(decls, models.DatasetDeclaration{
-				ID:        uuid.New(),
-				JobID:     jobID,
-				JobAlias:  alias,
-				StepName:  step.Name,
-				Name:      name,
-				Direction: models.DatasetDirectionConsumes,
+				ID:            uuid.New(),
+				JobID:         jobID,
+				JobAlias:      alias,
+				StepName:      step.Name,
+				Name:          name,
+				Direction:     models.DatasetDirectionConsumes,
+				SkipWhenFresh: skipWhenFreshPtr,
 			})
 		}
 	}
 
 	return decls, nil
+}
+
+func boolPtr(value bool) *bool {
+	v := value
+	return &v
 }
 
 func marshalArrivalBinding(arrival *schema.Arrival) (datatypes.JSON, error) {

--- a/internal/freshness/registry_test.go
+++ b/internal/freshness/registry_test.go
@@ -3,6 +3,7 @@ package freshness
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -100,10 +101,30 @@ func TestBuildDeclarations(t *testing.T) {
 	if prod.Name != "staging.orders" || prod.Freshness != "8h" || prod.WatermarkKey != "max_order_ts" || prod.StepName != "extract" {
 		t.Fatalf("unexpected produce declaration: %+v", prod)
 	}
+	if prod.SkipWhenFresh == nil || !*prod.SkipWhenFresh {
+		t.Fatalf("skipWhenFresh default = %v, want true", prod.SkipWhenFresh)
+	}
 
 	con := byDir[models.DatasetDirectionConsumes]
 	if con.Name != "raw.vendor_x" || con.StepName != "extract" {
 		t.Fatalf("unexpected consume declaration: %+v", con)
+	}
+}
+
+func TestBuildDeclarationsCarriesSkipWhenFreshOptOut(t *testing.T) {
+	src := strings.Replace(registrySampleJob, "  datasets:\n    sources:", "  datasets:\n    skipWhenFresh: false\n    sources:", 1)
+	def, err := schema.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	decls, err := BuildDeclarations(def, uuid.New(), def.Metadata.Alias)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	for _, decl := range decls {
+		if decl.SkipWhenFresh == nil || *decl.SkipWhenFresh {
+			t.Fatalf("declaration %s skipWhenFresh = %v, want false", decl.Name, decl.SkipWhenFresh)
+		}
 	}
 }
 

--- a/internal/freshness/scheduler.go
+++ b/internal/freshness/scheduler.go
@@ -111,13 +111,22 @@ func (e *Evaluator) shouldSkipCronRun(ctx context.Context, jobID uuid.UUID) (Cro
 		datasets = append(datasets, datasetParamName(decl.Namespace, decl.Name))
 	}
 
-	for _, record := range records {
-		if err := e.updateStatus(ctx, record.decl.Namespace, record.decl.Name, models.DatasetStatusFresh, strings.TrimPrefix(record.reason, "cron tick skipped: ")); err != nil {
-			return CronSkipDecision{}, err
+	// Commit the whole skip decision atomically: a mid-loop failure must not
+	// leave dataset state advanced for some produced datasets but not others.
+	// tx is threaded explicitly through the *Tx helpers rather than reassigning
+	// e.db, which would race a shared evaluator across concurrent cron ticks.
+	if err := e.db.Transaction(func(tx *gorm.DB) error {
+		for _, record := range records {
+			if err := e.updateStatusTx(ctx, tx, record.decl.Namespace, record.decl.Name, models.DatasetStatusFresh, strings.TrimPrefix(record.reason, "cron tick skipped: ")); err != nil {
+				return err
+			}
+			if err := e.recordDerivationTx(ctx, tx, record.decl, models.DatasetDecisionSkippedFresh, record.reason, record.consumed, nil); err != nil {
+				return err
+			}
 		}
-		if err := e.recordDerivation(ctx, record.decl, models.DatasetDecisionSkippedFresh, record.reason, record.consumed, nil); err != nil {
-			return CronSkipDecision{}, err
-		}
+		return nil
+	}); err != nil {
+		return CronSkipDecision{}, err
 	}
 	sort.Strings(datasets)
 	return CronSkipDecision{Skip: true, Reason: "all produced datasets fresh and consumed watermarks unchanged", Datasets: datasets}, nil

--- a/internal/freshness/scheduler.go
+++ b/internal/freshness/scheduler.go
@@ -1,0 +1,173 @@
+package freshness
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// CronSkipDecision is the P1 skip-when-fresh decision for one cron tick.
+type CronSkipDecision struct {
+	Skip     bool
+	Reason   string
+	Datasets []string
+}
+
+type cronSkipRecord struct {
+	decl     models.DatasetDeclaration
+	reason   string
+	consumed map[string]string
+}
+
+// ShouldSkipCronRun decides whether a cron tick can be omitted because every
+// produced dataset is fresh and the job's consumed watermarks have not advanced
+// since the run that produced the current outputs. It records skipped_fresh rows
+// only after the full job-level decision is proven.
+func ShouldSkipCronRun(ctx context.Context, db *gorm.DB, jobID uuid.UUID, now time.Time) (CronSkipDecision, error) {
+	if db == nil {
+		return CronSkipDecision{}, fmt.Errorf("freshness: cron skip requires database connection")
+	}
+	if jobID == uuid.Nil {
+		return CronSkipDecision{}, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+	e := &Evaluator{
+		db:       db,
+		store:    NewStore(db),
+		registry: NewRegistry(db),
+		now:      func() time.Time { return now },
+	}
+	return e.shouldSkipCronRun(ctx, jobID)
+}
+
+func (e *Evaluator) shouldSkipCronRun(ctx context.Context, jobID uuid.UUID) (CronSkipDecision, error) {
+	decls, err := e.registry.ListByJob(ctx, jobID)
+	if err != nil {
+		return CronSkipDecision{}, err
+	}
+	graph := newRegistrySnapshot(decls)
+	produced := graph.produced
+	if len(produced) == 0 {
+		return CronSkipDecision{Reason: "job declares no produced datasets"}, nil
+	}
+
+	records := make([]cronSkipRecord, 0, len(produced))
+	datasets := make([]string, 0, len(produced))
+	for _, decl := range produced {
+		if !declarationSkipWhenFresh(decl) {
+			return CronSkipDecision{Reason: "metadata.datasets.skipWhenFresh is false"}, nil
+		}
+		if strings.TrimSpace(decl.Freshness) == "" {
+			return CronSkipDecision{Reason: fmt.Sprintf("produced dataset %s has no freshness SLO", datasetParamName(decl.Namespace, decl.Name))}, nil
+		}
+		freshness, err := parsePositiveDuration(decl.Freshness)
+		if err != nil {
+			return CronSkipDecision{}, fmt.Errorf("freshness cron skip: parse freshness for %s: %w", decl.Name, err)
+		}
+		maxStaleness, err := parseOptionalDuration(decl.MaxStaleness)
+		if err != nil {
+			return CronSkipDecision{}, fmt.Errorf("freshness cron skip: parse maxStaleness for %s: %w", decl.Name, err)
+		}
+
+		state, exists, err := e.store.Get(ctx, decl.Namespace, decl.Name)
+		if err != nil {
+			return CronSkipDecision{}, err
+		}
+		if !exists {
+			return CronSkipDecision{Reason: fmt.Sprintf("produced dataset %s has no state", datasetParamName(decl.Namespace, decl.Name))}, nil
+		}
+
+		status, reason, _, seen := e.statusFor(decl, state, e.now().UTC(), freshness, maxStaleness, true, "")
+		if !seen || status != models.DatasetStatusFresh {
+			if reason == "" {
+				reason = fmt.Sprintf("produced dataset %s is not fresh", datasetParamName(decl.Namespace, decl.Name))
+			}
+			return CronSkipDecision{Reason: reason}, nil
+		}
+
+		advanced, consumed, advancedReason, err := e.consumedWatermarksBlockSkip(ctx, state, graph.consumesByJob[jobID])
+		if err != nil {
+			return CronSkipDecision{}, err
+		}
+		if advanced {
+			return CronSkipDecision{Reason: advancedReason}, nil
+		}
+
+		records = append(records, cronSkipRecord{
+			decl:     decl,
+			reason:   "cron tick skipped: " + reason,
+			consumed: consumed,
+		})
+		datasets = append(datasets, datasetParamName(decl.Namespace, decl.Name))
+	}
+
+	for _, record := range records {
+		if err := e.updateStatus(ctx, record.decl.Namespace, record.decl.Name, models.DatasetStatusFresh, strings.TrimPrefix(record.reason, "cron tick skipped: ")); err != nil {
+			return CronSkipDecision{}, err
+		}
+		if err := e.recordDerivation(ctx, record.decl, models.DatasetDecisionSkippedFresh, record.reason, record.consumed, nil); err != nil {
+			return CronSkipDecision{}, err
+		}
+	}
+	sort.Strings(datasets)
+	return CronSkipDecision{Skip: true, Reason: "all produced datasets fresh and consumed watermarks unchanged", Datasets: datasets}, nil
+}
+
+func declarationSkipWhenFresh(decl models.DatasetDeclaration) bool {
+	return decl.SkipWhenFresh == nil || *decl.SkipWhenFresh
+}
+
+func (e *Evaluator) consumedWatermarksBlockSkip(ctx context.Context, outputState models.DatasetState, consumes []models.DatasetDeclaration) (bool, map[string]string, string, error) {
+	if len(consumes) == 0 {
+		return false, map[string]string{}, "", nil
+	}
+
+	lastConsumed := decodeConsumedWatermarks(outputState.ConsumedWatermarks)
+	current := make(map[string]string, len(consumes))
+	advanced := make([]string, 0)
+	missingSnapshot := make([]string, 0)
+	for _, consume := range consumes {
+		name := strings.TrimSpace(consume.Name)
+		if name == "" {
+			continue
+		}
+		key := datasetParamName(consume.Namespace, name)
+		state, ok, err := e.store.Get(ctx, consume.Namespace, name)
+		if err != nil {
+			return false, nil, "", err
+		}
+		watermark := ""
+		if ok {
+			watermark = state.Watermark
+		}
+		current[key] = watermark
+
+		previous, hadPrevious := lastConsumed[key]
+		if !hadPrevious {
+			missingSnapshot = append(missingSnapshot, key)
+			continue
+		}
+		if watermarkAdvancedPast(previous, watermark) {
+			advanced = append(advanced, key)
+		}
+	}
+	if len(missingSnapshot) > 0 {
+		sort.Strings(missingSnapshot)
+		return true, current, "missing consumed watermark snapshot for " + strings.Join(missingSnapshot, ","), nil
+	}
+	if len(advanced) > 0 {
+		sort.Strings(advanced)
+		return true, current, "consumed watermark advanced for " + strings.Join(advanced, ","), nil
+	}
+	return false, current, "", nil
+}

--- a/internal/freshness/scheduler_test.go
+++ b/internal/freshness/scheduler_test.go
@@ -1,0 +1,98 @@
+package freshness
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+)
+
+func TestShouldSkipCronRunRecordsSkippedFresh(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	now := t0.Add(2 * time.Hour)
+	jobID := seedFreshnessJobWithTriggerType(t, db, "cron-skip", models.TriggerTypeCron)
+	seedDeclarations(t, db,
+		produceDecl(jobID, "mart.orders", "1h", ""),
+		consumeDecl(jobID, "raw.orders"),
+	)
+	seedState(t, db, "mart.orders", "100", now.Add(-10*time.Minute), map[string]string{"raw.orders": "42"})
+	seedState(t, db, "raw.orders", "42", now.Add(-5*time.Minute), nil)
+
+	decision, err := ShouldSkipCronRun(ctx, db, jobID, now)
+	if err != nil {
+		t.Fatalf("skip decision: %v", err)
+	}
+	if !decision.Skip {
+		t.Fatalf("skip = false, reason = %q", decision.Reason)
+	}
+	if len(decision.Datasets) != 1 || decision.Datasets[0] != "mart.orders" {
+		t.Fatalf("datasets = %v, want [mart.orders]", decision.Datasets)
+	}
+
+	var derivation models.DatasetDerivation
+	if err := db.Where("name = ? AND decision = ?", "mart.orders", models.DatasetDecisionSkippedFresh).Take(&derivation).Error; err != nil {
+		t.Fatalf("load skipped derivation: %v", err)
+	}
+	if derivation.RunID != nil {
+		t.Fatalf("skipped derivation run_id = %v, want nil", derivation.RunID)
+	}
+	if got := string(derivation.ConsumedWatermarks); got != `{"raw.orders":"42"}` {
+		t.Fatalf("consumed watermarks = %s, want raw.orders snapshot", got)
+	}
+}
+
+func TestShouldSkipCronRunRunsWhenConsumedWatermarkAdvanced(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	now := t0.Add(2 * time.Hour)
+	jobID := seedFreshnessJobWithTriggerType(t, db, "cron-advanced", models.TriggerTypeCron)
+	seedDeclarations(t, db,
+		produceDecl(jobID, "mart.orders", "1h", ""),
+		consumeDecl(jobID, "raw.orders"),
+	)
+	seedState(t, db, "mart.orders", "100", now.Add(-10*time.Minute), map[string]string{"raw.orders": "42"})
+	seedState(t, db, "raw.orders", "43", now.Add(-5*time.Minute), nil)
+
+	decision, err := ShouldSkipCronRun(ctx, db, jobID, now)
+	if err != nil {
+		t.Fatalf("skip decision: %v", err)
+	}
+	if decision.Skip {
+		t.Fatalf("skip = true, want false")
+	}
+	if decision.Reason != "consumed watermark advanced for raw.orders" {
+		t.Fatalf("reason = %q, want consumed watermark advanced", decision.Reason)
+	}
+	var count int64
+	if err := db.Model(&models.DatasetDerivation{}).Count(&count).Error; err != nil {
+		t.Fatalf("count derivations: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("derivations = %d, want 0", count)
+	}
+}
+
+func TestShouldSkipCronRunHonorsSkipWhenFreshOptOut(t *testing.T) {
+	db := openRegistryDB(t)
+	ctx := context.Background()
+	now := t0.Add(2 * time.Hour)
+	jobID := seedFreshnessJobWithTriggerType(t, db, "cron-optout", models.TriggerTypeCron)
+	produced := produceDecl(jobID, "mart.orders", "1h", "")
+	optOut := false
+	produced.SkipWhenFresh = &optOut
+	seedDeclarations(t, db, produced)
+	seedState(t, db, "mart.orders", "100", now.Add(-10*time.Minute), nil)
+
+	decision, err := ShouldSkipCronRun(ctx, db, jobID, now)
+	if err != nil {
+		t.Fatalf("skip decision: %v", err)
+	}
+	if decision.Skip {
+		t.Fatalf("skip = true, want false")
+	}
+	if decision.Reason != "metadata.datasets.skipWhenFresh is false" {
+		t.Fatalf("reason = %q, want opt-out reason", decision.Reason)
+	}
+}

--- a/internal/models/dataset_declaration.go
+++ b/internal/models/dataset_declaration.go
@@ -63,6 +63,12 @@ type DatasetDeclaration struct {
 	// advance the dataset. Empty in degraded mode (no declared watermark).
 	WatermarkKey string `gorm:"type:text;not null;default:''" json:"watermark_key,omitempty"`
 
+	// SkipWhenFresh carries metadata.datasets.skipWhenFresh after defaulting.
+	// It is evaluated at the cron scheduling seam only and never affects a task's
+	// cache identity. Pointer form preserves an explicit false across GORM's
+	// default:true create path.
+	SkipWhenFresh *bool `gorm:"not null;default:true" json:"skip_when_fresh,omitempty"`
+
 	// External marks a source dataset nobody in Caesium produces.
 	External bool `gorm:"not null;default:false" json:"external"`
 

--- a/internal/models/trigger.go
+++ b/internal/models/trigger.go
@@ -12,9 +12,10 @@ import (
 type TriggerType string
 
 const (
-	TriggerTypeCron  TriggerType = "cron"
-	TriggerTypeHTTP  TriggerType = "http"
-	TriggerTypeEvent TriggerType = "event"
+	TriggerTypeCron      TriggerType = "cron"
+	TriggerTypeHTTP      TriggerType = "http"
+	TriggerTypeEvent     TriggerType = "event"
+	TriggerTypeFreshness TriggerType = "freshness"
 )
 
 type Trigger struct {

--- a/internal/trigger/cron/cron.go
+++ b/internal/trigger/cron/cron.go
@@ -9,11 +9,14 @@ import (
 	"time"
 
 	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
+	"github.com/caesium-cloud/caesium/internal/freshness"
 	"github.com/caesium-cloud/caesium/internal/job"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	runstore "github.com/caesium-cloud/caesium/internal/run"
 	"github.com/caesium-cloud/caesium/internal/trigger"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
 	"github.com/google/uuid"
 	"github.com/robfig/cron"
@@ -135,6 +138,15 @@ func (c *Cron) fireAt(ctx context.Context, logicalDate time.Time) error {
 			log.Info("skipping paused job", "id", j.ID)
 			continue
 		}
+		if env.Variables().FreshnessEnabled {
+			decision, err := freshness.ShouldSkipCronRun(ctx, db.Connection(), j.ID, logicalDate)
+			if err != nil {
+				log.Warn("freshness cron skip check failed; running job", "job_id", j.ID, "error", err)
+			} else if decision.Skip {
+				log.Info("skipping fresh job", "job_id", j.ID, "reason", decision.Reason, "datasets", strings.Join(decision.Datasets, ","))
+				continue
+			}
+		}
 		metrics.TriggerFiresTotal.WithLabelValues(j.ID.String(), string(models.TriggerTypeCron)).Inc()
 		params := c.scheduledRunParams(logicalDate)
 		go func() {
@@ -156,6 +168,15 @@ func (c *Cron) fireCatchup(ctx context.Context, jobs models.Jobs) {
 	for _, j := range jobs {
 		if j.Paused {
 			continue
+		}
+		if env.Variables().FreshnessEnabled {
+			decision, err := freshness.ShouldSkipCronRun(ctx, db.Connection(), j.ID, now)
+			if err != nil {
+				log.Warn("freshness catchup skip check failed; queueing catchup runs", "job_id", j.ID, "error", err)
+			} else if decision.Skip {
+				log.Info("skipping fresh catchup job", "job_id", j.ID, "reason", decision.Reason, "datasets", strings.Join(decision.Datasets, ","))
+				continue
+			}
 		}
 
 		// Use the last successful cron-triggered run as the watermark so that

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -3,9 +3,11 @@ package jobdef
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,9 +19,10 @@ const (
 	APIVersionV1 = "v1"
 	KindJob      = "Job"
 
-	TriggerCron  = "cron"
-	TriggerHTTP  = "http"
-	TriggerEvent = "event"
+	TriggerCron      = "cron"
+	TriggerHTTP      = "http"
+	TriggerEvent     = "event"
+	TriggerFreshness = "freshness"
 
 	CallbackNotification = "notification"
 
@@ -290,9 +293,20 @@ type SourceDataset struct {
 }
 
 // MetadataDatasets is the job-level datasets surface: the external source
-// datasets the job's steps consume.
+// datasets the job's steps consume plus scheduling controls for freshness.
 type MetadataDatasets struct {
 	Sources []SourceDataset `yaml:"sources,omitempty" json:"sources,omitempty"`
+	// SkipWhenFresh controls P1 cron skipping. Nil means the default: true when a
+	// job declares datasets. This is scheduling metadata and does not affect cache
+	// identity.
+	SkipWhenFresh *bool `yaml:"skipWhenFresh,omitempty" json:"skipWhenFresh,omitempty"`
+}
+
+// SkipWhenFreshEnabled applies the metadata.datasets.skipWhenFresh default.
+// A nil metadata.datasets block also defaults to true so step-level datasets
+// declared without job-level sources still opt into skip-when-fresh.
+func SkipWhenFreshEnabled(datasets *MetadataDatasets) bool {
+	return datasets == nil || datasets.SkipWhenFresh == nil || *datasets.SkipWhenFresh
 }
 
 // Failure class names accepted by metadata.remediation.classes and the keys
@@ -684,6 +698,9 @@ func (d *Definition) Validate() error {
 	if err := validateDatasets(d); err != nil {
 		return err
 	}
+	if err := validateFreshnessTriggerDefinition(d); err != nil {
+		return err
+	}
 	if err := validateRemediation(d); err != nil {
 		return err
 	}
@@ -982,9 +999,9 @@ func validateSchedulingMetadata(metadata *Metadata) (map[string]struct{}, error)
 
 func validateTrigger(t *Trigger) error {
 	switch t.Type {
-	case TriggerCron, TriggerHTTP, TriggerEvent:
+	case TriggerCron, TriggerHTTP, TriggerEvent, TriggerFreshness:
 	default:
-		return fmt.Errorf("trigger.type must be one of [%s,%s,%s]", TriggerCron, TriggerHTTP, TriggerEvent)
+		return fmt.Errorf("trigger.type must be one of [%s,%s,%s,%s]", TriggerCron, TriggerHTTP, TriggerEvent, TriggerFreshness)
 	}
 	if t.Configuration == nil {
 		t.Configuration = map[string]any{}
@@ -998,12 +1015,57 @@ func validateTrigger(t *Trigger) error {
 		if err := validateEventTriggerConfiguration(t.Configuration); err != nil {
 			return err
 		}
+	case TriggerFreshness:
+		if !freshnessFeatureEnabled() {
+			return fmt.Errorf("trigger.type %q requires CAESIUM_FRESHNESS_ENABLED=true", TriggerFreshness)
+		}
 	}
 	return nil
 }
 
-func ValidateTriggerSpec(t *Trigger) error {
-	return validateTrigger(t)
+func ValidateTriggerSpec(t *Trigger, defs ...*Definition) error {
+	if err := validateTrigger(t); err != nil {
+		return err
+	}
+	for _, def := range defs {
+		if def == nil {
+			continue
+		}
+		if err := validateFreshnessTriggerDefinition(def); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func freshnessFeatureEnabled() bool {
+	enabled, err := strconv.ParseBool(strings.TrimSpace(os.Getenv("CAESIUM_FRESHNESS_ENABLED")))
+	return err == nil && enabled
+}
+
+func validateFreshnessTriggerDefinition(d *Definition) error {
+	if d == nil || d.Trigger.Type != TriggerFreshness {
+		return nil
+	}
+	consumes, producesWithFreshness := false, false
+	for i := range d.Steps {
+		if d.Steps[i].Datasets == nil {
+			continue
+		}
+		if len(d.Steps[i].Datasets.Consumes) > 0 {
+			consumes = true
+		}
+		for j := range d.Steps[i].Datasets.Produces {
+			if strings.TrimSpace(d.Steps[i].Datasets.Produces[j].Freshness) != "" {
+				producesWithFreshness = true
+				break
+			}
+		}
+	}
+	if !consumes || !producesWithFreshness {
+		return fmt.Errorf("trigger.type %q requires at least one consumed dataset and one produced dataset with freshness", TriggerFreshness)
+	}
+	return nil
 }
 
 func validateHTTPTriggerConfiguration(cfg map[string]any) error {

--- a/pkg/jobdef/definition.go
+++ b/pkg/jobdef/definition.go
@@ -1023,17 +1023,31 @@ func validateTrigger(t *Trigger) error {
 	return nil
 }
 
+// ValidateTriggerSpec validates a trigger, optionally against the job
+// definition(s) it belongs to. A freshness trigger derives its runs from the
+// job's declared dataset graph (a consumed input plus a produced dataset with a
+// freshness SLO), which lives on the definition rather than the trigger. Callers
+// that own the definition (the apply path validates it via Definition.Validate)
+// pass it here so the dataset requirement is enforced; the trigger-create/update
+// API validates with the trigger alone and therefore has no dataset context. A
+// bare freshness trigger (no definition supplied) is rejected: it cannot satisfy
+// the dataset requirement, so it must be declared on a job definition instead.
 func ValidateTriggerSpec(t *Trigger, defs ...*Definition) error {
 	if err := validateTrigger(t); err != nil {
 		return err
 	}
+	sawDefinition := false
 	for _, def := range defs {
 		if def == nil {
 			continue
 		}
+		sawDefinition = true
 		if err := validateFreshnessTriggerDefinition(def); err != nil {
 			return err
 		}
+	}
+	if t != nil && t.Type == TriggerFreshness && !sawDefinition {
+		return fmt.Errorf("trigger.type %q cannot be created via the trigger API; declare it on a job definition with its consumed and produced datasets", TriggerFreshness)
 	}
 	return nil
 }
@@ -1048,6 +1062,19 @@ func validateFreshnessTriggerDefinition(d *Definition) error {
 		return nil
 	}
 	consumes, producesWithFreshness := false, false
+	// metadata.datasets.sources are the external-arrival binding path for a
+	// consumed input: BuildDeclarations persists each named source as a
+	// declaration, so a job that binds its input through sources (rather than a
+	// step-level consumes) still has a consumed input and satisfies the
+	// requirement. Mirror BuildDeclarations' non-empty-name check.
+	if d.Metadata.Datasets != nil {
+		for i := range d.Metadata.Datasets.Sources {
+			if strings.TrimSpace(d.Metadata.Datasets.Sources[i].Name) != "" {
+				consumes = true
+				break
+			}
+		}
+	}
 	for i := range d.Steps {
 		if d.Steps[i].Datasets == nil {
 			continue
@@ -1063,7 +1090,7 @@ func validateFreshnessTriggerDefinition(d *Definition) error {
 		}
 	}
 	if !consumes || !producesWithFreshness {
-		return fmt.Errorf("trigger.type %q requires at least one consumed dataset and one produced dataset with freshness", TriggerFreshness)
+		return fmt.Errorf("trigger.type %q requires at least one consumed dataset (a step-level consumes or a metadata.datasets.sources entry) and one produced dataset with freshness", TriggerFreshness)
 	}
 	return nil
 }

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -928,6 +928,44 @@ func TestValidateEventTriggerConfiguration(t *testing.T) {
 	require.Error(t, ValidateTriggerSpec(badDefaultParams))
 }
 
+func TestValidateFreshnessTriggerRequiresGateAndDatasets(t *testing.T) {
+	t.Setenv("CAESIUM_FRESHNESS_ENABLED", "false")
+	err := ValidateTriggerSpec(&Trigger{Type: TriggerFreshness, Configuration: map[string]any{}})
+	require.ErrorContains(t, err, "CAESIUM_FRESHNESS_ENABLED=true")
+
+	t.Setenv("CAESIUM_FRESHNESS_ENABLED", "true")
+	require.NoError(t, ValidateTriggerSpec(&Trigger{Type: TriggerFreshness, Configuration: map[string]any{}}))
+
+	valid := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: freshness-job
+  datasets:
+    skipWhenFresh: false
+trigger:
+  type: freshness
+  configuration: {}
+steps:
+  - name: build
+    image: alpine:3.23
+    datasets:
+      consumes: [raw.vendor_x]
+      produces:
+        - name: mart.vendor_x
+          freshness: 1h
+`
+	def, err := Parse([]byte(valid))
+	require.NoError(t, err)
+	require.NotNil(t, def.Metadata.Datasets)
+	require.NotNil(t, def.Metadata.Datasets.SkipWhenFresh)
+	require.False(t, *def.Metadata.Datasets.SkipWhenFresh)
+
+	missingDatasets := strings.Replace(valid, "      consumes: [raw.vendor_x]\n", "", 1)
+	_, err = Parse([]byte(missingDatasets))
+	require.ErrorContains(t, err, "requires at least one consumed dataset")
+}
+
 func TestStepUnmarshalJSONAppliesDefaults(t *testing.T) {
 	var step Step
 	err := json.Unmarshal([]byte(`{"name":"emit","image":"alpine:3.23","command":["echo","ok"]}`), &step)

--- a/pkg/jobdef/definition_test.go
+++ b/pkg/jobdef/definition_test.go
@@ -933,8 +933,12 @@ func TestValidateFreshnessTriggerRequiresGateAndDatasets(t *testing.T) {
 	err := ValidateTriggerSpec(&Trigger{Type: TriggerFreshness, Configuration: map[string]any{}})
 	require.ErrorContains(t, err, "CAESIUM_FRESHNESS_ENABLED=true")
 
+	// A bare freshness trigger (no accompanying definition, the trigger-create/
+	// update API path) has no dataset context to satisfy the requirement, so it
+	// is rejected even when the feature is enabled.
 	t.Setenv("CAESIUM_FRESHNESS_ENABLED", "true")
-	require.NoError(t, ValidateTriggerSpec(&Trigger{Type: TriggerFreshness, Configuration: map[string]any{}}))
+	err = ValidateTriggerSpec(&Trigger{Type: TriggerFreshness, Configuration: map[string]any{}})
+	require.ErrorContains(t, err, "cannot be created via the trigger API")
 
 	valid := `
 apiVersion: v1
@@ -960,10 +964,47 @@ steps:
 	require.NotNil(t, def.Metadata.Datasets)
 	require.NotNil(t, def.Metadata.Datasets.SkipWhenFresh)
 	require.False(t, *def.Metadata.Datasets.SkipWhenFresh)
+	// Validated with its definition, the same freshness trigger is accepted.
+	require.NoError(t, ValidateTriggerSpec(&def.Trigger, def))
 
 	missingDatasets := strings.Replace(valid, "      consumes: [raw.vendor_x]\n", "", 1)
 	_, err = Parse([]byte(missingDatasets))
 	require.ErrorContains(t, err, "requires at least one consumed dataset")
+}
+
+// A freshness job that binds its consumed input through metadata.datasets.sources
+// (the external-arrival path) rather than a step-level consumes still satisfies
+// the "has a consumed input" requirement, because BuildDeclarations persists each
+// source as a declaration.
+func TestValidateFreshnessTriggerAcceptsMetadataSourcesAsConsumedInput(t *testing.T) {
+	t.Setenv("CAESIUM_FRESHNESS_ENABLED", "true")
+	sourcesOnly := `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: freshness-sources
+  datasets:
+    sources:
+      - name: raw.vendor_x
+        external: true
+        arrival:
+          event:
+            type: s3.object.created
+          watermark: $.detail.object.key
+trigger:
+  type: freshness
+  configuration: {}
+steps:
+  - name: build
+    image: alpine:3.23
+    datasets:
+      produces:
+        - name: mart.vendor_x
+          freshness: 1h
+`
+	def, err := Parse([]byte(sourcesOnly))
+	require.NoError(t, err)
+	require.NoError(t, ValidateTriggerSpec(&def.Trigger, def))
 }
 
 func TestStepUnmarshalJSONAppliesDefaults(t *testing.T) {


### PR DESCRIPTION
Stream G of the freshness-scheduling plan (Wave 4). Makes freshness *replace* cron rather than merely observe — all gated behind `CAESIUM_FRESHNESS_ENABLED`.

- **G1 (P1) skip-when-fresh:** a cron tick consults dataset state and skips when every produced dataset is fresh and no consumed watermark advanced since the last run, recording `skipped_fresh` on `DatasetDerivation`. Opt-out per job via `metadata.datasets.skipWhenFresh: false`. Cron stays the guaranteed upper-bound cadence — this only removes provably-unnecessary runs.
- **G2 (P2) `trigger: {type: freshness}`:** a purely data-derived job may drop cron; the evaluator owns its cadence. Adds `TriggerTypeFreshness` + type-specific `ValidateTriggerSpec` (a freshness-triggered job must declare consumed + produced-with-freshness datasets) and registers such jobs with the evaluator.
- **Cache identity preserved:** `skipWhenFresh` / trigger type are scheduling/admission controls, not per-atom execution inputs, so `internal/cache/hash.go` is unchanged.
- Unit coverage for the skip decision, trigger validation, and evaluator trigger-ownership; builds on BC-2's `dataset_advanced` evaluator wiring (#296).

Verify: `just lint` + `just unit-test` green locally; freshness integration gate runs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)