### PR TITLE
Add Console freshness UI: dataset board, lineage overlay, derivations panel (freshness-scheduling W4-α)

### DIFF
--- a/api/rest/service/system/system.go
+++ b/api/rest/service/system/system.go
@@ -38,6 +38,7 @@ type Features struct {
 	LogConsoleEnabled       bool   `json:"log_console_enabled"`
 	ExternalURL             string `json:"external_url,omitempty"`
 	AgentRemediationEnabled bool   `json:"agent_remediation_enabled"`
+	FreshnessEnabled        bool   `json:"freshness_enabled"`
 }
 
 type Service struct {
@@ -127,5 +128,6 @@ func (s *Service) Features() (*Features, error) {
 		LogConsoleEnabled:       v.LogConsoleEnabled,
 		ExternalURL:             v.APIExternalURL,
 		AgentRemediationEnabled: v.AgentRemediationEnabled,
+		FreshnessEnabled:        v.FreshnessEnabled,
 	}, nil
 }

--- a/docs/exec-plans/active/freshness-scheduling.md
+++ b/docs/exec-plans/active/freshness-scheduling.md
@@ -453,18 +453,20 @@ data-plane-memory-ui precedent (the backend REST/CLI ships first; UI consumes
 it). New feature dir `ui/src/features/datasets/`. UI-gated by a `Features`
 field so the nav hides when the backend has freshness off.
 
-- [ ] F1. Add the dataset freshness board at `/datasets` (nav-level): status
+- [x] F1. Add the dataset freshness board at `/datasets` (nav-level): status
       chip, staleness-vs-SLO bar, producing job, and the `stale-upstream` reason,
       readable without DAGs. Route in `ui/src/router.tsx`, an `api.ts` method per
       `GET /v1/datasets` / `:ns/:name`, a nav entry, and a
       `FreshnessEnabled` field on the `Features` struct
       (`api/rest/service/system/system.go:36`) so the page hides when
       `CAESIUM_FRESHNESS_ENABLED=false`.
+      Note: W4-alpha landed the gated `/datasets` board, detail rail, producer/SLO
+      enrichment, and `freshness_enabled` system feature wiring.
       Files: new `ui/src/features/datasets/` (board), `ui/src/router.tsx`,
       `ui/src/lib/api.ts`, `ui/src/components/layout/Sidebar.tsx`,
       `api/rest/service/system/system.go`.
       Depends on: E1.
-- [ ] F2. Add the lineage freshness overlay + "why did/didn't this run"
+- [x] F2. Add the lineage freshness overlay + "why did/didn't this run"
       derivations panel: the existing `LineageGraph` component
       (`ui/src/features/jobs/LineageGraph.tsx`) gains a freshness coloring overlay
       ("everything downstream of vendor-x is amber"; declared edges render before
@@ -472,6 +474,8 @@ field so the nav hides when the backend has freshness off.
       `DatasetDerivation` rows ("18:00 tick skipped — fresh (2h/6h)", "04:31
       derived by raw.vendor_x advance") with the run's consumed-watermark set
       linking back to the arrival event (`GET /v1/datasets/:ns/:name/derivations`).
+      Note: W4-alpha landed the opt-in lineage freshness coloring/dashed declared
+      edge overlay and dataset derivation audit panel with consumed-watermark links.
       Files: `ui/src/features/jobs/LineageGraph.tsx`, `ui/src/features/datasets/`
       (derivations panel), `ui/src/lib/api.ts`.
       Depends on: F1 + E1.

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   BarChart,
   Database,
   FileCode2,
+  GitBranch,
   LayoutDashboard,
   Radio,
   Server,
@@ -80,6 +81,7 @@ export function Sidebar() {
     staleTime: 60_000,
   });
   const incidentsEnabled = features?.agent_remediation_enabled === true;
+  const freshnessEnabled = features?.freshness_enabled === true;
 
   const { data: incidentNav } = useQuery({
     queryKey: ["incidents", "nav"],
@@ -113,6 +115,9 @@ export function Sidebar() {
     { to: "/jobs", label: "Jobs", icon: LayoutDashboard, count: counts.jobs },
     { to: "/triggers", label: "Triggers", icon: Radio, count: counts.triggers },
     { to: "/atoms", label: "Atoms", icon: Database, count: counts.atoms },
+    ...(freshnessEnabled
+      ? [{ to: "/datasets", label: "Datasets", icon: GitBranch, count: null }]
+      : []),
     ...(incidentsEnabled
       ? [{ to: "/incidents", label: "Incidents", icon: Siren, count: activeIncidentCount }]
       : []),

--- a/ui/src/features/datasets/DatasetsPage.tsx
+++ b/ui/src/features/datasets/DatasetsPage.tsx
@@ -1,9 +1,17 @@
 import { useMemo, useState } from "react";
 import { Link, getRouteApi, useNavigate } from "@tanstack/react-router";
 import { useQueries, useQuery } from "@tanstack/react-query";
-import { AlertTriangle, Database, GitBranch, History } from "lucide-react";
+import {
+  AlertTriangle,
+  ChevronLeft,
+  ChevronRight,
+  Database,
+  GitBranch,
+  History,
+} from "lucide-react";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -31,6 +39,10 @@ import {
 
 const datasetsRouteApi = getRouteApi("/datasets");
 
+// Backend caps a single /datasets page at 200 rows (maxListLimit), so the board
+// pages through the feed by offset rather than fetching an unbounded slice.
+const PAGE_SIZE = 50;
+
 type DatasetsSearch = {
   status?: DatasetStatusFilter;
   namespace?: string;
@@ -43,18 +55,32 @@ export function DatasetsPage() {
   const statusFilter = normalizeStatusFilter(search.status);
   const selectedNamespace = search.namespace ?? "";
   const selectedName = cleanDatasetParam(search.name);
+  const [page, setPage] = useState(0);
+
+  // Reset to the first page whenever the status filter changes so the offset
+  // never points past the end of a narrower result set. Adjusting state during
+  // render (rather than in an effect) is React's recommended pattern for
+  // deriving state from a changed input and avoids a cascading-render pass.
+  const [pagedFilter, setPagedFilter] = useState(statusFilter);
+  if (pagedFilter !== statusFilter) {
+    setPagedFilter(statusFilter);
+    setPage(0);
+  }
 
   const listQuery = useQuery({
-    queryKey: ["datasets", "list", statusFilter],
+    queryKey: ["datasets", "list", statusFilter, page],
     queryFn: () =>
       api.getDatasets({
         status: statusFilter === "all" ? undefined : statusFilter,
-        limit: 50,
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
       }),
     placeholderData: (previous) => previous,
     refetchInterval: 30_000,
   });
 
+  const total = listQuery.data?.total ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const rows = useMemo(() => listQuery.data?.datasets ?? [], [listQuery.data]);
   const detailQueries = useQueries({
     queries: rows.map((state) => {
@@ -134,6 +160,17 @@ export function DatasetsPage() {
             statusFilter={statusFilter}
             onSelect={selectDataset}
           />
+          {!listQuery.isLoading && !listQuery.error && total > PAGE_SIZE ? (
+            <BoardPagination
+              page={page}
+              totalPages={totalPages}
+              rangeStart={total === 0 ? 0 : page * PAGE_SIZE + 1}
+              rangeEnd={Math.min((page + 1) * PAGE_SIZE, total)}
+              total={total}
+              onPrev={() => setPage((current) => Math.max(0, current - 1))}
+              onNext={() => setPage((current) => Math.min(totalPages - 1, current + 1))}
+            />
+          ) : null}
         </section>
 
         <aside className="space-y-4">
@@ -319,6 +356,60 @@ function DatasetBoard({
   );
 }
 
+function BoardPagination({
+  page,
+  totalPages,
+  rangeStart,
+  rangeEnd,
+  total,
+  onPrev,
+  onNext,
+}: {
+  page: number;
+  totalPages: number;
+  rangeStart: number;
+  rangeEnd: number;
+  total: number;
+  onPrev: () => void;
+  onNext: () => void;
+}) {
+  return (
+    <div
+      className="flex items-center justify-between gap-3 border-t border-border/50 px-4 py-2.5 text-xs text-text-3"
+      data-testid="datasets-pagination"
+    >
+      <span data-testid="datasets-pagination-range">
+        Showing {rangeStart}-{rangeEnd} of {total}
+      </span>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onPrev}
+          disabled={page === 0}
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <span className="px-1 tabular-nums">
+          Page {page + 1} of {totalPages}
+        </span>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onNext}
+          disabled={page >= totalPages - 1}
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 function DatasetIdentity({ state }: { state: DatasetState }) {
   const namespace = datasetNamespace(state);
   return (
@@ -394,7 +485,7 @@ function StalenessBar({
 }) {
   const [nowMs] = useState(() => Date.now());
   const slo = freshnessSLO(detail);
-  const percent = stalenessPercent(state, slo);
+  const percent = stalenessPercent(state, slo, nowMs);
   const observedAt = effectiveObservedAt(state);
   const tone = freshnessTone(state.status);
 

--- a/ui/src/features/datasets/DatasetsPage.tsx
+++ b/ui/src/features/datasets/DatasetsPage.tsx
@@ -1,0 +1,604 @@
+import { useMemo, useState } from "react";
+import { Link, getRouteApi, useNavigate } from "@tanstack/react-router";
+import { useQueries, useQuery } from "@tanstack/react-query";
+import { AlertTriangle, Database, GitBranch, History } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  api,
+  type DatasetDetail,
+  type DatasetState,
+  type DatasetStatus,
+} from "@/lib/api";
+import { cn, shortId } from "@/lib/utils";
+import { DerivationsPanel } from "./DerivationsPanel";
+import { FreshnessStatusChip } from "./FreshnessStatusChip";
+import {
+  DATASET_STATUS_FILTERS,
+  cleanDatasetParam,
+  datasetKey,
+  datasetNamespace,
+  displayNamespace,
+  effectiveObservedAt,
+  formatDurationShort,
+  freshnessTone,
+  normalizeStatusFilter,
+  stalenessPercent,
+  type DatasetStatusFilter,
+} from "./freshness-utils";
+
+const datasetsRouteApi = getRouteApi("/datasets");
+
+type DatasetsSearch = {
+  status?: DatasetStatusFilter;
+  namespace?: string;
+  name?: string;
+};
+
+export function DatasetsPage() {
+  const search = datasetsRouteApi.useSearch() as DatasetsSearch;
+  const navigate = useNavigate();
+  const statusFilter = normalizeStatusFilter(search.status);
+  const selectedNamespace = search.namespace ?? "";
+  const selectedName = cleanDatasetParam(search.name);
+
+  const listQuery = useQuery({
+    queryKey: ["datasets", "list", statusFilter],
+    queryFn: () =>
+      api.getDatasets({
+        status: statusFilter === "all" ? undefined : statusFilter,
+        limit: 50,
+      }),
+    placeholderData: (previous) => previous,
+    refetchInterval: 30_000,
+  });
+
+  const rows = useMemo(() => listQuery.data?.datasets ?? [], [listQuery.data]);
+  const detailQueries = useQueries({
+    queries: rows.map((state) => {
+      const namespace = datasetNamespace(state);
+      return {
+        queryKey: ["datasets", "detail", namespace, state.name],
+        queryFn: () => api.getDataset(namespace, state.name),
+        enabled: listQuery.isSuccess,
+        staleTime: 30_000,
+      };
+    }),
+  });
+
+  const detailByKey = useMemo(() => {
+    const map = new Map<string, DatasetDetail>();
+    detailQueries.forEach((query, index) => {
+      if (query.data) {
+        const state = rows[index];
+        if (!state) {
+          return;
+        }
+        map.set(datasetKey(datasetNamespace(state), state.name), query.data as DatasetDetail);
+      }
+    });
+    return map;
+  }, [detailQueries, rows]);
+
+  const selectedDetailQuery = useQuery({
+    queryKey: ["datasets", "detail", selectedNamespace, selectedName],
+    queryFn: () => api.getDataset(selectedNamespace, selectedName!),
+    enabled: Boolean(selectedName),
+    staleTime: 30_000,
+    placeholderData: selectedName
+      ? detailByKey.get(datasetKey(selectedNamespace, selectedName))
+      : undefined,
+  });
+
+  const selectedDetail = selectedDetailQuery.data;
+
+  function selectDataset(state: DatasetState) {
+    const namespace = datasetNamespace(state);
+    void navigate({
+      to: "/datasets",
+      search: {
+        status: statusFilter === "all" ? undefined : statusFilter,
+        namespace: namespace || undefined,
+        name: state.name,
+      },
+    });
+  }
+
+  function setStatusFilter(next: DatasetStatusFilter) {
+    void navigate({
+      to: "/datasets",
+      search: {
+        status: next === "all" ? undefined : next,
+        namespace: selectedNamespace || undefined,
+        name: selectedName,
+      },
+    });
+  }
+
+  return (
+    <div className="space-y-5" data-testid="datasets-page">
+      <PageHeader total={listQuery.data?.total} />
+
+      <StatusFilterBar value={statusFilter} onChange={setStatusFilter} />
+
+      <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_390px]">
+        <section className="min-w-0 rounded-md border border-border/50 bg-card">
+          <DatasetBoard
+            rows={rows}
+            detailByKey={detailByKey}
+            selectedKey={selectedName ? datasetKey(selectedNamespace, selectedName) : undefined}
+            isLoading={listQuery.isLoading}
+            error={listQuery.error}
+            statusFilter={statusFilter}
+            onSelect={selectDataset}
+          />
+        </section>
+
+        <aside className="space-y-4">
+          <DatasetDetailPanel
+            namespace={selectedNamespace}
+            name={selectedName}
+            detail={selectedDetail}
+            isLoading={selectedDetailQuery.isLoading}
+            error={selectedDetailQuery.error}
+          />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+function PageHeader({ total }: { total: number | undefined }) {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div>
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-text-3">
+          Freshness
+        </div>
+        <h1 className="text-xl font-semibold tracking-tight text-text-1">Datasets</h1>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="font-mono text-[10px]">
+          {total ?? 0} datasets
+        </Badge>
+        <Badge variant="outline" className="text-[10px]">
+          Live SLO state
+        </Badge>
+      </div>
+    </div>
+  );
+}
+
+function StatusFilterBar({
+  value,
+  onChange,
+}: {
+  value: DatasetStatusFilter;
+  onChange: (value: DatasetStatusFilter) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-card p-1">
+      {DATASET_STATUS_FILTERS.map((filter) => {
+        const active = value === filter.key;
+        return (
+          <button
+            key={filter.key}
+            type="button"
+            onClick={() => onChange(filter.key)}
+            className={cn(
+              "rounded px-2.5 py-1 text-[11px] font-medium transition-colors",
+              active
+                ? "bg-obsidian text-text-1 shadow-sm"
+                : "text-text-3 hover:bg-obsidian/50 hover:text-text-2",
+            )}
+          >
+            {filter.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function DatasetBoard({
+  rows,
+  detailByKey,
+  selectedKey,
+  isLoading,
+  error,
+  statusFilter,
+  onSelect,
+}: {
+  rows: DatasetState[];
+  detailByKey: Map<string, DatasetDetail>;
+  selectedKey: string | undefined;
+  isLoading: boolean;
+  error: unknown;
+  statusFilter: DatasetStatusFilter;
+  onSelect: (state: DatasetState) => void;
+}) {
+  if (isLoading) {
+    return (
+      <div className="space-y-0 divide-y divide-border/40">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <Skeleton key={index} className="h-16 rounded-none" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          title="Datasets unavailable"
+          subtitle={error instanceof Error ? error.message : "The dataset endpoint returned an error."}
+          icon={<AlertTriangle className="h-12 w-12 text-danger" />}
+        />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title={statusFilter === "all" ? "No datasets yet" : "No datasets match"}
+        subtitle={
+          statusFilter === "all"
+            ? "Declared or observed datasets will appear here once jobs are applied."
+            : "Try another freshness status filter."
+        }
+        icon={<Database className="h-12 w-12 text-text-3" />}
+        className="py-20"
+      />
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="grid min-w-[980px] items-center border-b border-border/50 bg-obsidian/30 px-4 py-2"
+        style={{ gridTemplateColumns: "1.45fr 128px 190px 190px 1.1fr 110px" }}
+      >
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">Dataset</span>
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">Status</span>
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">Staleness / SLO</span>
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">Producer</span>
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">Reason</span>
+        <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">Observed</span>
+      </div>
+      <div className="min-w-[980px] divide-y divide-border/40">
+        {rows.map((state) => {
+          const namespace = datasetNamespace(state);
+          const key = datasetKey(namespace, state.name);
+          const detail = detailByKey.get(key);
+          const selected = selectedKey === key;
+          return (
+            <div
+              key={key}
+              role="button"
+              tabIndex={0}
+              data-testid="dataset-row"
+              data-state={selected ? "selected" : undefined}
+              onClick={() => onSelect(state)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                  event.preventDefault();
+                  onSelect(state);
+                }
+              }}
+              className={cn(
+                "grid w-full cursor-pointer items-center px-4 text-left transition-colors hover:bg-obsidian/60 focus:outline-none focus:ring-1 focus:ring-cyan/40",
+                selected && "bg-cyan/5 shadow-[inset_2px_0_0_hsl(var(--cyan-glow))]",
+              )}
+              style={{ gridTemplateColumns: "1.45fr 128px 190px 190px 1.1fr 110px", minHeight: "64px" }}
+            >
+              <DatasetIdentity state={state} />
+              <div className="py-3">
+                <FreshnessStatusChip status={state.status} />
+              </div>
+              <div className="py-3 pr-4">
+                <StalenessBar state={state} detail={detail} />
+              </div>
+              <div className="min-w-0 py-3 pr-4">
+                <ProducingJobCell detail={detail} />
+              </div>
+              <div className="min-w-0 py-3 pr-4">
+                <ReasonCell status={state.status} reason={state.reason || detail?.last_decision?.reason} />
+              </div>
+              <div className="py-3 text-xs text-text-3">
+                <ObservedAt state={state} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function DatasetIdentity({ state }: { state: DatasetState }) {
+  const namespace = datasetNamespace(state);
+  return (
+    <div className="min-w-0 py-3 pr-4">
+      <div className="truncate font-mono text-sm font-medium text-text-1" title={state.name}>
+        {state.name}
+      </div>
+      <div className="mt-1 flex items-center gap-2 text-[10px] text-text-4">
+        <span className="font-mono">{displayNamespace(namespace)}</span>
+        {state.watermark ? (
+          <span className="truncate font-mono" title={state.watermark}>
+            wm {state.watermark}
+          </span>
+        ) : (
+          <span>no watermark</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ProducingJobCell({ detail }: { detail: DatasetDetail | undefined }) {
+  const producer = detail?.producing_job;
+  if (!producer) {
+    return <span className="text-xs text-text-4">No Caesium producer</span>;
+  }
+  return (
+    <div className="min-w-0 space-y-1">
+      <Link
+        to="/jobs/$jobId"
+        params={{ jobId: producer.id }}
+        className="block truncate text-sm font-medium text-text-1 hover:text-cyan-glow"
+        title={producer.alias}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {producer.alias}
+      </Link>
+      {producer.step_name ? (
+        <div className="truncate font-mono text-[10px] text-text-4" title={producer.step_name}>
+          {producer.step_name}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ReasonCell({ status, reason }: { status: DatasetStatus; reason: string | undefined }) {
+  if (!reason) {
+    return <span className="text-xs text-text-4">-</span>;
+  }
+  const tone = freshnessTone(status);
+  return (
+    <div className={cn("truncate text-xs", status === "stale-upstream" ? tone.textClass : "text-text-3")} title={reason}>
+      {reason}
+    </div>
+  );
+}
+
+function ObservedAt({ state }: { state: DatasetState }) {
+  const observedAt = effectiveObservedAt(state);
+  if (!observedAt) {
+    return <span className="text-text-4">never</span>;
+  }
+  return <RelativeTime date={observedAt} />;
+}
+
+function StalenessBar({
+  state,
+  detail,
+}: {
+  state: DatasetState;
+  detail: DatasetDetail | undefined;
+}) {
+  const [nowMs] = useState(() => Date.now());
+  const slo = freshnessSLO(detail);
+  const percent = stalenessPercent(state, slo);
+  const observedAt = effectiveObservedAt(state);
+  const tone = freshnessTone(state.status);
+
+  if (!slo) {
+    return (
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-2 text-[11px]">
+          <span className="text-text-4">No SLO</span>
+          <span className="font-mono text-text-4">-</span>
+        </div>
+        <div className="h-2 rounded-full bg-graphite/60" />
+      </div>
+    );
+  }
+
+  if (percent == null || !observedAt) {
+    return (
+      <div className="space-y-1">
+        <div className="flex items-center justify-between gap-2 text-[11px]">
+          <span className="text-text-4">Awaiting first observation</span>
+          <span className="font-mono text-text-3">{slo}</span>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-graphite/60">
+          <div className="h-full w-[8%] rounded-full bg-text-4" />
+        </div>
+      </div>
+    );
+  }
+
+  const ageMs = nowMs - new Date(observedAt).getTime();
+  const width = Math.max(4, Math.min(100, percent));
+  const label = `${formatDurationShort(ageMs)} / ${slo}`;
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between gap-2 text-[11px]">
+        <span className={cn("font-mono tabular-nums", tone.textClass)}>{label}</span>
+        <span className="font-mono text-text-4">{Math.round(percent)}%</span>
+      </div>
+      <div
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.min(100, Math.round(percent))}
+        aria-label={`Dataset staleness ${label}`}
+        className="h-2 overflow-hidden rounded-full bg-graphite/60"
+      >
+        <div className={cn("h-full rounded-full transition-[width] duration-500", tone.barClass)} style={{ width: `${width}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function DatasetDetailPanel({
+  namespace,
+  name,
+  detail,
+  isLoading,
+  error,
+}: {
+  namespace: string | undefined;
+  name: string | undefined;
+  detail: DatasetDetail | undefined;
+  isLoading: boolean;
+  error: unknown;
+}) {
+  if (!name) {
+    return (
+      <div className="rounded-md border border-border/50 bg-card p-4">
+        <EmptyState
+          title="Select a dataset"
+          subtitle="Choose a row to inspect the producer, SLO, and derivation audit."
+          icon={<Database className="h-12 w-12 text-text-3" />}
+          className="py-12"
+        />
+      </div>
+    );
+  }
+
+  if (isLoading && !detail) {
+    return (
+      <div className="rounded-md border border-border/50 bg-card p-4">
+        <Skeleton className="h-8 w-52" />
+        <Skeleton className="mt-4 h-28 w-full" />
+        <Skeleton className="mt-4 h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (error && !detail) {
+    return (
+      <div className="rounded-md border border-danger/30 bg-danger/5 p-4">
+        <EmptyState
+          title="Dataset detail unavailable"
+          subtitle={error instanceof Error ? error.message : "The dataset detail endpoint returned an error."}
+          icon={<AlertTriangle className="h-12 w-12 text-danger" />}
+        />
+      </div>
+    );
+  }
+
+  const state = detail?.state;
+  const producer = detail?.producing_job;
+  const slo = detail?.slo;
+
+  return (
+    <div className="rounded-md border border-border/50 bg-card p-4" data-testid="dataset-detail-panel">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-3">
+            Dataset detail
+          </div>
+          <h2 className="mt-1 truncate font-mono text-base font-semibold text-text-1" title={name}>
+            {name}
+          </h2>
+          <div className="mt-1 font-mono text-[11px] text-text-4">{displayNamespace(namespace)}</div>
+        </div>
+        <FreshnessStatusChip status={state?.status} />
+      </div>
+
+      <dl className="mt-4 grid gap-3 text-xs">
+        <MetadataRow label="Watermark" value={state?.watermark || "-"} mono />
+        <MetadataRow label="Reason" value={state?.reason || detail?.last_decision?.reason || "-"} />
+        <MetadataRow label="Freshness" value={slo?.freshness || "-"} mono />
+        <MetadataRow label="Max staleness" value={slo?.max_staleness || "-"} mono />
+        <MetadataRow label="Expected every" value={slo?.expected_every || "-"} mono />
+        <MetadataRow label="Direction" value={detail?.declaration?.direction || "-"} />
+        {detail?.declaration?.watermark_key ? (
+          <MetadataRow label="Watermark key" value={detail.declaration.watermark_key} mono />
+        ) : null}
+      </dl>
+
+      {producer ? (
+        <div className="mt-4 rounded-md border border-border/50 bg-obsidian/30 p-3">
+          <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-3">
+            <GitBranch className="h-3 w-3" />
+            Producer
+          </div>
+          <Link
+            to="/jobs/$jobId"
+            params={{ jobId: producer.id }}
+            className="mt-2 block truncate text-sm font-medium text-cyan-glow hover:underline"
+          >
+            {producer.alias}
+          </Link>
+          {producer.step_name ? (
+            <div className="mt-1 font-mono text-[11px] text-text-4">{producer.step_name}</div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {detail?.last_decision ? (
+        <div className="mt-4 rounded-md border border-border/50 bg-obsidian/30 p-3">
+          <div className="flex items-center gap-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-text-3">
+            <History className="h-3 w-3" />
+            Last decision
+          </div>
+          <div className="mt-2 text-sm text-text-1">{detail.last_decision.decision.replaceAll("_", " ")}</div>
+          {detail.last_decision.reason ? (
+            <div className="mt-1 text-xs text-text-3">{detail.last_decision.reason}</div>
+          ) : null}
+        </div>
+      ) : null}
+
+      <div className="mt-5 border-t border-border/50 pt-4">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-3">
+            Derivations
+          </div>
+          {state?.last_run_id ? (
+            <span className="font-mono text-[10px] text-text-4">run {shortId(state.last_run_id)}</span>
+          ) : null}
+        </div>
+        <DerivationsPanel namespace={namespace} name={name} producingJob={producer} />
+      </div>
+    </div>
+  );
+}
+
+function MetadataRow({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-[120px_minmax(0,1fr)] gap-3">
+      <dt className="text-text-4">{label}</dt>
+      <dd className={cn("truncate text-text-2", mono && "font-mono")} title={value}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function freshnessSLO(detail: DatasetDetail | undefined): string | undefined {
+  return (
+    detail?.slo?.freshness ||
+    detail?.slo?.expected_every ||
+    detail?.slo?.max_staleness ||
+    detail?.declaration?.freshness ||
+    detail?.declaration?.expected_every ||
+    detail?.declaration?.max_staleness
+  );
+}

--- a/ui/src/features/datasets/DerivationsPanel.tsx
+++ b/ui/src/features/datasets/DerivationsPanel.tsx
@@ -1,0 +1,181 @@
+import { Link } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { GitBranch, History } from "lucide-react";
+import { RelativeTime } from "@/components/relative-time";
+import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { api, type DatasetDerivation, type DatasetProducingJob } from "@/lib/api";
+import { cn, shortId } from "@/lib/utils";
+import { decisionLabel, displayNamespace } from "./freshness-utils";
+
+interface DerivationsPanelProps {
+  namespace: string | undefined;
+  name: string | undefined;
+  producingJob?: DatasetProducingJob;
+}
+
+export function DerivationsPanel({ namespace, name, producingJob }: DerivationsPanelProps) {
+  const derivationsQuery = useQuery({
+    queryKey: ["datasets", "derivations", namespace ?? "", name],
+    queryFn: () => api.getDatasetDerivations(namespace, name!, { limit: 25 }),
+    enabled: Boolean(name),
+    staleTime: 30_000,
+  });
+
+  if (!name) {
+    return (
+      <EmptyState
+        title="Select a dataset"
+        subtitle="The derivation audit explains why freshness runs did or did not start."
+        icon={<History className="h-12 w-12 text-text-3" />}
+        className="py-10"
+      />
+    );
+  }
+
+  if (derivationsQuery.isLoading) {
+    return (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Skeleton key={index} className="h-24 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (derivationsQuery.error) {
+    return (
+      <div className="rounded-md border border-danger/30 bg-danger/5 p-4 text-sm text-danger">
+        Failed to load derivations:{" "}
+        {derivationsQuery.error instanceof Error ? derivationsQuery.error.message : "unknown error"}
+      </div>
+    );
+  }
+
+  const rows = derivationsQuery.data?.derivations ?? [];
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        title="No derivations recorded"
+        subtitle="The evaluator has not appended a decision for this dataset yet."
+        icon={<History className="h-12 w-12 text-text-3" />}
+        className="py-10"
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3" data-testid="dataset-derivations-panel">
+      {rows.map((row) => (
+        <DerivationRow
+          key={row.id}
+          row={row}
+          selectedNamespace={namespace}
+          producingJob={producingJob}
+        />
+      ))}
+    </div>
+  );
+}
+
+function DerivationRow({
+  row,
+  selectedNamespace,
+  producingJob,
+}: {
+  row: DatasetDerivation;
+  selectedNamespace: string | undefined;
+  producingJob?: DatasetProducingJob;
+}) {
+  const consumed = Object.entries(row.consumed_watermarks ?? {});
+  const decision = decisionLabel(row.decision);
+  const isSkip = row.decision.startsWith("skipped");
+
+  return (
+    <article className="rounded-md border border-border/50 bg-obsidian/25 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-xs text-text-2">{formatClock(row.created_at)}</span>
+            <Badge
+              variant="outline"
+              className={cn(
+                "text-[10px]",
+                isSkip ? "border-warning/30 bg-warning/10 text-warning" : "border-success/30 bg-success/10 text-success",
+              )}
+            >
+              {decision}
+            </Badge>
+          </div>
+          <p className="mt-2 text-sm text-text-1">{derivationSentence(row)}</p>
+        </div>
+        <span className="shrink-0 text-[11px] text-text-4">
+          <RelativeTime date={row.created_at} />
+        </span>
+      </div>
+
+      {consumed.length > 0 ? (
+        <div className="mt-3 space-y-1.5">
+          <div className="text-[10px] font-semibold uppercase tracking-[0.14em] text-text-3">
+            Consumed arrivals
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {consumed.map(([datasetName, watermark]) => (
+              <Link
+                key={`${datasetName}:${watermark}`}
+                to="/datasets"
+                search={{ status: undefined, namespace: selectedNamespace || undefined, name: datasetName }}
+                className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] text-text-2 transition-colors hover:border-cyan/40 hover:text-cyan-glow"
+                title={`${displayNamespace(selectedNamespace)} / ${datasetName} @ ${watermark}`}
+              >
+                <GitBranch className="h-3 w-3 shrink-0" />
+                <span className="truncate font-mono">{datasetName}</span>
+                <span className="max-w-[9rem] truncate font-mono text-text-4">{watermark}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {row.run_id && producingJob ? (
+        <div className="mt-3 text-[11px] text-text-3">
+          Derived run{" "}
+          <Link
+            to="/jobs/$jobId/runs/$runId"
+            params={{ jobId: producingJob.id, runId: row.run_id }}
+            className="font-mono text-cyan-glow hover:underline"
+          >
+            {shortId(row.run_id)}
+          </Link>
+        </div>
+      ) : null}
+    </article>
+  );
+}
+
+function derivationSentence(row: DatasetDerivation): string {
+  const consumed = Object.keys(row.consumed_watermarks ?? {});
+  if (row.decision === "derived") {
+    if (consumed.length > 0) {
+      return `${decisionTimestamp(row)} derived by ${consumed.join(", ")} advance`;
+    }
+    return `${decisionTimestamp(row)} derived a freshness run`;
+  }
+  if (row.reason) {
+    return `${decisionTimestamp(row)} tick skipped - ${row.reason}`;
+  }
+  return `${decisionTimestamp(row)} tick skipped - ${decisionLabel(row.decision)}`;
+}
+
+function decisionTimestamp(row: DatasetDerivation): string {
+  return formatClock(row.created_at);
+}
+
+function formatClock(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "--:--";
+  }
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}

--- a/ui/src/features/datasets/DerivationsPanel.tsx
+++ b/ui/src/features/datasets/DerivationsPanel.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { api, type DatasetDerivation, type DatasetProducingJob } from "@/lib/api";
 import { cn, shortId } from "@/lib/utils";
-import { decisionLabel, displayNamespace } from "./freshness-utils";
+import { consumedDatasetTarget, decisionLabel, displayNamespace } from "./freshness-utils";
 
 interface DerivationsPanelProps {
   namespace: string | undefined;
@@ -68,12 +68,7 @@ export function DerivationsPanel({ namespace, name, producingJob }: DerivationsP
   return (
     <div className="space-y-3" data-testid="dataset-derivations-panel">
       {rows.map((row) => (
-        <DerivationRow
-          key={row.id}
-          row={row}
-          selectedNamespace={namespace}
-          producingJob={producingJob}
-        />
+        <DerivationRow key={row.id} row={row} producingJob={producingJob} />
       ))}
     </div>
   );
@@ -81,11 +76,9 @@ export function DerivationsPanel({ namespace, name, producingJob }: DerivationsP
 
 function DerivationRow({
   row,
-  selectedNamespace,
   producingJob,
 }: {
   row: DatasetDerivation;
-  selectedNamespace: string | undefined;
   producingJob?: DatasetProducingJob;
 }) {
   const consumed = Object.entries(row.consumed_watermarks ?? {});
@@ -121,19 +114,22 @@ function DerivationRow({
             Consumed arrivals
           </div>
           <div className="flex flex-wrap gap-1.5">
-            {consumed.map(([datasetName, watermark]) => (
-              <Link
-                key={`${datasetName}:${watermark}`}
-                to="/datasets"
-                search={{ status: undefined, namespace: selectedNamespace || undefined, name: datasetName }}
-                className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] text-text-2 transition-colors hover:border-cyan/40 hover:text-cyan-glow"
-                title={`${displayNamespace(selectedNamespace)} / ${datasetName} @ ${watermark}`}
-              >
-                <GitBranch className="h-3 w-3 shrink-0" />
-                <span className="truncate font-mono">{datasetName}</span>
-                <span className="max-w-[9rem] truncate font-mono text-text-4">{watermark}</span>
-              </Link>
-            ))}
+            {consumed.map(([datasetKey, watermark]) => {
+              const target = consumedDatasetTarget(datasetKey);
+              return (
+                <Link
+                  key={`${datasetKey}:${watermark}`}
+                  to="/datasets"
+                  search={{ status: undefined, namespace: target.namespace, name: target.name }}
+                  className="inline-flex max-w-full items-center gap-1.5 rounded-md border border-border/60 bg-card px-2 py-1 text-[11px] text-text-2 transition-colors hover:border-cyan/40 hover:text-cyan-glow"
+                  title={`${displayNamespace(target.namespace)} / ${target.name} @ ${watermark}`}
+                >
+                  <GitBranch className="h-3 w-3 shrink-0" />
+                  <span className="truncate font-mono">{target.name}</span>
+                  <span className="max-w-[9rem] truncate font-mono text-text-4">{watermark}</span>
+                </Link>
+              );
+            })}
           </div>
         </div>
       ) : null}
@@ -158,18 +154,14 @@ function derivationSentence(row: DatasetDerivation): string {
   const consumed = Object.keys(row.consumed_watermarks ?? {});
   if (row.decision === "derived") {
     if (consumed.length > 0) {
-      return `${decisionTimestamp(row)} derived by ${consumed.join(", ")} advance`;
+      return `Derived by ${consumed.join(", ")} advance`;
     }
-    return `${decisionTimestamp(row)} derived a freshness run`;
+    return "Derived a freshness run";
   }
   if (row.reason) {
-    return `${decisionTimestamp(row)} tick skipped - ${row.reason}`;
+    return `Tick skipped - ${row.reason}`;
   }
-  return `${decisionTimestamp(row)} tick skipped - ${decisionLabel(row.decision)}`;
-}
-
-function decisionTimestamp(row: DatasetDerivation): string {
-  return formatClock(row.created_at);
+  return `Tick skipped - ${decisionLabel(row.decision)}`;
 }
 
 function formatClock(value: string): string {

--- a/ui/src/features/datasets/FreshnessStatusChip.tsx
+++ b/ui/src/features/datasets/FreshnessStatusChip.tsx
@@ -1,0 +1,28 @@
+import { Badge } from "@/components/ui/badge";
+import type { DatasetStatus } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { freshnessTone } from "./freshness-utils";
+
+interface FreshnessStatusChipProps {
+  status: DatasetStatus | undefined;
+  inheritedStale?: boolean;
+  className?: string;
+}
+
+export function FreshnessStatusChip({
+  status,
+  inheritedStale = false,
+  className,
+}: FreshnessStatusChipProps) {
+  const tone = freshnessTone(status, inheritedStale);
+  return (
+    <Badge
+      variant="outline"
+      className={cn("gap-1.5 whitespace-nowrap px-2 py-0.5 text-[10px]", tone.badgeClass, className)}
+      data-freshness-status={status ?? "unknown"}
+    >
+      <span className={cn("h-1.5 w-1.5 rounded-full", tone.dotClass)} />
+      {tone.label}
+    </Badge>
+  );
+}

--- a/ui/src/features/datasets/freshness-utils.ts
+++ b/ui/src/features/datasets/freshness-utils.ts
@@ -1,0 +1,221 @@
+import type { DatasetDecision, DatasetState, DatasetStatus } from "@/lib/api";
+
+export type DatasetStatusFilter =
+  | "all"
+  | "unknown"
+  | "fresh"
+  | "stale"
+  | "stale-upstream"
+  | "violated"
+  | "quarantined";
+
+export const DATASET_STATUS_FILTERS: Array<{ key: DatasetStatusFilter; label: string }> = [
+  { key: "all", label: "All" },
+  { key: "fresh", label: "Fresh" },
+  { key: "stale", label: "Stale" },
+  { key: "stale-upstream", label: "Stale upstream" },
+  { key: "violated", label: "Violated" },
+  { key: "unknown", label: "Unknown" },
+  { key: "quarantined", label: "Quarantined" },
+];
+
+export interface FreshnessTone {
+  label: string;
+  badgeClass: string;
+  dotClass: string;
+  textClass: string;
+  borderClass: string;
+  surfaceClass: string;
+  barClass: string;
+  edgeColor: string;
+}
+
+const NEUTRAL_TONE: FreshnessTone = {
+  label: "unknown",
+  badgeClass: "border-text-4/30 bg-text-4/10 text-text-3",
+  dotClass: "bg-text-4",
+  textClass: "text-text-3",
+  borderClass: "border-text-4/35",
+  surfaceClass: "bg-text-4/10",
+  barClass: "bg-text-4",
+  edgeColor: "hsl(var(--text-4))",
+};
+
+const FRESH_TONE: FreshnessTone = {
+  label: "fresh",
+  badgeClass: "border-success/30 bg-success/10 text-success",
+  dotClass: "bg-success",
+  textClass: "text-success",
+  borderClass: "border-success/45",
+  surfaceClass: "bg-success/10",
+  barClass: "bg-success",
+  edgeColor: "hsl(var(--success))",
+};
+
+const WARNING_TONE: FreshnessTone = {
+  label: "stale",
+  badgeClass: "border-warning/35 bg-warning/10 text-warning",
+  dotClass: "bg-warning animate-gold-pulse",
+  textClass: "text-warning",
+  borderClass: "border-warning/55",
+  surfaceClass: "bg-warning/10",
+  barClass: "bg-warning",
+  edgeColor: "hsl(var(--warning))",
+};
+
+const DANGER_TONE: FreshnessTone = {
+  label: "violated",
+  badgeClass: "border-danger/35 bg-danger/10 text-danger",
+  dotClass: "bg-danger",
+  textClass: "text-danger",
+  borderClass: "border-danger/55",
+  surfaceClass: "bg-danger/10",
+  barClass: "bg-danger",
+  edgeColor: "hsl(var(--danger))",
+};
+
+export function datasetKey(namespace: string | undefined, name: string): string {
+  return `${namespace?.trim() ?? ""}\u0000${name.trim()}`;
+}
+
+export function datasetNamespace(state: Pick<DatasetState, "namespace">): string {
+  return state.namespace?.trim() ?? "";
+}
+
+export function displayNamespace(namespace: string | undefined): string {
+  return namespace?.trim() || "_";
+}
+
+export function normalizeStatusFilter(value: unknown): DatasetStatusFilter {
+  return DATASET_STATUS_FILTERS.some((entry) => entry.key === value)
+    ? (value as DatasetStatusFilter)
+    : "all";
+}
+
+export function cleanDatasetParam(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function freshnessTone(status: DatasetStatus | undefined, inheritedStale = false): FreshnessTone {
+  if (inheritedStale) {
+    return { ...WARNING_TONE, label: "downstream stale" };
+  }
+  switch (status) {
+    case "fresh":
+      return FRESH_TONE;
+    case "stale":
+      return WARNING_TONE;
+    case "stale-upstream":
+      return { ...WARNING_TONE, label: "stale upstream" };
+    case "violated":
+      return DANGER_TONE;
+    case "quarantined":
+      return { ...DANGER_TONE, label: "quarantined" };
+    case "unknown":
+    default:
+      return NEUTRAL_TONE;
+  }
+}
+
+export function isStaleLike(status: DatasetStatus | undefined): boolean {
+  return status === "stale" || status === "stale-upstream" || status === "violated" || status === "quarantined";
+}
+
+export function isDeclaredBeforeRun(status: DatasetStatus | undefined): boolean {
+  return status === "unknown";
+}
+
+export function effectiveObservedAt(state: DatasetState): string | undefined {
+  const candidates = [state.advanced_at, state.verified_at, state.watermark_run_at].filter(
+    (value): value is string => Boolean(value),
+  );
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  return candidates.reduce((latest, value) => (
+    new Date(value).getTime() > new Date(latest).getTime() ? value : latest
+  ));
+}
+
+export function parseGoDurationMs(raw: string | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const unitMs: Record<string, number> = {
+    ns: 0.000001,
+    us: 0.001,
+    "\u00b5s": 0.001,
+    ms: 1,
+    s: 1000,
+    m: 60_000,
+    h: 3_600_000,
+  };
+  const pattern = /([0-9]+(?:\.[0-9]+)?)(ns|us|\u00b5s|ms|s|m|h)/g;
+  let total = 0;
+  let matched = "";
+  for (const match of trimmed.matchAll(pattern)) {
+    const amount = Number(match[1]);
+    const multiplier = unitMs[match[2] ?? ""];
+    if (!Number.isFinite(amount) || multiplier === undefined) {
+      return null;
+    }
+    matched += match[0];
+    total += amount * multiplier;
+  }
+  return matched === trimmed && total > 0 ? total : null;
+}
+
+export function formatDurationShort(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "unknown";
+  }
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 48) {
+    return `${hours}h`;
+  }
+  return `${Math.floor(hours / 24)}d`;
+}
+
+export function stalenessPercent(state: DatasetState, slo: string | undefined, now = Date.now()): number | null {
+  const observedAt = effectiveObservedAt(state);
+  const sloMs = parseGoDurationMs(slo);
+  if (!observedAt || !sloMs) {
+    return null;
+  }
+  const observedMs = new Date(observedAt).getTime();
+  if (!Number.isFinite(observedMs)) {
+    return null;
+  }
+  return Math.max(0, (now - observedMs) / sloMs) * 100;
+}
+
+export function decisionLabel(decision: DatasetDecision): string {
+  switch (decision) {
+    case "derived":
+      return "derived";
+    case "skipped_fresh":
+      return "skipped fresh";
+    case "skipped_upstream":
+      return "skipped upstream";
+    case "skipped_admission":
+      return "admission skip";
+    case "skipped_active_run":
+      return "active run";
+    default:
+      return decision.replaceAll("_", " ");
+  }
+}

--- a/ui/src/features/datasets/freshness-utils.ts
+++ b/ui/src/features/datasets/freshness-utils.ts
@@ -86,6 +86,30 @@ export function displayNamespace(namespace: string | undefined): string {
   return namespace?.trim() || "_";
 }
 
+/**
+ * Resolve a `consumed_watermarks` map key to a routable dataset target.
+ *
+ * The backend keys that map with `datasetParamName` (internal/freshness):
+ * `"<namespace>.<name>"` when the consumed dataset carries a namespace, or the
+ * bare `"<name>"` when it does not. Dataset names themselves contain dots
+ * (e.g. `raw.vendor_x`, `staging.orders`), and declarations parsed from job
+ * definitions never populate a namespace today — so in practice every key is a
+ * bare, possibly-dotted name, and a bare-dot `namespace.name` key is not
+ * unambiguously splittable back into its parts.
+ *
+ * We therefore resolve the consumed dataset by NAME in the default namespace
+ * (`namespace: undefined`) rather than guessing a split point or reusing the
+ * *selected* dataset's namespace — a consumed source can live in a different
+ * namespace than the dataset consuming it, so reusing the selected namespace
+ * navigates to the wrong dataset / a 404.
+ */
+export function consumedDatasetTarget(key: string): {
+  namespace: string | undefined;
+  name: string;
+} {
+  return { namespace: undefined, name: key.trim() };
+}
+
 export function normalizeStatusFilter(value: unknown): DatasetStatusFilter {
   return DATASET_STATUS_FILTERS.some((entry) => entry.key === value)
     ? (value as DatasetStatusFilter)

--- a/ui/src/features/jobs/LineageGraph.tsx
+++ b/ui/src/features/jobs/LineageGraph.tsx
@@ -23,7 +23,14 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
-import { api, type ImpactNode } from "@/lib/api";
+import { FreshnessStatusChip } from "@/features/datasets/FreshnessStatusChip";
+import {
+  datasetKey,
+  freshnessTone,
+  isDeclaredBeforeRun,
+  isStaleLike,
+} from "@/features/datasets/freshness-utils";
+import { api, type DatasetState, type ImpactNode } from "@/lib/api";
 import { usePrincipal } from "@/lib/auth";
 import { cn, shortId } from "@/lib/utils";
 
@@ -45,6 +52,10 @@ type LineageNodeData = {
   producingStep?: string;
   lastSeen?: string;
   depth?: number;
+  freshnessStatus?: DatasetState["status"];
+  freshnessReason?: string;
+  freshnessInherited?: boolean;
+  declaredBeforeRun?: boolean;
 };
 
 type LineageEdgeData = {
@@ -52,12 +63,18 @@ type LineageEdgeData = {
   testId: string;
   sourceName: string;
   targetName: string;
+  freshnessStatus?: DatasetState["status"];
+  freshnessInherited?: boolean;
+  declaredBeforeRun?: boolean;
 };
 
 type GraphNodeRef = {
   id: string;
   name: string;
   depth: number;
+  freshnessStatus?: DatasetState["status"];
+  freshnessInherited?: boolean;
+  declaredBeforeRun?: boolean;
 };
 
 export function LineageRoutePage() {
@@ -90,18 +107,42 @@ export function LineageGraph({
   const hasDataset = namespace !== "" && name !== "";
   const isScoped = principal.isScoped;
 
+  const featuresQuery = useQuery({
+    queryKey: ["system-features"],
+    queryFn: api.getSystemFeatures,
+    staleTime: 60_000,
+  });
+  const freshnessEnabled = featuresQuery.data?.freshness_enabled === true;
+
   const impactQuery = useQuery({
     queryKey: ["lineage", "impact", namespace, name],
     queryFn: () => api.getLineageImpact({ namespace, name }),
     enabled: hasDataset && !isScoped,
   });
 
+  const freshnessQuery = useQuery({
+    queryKey: ["datasets", "lineage-overlay"],
+    queryFn: () => api.getDatasets({ limit: 200 }),
+    enabled: hasDataset && !isScoped && freshnessEnabled,
+    staleTime: 30_000,
+  });
+
+  const freshnessByDataset = useMemo(
+    () => datasetStateMap(freshnessQuery.data?.datasets ?? []),
+    [freshnessQuery.data?.datasets],
+  );
+
   const graph = useMemo(() => {
     if (!impactQuery.data) {
       return { nodes: [] as Node<LineageNodeData>[], edges: [] as Edge[] };
     }
-    return buildGraph(impactQuery.data.root_namespace, impactQuery.data.root_name, impactQuery.data.downstream ?? []);
-  }, [impactQuery.data]);
+    return buildGraph(
+      impactQuery.data.root_namespace,
+      impactQuery.data.root_name,
+      impactQuery.data.downstream ?? [],
+      freshnessByDataset,
+    );
+  }, [freshnessByDataset, impactQuery.data]);
 
   function applyDataset(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -229,6 +270,14 @@ function lineageImpactNodeTestId(namespace: string, name: string, jobId?: string
 
 function lineageImpactEdgeTestId(sourceName: string, targetName: string, index: number) {
   return `lineage-edge:${sourceName}:${targetName}:${index}`;
+}
+
+function datasetStateMap(states: DatasetState[]) {
+  const map = new Map<string, DatasetState>();
+  states.forEach((state) => {
+    map.set(datasetKey(state.namespace, state.name), state);
+  });
+  return map;
 }
 
 function LineageHeader() {
@@ -362,9 +411,22 @@ function MetadataCell({ label, value }: { label: string; value: string }) {
   );
 }
 
-function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactNode[]) {
+function buildGraph(
+  rootNamespace: string,
+  rootName: string,
+  downstream: ImpactNode[],
+  freshnessByDataset: Map<string, DatasetState>,
+) {
   const rootId = `root:${rootNamespace}:${rootName}`;
-  const rootRef: GraphNodeRef = { id: rootId, name: rootName, depth: -1 };
+  const rootState = freshnessByDataset.get(datasetKey(rootNamespace, rootName));
+  const rootIsStale = isStaleLike(rootState?.status);
+  const rootRef: GraphNodeRef = {
+    id: rootId,
+    name: rootName,
+    depth: -1,
+    freshnessStatus: rootState?.status,
+    declaredBeforeRun: isDeclaredBeforeRun(rootState?.status),
+  };
   const initialNodes: Node<LineageNodeData>[] = [
     {
       id: rootId,
@@ -373,6 +435,9 @@ function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactN
         kind: "root",
         namespace: rootNamespace,
         name: rootName,
+        freshnessStatus: rootState?.status,
+        freshnessReason: rootState?.reason,
+        declaredBeforeRun: isDeclaredBeforeRun(rootState?.status),
       },
       position: { x: 0, y: 0 },
     },
@@ -384,10 +449,16 @@ function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactN
 
   downstream.forEach((node, index) => {
     const nodeId = `impact:${node.dataset_namespace}:${node.dataset_name}:${node.job_id}:${index}`;
+    const state = freshnessByDataset.get(datasetKey(node.dataset_namespace, node.dataset_name));
+    const inheritedStale = rootIsStale && !isStaleLike(state?.status);
+    const declaredBeforeRun = isDeclaredBeforeRun(state?.status);
     const nodeRef = {
       id: nodeId,
       name: node.dataset_name,
       depth: node.depth,
+      freshnessStatus: state?.status,
+      freshnessInherited: inheritedStale,
+      declaredBeforeRun,
     };
     initialNodes.push({
       id: nodeId,
@@ -401,6 +472,10 @@ function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactN
         producingStep: node.producing_step,
         lastSeen: node.last_seen,
         depth: node.depth,
+        freshnessStatus: state?.status,
+        freshnessReason: state?.reason,
+        freshnessInherited: inheritedStale,
+        declaredBeforeRun,
       },
       position: { x: 0, y: 0 },
     });
@@ -421,6 +496,8 @@ function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactN
     sourceRefs.forEach((sourceRef) => {
       const index = edgeIndex;
       edgeIndex += 1;
+      const tone = freshnessTone(nodeRef.freshnessStatus, nodeRef.freshnessInherited);
+      const edgeColor = nodeRef.declaredBeforeRun ? "hsl(var(--text-4))" : tone.edgeColor;
       initialEdges.push({
         id: `lineage-edge-${index}`,
         source: sourceRef.id,
@@ -431,16 +508,20 @@ function buildGraph(rootNamespace: string, rootName: string, downstream: ImpactN
           sourceName: sourceRef.name,
           targetName: nodeRef.name,
           testId: lineageImpactEdgeTestId(sourceRef.name, nodeRef.name, index),
+          freshnessStatus: nodeRef.freshnessStatus,
+          freshnessInherited: nodeRef.freshnessInherited,
+          declaredBeforeRun: nodeRef.declaredBeforeRun,
         },
         markerEnd: {
           type: MarkerType.ArrowClosed,
           width: 20,
           height: 20,
-          color: "hsl(var(--running))",
+          color: edgeColor,
         },
         style: {
           strokeWidth: 2,
-          stroke: "hsl(var(--running))",
+          stroke: edgeColor,
+          strokeDasharray: nodeRef.declaredBeforeRun ? "6 5" : undefined,
         },
       });
     });
@@ -503,6 +584,8 @@ const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
   const hop = typeof data.depth === "number" ? data.depth + 1 : undefined;
   const displayJob = jobLabel(data.jobAlias, data.jobId);
   const jobTitle = data.jobId ? `Open job ${displayJob}` : displayJob;
+  const hasFreshnessOverlay = Boolean(data.freshnessStatus || data.freshnessInherited);
+  const tone = freshnessTone(data.freshnessStatus, data.freshnessInherited);
 
   return (
     <div
@@ -514,21 +597,39 @@ const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
       data-job-alias={data.jobAlias}
       className={cn(
         "relative h-[150px] w-[320px] overflow-hidden rounded-lg border-2 px-4 py-3 shadow-sm transition-colors",
-        isRoot
-          ? "border-gold/50 bg-[linear-gradient(155deg,hsl(var(--gold)/0.18),hsl(var(--node-surface)/0.95)_60%)]"
-          : "cursor-pointer border-caesium-cyan/45 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.18),hsl(var(--node-surface)/0.95)_60%)] hover:border-caesium-cyan/80",
+        hasFreshnessOverlay
+          ? [
+              tone.borderClass,
+              data.declaredBeforeRun && "border-dashed",
+              data.freshnessInherited
+                ? "bg-[linear-gradient(155deg,hsl(var(--warning)/0.18),hsl(var(--node-surface)/0.95)_60%)]"
+                : tone.surfaceClass,
+            ]
+          : isRoot
+            ? "border-gold/50 bg-[linear-gradient(155deg,hsl(var(--gold)/0.18),hsl(var(--node-surface)/0.95)_60%)]"
+            : "cursor-pointer border-caesium-cyan/45 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.18),hsl(var(--node-surface)/0.95)_60%)] hover:border-caesium-cyan/80",
+        !isRoot && "cursor-pointer",
+        hasFreshnessOverlay && !isRoot && "hover:border-text-2/60",
       )}
       title={isRoot ? `${data.namespace}/${data.name}` : jobTitle}
     >
       {!isRoot ? (
-        <Handle type="target" position={Position.Left} className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan" />
+        <Handle
+          type="target"
+          position={Position.Left}
+          className={cn("h-3 w-3 border-2 border-dag-bg", hasFreshnessOverlay ? tone.dotClass : "bg-caesium-cyan")}
+        />
       ) : null}
-      <Handle type="source" position={Position.Right} className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan" />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className={cn("h-3 w-3 border-2 border-dag-bg", hasFreshnessOverlay ? tone.dotClass : "bg-caesium-cyan")}
+      />
 
       <div className="flex h-full flex-col justify-between gap-3">
         <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <Database className={cn("h-4 w-4 shrink-0", isRoot ? "text-gold" : "text-running")} />
+          <div className="flex flex-wrap items-center gap-2">
+            <Database className={cn("h-4 w-4 shrink-0", hasFreshnessOverlay ? tone.textClass : isRoot ? "text-gold" : "text-running")} />
             <Badge variant="outline" className="text-[10px]">
               {isRoot ? "Root dataset" : "Downstream output"}
             </Badge>
@@ -536,6 +637,13 @@ const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
               <span className="rounded border border-running/30 bg-running/10 px-1.5 py-0.5 text-[10px] font-semibold text-running">
                 Hop {hop}
               </span>
+            ) : null}
+            {hasFreshnessOverlay ? (
+              <FreshnessStatusChip
+                status={data.freshnessStatus}
+                inheritedStale={data.freshnessInherited}
+                className="max-w-[10rem]"
+              />
             ) : null}
           </div>
           <div className="mt-3 truncate font-mono text-sm font-semibold text-text-1" title={data.name}>
@@ -561,6 +669,11 @@ const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
             {data.lastSeen ? (
               <div className="truncate font-mono text-[10px]" title={data.lastSeen}>
                 {new Date(data.lastSeen).toLocaleString()}
+              </div>
+            ) : null}
+            {data.freshnessReason ? (
+              <div className={cn("truncate text-[10px]", tone.textClass)} title={data.freshnessReason}>
+                {data.freshnessReason}
               </div>
             ) : null}
           </div>
@@ -595,6 +708,15 @@ const LineageImpactEdge = memo(({
   });
   const depth = typeof data?.depth === "number" ? data.depth : 0;
   const testId = data?.testId ?? `lineage-edge:${id}`;
+  const hasFreshnessOverlay = Boolean(data?.freshnessStatus || data?.freshnessInherited || data?.declaredBeforeRun);
+  const tone = freshnessTone(data?.freshnessStatus, data?.freshnessInherited);
+  const label = data?.declaredBeforeRun
+    ? "declared"
+    : data?.freshnessInherited
+      ? "stale path"
+      : depth === 0
+        ? "downstream"
+        : `depth ${depth + 1}`;
 
   return (
     <>
@@ -605,13 +727,18 @@ const LineageImpactEdge = memo(({
           data-edge-id={id}
           data-edge-source={data?.sourceName}
           data-edge-target={data?.targetName}
-          className="nodrag nopan rounded-full border border-running/35 bg-card/95 px-2 py-1 text-[10px] font-semibold text-running shadow-sm"
+          className={cn(
+            "nodrag nopan rounded-full border bg-card/95 px-2 py-1 text-[10px] font-semibold shadow-sm",
+            hasFreshnessOverlay
+              ? [tone.borderClass, tone.surfaceClass, tone.textClass]
+              : "border-running/35 text-running",
+          )}
           style={{
             position: "absolute",
             transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
           }}
         >
-          {depth === 0 ? "downstream" : `depth ${depth + 1}`}
+          {label}
         </div>
       </EdgeLabelRenderer>
     </>

--- a/ui/src/features/jobs/LineageGraph.tsx
+++ b/ui/src/features/jobs/LineageGraph.tsx
@@ -1,6 +1,6 @@
 import { type FormEvent, memo, useCallback, useMemo, useState } from "react";
 import { Link, getRouteApi, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import ReactFlow, {
   Background,
   BaseEdge,
@@ -120,17 +120,50 @@ export function LineageGraph({
     enabled: hasDataset && !isScoped,
   });
 
-  const freshnessQuery = useQuery({
-    queryKey: ["datasets", "lineage-overlay"],
-    queryFn: () => api.getDatasets({ limit: 200 }),
-    enabled: hasDataset && !isScoped && freshnessEnabled,
-    staleTime: 30_000,
+  // Overlay freshness on exactly the datasets present in this lineage graph (the
+  // root plus each downstream node) rather than a first-N page of /datasets — a
+  // page cap left nodes beyond the first 200 unstyled even when stale.
+  const overlayTargets = useMemo(() => {
+    if (!impactQuery.data) {
+      return [] as Array<{ namespace: string; name: string }>;
+    }
+    const seen = new Set<string>();
+    const targets: Array<{ namespace: string; name: string }> = [];
+    const push = (ns: string, datasetName: string) => {
+      const key = datasetKey(ns, datasetName);
+      if (seen.has(key)) {
+        return;
+      }
+      seen.add(key);
+      targets.push({ namespace: ns, name: datasetName });
+    };
+    push(impactQuery.data.root_namespace, impactQuery.data.root_name);
+    (impactQuery.data.downstream ?? []).forEach((node) =>
+      push(node.dataset_namespace, node.dataset_name),
+    );
+    return targets;
+  }, [impactQuery.data]);
+
+  const freshnessQueries = useQueries({
+    queries: overlayTargets.map((target) => ({
+      queryKey: ["datasets", "detail", target.namespace, target.name],
+      queryFn: () => api.getDataset(target.namespace, target.name),
+      enabled: freshnessEnabled && !isScoped,
+      staleTime: 30_000,
+    })),
   });
 
-  const freshnessByDataset = useMemo(
-    () => datasetStateMap(freshnessQuery.data?.datasets ?? []),
-    [freshnessQuery.data?.datasets],
-  );
+  const freshnessByDataset = useMemo(() => {
+    const map = new Map<string, DatasetState>();
+    freshnessQueries.forEach((query, index) => {
+      const target = overlayTargets[index];
+      const state = query.data?.state;
+      if (target && state) {
+        map.set(datasetKey(target.namespace, target.name), state);
+      }
+    });
+    return map;
+  }, [freshnessQueries, overlayTargets]);
 
   const graph = useMemo(() => {
     if (!impactQuery.data) {
@@ -270,14 +303,6 @@ function lineageImpactNodeTestId(namespace: string, name: string, jobId?: string
 
 function lineageImpactEdgeTestId(sourceName: string, targetName: string, index: number) {
   return `lineage-edge:${sourceName}:${targetName}:${index}`;
-}
-
-function datasetStateMap(states: DatasetState[]) {
-  const map = new Map<string, DatasetState>();
-  states.forEach((state) => {
-    map.set(datasetKey(state.namespace, state.name), state);
-  });
-  return map;
 }
 
 function LineageHeader() {

--- a/ui/src/features/stats/__tests__/StatsPage.test.tsx
+++ b/ui/src/features/stats/__tests__/StatsPage.test.tsx
@@ -62,6 +62,7 @@ describe('StatsPage', () => {
       database_console_enabled: false,
       log_console_enabled: false,
       agent_remediation_enabled: false,
+      freshness_enabled: false,
     });
   });
 

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -392,6 +392,7 @@ export interface SystemFeatures {
   database_console_enabled: boolean;
   log_console_enabled: boolean;
   agent_remediation_enabled: boolean;
+  freshness_enabled: boolean;
   external_url?: string;
 }
 
@@ -699,6 +700,119 @@ export interface VerifyResult {
   rederived: Receipt | null;
 }
 
+export type DatasetStatus =
+  | "unknown"
+  | "fresh"
+  | "stale"
+  | "stale-upstream"
+  | "violated"
+  | "quarantined"
+  | string;
+
+export type DatasetDeclarationDirection =
+  | "produces"
+  | "consumes"
+  | "source"
+  | string;
+
+export type DatasetDecision =
+  | "derived"
+  | "skipped_fresh"
+  | "skipped_upstream"
+  | "skipped_admission"
+  | "skipped_active_run"
+  | string;
+
+export interface DatasetState {
+  id: string;
+  namespace?: string;
+  name: string;
+  watermark: string;
+  watermark_run_at?: string;
+  advanced_at?: string;
+  verified_at?: string;
+  status: DatasetStatus;
+  reason?: string;
+  last_run_id?: string;
+  consumed_watermarks?: Record<string, string>;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DatasetDeclaration {
+  id: string;
+  job_id: string;
+  job_alias: string;
+  step_name: string;
+  namespace?: string;
+  name: string;
+  direction: DatasetDeclarationDirection;
+  freshness?: string;
+  max_staleness?: string;
+  expected_every?: string;
+  watermark_key?: string;
+  external: boolean;
+  arrival_binding?: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DatasetSLO {
+  freshness?: string;
+  max_staleness?: string;
+  expected_every?: string;
+}
+
+export interface DatasetProducingJob {
+  id: string;
+  alias: string;
+  step_name?: string;
+}
+
+export interface DatasetDerivation {
+  id: string;
+  namespace?: string;
+  name: string;
+  decision: DatasetDecision;
+  reason?: string;
+  consumed_watermarks?: Record<string, string>;
+  run_id?: string;
+  created_at: string;
+}
+
+export interface DatasetListParams {
+  status?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface DatasetListResponse {
+  datasets: DatasetState[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface DatasetDetail {
+  state: DatasetState;
+  declaration?: DatasetDeclaration;
+  slo?: DatasetSLO;
+  producing_job?: DatasetProducingJob;
+  last_decision?: DatasetDerivation;
+}
+
+export interface DatasetDerivationsParams {
+  limit?: number;
+  offset?: number;
+}
+
+export interface DatasetDerivationsResponse {
+  derivations: DatasetDerivation[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
 export interface LineageImpactQuery {
   namespace: string;
   name: string;
@@ -864,6 +978,10 @@ function queryString(params: Record<string, string | number | boolean | undefine
   return query.toString();
 }
 
+function datasetPath(namespace: string | undefined, name: string): string {
+  return `/datasets/${encodeURIComponent(namespace?.trim() || "_")}/${encodeURIComponent(name)}`;
+}
+
 function parseJobDefinitions(yaml: string) {
   const docs = parseAllDocuments(yaml);
   return docs
@@ -976,6 +1094,26 @@ export const api = {
   deleteTaskCache: (jobId: string, taskName: string) =>
     request<void>(`/jobs/${jobId}/cache/${encodeURIComponent(taskName)}`, { method: "DELETE" }),
   pruneCache: () => request<CachePruneResponse>("/cache/prune", { method: "POST" }),
+  getDatasets: (params: DatasetListParams = {}) => {
+    const query = queryString({
+      status: params.status,
+      limit: params.limit,
+      offset: params.offset,
+    });
+    return request<DatasetListResponse>(`/datasets${query ? `?${query}` : ""}`);
+  },
+  getDataset: (namespace: string | undefined, name: string) =>
+    request<DatasetDetail>(datasetPath(namespace, name)),
+  getDatasetDerivations: (
+    namespace: string | undefined,
+    name: string,
+    params: DatasetDerivationsParams = {},
+  ) => {
+    const query = queryString({ limit: params.limit, offset: params.offset });
+    return request<DatasetDerivationsResponse>(
+      `${datasetPath(namespace, name)}/derivations${query ? `?${query}` : ""}`,
+    );
+  },
   getSystemNodes: () => request<Node[]>("/system/nodes"),
   getSystemFeatures: () => request<SystemFeatures>("/system/features"),
   getIncidents: (params: IncidentListParams = {}) => {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, createRoute, createRouter, redirect } from "@tanstack/
 import { AppShell } from "./components/layout/AppShell";
 import { AtomsPage } from "./features/atoms/AtomsPage";
 import { DatabaseConsolePage } from "./features/database/DatabaseConsolePage";
+import { DatasetsPage } from "./features/datasets/DatasetsPage";
 import { IncidentDetailPage } from "./features/incidents/IncidentDetailPage";
 import { IncidentsPage } from "./features/incidents/IncidentsPage";
 import { LogConsolePage } from "./features/logs/LogConsolePage";
@@ -16,6 +17,7 @@ import { StatsPage } from "./features/stats/StatsPage";
 import { SystemPage } from "./features/system/SystemPage";
 import { TriggersPage } from "./features/triggers/TriggersPage";
 import { api } from "./lib/api";
+import { normalizeStatusFilter } from "./features/datasets/freshness-utils";
 
 const rootRoute = createRootRoute({
   component: AppShell,
@@ -73,6 +75,28 @@ const lineageRoute = createRoute({
     name: typeof search.name === "string" ? search.name : undefined,
   }),
   component: LineageRoutePage,
+});
+
+async function requireFreshnessEnabled() {
+  const features = await api.getSystemFeatures();
+  if (!features.freshness_enabled) {
+    throw redirect({ to: "/jobs" });
+  }
+}
+
+const datasetsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "datasets",
+  validateSearch: (search: Record<string, unknown>) => {
+    const status = normalizeStatusFilter(search.status);
+    return {
+      status: status === "all" ? undefined : status,
+      namespace: typeof search.namespace === "string" ? search.namespace : undefined,
+      name: typeof search.name === "string" ? search.name : undefined,
+    };
+  },
+  loader: requireFreshnessEnabled,
+  component: DatasetsPage,
 });
 
 async function requireAgentRemediationEnabled() {
@@ -170,6 +194,7 @@ const routeTree = rootRoute.addChildren([
   runDiffRoute,
   runDetailRoute,
   lineageRoute,
+  datasetsRoute,
   incidentsRoute,
   incidentDetailRoute,
   statsRoute,


### PR DESCRIPTION
Stream F of the freshness-scheduling plan (Wave 4). The consumer-facing "is my table up to date" surface, consuming the Stream E1 REST endpoints (`GET /v1/datasets*`). Mirrors the data-plane-memory-ui precedent (backend ships first; UI consumes).

- **F1 — dataset freshness board at `/datasets`:** status chip, staleness-vs-SLO bar, producing job, and the `stale-upstream` reason, readable without DAGs. New `ui/src/features/datasets/`, route, api.ts methods/types matching the backend shapes exactly, nav entry.
- **F2 — lineage overlay + derivations panel:** the `LineageGraph` gains an opt-in freshness coloring overlay (existing rendering untouched when off); a derivations panel renders `DatasetDerivation` rows with consumed-watermark links back to the arrival event.
- **Feature-gated:** adds `FreshnessEnabled` to the `/system/features` `Features` struct (populated from `CAESIUM_FRESHNESS_ENABLED`); the nav + route hide when off.

Verify: `just lint` + `just unit-test` + `just ui-lint` + `just ui-test` green locally (orchestrator fixed three UI-toolchain gaps codex couldn't run: an impure `Date.now()` in render → `useState(() => Date.now())`, a `useMemo` dep, and a TanStack `<Link search>` typing). ui-e2e gate runs before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)