### PR TITLE
Fix System workers KPI and resolve short-id job deep links (console-v2-bug-sweep W1-ζ)

### DIFF
--- a/api/rest/controller/job/get.go
+++ b/api/rest/controller/job/get.go
@@ -9,7 +9,6 @@ import (
 	tsvc "github.com/caesium-cloud/caesium/api/rest/service/trigger"
 	"github.com/caesium-cloud/caesium/internal/models"
 	runstorage "github.com/caesium-cloud/caesium/internal/run"
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 	"gorm.io/gorm"
 )
@@ -21,17 +20,17 @@ type JobResponse struct {
 }
 
 func Get(c *echo.Context) error {
-	id, err := uuid.Parse(c.Param("id"))
-	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
-	}
-
 	ctx := c.Request().Context()
 
-	j, err := jsvc.Service(ctx).Get(id)
+	j, err := jsvc.Service(ctx).GetByIDPrefix(c.Param("id"))
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+		switch {
+		case errors.Is(err, gorm.ErrRecordNotFound):
 			return echo.ErrNotFound
+		case errors.Is(err, jsvc.ErrInvalidJobIDPrefix):
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error()).Wrap(err)
+		case errors.Is(err, jsvc.ErrAmbiguousJobIDPrefix):
+			return echo.NewHTTPError(http.StatusConflict, err.Error()).Wrap(err)
 		}
 
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)

--- a/api/rest/service/job/job.go
+++ b/api/rest/service/job/job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strings"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ type Job interface {
 	SetBus(event.Bus)
 	List(*ListRequest) (models.Jobs, error)
 	Get(uuid.UUID) (*models.Job, error)
+	GetByIDPrefix(string) (*models.Job, error)
 	Queue(uuid.UUID) ([]QueueItem, error)
 	Create(*CreateRequest) (*models.Job, error)
 	Delete(uuid.UUID) error
@@ -39,6 +41,11 @@ type jobService struct {
 var (
 	defaultService   *jobService
 	defaultServiceMu sync.Mutex
+
+	// ErrAmbiguousJobIDPrefix means a prefix matched more than one job ID.
+	ErrAmbiguousJobIDPrefix = errors.New("ambiguous job id prefix")
+	// ErrInvalidJobIDPrefix means a job ID prefix cannot match a canonical UUID.
+	ErrInvalidJobIDPrefix = errors.New("invalid job id prefix")
 )
 
 func Service(ctx context.Context) Job {
@@ -154,6 +161,70 @@ func (j *jobService) Get(id uuid.UUID) (*models.Job, error) {
 		return nil, err
 	}
 
+	j.attachLatestRun(job)
+
+	return job, nil
+}
+
+func (j *jobService) GetByIDPrefix(rawID string) (*models.Job, error) {
+	rawID = strings.TrimSpace(rawID)
+	if rawID == "" {
+		return nil, ErrInvalidJobIDPrefix
+	}
+
+	if id, err := uuid.Parse(rawID); err == nil {
+		return j.Get(id)
+	}
+
+	prefix := strings.ToLower(rawID)
+	if !isCanonicalUUIDPrefix(prefix) {
+		return nil, ErrInvalidJobIDPrefix
+	}
+
+	var matches []models.Job
+	if err := j.db.WithContext(j.ctx).
+		Where("id LIKE ?", prefix+"%").
+		Limit(2).
+		Find(&matches).Error; err != nil {
+		return nil, err
+	}
+
+	switch len(matches) {
+	case 0:
+		return nil, gorm.ErrRecordNotFound
+	case 1:
+		job := &matches[0]
+		j.attachLatestRun(job)
+		return job, nil
+	default:
+		return nil, ErrAmbiguousJobIDPrefix
+	}
+}
+
+func isCanonicalUUIDPrefix(prefix string) bool {
+	if len(prefix) > 36 {
+		return false
+	}
+	for i, r := range prefix {
+		switch i {
+		case 8, 13, 18, 23:
+			if r != '-' {
+				return false
+			}
+		default:
+			if !isHexRune(r) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isHexRune(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')
+}
+
+func (j *jobService) attachLatestRun(job *models.Job) {
 	runStore := runstorage.NewStore(j.db)
 	if latest, err := runStore.Latest(job.ID); err == nil && latest != nil {
 		job.LatestRun = &models.JobRun{
@@ -168,8 +239,6 @@ func (j *jobService) Get(id uuid.UUID) (*models.Job, error) {
 			TotalTasks:    latest.TotalTasks,
 		}
 	}
-
-	return job, nil
 }
 
 type QueueItem struct {

--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -310,12 +310,14 @@ Lower-priority polish spanning the app shell. F1/F2/F4 are independent; F3 is a
 cross-cutting timestamp sweep that shares files with Streams C and D, so it is
 sequenced after them (see `## Sequencing & Dependencies`).
 
-- [ ] F1. Fix the System page NODES card, which is labelled "Active workers"
+- [x] F1. Fix the System page NODES card, which is labelled "Active workers"
       but displays a **node** count while the node row below shows WORKERS
       "0/4" (zero active). Either relabel the card sub-text to "Nodes" /
       "Tracked nodes", or add a real Workers KPI that sums `workers_busy` /
       `workers_total` across nodes. Files:
       `ui/src/features/system/SystemPage.tsx` (~138 `SysKpi`).
+      Notes: W1-zeta relabelled the existing Nodes KPI sub-text to
+      "Tracked nodes", keeping the displayed node count honest.
 - [ ] F2. Unify the app's not-found states (issue #17 is "two inconsistent
       404s"). (a) Add a catch-all `NotFoundComponent` (or `*` route) so unknown
       SPA paths render a coherent 404 instead of a bare/empty fallback. (b)
@@ -346,7 +348,7 @@ sequenced after them (see `## Sequencing & Dependencies`).
       `ui/src/features/jobs/components/TaskNode.tsx`,
       `ui/src/features/stats/components/TrendChart.tsx`.
       Depends on: C, D (shares `JobDetailPage.tsx` / `RunDetailPage.tsx`).
-- [ ] F4. Resolve short-id deep links. The list displays an 8-char id but
+- [x] F4. Resolve short-id deep links. The list displays an 8-char id but
       `GET /v1/jobs/:id` calls `uuid.Parse` (`api/rest/controller/job/get.go`
       ~24) and 400s on anything that isn't a full UUID, so a hand-typed/shared
       `/jobs/15bbde04` never resolves (row clicks already carry the full id).
@@ -357,6 +359,10 @@ sequenced after them (see `## Sequencing & Dependencies`).
       jobs list. Files: `api/rest/controller/job/get.go` +
       `api/rest/service/job/job.go` (`Get`), or `ui/src/router.tsx` +
       `ui/src/lib/api.ts`; `test/*_test.go` if backend.
+      Notes: W1-zeta added backend prefix resolution for `GET /v1/jobs/:id`;
+      invalid prefixes return 400, missing prefixes return 404, and ambiguous
+      prefixes return 409 with an integration scenario covering all three HTTP
+      surfaces.
 
 ## Harness Strengthening
 

--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -360,7 +360,7 @@ sequenced after them (see `## Sequencing & Dependencies`).
 
 ## Harness Strengthening
 
-- [ ] H-1. Seed a richer e2e/integration fixture set so the assertions the
+- [x] H-1. Seed a richer e2e/integration fixture set so the assertions the
       above items need have real data to render against: a job with a
       **multi-step DAG** that produces a **failed run** carrying a **failed
       callback**, plus an **event trigger** and one or more **cron triggers**.
@@ -369,6 +369,9 @@ sequenced after them (see `## Sequencing & Dependencies`).
       validator (A1). Files: `ui/e2e/helpers/fixtures.ts`, new
       `ui/e2e/` fixture `*.job.yaml`, and any `test/` harness seed needed for
       the integration scenarios (B4, E1, F4).
+      Landed W1-H1: shared `fixtures.ts` helpers now index the existing
+      `docs/examples/` coverage and centralize fixture load/apply, job lookup,
+      trigger, and run-await flows; no new fixture was needed.
 
 ## Navigational / Organizational Improvements
 

--- a/test/job_test.go
+++ b/test/job_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/service/atom"
 	"github.com/caesium-cloud/caesium/api/rest/service/trigger"
 	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -131,6 +132,51 @@ func (s *IntegrationTestSuite) TestJobListFilterByTrigger() {
 	assert.Equal(s.T(), created.ID, jobs[0].ID)
 }
 
+func (s *IntegrationTestSuite) TestJobGetResolvesShortIDPrefix() {
+	alias := fmt.Sprintf("test_job_short_id_%d", time.Now().UnixNano())
+	created := s.createJob(alias, nil)
+	prefix := created.ID.String()[:8]
+
+	resp, err := s.doRequest(http.MethodGet, fmt.Sprintf("%v/v1/jobs/%s", s.caesiumURL, prefix), nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Require().Equal(http.StatusOK, resp.StatusCode, string(body))
+
+	var detail jobSummary
+	s.Require().NoError(json.Unmarshal(body, &detail))
+	s.Equal(created.ID.String(), detail.ID)
+	s.Equal(alias, detail.Alias)
+
+	resp, err = s.doRequest(http.MethodGet, fmt.Sprintf("%v/v1/jobs/%s", s.caesiumURL, "not-a-uuid-prefix"), nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	invalidBody, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Equal(http.StatusBadRequest, resp.StatusCode, string(invalidBody))
+	s.Contains(string(invalidBody), "invalid job id prefix")
+
+	missingPrefix := s.unusedJobIDPrefix(8)
+	resp, err = s.doRequest(http.MethodGet, fmt.Sprintf("%v/v1/jobs/%s", s.caesiumURL, missingPrefix), nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	missingBody, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Equal(http.StatusNotFound, resp.StatusCode, string(missingBody))
+	s.NotEmpty(strings.TrimSpace(string(missingBody)))
+
+	ambiguousPrefix := s.createAmbiguousJobIDPrefix()
+	resp, err = s.doRequest(http.MethodGet, fmt.Sprintf("%v/v1/jobs/%s", s.caesiumURL, ambiguousPrefix), nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+	ambiguousBody, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	s.Equal(http.StatusConflict, resp.StatusCode, string(ambiguousBody))
+	s.Contains(string(ambiguousBody), "ambiguous job id prefix")
+}
+
 func (s *IntegrationTestSuite) TestJobDeleteRemovesJob() {
 	created := s.createJob("test_job_delete", nil)
 
@@ -188,6 +234,45 @@ func (s *IntegrationTestSuite) TestJobApplyCommand() {
 
 func (s *IntegrationTestSuite) createJob(alias string, metadata *job.MetadataRequest) *models.Job {
 	return s.createJobWithTrigger(alias, metadata, models.TriggerTypeCron)
+}
+
+func (s *IntegrationTestSuite) unusedJobIDPrefix(length int) string {
+	var jobs []jobSummary
+	s.getJSON("/v1/jobs", &jobs)
+
+	used := make(map[string]struct{}, len(jobs))
+	for _, job := range jobs {
+		if len(job.ID) >= length {
+			used[strings.ToLower(job.ID[:length])] = struct{}{}
+		}
+	}
+
+	for i := 0; i < 128; i++ {
+		candidate := uuid.NewString()[:length]
+		if _, ok := used[candidate]; !ok {
+			return candidate
+		}
+	}
+
+	s.T().Fatalf("could not find unused %d-character job id prefix", length)
+	return ""
+}
+
+func (s *IntegrationTestSuite) createAmbiguousJobIDPrefix() string {
+	baseAlias := fmt.Sprintf("test_job_short_id_ambiguous_%d", time.Now().UnixNano())
+	idsByPrefix := map[string][]string{}
+
+	for i := 0; i < 17; i++ {
+		created := s.createJob(fmt.Sprintf("%s_%02d", baseAlias, i), nil)
+		prefix := strings.ToLower(created.ID.String()[:1])
+		idsByPrefix[prefix] = append(idsByPrefix[prefix], created.ID.String())
+		if len(idsByPrefix[prefix]) > 1 {
+			return prefix
+		}
+	}
+
+	s.T().Fatalf("expected an ambiguous one-character job id prefix from generated jobs: %#v", idsByPrefix)
+	return ""
 }
 
 func (s *IntegrationTestSuite) createJobWithTrigger(alias string, metadata *job.MetadataRequest, trigType models.TriggerType) *models.Job {

--- a/ui/e2e/helpers/fixtures.ts
+++ b/ui/e2e/helpers/fixtures.ts
@@ -4,8 +4,21 @@ import { fileURLToPath } from "node:url";
 import type { APIRequestContext } from "@playwright/test";
 import { parseAllDocuments } from "yaml";
 
+/**
+ * Console v2 bug-sweep fixture index:
+ * - docs/examples/callback-failure.job.yaml backs D3 failed-callback rendering.
+ * - docs/examples/run-history.job.yaml backs A1 cron next-fire via cron-success-fast
+ *   and B4/C1 failed-run history/DAG counts via cron-failure-fast.
+ * - docs/examples/event-trigger.job.yaml backs A2 event-trigger rendering.
+ * - docs/examples/branching.job.yaml and fanout-join.job.yaml back multi-step DAG views.
+ */
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const manualTriggerAPIKey = process.env.CAESIUM_MANUAL_TRIGGER_API_KEY?.trim() || "e2e-test-key";
+const terminalRunStatuses = new Set(["succeeded", "failed", "cancelled"]);
+const defaultRunTimeoutMs = 180_000;
+const pollIntervalMs = 1_000;
 
 export type FixtureDefinition = {
   metadata?: Record<string, unknown> & { alias?: string };
@@ -14,30 +27,123 @@ export type FixtureDefinition = {
   };
 };
 
+export type E2EJob = {
+  id: string;
+  alias: string;
+};
+
+type E2EJobWithTrigger = E2EJob & {
+  trigger_id?: string;
+  trigger?: {
+    id: string;
+    type: string;
+  };
+};
+
+export type E2ECallbackRun = {
+  id: string;
+  callback_id: string;
+  status: string;
+  error?: string;
+  started_at: string;
+  completed_at?: string;
+} & Record<string, unknown>;
+
+export type E2ETaskRun = {
+  id: string;
+  job_run_id: string;
+  task_id: string;
+  atom_id?: string;
+  engine?: string;
+  image?: string;
+  command?: string[];
+  runtime_id?: string;
+  status: string;
+  result?: string;
+  error?: string;
+  output?: Record<string, string>;
+  cache_hit?: boolean;
+  cache_origin_run_id?: string;
+  started_at?: string;
+  completed_at?: string;
+  created_at?: string;
+  updated_at?: string;
+} & Record<string, unknown>;
+
+export type E2ERun = {
+  id: string;
+  job_id: string;
+  job_alias?: string;
+  backfill_id?: string;
+  trigger_type?: string;
+  trigger_alias?: string;
+  status: string;
+  priority?: number;
+  params?: Record<string, string>;
+  quarantine?: boolean;
+  started_at: string;
+  completed_at?: string;
+  created_at: string;
+  updated_at: string;
+  error?: string;
+  tasks: E2ETaskRun[];
+  callbacks: E2ECallbackRun[];
+  cache_hits?: number;
+  executed_tasks?: number;
+  total_tasks?: number;
+} & Record<string, unknown>;
+
+export type TriggerJobOptions = {
+  params?: Record<string, string>;
+  priority?: "low" | "normal" | "high";
+};
+
+export type AwaitRunOptions = {
+  status?: string | string[];
+  timeoutMs?: number;
+};
+
+export type ApplyAndRunOptions = TriggerJobOptions &
+  AwaitRunOptions & {
+    definitionIndex?: number;
+  };
+
 /**
  * Load a job-definition YAML from docs/examples/, mutating the alias (and any
  * HTTP webhook path) so each test invocation gets a unique resource and tests
  * can run repeatedly without colliding with prior state.
  */
 export async function loadFixtureDefinition(filename: string): Promise<FixtureDefinition> {
+  const defs = await loadFixtureDefinitions(filename);
+  const first = defs[0];
+  if (!first) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+  return first;
+}
+
+export async function loadFixtureDefinitions(filename: string): Promise<FixtureDefinition[]> {
   const fixturePath = path.resolve(__dirname, "../../../docs/examples", filename);
   const yaml = await fs.readFile(fixturePath, "utf8");
   const docs = parseAllDocuments(yaml);
-  const raw = docs[0]?.toJS();
-  if (!raw || typeof raw !== "object") {
-    throw new Error(`failed to parse fixture: ${filename}`);
-  }
-  const def = raw as FixtureDefinition;
-
   const suffix = crypto.randomUUID().split("-")[0];
-  const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
-  def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
 
-  if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
-    def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
-  }
+  return docs.map((doc, index) => {
+    const raw = doc.toJS();
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`failed to parse fixture ${filename} document ${index}`);
+    }
 
-  return def;
+    const def = raw as FixtureDefinition;
+    const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
+    def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
+
+    if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
+      def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
+    }
+
+    return def;
+  });
 }
 
 export async function applyDefinitions(request: APIRequestContext, ...defs: FixtureDefinition[]): Promise<void> {
@@ -47,4 +153,185 @@ export async function applyDefinitions(request: APIRequestContext, ...defs: Fixt
   if (!response.ok()) {
     throw new Error(`failed to apply fixture: ${response.status()} ${await response.text()}`);
   }
+}
+
+export async function findJobByAlias(request: APIRequestContext, alias: string): Promise<E2EJob> {
+  const job = await findJobWithTriggerByAlias(request, alias);
+  return { id: job.id, alias: job.alias };
+}
+
+export async function triggerJob(
+  request: APIRequestContext,
+  jobId: string,
+  params?: Record<string, string> | TriggerJobOptions,
+): Promise<void> {
+  const options = normalizeTriggerJobOptions(params);
+  const job = await getJob(request, jobId);
+  if (!job.trigger_id) {
+    throw new Error(`job ${jobId} did not include trigger_id`);
+  }
+
+  if (job.trigger?.type === "http") {
+    await fireHTTPTrigger(request, jobId, job.trigger_id, options);
+    return;
+  }
+
+  await startJobRun(request, jobId, options);
+}
+
+export async function awaitRun(
+  request: APIRequestContext,
+  jobId: string,
+  opts: AwaitRunOptions = {},
+): Promise<E2ERun> {
+  const expectedStatuses = normalizeExpectedStatuses(opts.status);
+  const deadline = Date.now() + (opts.timeoutMs ?? defaultRunTimeoutMs);
+  let lastRun: E2ERun | undefined;
+  let lastStatus = "no runs";
+
+  while (Date.now() <= deadline) {
+    const runs = await listRuns(request, jobId);
+    lastRun = latestRun(runs);
+    if (lastRun) {
+      lastStatus = lastRun.status;
+      if (expectedStatuses.has(lastRun.status) || (!opts.status && terminalRunStatuses.has(lastRun.status))) {
+        return getRun(request, jobId, lastRun.id);
+      }
+    }
+
+    await delay(pollIntervalMs);
+  }
+
+  const wanted = opts.status ? [...expectedStatuses].join(", ") : "terminal status";
+  throw new Error(`timed out waiting for job ${jobId} latest run to reach ${wanted}; last status: ${lastStatus}`);
+}
+
+export async function applyAndRun(
+  request: APIRequestContext,
+  filename: string,
+  opts: ApplyAndRunOptions = {},
+): Promise<{ job: E2EJob; run: E2ERun }> {
+  const defs = await loadFixtureDefinitions(filename);
+  if (defs.length === 0) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+
+  const index = opts.definitionIndex ?? 0;
+  const def = defs[index];
+  if (!def) {
+    throw new Error(`fixture ${filename} does not include document ${index}`);
+  }
+  const alias = String(def.metadata?.alias ?? "");
+  if (!alias) {
+    throw new Error(`fixture ${filename} document ${index} did not include an alias`);
+  }
+
+  await applyDefinitions(request, ...defs);
+  const job = await findJobByAlias(request, alias);
+  await triggerJob(request, job.id, { params: opts.params, priority: opts.priority });
+  const run = await awaitRun(request, job.id, opts);
+
+  return { job, run };
+}
+
+async function fireHTTPTrigger(
+  request: APIRequestContext,
+  jobId: string,
+  triggerId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/triggers/${triggerId}/fire`, {
+    headers: {
+      "X-Caesium-API-Key": manualTriggerAPIKey,
+    },
+    ...requestBody(options),
+  });
+  if (!response.ok()) {
+    throw new Error(`failed to manually fire trigger for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function startJobRun(
+  request: APIRequestContext,
+  jobId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`, requestBody(options));
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function findJobWithTriggerByAlias(request: APIRequestContext, alias: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get("/v1/jobs");
+  if (!response.ok()) {
+    throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+  }
+
+  const jobs = (await response.json()) as E2EJobWithTrigger[];
+  const job = jobs.find((candidate) => candidate.alias === alias);
+  if (!job) {
+    throw new Error(`job not found after apply: ${alias}`);
+  }
+  return job;
+}
+
+async function getJob(request: APIRequestContext, jobId: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get(`/v1/jobs/${jobId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2EJobWithTrigger;
+}
+
+async function listRuns(request: APIRequestContext, jobId: string): Promise<E2ERun[]> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs`);
+  if (!response.ok()) {
+    throw new Error(`failed to list runs for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun[];
+}
+
+async function getRun(request: APIRequestContext, jobId: string, runId: string): Promise<E2ERun> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load run ${runId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun;
+}
+
+function requestBody(options: TriggerJobOptions): { data?: TriggerJobOptions } {
+  const body: TriggerJobOptions = {};
+  if (options.params && Object.keys(options.params).length > 0) {
+    body.params = options.params;
+  }
+  if (options.priority) {
+    body.priority = options.priority;
+  }
+  return Object.keys(body).length > 0 ? { data: body } : {};
+}
+
+function normalizeTriggerJobOptions(input: Record<string, string> | TriggerJobOptions | undefined): TriggerJobOptions {
+  if (!input || Object.keys(input).length === 0) {
+    return {};
+  }
+  if ("params" in input || "priority" in input) {
+    return input as TriggerJobOptions;
+  }
+  return { params: input };
+}
+
+function normalizeExpectedStatuses(status: string | string[] | undefined): Set<string> {
+  if (!status) {
+    return new Set();
+  }
+  return new Set(Array.isArray(status) ? status : [status]);
+}
+
+function latestRun(runs: E2ERun[]): E2ERun | undefined {
+  return runs.at(-1);
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/ui/src/features/system/SystemPage.tsx
+++ b/ui/src/features/system/SystemPage.tsx
@@ -135,7 +135,7 @@ export function SystemPage() {
         <SysKpi icon={Database} label="Database" value={<span className="capitalize text-success">{db?.status || "unknown"}</span>} sub={db?.latency_ms != null ? `${db.latency_ms}ms latency` : "--"} dot={db?.status === "healthy"} />
         <SysKpi icon={Activity} label="Active runs" value={<span className="font-mono text-cyan-glow">{activeRuns?.count ?? 0}</span>} sub="Currently executing" />
         <SysKpi icon={Zap} label="Triggers" value={<span className="font-mono">{triggers?.count ?? 0}</span>} sub="Registered" />
-        <SysKpi icon={Server} label="Nodes" value={<span className="font-mono">{nodesCheck?.count ?? nodes.length}</span>} sub="Active workers" dot={nodes.length > 0} />
+        <SysKpi icon={Server} label="Nodes" value={<span className="font-mono">{nodesCheck?.count ?? nodes.length}</span>} sub="Tracked nodes" dot={nodes.length > 0} />
       </div>
 
       <div className="grid lg:grid-cols-[2fr_1fr] gap-4 items-start">


### PR DESCRIPTION
## Summary
- **F1**: relabels the System page Nodes KPI subtext from the misleading "Active workers" to "Tracked nodes" (the card shows a node count, not a worker count).
- **F4**: `GET /v1/jobs/:id` now resolves an unambiguous UUID **prefix** (the 8-char id the list displays), preserving exact full-UUID lookup. Prefix is validated (`isCanonicalUUIDPrefix`), queried via a parameterized `LIKE ?` with `Limit(2)` for cheap ambiguity detection.
- Error mapping: invalid prefix → **400**, no match → **404**, ambiguous (>1 match) → **409**.
- Adds live-server integration coverage in `test/job_test.go` for the prefix resolution.
- Marks Stream F items **F1** and **F4** complete (F2/F3 are a later wave).

## Test plan
- [ ] GHA CI: `lint`, `unit-test`, `build-and-integration-test` (exercises the new `test/job_test.go` prefix scenario), `ui-test`.

_Diff cosmetically includes the W1-H1 e2e-helper (stacked branch); collapses once #300 merges first._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
