### PR TITLE
Report accurate step count in JobDefs lint summary (console-v2-bug-sweep W1-ε)

### DIFF
--- a/api/rest/controller/jobdef/lint.go
+++ b/api/rest/controller/jobdef/lint.go
@@ -22,7 +22,8 @@ type LintMessage struct {
 }
 
 type LintSummary struct {
-	Steps string `json:"steps"`
+	Steps     int    `json:"steps"`
+	Contracts string `json:"contracts,omitempty"`
 }
 
 type LintResponse struct {
@@ -71,15 +72,14 @@ func Lint(c *echo.Context) error {
 		}
 	}
 
-	var stepsSummary string
 	if len(resp.Errors) == 0 {
 		var allSteps []schema.Step
 		for _, def := range req.Definitions {
 			allSteps = append(allSteps, def.Steps...)
 		}
-		stepsSummary = contractSummary(allSteps)
+		resp.Summary.Steps = len(allSteps)
+		resp.Summary.Contracts = contractSummary(allSteps)
 	}
-	resp.Summary.Steps = stepsSummary
 
 	return c.JSON(http.StatusOK, resp)
 }

--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -281,7 +281,7 @@ Fixes on the run detail page and its timeline
 
 ### Stream E — JobDefs lint accuracy
 
-- [ ] E1. Make the JobDefs live-lint status bar report an accurate step
+- [x] E1. Make the JobDefs live-lint status bar report an accurate step
       summary. It currently reads "Schema valid · No steps" even for a
       two-step manifest, because the frontend renders
       `lintResult.summary?.steps || "No steps"` and the backend's
@@ -303,6 +303,9 @@ Fixes on the run detail page and its timeline
       `ui/src/lib/api.ts` (`LintSummary`),
       `ui/src/features/jobdefs/JobDefsPage.tsx` (~304, ~325-329), new
       `test/*_test.go` scenario.
+      Note: W1-epsilon now returns numeric `summary.steps` plus optional
+      `summary.contracts`, formats the JobDefs bar from the count, and adds
+      live-server lint assertions for multi-step and stepless manifests.
 
 ### Stream F — Shell & display consistency
 

--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -360,7 +360,7 @@ sequenced after them (see `## Sequencing & Dependencies`).
 
 ## Harness Strengthening
 
-- [ ] H-1. Seed a richer e2e/integration fixture set so the assertions the
+- [x] H-1. Seed a richer e2e/integration fixture set so the assertions the
       above items need have real data to render against: a job with a
       **multi-step DAG** that produces a **failed run** carrying a **failed
       callback**, plus an **event trigger** and one or more **cron triggers**.
@@ -369,6 +369,9 @@ sequenced after them (see `## Sequencing & Dependencies`).
       validator (A1). Files: `ui/e2e/helpers/fixtures.ts`, new
       `ui/e2e/` fixture `*.job.yaml`, and any `test/` harness seed needed for
       the integration scenarios (B4, E1, F4).
+      Landed W1-H1: shared `fixtures.ts` helpers now index the existing
+      `docs/examples/` coverage and centralize fixture load/apply, job lookup,
+      trigger, and run-await flows; no new fixture was needed.
 
 ## Navigational / Organizational Improvements
 

--- a/test/jobdef_lint_summary_test.go
+++ b/test/jobdef_lint_summary_test.go
@@ -1,0 +1,86 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestJobdefLintSummaryReportsStepCount() {
+	alias := fmt.Sprintf("integration-lint-summary-%d", time.Now().UnixNano())
+	payload := fmt.Sprintf(`{"definitions":[{
+		"apiVersion": "v1",
+		"kind": "Job",
+		"metadata": {"alias": %q},
+		"trigger": {"type": "cron", "configuration": {"expression": "0 * * * *"}},
+		"steps": [
+			{"name": "extract", "image": "busybox:1.36.1"},
+			{"name": "load", "image": "busybox:1.36.1", "dependsOn": ["extract"]}
+		]
+	}]}`, alias)
+
+	var lintResp struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+		Summary struct {
+			Steps     int    `json:"steps"`
+			Contracts string `json:"contracts"`
+		} `json:"summary"`
+	}
+
+	resp, err := s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/jobdefs/lint", strings.NewReader(payload))
+	s.Require().NoError(err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode, string(body))
+	s.Require().NoError(json.Unmarshal(body, &lintResp))
+	s.Empty(lintResp.Errors, "expected no lint errors, got %+v", lintResp.Errors)
+	s.Equal(2, lintResp.Summary.Steps)
+	s.Empty(lintResp.Summary.Contracts)
+}
+
+func (s *IntegrationTestSuite) TestJobdefLintRejectsSteplessDefinition() {
+	alias := fmt.Sprintf("integration-lint-stepless-%d", time.Now().UnixNano())
+	payload := fmt.Sprintf(`{"definitions":[{
+		"apiVersion": "v1",
+		"kind": "Job",
+		"metadata": {"alias": %q},
+		"trigger": {"type": "cron", "configuration": {"expression": "0 * * * *"}},
+		"steps": []
+	}]}`, alias)
+
+	var lintResp struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+		Summary struct {
+			Steps int `json:"steps"`
+		} `json:"summary"`
+	}
+
+	resp, err := s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/jobdefs/lint", strings.NewReader(payload))
+	s.Require().NoError(err)
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode, string(body))
+	s.Require().NoError(json.Unmarshal(body, &lintResp))
+	s.Equal(0, lintResp.Summary.Steps)
+	s.Require().NotEmpty(lintResp.Errors, "expected a lint error for a stepless definition")
+
+	found := false
+	for _, err := range lintResp.Errors {
+		if strings.Contains(err.Message, "steps must contain at least one entry") {
+			found = true
+			break
+		}
+	}
+	s.True(found, "expected stepless validation error, got %+v", lintResp.Errors)
+}

--- a/ui/e2e/helpers/fixtures.ts
+++ b/ui/e2e/helpers/fixtures.ts
@@ -4,8 +4,21 @@ import { fileURLToPath } from "node:url";
 import type { APIRequestContext } from "@playwright/test";
 import { parseAllDocuments } from "yaml";
 
+/**
+ * Console v2 bug-sweep fixture index:
+ * - docs/examples/callback-failure.job.yaml backs D3 failed-callback rendering.
+ * - docs/examples/run-history.job.yaml backs A1 cron next-fire via cron-success-fast
+ *   and B4/C1 failed-run history/DAG counts via cron-failure-fast.
+ * - docs/examples/event-trigger.job.yaml backs A2 event-trigger rendering.
+ * - docs/examples/branching.job.yaml and fanout-join.job.yaml back multi-step DAG views.
+ */
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const manualTriggerAPIKey = process.env.CAESIUM_MANUAL_TRIGGER_API_KEY?.trim() || "e2e-test-key";
+const terminalRunStatuses = new Set(["succeeded", "failed", "cancelled"]);
+const defaultRunTimeoutMs = 180_000;
+const pollIntervalMs = 1_000;
 
 export type FixtureDefinition = {
   metadata?: Record<string, unknown> & { alias?: string };
@@ -14,30 +27,123 @@ export type FixtureDefinition = {
   };
 };
 
+export type E2EJob = {
+  id: string;
+  alias: string;
+};
+
+type E2EJobWithTrigger = E2EJob & {
+  trigger_id?: string;
+  trigger?: {
+    id: string;
+    type: string;
+  };
+};
+
+export type E2ECallbackRun = {
+  id: string;
+  callback_id: string;
+  status: string;
+  error?: string;
+  started_at: string;
+  completed_at?: string;
+} & Record<string, unknown>;
+
+export type E2ETaskRun = {
+  id: string;
+  job_run_id: string;
+  task_id: string;
+  atom_id?: string;
+  engine?: string;
+  image?: string;
+  command?: string[];
+  runtime_id?: string;
+  status: string;
+  result?: string;
+  error?: string;
+  output?: Record<string, string>;
+  cache_hit?: boolean;
+  cache_origin_run_id?: string;
+  started_at?: string;
+  completed_at?: string;
+  created_at?: string;
+  updated_at?: string;
+} & Record<string, unknown>;
+
+export type E2ERun = {
+  id: string;
+  job_id: string;
+  job_alias?: string;
+  backfill_id?: string;
+  trigger_type?: string;
+  trigger_alias?: string;
+  status: string;
+  priority?: number;
+  params?: Record<string, string>;
+  quarantine?: boolean;
+  started_at: string;
+  completed_at?: string;
+  created_at: string;
+  updated_at: string;
+  error?: string;
+  tasks: E2ETaskRun[];
+  callbacks: E2ECallbackRun[];
+  cache_hits?: number;
+  executed_tasks?: number;
+  total_tasks?: number;
+} & Record<string, unknown>;
+
+export type TriggerJobOptions = {
+  params?: Record<string, string>;
+  priority?: "low" | "normal" | "high";
+};
+
+export type AwaitRunOptions = {
+  status?: string | string[];
+  timeoutMs?: number;
+};
+
+export type ApplyAndRunOptions = TriggerJobOptions &
+  AwaitRunOptions & {
+    definitionIndex?: number;
+  };
+
 /**
  * Load a job-definition YAML from docs/examples/, mutating the alias (and any
  * HTTP webhook path) so each test invocation gets a unique resource and tests
  * can run repeatedly without colliding with prior state.
  */
 export async function loadFixtureDefinition(filename: string): Promise<FixtureDefinition> {
+  const defs = await loadFixtureDefinitions(filename);
+  const first = defs[0];
+  if (!first) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+  return first;
+}
+
+export async function loadFixtureDefinitions(filename: string): Promise<FixtureDefinition[]> {
   const fixturePath = path.resolve(__dirname, "../../../docs/examples", filename);
   const yaml = await fs.readFile(fixturePath, "utf8");
   const docs = parseAllDocuments(yaml);
-  const raw = docs[0]?.toJS();
-  if (!raw || typeof raw !== "object") {
-    throw new Error(`failed to parse fixture: ${filename}`);
-  }
-  const def = raw as FixtureDefinition;
-
   const suffix = crypto.randomUUID().split("-")[0];
-  const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
-  def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
 
-  if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
-    def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
-  }
+  return docs.map((doc, index) => {
+    const raw = doc.toJS();
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`failed to parse fixture ${filename} document ${index}`);
+    }
 
-  return def;
+    const def = raw as FixtureDefinition;
+    const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
+    def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
+
+    if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
+      def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
+    }
+
+    return def;
+  });
 }
 
 export async function applyDefinitions(request: APIRequestContext, ...defs: FixtureDefinition[]): Promise<void> {
@@ -47,4 +153,185 @@ export async function applyDefinitions(request: APIRequestContext, ...defs: Fixt
   if (!response.ok()) {
     throw new Error(`failed to apply fixture: ${response.status()} ${await response.text()}`);
   }
+}
+
+export async function findJobByAlias(request: APIRequestContext, alias: string): Promise<E2EJob> {
+  const job = await findJobWithTriggerByAlias(request, alias);
+  return { id: job.id, alias: job.alias };
+}
+
+export async function triggerJob(
+  request: APIRequestContext,
+  jobId: string,
+  params?: Record<string, string> | TriggerJobOptions,
+): Promise<void> {
+  const options = normalizeTriggerJobOptions(params);
+  const job = await getJob(request, jobId);
+  if (!job.trigger_id) {
+    throw new Error(`job ${jobId} did not include trigger_id`);
+  }
+
+  if (job.trigger?.type === "http") {
+    await fireHTTPTrigger(request, jobId, job.trigger_id, options);
+    return;
+  }
+
+  await startJobRun(request, jobId, options);
+}
+
+export async function awaitRun(
+  request: APIRequestContext,
+  jobId: string,
+  opts: AwaitRunOptions = {},
+): Promise<E2ERun> {
+  const expectedStatuses = normalizeExpectedStatuses(opts.status);
+  const deadline = Date.now() + (opts.timeoutMs ?? defaultRunTimeoutMs);
+  let lastRun: E2ERun | undefined;
+  let lastStatus = "no runs";
+
+  while (Date.now() <= deadline) {
+    const runs = await listRuns(request, jobId);
+    lastRun = latestRun(runs);
+    if (lastRun) {
+      lastStatus = lastRun.status;
+      if (expectedStatuses.has(lastRun.status) || (!opts.status && terminalRunStatuses.has(lastRun.status))) {
+        return getRun(request, jobId, lastRun.id);
+      }
+    }
+
+    await delay(pollIntervalMs);
+  }
+
+  const wanted = opts.status ? [...expectedStatuses].join(", ") : "terminal status";
+  throw new Error(`timed out waiting for job ${jobId} latest run to reach ${wanted}; last status: ${lastStatus}`);
+}
+
+export async function applyAndRun(
+  request: APIRequestContext,
+  filename: string,
+  opts: ApplyAndRunOptions = {},
+): Promise<{ job: E2EJob; run: E2ERun }> {
+  const defs = await loadFixtureDefinitions(filename);
+  if (defs.length === 0) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+
+  const index = opts.definitionIndex ?? 0;
+  const def = defs[index];
+  if (!def) {
+    throw new Error(`fixture ${filename} does not include document ${index}`);
+  }
+  const alias = String(def.metadata?.alias ?? "");
+  if (!alias) {
+    throw new Error(`fixture ${filename} document ${index} did not include an alias`);
+  }
+
+  await applyDefinitions(request, ...defs);
+  const job = await findJobByAlias(request, alias);
+  await triggerJob(request, job.id, { params: opts.params, priority: opts.priority });
+  const run = await awaitRun(request, job.id, opts);
+
+  return { job, run };
+}
+
+async function fireHTTPTrigger(
+  request: APIRequestContext,
+  jobId: string,
+  triggerId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/triggers/${triggerId}/fire`, {
+    headers: {
+      "X-Caesium-API-Key": manualTriggerAPIKey,
+    },
+    ...requestBody(options),
+  });
+  if (!response.ok()) {
+    throw new Error(`failed to manually fire trigger for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function startJobRun(
+  request: APIRequestContext,
+  jobId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`, requestBody(options));
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function findJobWithTriggerByAlias(request: APIRequestContext, alias: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get("/v1/jobs");
+  if (!response.ok()) {
+    throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+  }
+
+  const jobs = (await response.json()) as E2EJobWithTrigger[];
+  const job = jobs.find((candidate) => candidate.alias === alias);
+  if (!job) {
+    throw new Error(`job not found after apply: ${alias}`);
+  }
+  return job;
+}
+
+async function getJob(request: APIRequestContext, jobId: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get(`/v1/jobs/${jobId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2EJobWithTrigger;
+}
+
+async function listRuns(request: APIRequestContext, jobId: string): Promise<E2ERun[]> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs`);
+  if (!response.ok()) {
+    throw new Error(`failed to list runs for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun[];
+}
+
+async function getRun(request: APIRequestContext, jobId: string, runId: string): Promise<E2ERun> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load run ${runId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun;
+}
+
+function requestBody(options: TriggerJobOptions): { data?: TriggerJobOptions } {
+  const body: TriggerJobOptions = {};
+  if (options.params && Object.keys(options.params).length > 0) {
+    body.params = options.params;
+  }
+  if (options.priority) {
+    body.priority = options.priority;
+  }
+  return Object.keys(body).length > 0 ? { data: body } : {};
+}
+
+function normalizeTriggerJobOptions(input: Record<string, string> | TriggerJobOptions | undefined): TriggerJobOptions {
+  if (!input || Object.keys(input).length === 0) {
+    return {};
+  }
+  if ("params" in input || "priority" in input) {
+    return input as TriggerJobOptions;
+  }
+  return { params: input };
+}
+
+function normalizeExpectedStatuses(status: string | string[] | undefined): Set<string> {
+  if (!status) {
+    return new Set();
+  }
+  return new Set(Array.isArray(status) ? status : [status]);
+}
+
+function latestRun(runs: E2ERun[]): E2ERun | undefined {
+  return runs.at(-1);
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/ui/src/features/jobdefs/JobDefsPage.tsx
+++ b/ui/src/features/jobdefs/JobDefsPage.tsx
@@ -82,11 +82,20 @@ const customTheme = EditorView.theme({
   },
 }, { dark: true });
 
+function formatStepCount(count: number) {
+  return `${count} ${count === 1 ? "step" : "steps"}`;
+}
+
+function contractStatusLabel(summary: string) {
+  const detailStart = summary.indexOf(" (");
+  return detailStart === -1 ? summary : summary.slice(0, detailStart);
+}
+
 export function JobDefsPage() {
   const queryClient = useQueryClient();
   const [yaml, setYaml] = useState(EXAMPLE_YAML);
   const [tab, setTab] = useState("editor");
-  const [lintResult, setLintResult] = useState<LintResponse>({ errors: [], warnings: [], summary: { steps: "" } });
+  const [lintResult, setLintResult] = useState<LintResponse>({ errors: [], warnings: [], summary: { steps: 0 } });
   const [diffResult, setDiffResult] = useState<DiffResponse | null>(null);
   const [isLinting, setIsLinting] = useState(false);
   
@@ -119,7 +128,7 @@ export function JobDefsPage() {
         setLintResult({
           errors: [{ message: err instanceof Error ? err.message : "Request failed", line: 1 }],
           warnings: [],
-          summary: { steps: "" },
+          summary: { steps: 0 },
         });
         setDiffResult(null);
       } finally {
@@ -171,6 +180,9 @@ export function JobDefsPage() {
   const lineCount = yaml.split("\n").length;
   const diffCount = diffResult ? (diffResult.added?.length || 0) + (diffResult.removed?.length || 0) + (diffResult.modified?.length || 0) : 0;
   const hasErrors = lintResult.errors && lintResult.errors.length > 0;
+  const stepLabel = formatStepCount(lintResult.summary?.steps ?? 0);
+  const contractSummary = lintResult.summary?.contracts?.trim() ?? "";
+  const summaryLabel = contractSummary ? `${stepLabel} · ${contractStatusLabel(contractSummary)}` : stepLabel;
   const deferredYaml = useDeferredValue(yaml);
   const runtimeHints = useMemo(() => getJobDefRuntimeHints(deferredYaml), [deferredYaml]);
 
@@ -301,7 +313,7 @@ export function JobDefsPage() {
                         <CheckCircle2 className="h-3.5 w-3.5 text-success" />
                         <span className="text-success">Schema valid</span>
                         <span className="text-text-4 mx-1">·</span>
-                        <span className="text-text-3">{lintResult.summary?.steps || "No steps"}</span>
+                        <span className="text-text-3">{summaryLabel}</span>
                       </>
                     )}
                   </div>
@@ -322,11 +334,11 @@ export function JobDefsPage() {
                   </div>
                 )}
                 
-                {!hasErrors && lintResult.summary?.steps && (
+                {!hasErrors && contractSummary && (
                   <div className="p-3">
                     <div className="flex items-start gap-2.5 text-xs">
                       <Info className="h-3.5 w-3.5 text-success mt-0.5 flex-shrink-0" />
-                      <span className="text-text-2">{lintResult.summary.steps}</span>
+                      <span className="text-text-2">{contractSummary}</span>
                     </div>
                   </div>
                 )}

--- a/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
+++ b/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
@@ -61,7 +61,7 @@ describe("JobDefsPage", () => {
     vi.mocked(api.lintJobDef).mockResolvedValue({
       errors: [],
       warnings: [],
-      summary: { steps: "2 steps" },
+      summary: { steps: 2 },
     });
     vi.mocked(api.diffJobDef).mockResolvedValue({
       added: [],

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -406,7 +406,8 @@ export interface LintMessage {
 }
 
 export interface LintSummary {
-  steps: string;
+  steps: number;
+  contracts?: string;
 }
 
 export interface LintResponse {


### PR DESCRIPTION
## Summary
- Changes the `/v1/jobdefs/lint` summary shape to a numeric `steps` count plus an optional `contracts` string (the prior data-contract text).
- Updates the JobDefs UI status bar to format the count directly ("2 steps"), so a multi-step manifest no longer reads "No steps" when it has no declared data contracts.
- Preserves contract detail display when contract metadata exists.
- Adds `test/jobdef_lint_summary_test.go` — a live-server integration scenario asserting the multi-step summary and the stepless-invalid path through the real `/v1/jobdefs/lint` endpoint.
- Marks Stream E (E1) complete.

## Test plan
- [ ] GHA CI: `lint`, `unit-test`, `build-and-integration-test` (exercises the new `test/jobdef_lint_summary_test.go`), `ui-test` (tsc over the new `LintSummary` type).

_Diff cosmetically includes the W1-H1 e2e-helper (this branch is stacked on it); it collapses once #300 merges first._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
