### PR TITLE
Order run tasks by DAG, label by name, surface callbacks (console-v2-bug-sweep W1-δ)

### DIFF
--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -234,7 +234,7 @@ Fixes on the run detail page and its timeline
 (`ui/src/features/jobs/RunDetailPage.tsx`, `RunTimeline.tsx`,
 `ui/src/lib/status.ts`). All frontend-only.
 
-- [ ] D1. Order run-detail tasks by DAG/topological order (e.g. list → convert
+- [x] D1. Order run-detail tasks by DAG/topological order (e.g. list → convert
       → publish) rather than in the unspecified DB/payload order they arrive
       in, which currently lists "convert" before "list". Tasks are rendered
       unsorted via `<RunTimeline tasks={run.tasks} />`
@@ -248,7 +248,9 @@ Fixes on the run detail page and its timeline
       into `RunTimeline`**, then topo-sort by `next_id`, falling back to
       `started_at`. Files: `ui/src/features/jobs/RunDetailPage.tsx` (~431 the
       `RunTimeline` call + ~186-192 the task defs), `ui/src/features/jobs/RunTimeline.tsx`.
-- [ ] D2. Fix execution-timeline labels and legend: (a) rows are labelled by
+      Done: threaded `taskDefinitions` into `RunTimeline`; timeline rows are
+      topo-sorted from `JobTask.next_id` with `started_at`/input-order fallback.
+- [x] D2. Fix execution-timeline labels and legend: (a) rows are labelled by
       the container image name (the walkthrough saw steps show their base
       image name rather than the step name) — label by **task name** instead,
       falling
@@ -261,7 +263,9 @@ Fixes on the run detail page and its timeline
       ~210), `ui/src/lib/status.ts` (`skipped` / `queued` `META` entries
       ~57-82). Depends on: D1 (shares the `JobTask`-defs threading into
       `RunTimeline`).
-- [ ] D3. Surface a callbacks section on the run detail so failed callbacks
+      Done: timeline labels prefer `JobTask.name`; pending/queued now uses gold
+      status colors while skipped remains neutral gray, covered by vitest.
+- [x] D3. Surface a callbacks section on the run detail so failed callbacks
       ("webhook responded 404: no_team") are visible. The run payload
       **already** includes them — `internal/run/store.go:160` serializes
       `callbacks: []CallbackRun{id, callback_id, status, error, started_at,
@@ -271,6 +275,8 @@ Fixes on the run detail page and its timeline
       highlights failures with their `error`. Frontend-only. Files:
       `ui/src/lib/api.ts` (`JobRun.callbacks` + `CallbackRun` type),
       `ui/src/features/jobs/RunDetailPage.tsx` (new callbacks section).
+      Done: added `CallbackRun`/`JobRun.callbacks`, rendered a failure-highlighted
+      callbacks section, and added a Playwright spec for the failed-callback fixture.
 
 #### Rejected / deferred for Stream D
 

--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -360,7 +360,7 @@ sequenced after them (see `## Sequencing & Dependencies`).
 
 ## Harness Strengthening
 
-- [ ] H-1. Seed a richer e2e/integration fixture set so the assertions the
+- [x] H-1. Seed a richer e2e/integration fixture set so the assertions the
       above items need have real data to render against: a job with a
       **multi-step DAG** that produces a **failed run** carrying a **failed
       callback**, plus an **event trigger** and one or more **cron triggers**.
@@ -369,6 +369,9 @@ sequenced after them (see `## Sequencing & Dependencies`).
       validator (A1). Files: `ui/e2e/helpers/fixtures.ts`, new
       `ui/e2e/` fixture `*.job.yaml`, and any `test/` harness seed needed for
       the integration scenarios (B4, E1, F4).
+      Landed W1-H1: shared `fixtures.ts` helpers now index the existing
+      `docs/examples/` coverage and centralize fixture load/apply, job lookup,
+      trigger, and run-await flows; no new fixture was needed.
 
 ## Navigational / Organizational Improvements
 

--- a/ui/e2e/helpers/fixtures.ts
+++ b/ui/e2e/helpers/fixtures.ts
@@ -4,8 +4,21 @@ import { fileURLToPath } from "node:url";
 import type { APIRequestContext } from "@playwright/test";
 import { parseAllDocuments } from "yaml";
 
+/**
+ * Console v2 bug-sweep fixture index:
+ * - docs/examples/callback-failure.job.yaml backs D3 failed-callback rendering.
+ * - docs/examples/run-history.job.yaml backs A1 cron next-fire via cron-success-fast
+ *   and B4/C1 failed-run history/DAG counts via cron-failure-fast.
+ * - docs/examples/event-trigger.job.yaml backs A2 event-trigger rendering.
+ * - docs/examples/branching.job.yaml and fanout-join.job.yaml back multi-step DAG views.
+ */
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const manualTriggerAPIKey = process.env.CAESIUM_MANUAL_TRIGGER_API_KEY?.trim() || "e2e-test-key";
+const terminalRunStatuses = new Set(["succeeded", "failed", "cancelled"]);
+const defaultRunTimeoutMs = 180_000;
+const pollIntervalMs = 1_000;
 
 export type FixtureDefinition = {
   metadata?: Record<string, unknown> & { alias?: string };
@@ -14,30 +27,123 @@ export type FixtureDefinition = {
   };
 };
 
+export type E2EJob = {
+  id: string;
+  alias: string;
+};
+
+type E2EJobWithTrigger = E2EJob & {
+  trigger_id?: string;
+  trigger?: {
+    id: string;
+    type: string;
+  };
+};
+
+export type E2ECallbackRun = {
+  id: string;
+  callback_id: string;
+  status: string;
+  error?: string;
+  started_at: string;
+  completed_at?: string;
+} & Record<string, unknown>;
+
+export type E2ETaskRun = {
+  id: string;
+  job_run_id: string;
+  task_id: string;
+  atom_id?: string;
+  engine?: string;
+  image?: string;
+  command?: string[];
+  runtime_id?: string;
+  status: string;
+  result?: string;
+  error?: string;
+  output?: Record<string, string>;
+  cache_hit?: boolean;
+  cache_origin_run_id?: string;
+  started_at?: string;
+  completed_at?: string;
+  created_at?: string;
+  updated_at?: string;
+} & Record<string, unknown>;
+
+export type E2ERun = {
+  id: string;
+  job_id: string;
+  job_alias?: string;
+  backfill_id?: string;
+  trigger_type?: string;
+  trigger_alias?: string;
+  status: string;
+  priority?: number;
+  params?: Record<string, string>;
+  quarantine?: boolean;
+  started_at: string;
+  completed_at?: string;
+  created_at: string;
+  updated_at: string;
+  error?: string;
+  tasks: E2ETaskRun[];
+  callbacks: E2ECallbackRun[];
+  cache_hits?: number;
+  executed_tasks?: number;
+  total_tasks?: number;
+} & Record<string, unknown>;
+
+export type TriggerJobOptions = {
+  params?: Record<string, string>;
+  priority?: "low" | "normal" | "high";
+};
+
+export type AwaitRunOptions = {
+  status?: string | string[];
+  timeoutMs?: number;
+};
+
+export type ApplyAndRunOptions = TriggerJobOptions &
+  AwaitRunOptions & {
+    definitionIndex?: number;
+  };
+
 /**
  * Load a job-definition YAML from docs/examples/, mutating the alias (and any
  * HTTP webhook path) so each test invocation gets a unique resource and tests
  * can run repeatedly without colliding with prior state.
  */
 export async function loadFixtureDefinition(filename: string): Promise<FixtureDefinition> {
+  const defs = await loadFixtureDefinitions(filename);
+  const first = defs[0];
+  if (!first) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+  return first;
+}
+
+export async function loadFixtureDefinitions(filename: string): Promise<FixtureDefinition[]> {
   const fixturePath = path.resolve(__dirname, "../../../docs/examples", filename);
   const yaml = await fs.readFile(fixturePath, "utf8");
   const docs = parseAllDocuments(yaml);
-  const raw = docs[0]?.toJS();
-  if (!raw || typeof raw !== "object") {
-    throw new Error(`failed to parse fixture: ${filename}`);
-  }
-  const def = raw as FixtureDefinition;
-
   const suffix = crypto.randomUUID().split("-")[0];
-  const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
-  def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
 
-  if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
-    def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
-  }
+  return docs.map((doc, index) => {
+    const raw = doc.toJS();
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`failed to parse fixture ${filename} document ${index}`);
+    }
 
-  return def;
+    const def = raw as FixtureDefinition;
+    const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
+    def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
+
+    if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
+      def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
+    }
+
+    return def;
+  });
 }
 
 export async function applyDefinitions(request: APIRequestContext, ...defs: FixtureDefinition[]): Promise<void> {
@@ -47,4 +153,185 @@ export async function applyDefinitions(request: APIRequestContext, ...defs: Fixt
   if (!response.ok()) {
     throw new Error(`failed to apply fixture: ${response.status()} ${await response.text()}`);
   }
+}
+
+export async function findJobByAlias(request: APIRequestContext, alias: string): Promise<E2EJob> {
+  const job = await findJobWithTriggerByAlias(request, alias);
+  return { id: job.id, alias: job.alias };
+}
+
+export async function triggerJob(
+  request: APIRequestContext,
+  jobId: string,
+  params?: Record<string, string> | TriggerJobOptions,
+): Promise<void> {
+  const options = normalizeTriggerJobOptions(params);
+  const job = await getJob(request, jobId);
+  if (!job.trigger_id) {
+    throw new Error(`job ${jobId} did not include trigger_id`);
+  }
+
+  if (job.trigger?.type === "http") {
+    await fireHTTPTrigger(request, jobId, job.trigger_id, options);
+    return;
+  }
+
+  await startJobRun(request, jobId, options);
+}
+
+export async function awaitRun(
+  request: APIRequestContext,
+  jobId: string,
+  opts: AwaitRunOptions = {},
+): Promise<E2ERun> {
+  const expectedStatuses = normalizeExpectedStatuses(opts.status);
+  const deadline = Date.now() + (opts.timeoutMs ?? defaultRunTimeoutMs);
+  let lastRun: E2ERun | undefined;
+  let lastStatus = "no runs";
+
+  while (Date.now() <= deadline) {
+    const runs = await listRuns(request, jobId);
+    lastRun = latestRun(runs);
+    if (lastRun) {
+      lastStatus = lastRun.status;
+      if (expectedStatuses.has(lastRun.status) || (!opts.status && terminalRunStatuses.has(lastRun.status))) {
+        return getRun(request, jobId, lastRun.id);
+      }
+    }
+
+    await delay(pollIntervalMs);
+  }
+
+  const wanted = opts.status ? [...expectedStatuses].join(", ") : "terminal status";
+  throw new Error(`timed out waiting for job ${jobId} latest run to reach ${wanted}; last status: ${lastStatus}`);
+}
+
+export async function applyAndRun(
+  request: APIRequestContext,
+  filename: string,
+  opts: ApplyAndRunOptions = {},
+): Promise<{ job: E2EJob; run: E2ERun }> {
+  const defs = await loadFixtureDefinitions(filename);
+  if (defs.length === 0) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+
+  const index = opts.definitionIndex ?? 0;
+  const def = defs[index];
+  if (!def) {
+    throw new Error(`fixture ${filename} does not include document ${index}`);
+  }
+  const alias = String(def.metadata?.alias ?? "");
+  if (!alias) {
+    throw new Error(`fixture ${filename} document ${index} did not include an alias`);
+  }
+
+  await applyDefinitions(request, ...defs);
+  const job = await findJobByAlias(request, alias);
+  await triggerJob(request, job.id, { params: opts.params, priority: opts.priority });
+  const run = await awaitRun(request, job.id, opts);
+
+  return { job, run };
+}
+
+async function fireHTTPTrigger(
+  request: APIRequestContext,
+  jobId: string,
+  triggerId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/triggers/${triggerId}/fire`, {
+    headers: {
+      "X-Caesium-API-Key": manualTriggerAPIKey,
+    },
+    ...requestBody(options),
+  });
+  if (!response.ok()) {
+    throw new Error(`failed to manually fire trigger for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function startJobRun(
+  request: APIRequestContext,
+  jobId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`, requestBody(options));
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function findJobWithTriggerByAlias(request: APIRequestContext, alias: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get("/v1/jobs");
+  if (!response.ok()) {
+    throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+  }
+
+  const jobs = (await response.json()) as E2EJobWithTrigger[];
+  const job = jobs.find((candidate) => candidate.alias === alias);
+  if (!job) {
+    throw new Error(`job not found after apply: ${alias}`);
+  }
+  return job;
+}
+
+async function getJob(request: APIRequestContext, jobId: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get(`/v1/jobs/${jobId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2EJobWithTrigger;
+}
+
+async function listRuns(request: APIRequestContext, jobId: string): Promise<E2ERun[]> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs`);
+  if (!response.ok()) {
+    throw new Error(`failed to list runs for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun[];
+}
+
+async function getRun(request: APIRequestContext, jobId: string, runId: string): Promise<E2ERun> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load run ${runId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun;
+}
+
+function requestBody(options: TriggerJobOptions): { data?: TriggerJobOptions } {
+  const body: TriggerJobOptions = {};
+  if (options.params && Object.keys(options.params).length > 0) {
+    body.params = options.params;
+  }
+  if (options.priority) {
+    body.priority = options.priority;
+  }
+  return Object.keys(body).length > 0 ? { data: body } : {};
+}
+
+function normalizeTriggerJobOptions(input: Record<string, string> | TriggerJobOptions | undefined): TriggerJobOptions {
+  if (!input || Object.keys(input).length === 0) {
+    return {};
+  }
+  if ("params" in input || "priority" in input) {
+    return input as TriggerJobOptions;
+  }
+  return { params: input };
+}
+
+function normalizeExpectedStatuses(status: string | string[] | undefined): Set<string> {
+  if (!status) {
+    return new Set();
+  }
+  return new Set(Array.isArray(status) ? status : [status]);
+}
+
+function latestRun(runs: E2ERun[]): E2ERun | undefined {
+  return runs.at(-1);
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/ui/e2e/run-detail.spec.ts
+++ b/ui/e2e/run-detail.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+import { applyAndRun, type E2ECallbackRun, type E2ERun } from "./helpers/fixtures";
+
+type FailedCallbackRun = E2ECallbackRun & { error: string };
+
+test("run detail surfaces failed callback errors", async ({ page, request }) => {
+  test.slow();
+
+  const { job, run } = await applyAndRun(request, "callback-failure.job.yaml", {
+    status: "succeeded",
+  });
+  const failedCallback = await awaitFailedCallback(request, job.id, run.id);
+
+  await page.goto(`/jobs/${job.id}/runs/${run.id}`);
+  await expect(page.getByRole("heading", { name: /Run / })).toBeVisible({ timeout: 30_000 });
+
+  const callbacks = page.getByTestId("run-callbacks-section");
+  await expect(callbacks).toBeVisible();
+
+  const failedRow = callbacks.getByTestId("run-callback-row").filter({
+    hasText: failedCallback.error,
+  });
+  await expect(failedRow).toBeVisible();
+  await expect(failedRow).toContainText("failed");
+  await expect(failedRow.getByTestId("run-callback-error")).toContainText(failedCallback.error);
+});
+
+async function awaitFailedCallback(
+  request: APIRequestContext,
+  jobId: string,
+  runId: string,
+): Promise<FailedCallbackRun> {
+  const deadline = Date.now() + 45_000;
+  let lastCallbacks: E2ECallbackRun[] = [];
+
+  while (Date.now() <= deadline) {
+    const run = await getRun(request, jobId, runId);
+    lastCallbacks = run.callbacks ?? [];
+    const failed = lastCallbacks.find(
+      (callback): callback is FailedCallbackRun =>
+        callback.status === "failed" && typeof callback.error === "string" && callback.error.length > 0,
+    );
+    if (failed) return failed;
+
+    await delay(1_000);
+  }
+
+  throw new Error(
+    `timed out waiting for failed callback on run ${runId}; callbacks=${JSON.stringify(lastCallbacks)}`,
+  );
+}
+
+async function getRun(request: APIRequestContext, jobId: string, runId: string): Promise<E2ERun> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load run ${runId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun;
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/ui/src/features/jobs/RunDetailPage.tsx
+++ b/ui/src/features/jobs/RunDetailPage.tsx
@@ -17,7 +17,7 @@ import { StatusBadge } from "@/components/ui/status-badge";
 import { IncidentRibbon } from "@/features/incidents/IncidentRibbon";
 import { INCIDENT_EVENT_TYPES } from "@/features/incidents/incident-utils";
 import { useDagHeight } from "@/hooks/useDagHeight";
-import { api, type Atom, type Incident, type JobRun, type JobTask, type TaskRun } from "@/lib/api";
+import { api, type Atom, type CallbackRun, type Incident, type JobRun, type JobTask, type TaskRun } from "@/lib/api";
 import { usePrincipal } from "@/lib/auth";
 import { events, type CaesiumEvent } from "@/lib/events";
 import { shortId } from "@/lib/utils";
@@ -282,6 +282,7 @@ export function RunDetailPage() {
     : compareRuns.length === 0
       ? "No other runs to compare"
       : undefined;
+  const callbackRuns = run.callbacks ?? [];
 
   return (
     <div className="space-y-5">
@@ -472,7 +473,7 @@ export function RunDetailPage() {
         {timelineOpen && (
           <div className="p-4">
             {run.tasks && run.tasks.length > 0 ? (
-              <RunTimeline tasks={run.tasks} runStartedAt={run.started_at} />
+              <RunTimeline tasks={run.tasks} taskDefinitions={taskDefinitions} runStartedAt={run.started_at} />
             ) : (
               <div className="text-[12px] text-text-4 py-4 text-center">
                 No task execution data yet.
@@ -481,6 +482,8 @@ export function RunDetailPage() {
           </div>
         )}
       </div>
+
+      {callbackRuns.length > 0 ? <CallbackRunsSection callbacks={callbackRuns} /> : null}
 
       {/* Run parameters */}
       {run.params && Object.keys(run.params).length > 0 ? (
@@ -553,4 +556,46 @@ function parseTimestamp(value: string | undefined): number | undefined {
   if (!value) return undefined;
   const timestamp = new Date(value).getTime();
   return Number.isFinite(timestamp) ? timestamp : undefined;
+}
+
+function CallbackRunsSection({ callbacks }: { callbacks: CallbackRun[] }) {
+  return (
+    <Card data-testid="run-callbacks-section">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-sm">Callbacks</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {callbacks.map((callback) => {
+          const failed = callback.status.toLowerCase() === "failed";
+          return (
+            <div
+              key={callback.id}
+              data-testid="run-callback-row"
+              className={`rounded-md border px-3 py-2 ${
+                failed ? "border-danger/40 bg-danger/5" : "border-border/50 bg-obsidian/20"
+              }`}
+            >
+              <div className="flex flex-wrap items-center gap-2">
+                <StatusBadge status={callback.status} size="sm" />
+                <span className="font-mono text-xs text-text-2">
+                  callback {shortId(callback.callback_id)}
+                </span>
+                <span className="font-mono text-[10px] text-text-4">
+                  run {shortId(callback.id)}
+                </span>
+              </div>
+              {callback.error ? (
+                <div
+                  data-testid="run-callback-error"
+                  className={`mt-2 break-words font-mono text-xs ${failed ? "text-danger" : "text-text-3"}`}
+                >
+                  {callback.error}
+                </div>
+              ) : null}
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
 }

--- a/ui/src/features/jobs/RunTimeline.tsx
+++ b/ui/src/features/jobs/RunTimeline.tsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
-import type { TaskRun } from "@/lib/api";
+import type { JobTask, TaskRun } from "@/lib/api";
 import { shortId } from "@/lib/utils";
 import { statusMeta } from "@/lib/status";
 
 interface Props {
   tasks: TaskRun[];
+  taskDefinitions: Record<string, JobTask>;
   runStartedAt: string;
 }
 
@@ -21,14 +22,17 @@ function formatMs(ms: number): string {
   return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`;
 }
 
-export function RunTimeline({ tasks, runStartedAt }: Props) {
+export function RunTimeline({ tasks, taskDefinitions, runStartedAt }: Props) {
   const runStart = new Date(runStartedAt).getTime();
   // Pass Date.now as an initializer reference (not called during render) so
   // React captures wall-clock time once at mount without violating purity rules.
   const [now] = useState<number>(Date.now);
 
   // Only show tasks that have started
-  const startedTasks = tasks.filter(t => t.started_at || t.status === "cached");
+  const startedTasks = orderTasksByDAG(
+    tasks.filter(t => t.started_at || t.status === "cached"),
+    taskDefinitions,
+  );
   if (startedTasks.length === 0) {
     return (
       <div className="flex items-center justify-center h-32 text-muted-foreground text-sm">
@@ -100,9 +104,7 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
           const barX = LABEL_W + (start / maxEnd) * BAR_AREA;
           const barW = Math.max(2, ((end - start) / maxEnd) * BAR_AREA);
           const color = colorFor(task.status);
-          const label = task.image
-            ? task.image.split("/").pop()?.split(":")[0] ?? shortId(task.atom_id)
-            : shortId(task.atom_id);
+          const label = taskLabel(task, taskDefinitions);
           const duration = end - start;
 
           return (
@@ -213,4 +215,85 @@ export function RunTimeline({ tasks, runStartedAt }: Props) {
       </div>
     </div>
   );
+}
+
+function orderTasksByDAG(tasks: TaskRun[], taskDefinitions: Record<string, JobTask>): TaskRun[] {
+  if (tasks.length <= 1) return tasks;
+
+  const taskByID = new Map<string, TaskRun>();
+  const adjacency = new Map<string, Set<string>>();
+  const indegree = new Map<string, number>();
+  const fallbackOrder = new Map<string, { timestamp: number; index: number }>();
+
+  tasks.forEach((task, index) => {
+    taskByID.set(task.task_id, task);
+    adjacency.set(task.task_id, new Set());
+    indegree.set(task.task_id, 0);
+    fallbackOrder.set(task.task_id, {
+      timestamp: fallbackTimestamp(task),
+      index,
+    });
+  });
+
+  tasks.forEach((task) => {
+    const nextID = taskDefinitions[task.task_id]?.next_id;
+    if (!nextID || nextID === task.task_id || !taskByID.has(nextID)) return;
+
+    const edges = adjacency.get(task.task_id);
+    if (!edges || edges.has(nextID)) return;
+
+    edges.add(nextID);
+    indegree.set(nextID, (indegree.get(nextID) ?? 0) + 1);
+  });
+
+  const compareByFallback = (a: TaskRun, b: TaskRun) => {
+    const aOrder = fallbackOrder.get(a.task_id) ?? { timestamp: Number.POSITIVE_INFINITY, index: 0 };
+    const bOrder = fallbackOrder.get(b.task_id) ?? { timestamp: Number.POSITIVE_INFINITY, index: 0 };
+    if (aOrder.timestamp !== bOrder.timestamp) return aOrder.timestamp - bOrder.timestamp;
+    return aOrder.index - bOrder.index;
+  };
+
+  const ready = tasks.filter((task) => (indegree.get(task.task_id) ?? 0) === 0).sort(compareByFallback);
+  const ordered: TaskRun[] = [];
+
+  while (ready.length > 0) {
+    const task = ready.shift();
+    if (!task) break;
+    ordered.push(task);
+
+    for (const nextID of adjacency.get(task.task_id) ?? []) {
+      const nextDegree = (indegree.get(nextID) ?? 0) - 1;
+      indegree.set(nextID, nextDegree);
+
+      const nextTask = taskByID.get(nextID);
+      if (nextTask && nextDegree === 0) {
+        ready.push(nextTask);
+        ready.sort(compareByFallback);
+      }
+    }
+  }
+
+  if (ordered.length === tasks.length) return ordered;
+
+  const orderedIDs = new Set(ordered.map((task) => task.task_id));
+  const unresolved = tasks
+    .filter((task) => !orderedIDs.has(task.task_id))
+    .sort(compareByFallback);
+  return [...ordered, ...unresolved];
+}
+
+function fallbackTimestamp(task: TaskRun): number {
+  const parsed = new Date(task.started_at ?? task.created_at).getTime();
+  return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+function taskLabel(task: TaskRun, taskDefinitions: Record<string, JobTask>): string {
+  const name = taskDefinitions[task.task_id]?.name?.trim();
+  if (name) return name;
+
+  if (task.image) {
+    return task.image.split("/").pop()?.split(":")[0] ?? shortId(task.atom_id);
+  }
+
+  return shortId(task.atom_id);
 }

--- a/ui/src/lib/__tests__/status.test.ts
+++ b/ui/src/lib/__tests__/status.test.ts
@@ -31,6 +31,17 @@ describe("statusMeta", () => {
     expect(statusMeta("active").label).toBe("running");
   });
 
+  it("keeps pending and skipped visually distinct", () => {
+    const pending = statusMeta("pending");
+    const queued = statusMeta("queued");
+    const skipped = statusMeta("skipped");
+
+    expect(pending.fg).toBe(queued.fg);
+    expect(queued.fg).not.toBe(skipped.fg);
+    expect(queued.bg).not.toBe(skipped.bg);
+    expect(queued.border).not.toBe(skipped.border);
+  });
+
   it("falls back to a neutral 'unknown' meta", () => {
     const fallback = statusMeta("definitely-not-a-status");
     expect(fallback.label).toBe("unknown");

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -37,6 +37,16 @@ export interface JobRun {
   total_tasks?: number;
   quarantine?: boolean;
   tasks?: TaskRun[];
+  callbacks?: CallbackRun[];
+}
+
+export interface CallbackRun {
+  id: string;
+  callback_id: string;
+  status: string;
+  error?: string;
+  started_at: string;
+  completed_at?: string;
 }
 
 export interface Backfill {

--- a/ui/src/lib/status.ts
+++ b/ui/src/lib/status.ts
@@ -56,9 +56,9 @@ const META: Record<RunStatus, StatusMeta> = {
   },
   queued: {
     label: "queued",
-    fg: "hsl(var(--text-2))",
-    bg: "hsl(var(--text-3) / 0.12)",
-    border: "hsl(var(--text-3) / 0.25)",
+    fg: "hsl(var(--gold))",
+    bg: "hsl(var(--gold) / 0.12)",
+    border: "hsl(var(--gold) / 0.32)",
     dotClass: "",
   },
   paused: {


### PR DESCRIPTION
## Summary
- **D1**: run-detail tasks now render in DAG/topological order — `RunTimeline` receives the `JobTask` definitions (`TaskRun` carries no `next_id`) and topo-sorts by `next_id`, falling back to `started_at`. Fixes "convert before list".
- **D2**: timeline rows label by **task name** (`JobTask.name` by `task_id`), falling back to image/short-id only when absent; the near-identical-gray "skipped" and "pending" legend swatches get visually distinct colors in `status.ts`.
- **D3**: adds a callbacks section to the run detail listing callback runs and highlighting failures with their `error` — the run payload already serializes `callbacks`; adds `JobRun.callbacks` + a `CallbackRun` type to `api.ts` (shape matches the Go serializer).
- Adds Vitest coverage for the status color map and a Playwright `run-detail.spec.ts` using the `callback-failure` H-1 fixture.

## Test plan
- [ ] GHA CI: `ui-test` (vitest + tsc), `ui-e2e` (`run-detail.spec.ts` asserting the failed-callback section).

_Diff cosmetically includes the W1-H1 e2e-helper (stacked branch); collapses once #300 merges first._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
