### PR TITLE
Fix Live Activity dedup, redundant fetches, command palette, and HISTORY sparkline (console-v2-bug-sweep W1-β)

### DIFF
--- a/api/rest/controller/job/list.go
+++ b/api/rest/controller/job/list.go
@@ -1,17 +1,25 @@
 package job
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/caesium-cloud/caesium/api/middleware"
 	"github.com/caesium-cloud/caesium/api/rest/service/job"
-	runsvc "github.com/caesium-cloud/caesium/api/rest/service/run"
+	"github.com/caesium-cloud/caesium/internal/models"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
-	"gorm.io/gorm"
 )
+
+const jobListRunHistoryLimit = 10
+
+type ListJobResponse struct {
+	*models.Job
+	LatestRun *runstorage.JobRun   `json:"latest_run,omitempty"`
+	LastRuns  []job.RunListSummary `json:"last_runs"`
+}
 
 func List(c *echo.Context) error {
 	req, err := parseListRequest(c)
@@ -22,19 +30,36 @@ func List(c *echo.Context) error {
 		req.Aliases = aliases
 	}
 
-	jobs, err := job.Service(c.Request().Context()).List(req)
+	svc := job.Service(c.Request().Context())
+	jobs, err := svc.List(req)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
 	}
 
-	resp := make([]*JobResponse, 0, len(jobs))
+	jobIDs := make([]uuid.UUID, 0, len(jobs))
 	for _, entry := range jobs {
-		item := &JobResponse{Job: entry}
-		latest, latestErr := runsvc.New(c.Request().Context()).Latest(entry.ID)
-		if latestErr != nil && !errors.Is(latestErr, gorm.ErrRecordNotFound) {
-			return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(latestErr)
+		jobIDs = append(jobIDs, entry.ID)
+	}
+
+	runsByJob, err := svc.ListRecentRuns(jobIDs, jobListRunHistoryLimit)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	resp := make([]*ListJobResponse, 0, len(jobs))
+	for _, entry := range jobs {
+		history := runsByJob[entry.ID]
+		if history == nil {
+			history = []job.RunListSummary{}
 		}
-		item.LatestRun = latest
+
+		item := &ListJobResponse{
+			Job:      entry,
+			LastRuns: history,
+		}
+		if len(history) > 0 {
+			item.LatestRun = history[len(history)-1].JobRun()
+		}
 		resp = append(resp, item)
 	}
 

--- a/api/rest/service/job/job.go
+++ b/api/rest/service/job/job.go
@@ -22,6 +22,7 @@ type Job interface {
 	WithDatabase(*gorm.DB) Job
 	SetBus(event.Bus)
 	List(*ListRequest) (models.Jobs, error)
+	ListRecentRuns([]uuid.UUID, int) (map[uuid.UUID][]RunListSummary, error)
 	Get(uuid.UUID) (*models.Job, error)
 	Queue(uuid.UUID) ([]QueueItem, error)
 	Create(*CreateRequest) (*models.Job, error)
@@ -91,6 +92,33 @@ type ListRequest struct {
 	Aliases   []string
 }
 
+type RunListSummary struct {
+	ID            uuid.UUID  `json:"-"`
+	JobID         uuid.UUID  `json:"-"`
+	Status        string     `json:"status"`
+	Duration      *float64   `json:"duration,omitempty"`
+	StartedAt     time.Time  `json:"-"`
+	CompletedAt   *time.Time `json:"-"`
+	Error         string     `json:"-"`
+	CacheHits     int        `json:"-"`
+	ExecutedTasks int        `json:"-"`
+	TotalTasks    int        `json:"-"`
+}
+
+func (r RunListSummary) JobRun() *runstorage.JobRun {
+	return &runstorage.JobRun{
+		ID:            r.ID,
+		JobID:         r.JobID,
+		Status:        runstorage.Status(r.Status),
+		StartedAt:     r.StartedAt,
+		CompletedAt:   r.CompletedAt,
+		Error:         r.Error,
+		CacheHits:     r.CacheHits,
+		ExecutedTasks: r.ExecutedTasks,
+		TotalTasks:    r.TotalTasks,
+	}
+}
+
 func (j *jobService) List(req *ListRequest) (models.Jobs, error) {
 	var (
 		jobs = make(models.Jobs, 0)
@@ -124,24 +152,93 @@ func (j *jobService) List(req *ListRequest) (models.Jobs, error) {
 		return nil, err
 	}
 
-	runStore := runstorage.NewStore(j.db)
-	for _, job := range jobs {
-		if latest, err := runStore.Latest(job.ID); err == nil && latest != nil {
-			job.LatestRun = &models.JobRun{
-				ID:            latest.ID,
-				JobID:         latest.JobID,
-				Status:        string(latest.Status),
-				StartedAt:     latest.StartedAt,
-				CompletedAt:   latest.CompletedAt,
-				Error:         latest.Error,
-				CacheHits:     latest.CacheHits,
-				ExecutedTasks: latest.ExecutedTasks,
-				TotalTasks:    latest.TotalTasks,
-			}
-		}
+	return jobs, nil
+}
+
+func (j *jobService) ListRecentRuns(jobIDs []uuid.UUID, limit int) (map[uuid.UUID][]RunListSummary, error) {
+	out := make(map[uuid.UUID][]RunListSummary, len(jobIDs))
+	if len(jobIDs) == 0 {
+		return out, nil
+	}
+	if limit <= 0 {
+		limit = 10
 	}
 
-	return jobs, nil
+	type recentRunRow struct {
+		ID            uuid.UUID  `gorm:"column:id"`
+		JobID         uuid.UUID  `gorm:"column:job_id"`
+		Status        string     `gorm:"column:status"`
+		StartedAt     time.Time  `gorm:"column:started_at"`
+		CompletedAt   *time.Time `gorm:"column:completed_at"`
+		Error         string     `gorm:"column:error"`
+		CacheHits     int        `gorm:"column:cache_hits"`
+		ExecutedTasks int        `gorm:"column:executed_tasks"`
+		TotalTasks    int        `gorm:"column:total_tasks"`
+	}
+
+	ranked := j.db.WithContext(j.ctx).
+		Table("job_runs").
+		Select(`
+			job_runs.id,
+			job_runs.job_id,
+			job_runs.status,
+			job_runs.started_at,
+			job_runs.completed_at,
+			job_runs.error,
+			ROW_NUMBER() OVER (
+				PARTITION BY job_runs.job_id
+				ORDER BY job_runs.started_at DESC, job_runs.created_at DESC, job_runs.id DESC
+			) AS rn
+		`).
+		Where("job_runs.job_id IN ? AND job_runs.quarantine IS NOT TRUE", jobIDs)
+
+	var rows []recentRunRow
+	err := j.db.WithContext(j.ctx).
+		Table("(?) AS ranked", ranked).
+		Select(`
+			ranked.id,
+			ranked.job_id,
+			ranked.status,
+			ranked.started_at,
+			ranked.completed_at,
+			ranked.error,
+			COALESCE(SUM(CASE WHEN task_runs.cache_hit OR task_runs.status = 'cached' THEN 1 ELSE 0 END), 0) AS cache_hits,
+			COALESCE(SUM(CASE WHEN NOT (task_runs.cache_hit OR task_runs.status = 'cached') AND task_runs.status IN ('running', 'succeeded', 'failed') THEN 1 ELSE 0 END), 0) AS executed_tasks,
+			COUNT(task_runs.id) AS total_tasks
+		`).
+		Joins("LEFT JOIN task_runs ON task_runs.job_run_id = ranked.id").
+		Where("ranked.rn <= ?", limit).
+		Group("ranked.id, ranked.job_id, ranked.status, ranked.started_at, ranked.completed_at, ranked.error").
+		Order("ranked.job_id ASC, ranked.started_at ASC, ranked.id ASC").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	for _, row := range rows {
+		var duration *float64
+		if row.CompletedAt != nil {
+			seconds := row.CompletedAt.Sub(row.StartedAt).Seconds()
+			if seconds < 0 {
+				seconds = 0
+			}
+			duration = &seconds
+		}
+		out[row.JobID] = append(out[row.JobID], RunListSummary{
+			ID:            row.ID,
+			JobID:         row.JobID,
+			Status:        row.Status,
+			Duration:      duration,
+			StartedAt:     row.StartedAt,
+			CompletedAt:   row.CompletedAt,
+			Error:         row.Error,
+			CacheHits:     row.CacheHits,
+			ExecutedTasks: row.ExecutedTasks,
+			TotalTasks:    row.TotalTasks,
+		})
+	}
+
+	return out, nil
 }
 
 func (j *jobService) Get(id uuid.UUID) (*models.Job, error) {

--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -131,7 +131,7 @@ The Live Activity feed duplicates and contradicts itself; the page re-fetches
 `/v1/jobs` four times per load; the command palette over-matches; and the
 HISTORY column never renders. All four items are independent.
 
-- [ ] B1. Fix the Live Activity feed. Two symptoms, one root cause plus an
+- [x] B1. Fix the Live Activity feed. Two symptoms, one root cause plus an
       alias miss: (a) **duplicates + contradiction** — every terminal run
       emits both a specific `run_completed`/`run_failed` event **and** a
       separate `run_terminal` event (`internal/run/store.go` ~3395-3417), and
@@ -154,7 +154,7 @@ HISTORY column never renders. All four items are independent.
       (~109-124, subscription ~156), `ui/src/features/jobs/JobsPage.tsx`
       (activity feed label/color map ~335-342), `ui/src/lib/events.ts` (~66-73),
       `ui/src/lib/__tests__/events.test.ts`.
-- [ ] B2. Eliminate redundant duplicate fetches (one page load fires
+- [x] B2. Eliminate redundant duplicate fetches (one page load fires
       `/v1/jobs` ×4 and `/v1/triggers`, `/v1/atoms`, `/health` ×2). Set a
       sensible global react-query default (`staleTime` > 0 and/or
       `refetchOnMount: false`) on the `QueryClient`, and make the nav-count
@@ -164,14 +164,14 @@ HISTORY column never renders. All four items are independent.
       counts) share one in-flight request. Files: `ui/src/main.tsx`
       (`new QueryClient()`), `ui/src/features/jobs/useNavCounts.ts`,
       `ui/src/features/jobs/useJobsView.ts`, `ui/src/components/command-menu.tsx`.
-- [ ] B3. Fix the command palette (`⌘K`) matcher: it uses cmdk's default
+- [x] B3. Fix the command palette (`⌘K`) matcher: it uses cmdk's default
       subsequence scoring, so "cron" matches "pro**c**ess-p**r**oducti**o**n"
       via scattered letters. Supply a stricter custom `filter` (word / substring
       match against alias + short-id) and index `triggers` and `atoms` as their
       own search groups, not just jobs. Files:
       `ui/src/components/command-menu.tsx`, `ui/src/components/ui/command.tsx`
       (if the custom filter mounts there).
-- [ ] B4. Populate the HISTORY sparkline column, which is `—` for every job.
+- [x] B4. Populate the HISTORY sparkline column, which is `—` for every job.
       The sparkline reads `job.lastRuns` (from a `last_runs` field) but
       `/v1/jobs` only returns a single `latest_run`, so the array is always
       empty. Extend the list controller/service to return a bounded

--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -360,7 +360,7 @@ sequenced after them (see `## Sequencing & Dependencies`).
 
 ## Harness Strengthening
 
-- [ ] H-1. Seed a richer e2e/integration fixture set so the assertions the
+- [x] H-1. Seed a richer e2e/integration fixture set so the assertions the
       above items need have real data to render against: a job with a
       **multi-step DAG** that produces a **failed run** carrying a **failed
       callback**, plus an **event trigger** and one or more **cron triggers**.
@@ -369,6 +369,9 @@ sequenced after them (see `## Sequencing & Dependencies`).
       validator (A1). Files: `ui/e2e/helpers/fixtures.ts`, new
       `ui/e2e/` fixture `*.job.yaml`, and any `test/` harness seed needed for
       the integration scenarios (B4, E1, F4).
+      Landed W1-H1: shared `fixtures.ts` helpers now index the existing
+      `docs/examples/` coverage and centralize fixture load/apply, job lookup,
+      trigger, and run-await flows; no new fixture was needed.
 
 ## Navigational / Organizational Improvements
 

--- a/test/job_list_history_test.go
+++ b/test/job_list_history_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestJobsListIncludesLastRuns() {
+	alias := fmt.Sprintf("integration-list-history-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`
+apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+trigger:
+  type: cron
+  configuration:
+    cron: "*/10 * * * *"
+steps:
+  - name: history
+    image: alpine:3.23
+    command: ["sh", "-c", "echo history"]
+`, alias)
+
+	tmpDir := s.writeJobManifest(manifest)
+	defer os.RemoveAll(tmpDir)
+
+	s.runCLI("job", "apply", "--path", tmpDir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	runID := s.triggerRun(job.ID)
+	completed := s.awaitRun(job.ID, runID, runTimeout)
+
+	type lastRunSummary struct {
+		Status   string   `json:"status"`
+		Duration *float64 `json:"duration"`
+	}
+	type listJobResponse struct {
+		ID        string           `json:"id"`
+		Alias     string           `json:"alias"`
+		LatestRun *runResponse     `json:"latest_run"`
+		LastRuns  []lastRunSummary `json:"last_runs"`
+	}
+
+	var jobs []listJobResponse
+	s.getJSON("/v1/jobs?order_by=created_at desc", &jobs)
+
+	var listed *listJobResponse
+	for i := range jobs {
+		if jobs[i].Alias == alias {
+			listed = &jobs[i]
+			break
+		}
+	}
+	s.Require().NotNil(listed, "job %s not present in /v1/jobs", alias)
+	s.Require().NotNil(listed.LatestRun, "latest_run missing for %s", alias)
+	s.Equal(completed.ID, listed.LatestRun.ID)
+	s.Equal(completed.Status, listed.LatestRun.Status)
+	s.Require().NotEmpty(listed.LastRuns, "last_runs missing for %s", alias)
+	s.LessOrEqual(len(listed.LastRuns), 10)
+
+	latestHistory := listed.LastRuns[len(listed.LastRuns)-1]
+	s.Equal(completed.Status, latestHistory.Status)
+	s.Require().NotNil(latestHistory.Duration)
+	s.GreaterOrEqual(*latestHistory.Duration, float64(0))
+}

--- a/test/job_list_history_test.go
+++ b/test/job_list_history_test.go
@@ -66,7 +66,7 @@ func (s *IntegrationTestSuite) awaitListedJobRun(alias, runID, status string, ti
 
 	for {
 		var jobs []listJobResponse
-		if err := s.tryGetJSON("/v1/jobs?order_by=created_at desc", &jobs); err != nil {
+		if err := s.tryGetJSON("/v1/jobs", &jobs); err != nil {
 			lastErr = err
 		} else {
 			lastErr = nil

--- a/test/job_list_history_test.go
+++ b/test/job_list_history_test.go
@@ -8,6 +8,18 @@ import (
 	"time"
 )
 
+type lastRunSummary struct {
+	Status   string   `json:"status"`
+	Duration *float64 `json:"duration"`
+}
+
+type listJobResponse struct {
+	ID        string           `json:"id"`
+	Alias     string           `json:"alias"`
+	LatestRun *runResponse     `json:"latest_run"`
+	LastRuns  []lastRunSummary `json:"last_runs"`
+}
+
 func (s *IntegrationTestSuite) TestJobsListIncludesLastRuns() {
 	alias := fmt.Sprintf("integration-list-history-%d", time.Now().UnixNano())
 	manifest := fmt.Sprintf(`
@@ -33,29 +45,7 @@ steps:
 	runID := s.triggerRun(job.ID)
 	completed := s.awaitRun(job.ID, runID, runTimeout)
 
-	type lastRunSummary struct {
-		Status   string   `json:"status"`
-		Duration *float64 `json:"duration"`
-	}
-	type listJobResponse struct {
-		ID        string           `json:"id"`
-		Alias     string           `json:"alias"`
-		LatestRun *runResponse     `json:"latest_run"`
-		LastRuns  []lastRunSummary `json:"last_runs"`
-	}
-
-	var jobs []listJobResponse
-	s.getJSON("/v1/jobs?order_by=created_at desc", &jobs)
-
-	var listed *listJobResponse
-	for i := range jobs {
-		if jobs[i].Alias == alias {
-			listed = &jobs[i]
-			break
-		}
-	}
-	s.Require().NotNil(listed, "job %s not present in /v1/jobs", alias)
-	s.Require().NotNil(listed.LatestRun, "latest_run missing for %s", alias)
+	listed := s.awaitListedJobRun(alias, completed.ID, completed.Status, runTimeout)
 	s.Equal(completed.ID, listed.LatestRun.ID)
 	s.Equal(completed.Status, listed.LatestRun.Status)
 	s.Require().NotEmpty(listed.LastRuns, "last_runs missing for %s", alias)
@@ -65,4 +55,65 @@ steps:
 	s.Equal(completed.Status, latestHistory.Status)
 	s.Require().NotNil(latestHistory.Duration)
 	s.GreaterOrEqual(*latestHistory.Duration, float64(0))
+}
+
+func (s *IntegrationTestSuite) awaitListedJobRun(alias, runID, status string, timeout time.Duration) *listJobResponse {
+	s.T().Helper()
+
+	deadline := time.Now().Add(timeout)
+	lastObservation := "not checked yet"
+	var lastErr error
+
+	for {
+		var jobs []listJobResponse
+		if err := s.tryGetJSON("/v1/jobs?order_by=created_at desc", &jobs); err != nil {
+			lastErr = err
+		} else {
+			lastErr = nil
+			found := false
+			for i := range jobs {
+				if jobs[i].Alias != alias {
+					continue
+				}
+				found = true
+				listed := jobs[i]
+				if listed.LatestRun == nil {
+					lastObservation = "job found with nil latest_run"
+					break
+				}
+
+				historyStatus := "<empty>"
+				durationReady := false
+				if len(listed.LastRuns) > 0 {
+					latestHistory := listed.LastRuns[len(listed.LastRuns)-1]
+					historyStatus = latestHistory.Status
+					durationReady = latestHistory.Duration != nil
+				}
+				lastObservation = fmt.Sprintf("latest_run=%s/%s last_history=%s duration_ready=%t",
+					listed.LatestRun.ID, listed.LatestRun.Status, historyStatus, durationReady)
+
+				if listed.LatestRun.ID == runID &&
+					listed.LatestRun.Status == status &&
+					len(listed.LastRuns) > 0 {
+					latestHistory := listed.LastRuns[len(listed.LastRuns)-1]
+					if latestHistory.Status == status && latestHistory.Duration != nil {
+						return &listed
+					}
+				}
+				break
+			}
+			if !found {
+				lastObservation = "job not present"
+			}
+		}
+
+		if time.Now().After(deadline) {
+			if lastErr != nil {
+				s.T().Fatalf("timeout waiting for /v1/jobs history for %s run %s: last_error=%v", alias, runID, lastErr)
+			}
+			s.T().Fatalf("timeout waiting for /v1/jobs history for %s run %s to converge: %s", alias, runID, lastObservation)
+		}
+
+		time.Sleep(250 * time.Millisecond)
+	}
 }

--- a/ui/e2e/helpers/fixtures.ts
+++ b/ui/e2e/helpers/fixtures.ts
@@ -4,8 +4,21 @@ import { fileURLToPath } from "node:url";
 import type { APIRequestContext } from "@playwright/test";
 import { parseAllDocuments } from "yaml";
 
+/**
+ * Console v2 bug-sweep fixture index:
+ * - docs/examples/callback-failure.job.yaml backs D3 failed-callback rendering.
+ * - docs/examples/run-history.job.yaml backs A1 cron next-fire via cron-success-fast
+ *   and B4/C1 failed-run history/DAG counts via cron-failure-fast.
+ * - docs/examples/event-trigger.job.yaml backs A2 event-trigger rendering.
+ * - docs/examples/branching.job.yaml and fanout-join.job.yaml back multi-step DAG views.
+ */
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const manualTriggerAPIKey = process.env.CAESIUM_MANUAL_TRIGGER_API_KEY?.trim() || "e2e-test-key";
+const terminalRunStatuses = new Set(["succeeded", "failed", "cancelled"]);
+const defaultRunTimeoutMs = 180_000;
+const pollIntervalMs = 1_000;
 
 export type FixtureDefinition = {
   metadata?: Record<string, unknown> & { alias?: string };
@@ -14,30 +27,123 @@ export type FixtureDefinition = {
   };
 };
 
+export type E2EJob = {
+  id: string;
+  alias: string;
+};
+
+type E2EJobWithTrigger = E2EJob & {
+  trigger_id?: string;
+  trigger?: {
+    id: string;
+    type: string;
+  };
+};
+
+export type E2ECallbackRun = {
+  id: string;
+  callback_id: string;
+  status: string;
+  error?: string;
+  started_at: string;
+  completed_at?: string;
+} & Record<string, unknown>;
+
+export type E2ETaskRun = {
+  id: string;
+  job_run_id: string;
+  task_id: string;
+  atom_id?: string;
+  engine?: string;
+  image?: string;
+  command?: string[];
+  runtime_id?: string;
+  status: string;
+  result?: string;
+  error?: string;
+  output?: Record<string, string>;
+  cache_hit?: boolean;
+  cache_origin_run_id?: string;
+  started_at?: string;
+  completed_at?: string;
+  created_at?: string;
+  updated_at?: string;
+} & Record<string, unknown>;
+
+export type E2ERun = {
+  id: string;
+  job_id: string;
+  job_alias?: string;
+  backfill_id?: string;
+  trigger_type?: string;
+  trigger_alias?: string;
+  status: string;
+  priority?: number;
+  params?: Record<string, string>;
+  quarantine?: boolean;
+  started_at: string;
+  completed_at?: string;
+  created_at: string;
+  updated_at: string;
+  error?: string;
+  tasks: E2ETaskRun[];
+  callbacks: E2ECallbackRun[];
+  cache_hits?: number;
+  executed_tasks?: number;
+  total_tasks?: number;
+} & Record<string, unknown>;
+
+export type TriggerJobOptions = {
+  params?: Record<string, string>;
+  priority?: "low" | "normal" | "high";
+};
+
+export type AwaitRunOptions = {
+  status?: string | string[];
+  timeoutMs?: number;
+};
+
+export type ApplyAndRunOptions = TriggerJobOptions &
+  AwaitRunOptions & {
+    definitionIndex?: number;
+  };
+
 /**
  * Load a job-definition YAML from docs/examples/, mutating the alias (and any
  * HTTP webhook path) so each test invocation gets a unique resource and tests
  * can run repeatedly without colliding with prior state.
  */
 export async function loadFixtureDefinition(filename: string): Promise<FixtureDefinition> {
+  const defs = await loadFixtureDefinitions(filename);
+  const first = defs[0];
+  if (!first) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+  return first;
+}
+
+export async function loadFixtureDefinitions(filename: string): Promise<FixtureDefinition[]> {
   const fixturePath = path.resolve(__dirname, "../../../docs/examples", filename);
   const yaml = await fs.readFile(fixturePath, "utf8");
   const docs = parseAllDocuments(yaml);
-  const raw = docs[0]?.toJS();
-  if (!raw || typeof raw !== "object") {
-    throw new Error(`failed to parse fixture: ${filename}`);
-  }
-  const def = raw as FixtureDefinition;
-
   const suffix = crypto.randomUUID().split("-")[0];
-  const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
-  def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
 
-  if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
-    def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
-  }
+  return docs.map((doc, index) => {
+    const raw = doc.toJS();
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`failed to parse fixture ${filename} document ${index}`);
+    }
 
-  return def;
+    const def = raw as FixtureDefinition;
+    const baseAlias = String(def.metadata?.alias ?? path.basename(filename, ".job.yaml"));
+    def.metadata = { ...(def.metadata ?? {}), alias: `${baseAlias}-${suffix}` };
+
+    if (def.trigger?.configuration && typeof def.trigger.configuration.path === "string") {
+      def.trigger.configuration.path = `/hooks/demo/${baseAlias}-${suffix}`;
+    }
+
+    return def;
+  });
 }
 
 export async function applyDefinitions(request: APIRequestContext, ...defs: FixtureDefinition[]): Promise<void> {
@@ -47,4 +153,185 @@ export async function applyDefinitions(request: APIRequestContext, ...defs: Fixt
   if (!response.ok()) {
     throw new Error(`failed to apply fixture: ${response.status()} ${await response.text()}`);
   }
+}
+
+export async function findJobByAlias(request: APIRequestContext, alias: string): Promise<E2EJob> {
+  const job = await findJobWithTriggerByAlias(request, alias);
+  return { id: job.id, alias: job.alias };
+}
+
+export async function triggerJob(
+  request: APIRequestContext,
+  jobId: string,
+  params?: Record<string, string> | TriggerJobOptions,
+): Promise<void> {
+  const options = normalizeTriggerJobOptions(params);
+  const job = await getJob(request, jobId);
+  if (!job.trigger_id) {
+    throw new Error(`job ${jobId} did not include trigger_id`);
+  }
+
+  if (job.trigger?.type === "http") {
+    await fireHTTPTrigger(request, jobId, job.trigger_id, options);
+    return;
+  }
+
+  await startJobRun(request, jobId, options);
+}
+
+export async function awaitRun(
+  request: APIRequestContext,
+  jobId: string,
+  opts: AwaitRunOptions = {},
+): Promise<E2ERun> {
+  const expectedStatuses = normalizeExpectedStatuses(opts.status);
+  const deadline = Date.now() + (opts.timeoutMs ?? defaultRunTimeoutMs);
+  let lastRun: E2ERun | undefined;
+  let lastStatus = "no runs";
+
+  while (Date.now() <= deadline) {
+    const runs = await listRuns(request, jobId);
+    lastRun = latestRun(runs);
+    if (lastRun) {
+      lastStatus = lastRun.status;
+      if (expectedStatuses.has(lastRun.status) || (!opts.status && terminalRunStatuses.has(lastRun.status))) {
+        return getRun(request, jobId, lastRun.id);
+      }
+    }
+
+    await delay(pollIntervalMs);
+  }
+
+  const wanted = opts.status ? [...expectedStatuses].join(", ") : "terminal status";
+  throw new Error(`timed out waiting for job ${jobId} latest run to reach ${wanted}; last status: ${lastStatus}`);
+}
+
+export async function applyAndRun(
+  request: APIRequestContext,
+  filename: string,
+  opts: ApplyAndRunOptions = {},
+): Promise<{ job: E2EJob; run: E2ERun }> {
+  const defs = await loadFixtureDefinitions(filename);
+  if (defs.length === 0) {
+    throw new Error(`fixture did not contain any definitions: ${filename}`);
+  }
+
+  const index = opts.definitionIndex ?? 0;
+  const def = defs[index];
+  if (!def) {
+    throw new Error(`fixture ${filename} does not include document ${index}`);
+  }
+  const alias = String(def.metadata?.alias ?? "");
+  if (!alias) {
+    throw new Error(`fixture ${filename} document ${index} did not include an alias`);
+  }
+
+  await applyDefinitions(request, ...defs);
+  const job = await findJobByAlias(request, alias);
+  await triggerJob(request, job.id, { params: opts.params, priority: opts.priority });
+  const run = await awaitRun(request, job.id, opts);
+
+  return { job, run };
+}
+
+async function fireHTTPTrigger(
+  request: APIRequestContext,
+  jobId: string,
+  triggerId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/triggers/${triggerId}/fire`, {
+    headers: {
+      "X-Caesium-API-Key": manualTriggerAPIKey,
+    },
+    ...requestBody(options),
+  });
+  if (!response.ok()) {
+    throw new Error(`failed to manually fire trigger for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function startJobRun(
+  request: APIRequestContext,
+  jobId: string,
+  options: TriggerJobOptions,
+): Promise<void> {
+  const response = await request.post(`/v1/jobs/${jobId}/run`, requestBody(options));
+  if (!response.ok()) {
+    throw new Error(`failed to trigger run for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+}
+
+async function findJobWithTriggerByAlias(request: APIRequestContext, alias: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get("/v1/jobs");
+  if (!response.ok()) {
+    throw new Error(`failed to list jobs: ${response.status()} ${await response.text()}`);
+  }
+
+  const jobs = (await response.json()) as E2EJobWithTrigger[];
+  const job = jobs.find((candidate) => candidate.alias === alias);
+  if (!job) {
+    throw new Error(`job not found after apply: ${alias}`);
+  }
+  return job;
+}
+
+async function getJob(request: APIRequestContext, jobId: string): Promise<E2EJobWithTrigger> {
+  const response = await request.get(`/v1/jobs/${jobId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2EJobWithTrigger;
+}
+
+async function listRuns(request: APIRequestContext, jobId: string): Promise<E2ERun[]> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs`);
+  if (!response.ok()) {
+    throw new Error(`failed to list runs for job ${jobId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun[];
+}
+
+async function getRun(request: APIRequestContext, jobId: string, runId: string): Promise<E2ERun> {
+  const response = await request.get(`/v1/jobs/${jobId}/runs/${runId}`);
+  if (!response.ok()) {
+    throw new Error(`failed to load run ${runId}: ${response.status()} ${await response.text()}`);
+  }
+  return (await response.json()) as E2ERun;
+}
+
+function requestBody(options: TriggerJobOptions): { data?: TriggerJobOptions } {
+  const body: TriggerJobOptions = {};
+  if (options.params && Object.keys(options.params).length > 0) {
+    body.params = options.params;
+  }
+  if (options.priority) {
+    body.priority = options.priority;
+  }
+  return Object.keys(body).length > 0 ? { data: body } : {};
+}
+
+function normalizeTriggerJobOptions(input: Record<string, string> | TriggerJobOptions | undefined): TriggerJobOptions {
+  if (!input || Object.keys(input).length === 0) {
+    return {};
+  }
+  if ("params" in input || "priority" in input) {
+    return input as TriggerJobOptions;
+  }
+  return { params: input };
+}
+
+function normalizeExpectedStatuses(status: string | string[] | undefined): Set<string> {
+  if (!status) {
+    return new Set();
+  }
+  return new Set(Array.isArray(status) ? status : [status]);
+}
+
+function latestRun(runs: E2ERun[]): E2ERun | undefined {
+  return runs.at(-1);
+}
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/ui/e2e/jobs-management.spec.ts
+++ b/ui/e2e/jobs-management.spec.ts
@@ -1,5 +1,16 @@
 import { expect, test } from "@playwright/test";
-import { applyDefinitions, loadFixtureDefinition } from "./helpers/fixtures";
+import {
+  applyDefinitions,
+  awaitRun,
+  findJobByAlias,
+  loadFixtureDefinition,
+  loadFixtureDefinitions,
+  triggerJob,
+} from "./helpers/fixtures";
+
+function shortId(value: string) {
+  return value.slice(0, 8);
+}
 
 test("operator can pause and unpause a job from the detail page", async ({ page, request }) => {
   // The minimal fixture uses a daily cron in the future, so the job will sit
@@ -64,4 +75,37 @@ test("jobs list filters rows by search and shows empty state for no matches", as
   await searchInput.fill("definitely-not-an-alias-xyz");
   await expect(page.locator('[data-testid="job-row"]')).toHaveCount(0);
   await expect(page.getByText("No pipelines match")).toBeVisible();
+});
+
+test("jobs live activity de-duplicates terminal events and resolves aliases", async ({ page, request }) => {
+  const definitions = await loadFixtureDefinitions("run-history.job.yaml");
+  const successAlias = String(definitions[0]?.metadata?.alias);
+  const failureAlias = String(definitions[1]?.metadata?.alias);
+  await applyDefinitions(request, ...definitions);
+  const successJob = await findJobByAlias(request, successAlias);
+  const failureJob = await findJobByAlias(request, failureAlias);
+
+  await page.goto("/jobs");
+  await expect(page.locator('[data-testid="job-row"]', { hasText: successAlias }).first()).toBeVisible();
+  await expect(page.locator('[data-testid="job-row"]', { hasText: failureAlias }).first()).toBeVisible();
+
+  await triggerJob(request, successJob.id);
+  const successRun = await awaitRun(request, successJob.id, { status: "succeeded" });
+  await triggerJob(request, failureJob.id);
+  const failureRun = await awaitRun(request, failureJob.id, { status: "failed" });
+
+  const feed = page.getByTestId("activity-feed");
+  await expect(feed).toBeVisible();
+  await expect(feed).toContainText(successAlias);
+  await expect(feed).toContainText(failureAlias);
+  await expect(feed).not.toContainText(successJob.id);
+  await expect(feed).not.toContainText(failureJob.id);
+
+  const successEntries = page.getByTestId("activity-entry").filter({ hasText: shortId(successRun.id) });
+  await expect(successEntries.filter({ hasText: "Run completed" })).toHaveCount(1);
+  await expect(successEntries.filter({ hasText: "Run failed" })).toHaveCount(0);
+
+  const failureEntries = page.getByTestId("activity-entry").filter({ hasText: shortId(failureRun.id) });
+  await expect(failureEntries.filter({ hasText: "Run failed" })).toHaveCount(1);
+  await expect(failureEntries.filter({ hasText: "Run completed" })).toHaveCount(0);
 });

--- a/ui/src/components/__tests__/command-menu.test.ts
+++ b/ui/src/components/__tests__/command-menu.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { commandPaletteFilter } from "../command-menu";
+import { commandPaletteFilter } from "../command-filter";
 
 describe("commandPaletteFilter", () => {
   it("does not match scattered subsequence letters", () => {

--- a/ui/src/components/__tests__/command-menu.test.ts
+++ b/ui/src/components/__tests__/command-menu.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { commandPaletteFilter } from "../command-menu";
+
+describe("commandPaletteFilter", () => {
+  it("does not match scattered subsequence letters", () => {
+    expect(commandPaletteFilter("job process-production abc12345", "cron", ["process-production", "abc12345"])).toBe(0);
+  });
+
+  it("matches alias substrings and word prefixes", () => {
+    expect(commandPaletteFilter("job cron-success-fast abc12345", "cron", ["cron-success-fast", "abc12345"])).toBeGreaterThan(0);
+    expect(commandPaletteFilter("job process-production abc12345", "prod", ["process-production", "abc12345"])).toBeGreaterThan(0);
+  });
+
+  it("matches short ids", () => {
+    expect(commandPaletteFilter("trigger nightly abc12345", "abc123", ["nightly", "abc12345"])).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/components/command-filter.ts
+++ b/ui/src/components/command-filter.ts
@@ -1,0 +1,31 @@
+function normalizeSearchText(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function searchWords(value: string) {
+  return normalizeSearchText(value).split(/[^a-z0-9]+/).filter(Boolean)
+}
+
+function fieldScore(field: string, term: string) {
+  const normalized = normalizeSearchText(field)
+  if (!normalized) return 0
+  if (normalized === term) return 1
+  if (normalized.startsWith(term)) return 0.9
+  if (searchWords(normalized).some((word) => word.startsWith(term))) return 0.8
+  if (normalized.includes(term)) return 0.75
+  return 0
+}
+
+export function commandPaletteFilter(value: string, search: string, keywords?: string[]) {
+  const terms = searchWords(search)
+  if (terms.length === 0) return 1
+
+  const fields = [value, ...(keywords ?? [])]
+  let score = 0
+  for (const term of terms) {
+    const termScore = Math.max(...fields.map((field) => fieldScore(field, term)))
+    if (termScore === 0) return 0
+    score += termScore
+  }
+  return score / terms.length
+}

--- a/ui/src/components/command-menu.tsx
+++ b/ui/src/components/command-menu.tsx
@@ -24,38 +24,7 @@ import { useQuery } from "@tanstack/react-query"
 import { api } from "@/lib/api"
 import { shortId } from "@/lib/utils"
 import { RelativeTime } from "./relative-time"
-
-function normalizeSearchText(value: string) {
-  return value.trim().toLowerCase()
-}
-
-function searchWords(value: string) {
-  return normalizeSearchText(value).split(/[^a-z0-9]+/).filter(Boolean)
-}
-
-function fieldScore(field: string, term: string) {
-  const normalized = normalizeSearchText(field)
-  if (!normalized) return 0
-  if (normalized === term) return 1
-  if (normalized.startsWith(term)) return 0.9
-  if (searchWords(normalized).some((word) => word.startsWith(term))) return 0.8
-  if (normalized.includes(term)) return 0.75
-  return 0
-}
-
-export function commandPaletteFilter(value: string, search: string, keywords?: string[]) {
-  const terms = searchWords(search)
-  if (terms.length === 0) return 1
-
-  const fields = [value, ...(keywords ?? [])]
-  let score = 0
-  for (const term of terms) {
-    const termScore = Math.max(...fields.map((field) => fieldScore(field, term)))
-    if (termScore === 0) return 0
-    score += termScore
-  }
-  return score / terms.length
-}
+import { commandPaletteFilter } from "./command-filter"
 
 export function CommandMenu() {
   const [open, setOpen] = React.useState(false)

--- a/ui/src/components/command-menu.tsx
+++ b/ui/src/components/command-menu.tsx
@@ -25,6 +25,38 @@ import { api } from "@/lib/api"
 import { shortId } from "@/lib/utils"
 import { RelativeTime } from "./relative-time"
 
+function normalizeSearchText(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function searchWords(value: string) {
+  return normalizeSearchText(value).split(/[^a-z0-9]+/).filter(Boolean)
+}
+
+function fieldScore(field: string, term: string) {
+  const normalized = normalizeSearchText(field)
+  if (!normalized) return 0
+  if (normalized === term) return 1
+  if (normalized.startsWith(term)) return 0.9
+  if (normalized.includes(term)) return 0.75
+  if (searchWords(normalized).some((word) => word.startsWith(term))) return 0.8
+  return 0
+}
+
+export function commandPaletteFilter(value: string, search: string, keywords?: string[]) {
+  const terms = searchWords(search)
+  if (terms.length === 0) return 1
+
+  const fields = [value, ...(keywords ?? [])]
+  let score = 0
+  for (const term of terms) {
+    const termScore = Math.max(...fields.map((field) => fieldScore(field, term)))
+    if (termScore === 0) return 0
+    score += termScore
+  }
+  return score / terms.length
+}
+
 export function CommandMenu() {
   const [open, setOpen] = React.useState(false)
   const navigate = useNavigate()
@@ -32,6 +64,19 @@ export function CommandMenu() {
   const { data: jobs } = useQuery({
     queryKey: ["jobs"],
     queryFn: api.getJobs,
+    enabled: open,
+  })
+
+  const { data: triggers } = useQuery({
+    queryKey: ["triggers"],
+    queryFn: api.getTriggers,
+    enabled: open,
+  })
+
+  const { data: atoms } = useQuery({
+    queryKey: ["atoms"],
+    queryFn: api.getAtoms,
+    enabled: open,
   })
 
   React.useEffect(() => {
@@ -65,32 +110,32 @@ export function CommandMenu() {
           <span className="text-xs">⌘</span>K
         </kbd>
       </button>
-      <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandDialog open={open} onOpenChange={setOpen} commandProps={{ filter: commandPaletteFilter }}>
         <CommandInput placeholder="Type a command or search..." />
         <CommandList>
           <CommandEmpty>No results found.</CommandEmpty>
           <CommandGroup heading="Suggestions">
-            <CommandItem onSelect={() => runCommand(() => navigate({ to: "/jobs" }))}>
+            <CommandItem value="jobs pipelines" onSelect={() => runCommand(() => navigate({ to: "/jobs" }))}>
               <LayoutDashboard className="mr-2 h-4 w-4" />
               <span>Jobs</span>
             </CommandItem>
-            <CommandItem onSelect={() => runCommand(() => navigate({ to: "/stats" }))}>
+            <CommandItem value="stats analytics" onSelect={() => runCommand(() => navigate({ to: "/stats" }))}>
               <BarChart className="mr-2 h-4 w-4" />
               <span>Stats</span>
             </CommandItem>
-            <CommandItem onSelect={() => runCommand(() => navigate({ to: "/triggers" }))}>
+            <CommandItem value="triggers schedules events" onSelect={() => runCommand(() => navigate({ to: "/triggers" }))}>
               <Radio className="mr-2 h-4 w-4" />
               <span>Triggers</span>
             </CommandItem>
-            <CommandItem onSelect={() => runCommand(() => navigate({ to: "/atoms" }))}>
+            <CommandItem value="atoms containers" onSelect={() => runCommand(() => navigate({ to: "/atoms" }))}>
               <Database className="mr-2 h-4 w-4" />
               <span>Atoms</span>
             </CommandItem>
-            <CommandItem onSelect={() => runCommand(() => navigate({ to: "/system" }))}>
+            <CommandItem value="system health nodes" onSelect={() => runCommand(() => navigate({ to: "/system" }))}>
               <Server className="mr-2 h-4 w-4" />
               <span>System</span>
             </CommandItem>
-            <CommandItem onSelect={() => runCommand(() => navigate({ to: "/jobdefs" }))}>
+            <CommandItem value="job definitions manifests yaml" onSelect={() => runCommand(() => navigate({ to: "/jobdefs" }))}>
               <FileCode2 className="mr-2 h-4 w-4" />
               <span>Job Definitions</span>
             </CommandItem>
@@ -100,6 +145,8 @@ export function CommandMenu() {
             {jobs?.map((job) => (
               <CommandItem
                 key={job.id}
+                value={`job ${job.alias} ${shortId(job.id)}`}
+                keywords={[job.alias, shortId(job.id)]}
                 onSelect={() => runCommand(() => navigate({ to: "/jobs/$jobId", params: { jobId: job.id } }))}
                 className="flex items-center justify-between"
               >
@@ -111,6 +158,44 @@ export function CommandMenu() {
                 <div className="text-[10px] text-muted-foreground">
                   <RelativeTime date={job.created_at} />
                 </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Triggers">
+            {triggers?.map((trigger) => (
+              <CommandItem
+                key={trigger.id}
+                value={`trigger ${trigger.alias} ${shortId(trigger.id)}`}
+                keywords={[trigger.alias, shortId(trigger.id), trigger.type]}
+                onSelect={() => runCommand(() => navigate({ to: "/triggers" }))}
+                className="flex items-center justify-between"
+              >
+                <div className="flex items-center">
+                  <Radio className="mr-2 h-4 w-4 text-cyan-glow" />
+                  <span>{trigger.alias}</span>
+                  <span className="ml-2 text-xs text-muted-foreground font-mono">{shortId(trigger.id)}</span>
+                </div>
+                <div className="text-[10px] uppercase text-muted-foreground">{trigger.type}</div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+          <CommandSeparator />
+          <CommandGroup heading="Atoms">
+            {atoms?.map((atom) => (
+              <CommandItem
+                key={atom.id}
+                value={`atom ${atom.image} ${atom.engine} ${shortId(atom.id)}`}
+                keywords={[atom.image, atom.engine, shortId(atom.id)]}
+                onSelect={() => runCommand(() => navigate({ to: "/atoms" }))}
+                className="flex items-center justify-between"
+              >
+                <div className="flex min-w-0 items-center">
+                  <Database className="mr-2 h-4 w-4 shrink-0 text-success" />
+                  <span className="truncate">{atom.image}</span>
+                  <span className="ml-2 text-xs text-muted-foreground font-mono">{shortId(atom.id)}</span>
+                </div>
+                <div className="text-[10px] uppercase text-muted-foreground">{atom.engine}</div>
               </CommandItem>
             ))}
           </CommandGroup>

--- a/ui/src/components/command-menu.tsx
+++ b/ui/src/components/command-menu.tsx
@@ -38,8 +38,8 @@ function fieldScore(field: string, term: string) {
   if (!normalized) return 0
   if (normalized === term) return 1
   if (normalized.startsWith(term)) return 0.9
-  if (normalized.includes(term)) return 0.75
   if (searchWords(normalized).some((word) => word.startsWith(term))) return 0.8
+  if (normalized.includes(term)) return 0.75
   return 0
 }
 

--- a/ui/src/components/ui/command.tsx
+++ b/ui/src/components/ui/command.tsx
@@ -23,11 +23,21 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
+type CommandDialogProps = DialogProps & {
+  commandProps?: React.ComponentPropsWithoutRef<typeof CommandPrimitive>;
+}
+
+const CommandDialog = ({ children, commandProps, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          {...commandProps}
+          className={cn(
+            "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5",
+            commandProps?.className,
+          )}
+        >
           {children}
         </Command>
       </DialogContent>

--- a/ui/src/features/jobs/JobsPage.tsx
+++ b/ui/src/features/jobs/JobsPage.tsx
@@ -332,20 +332,19 @@ function FilterBar({ counts, statusFilter, onStatusFilter, search, onSearch, sor
 const ACTIVITY_LABELS: Record<string, string> = {
   run_started: "Run started",
   run_completed: "Run completed",
-  run_terminal: "Run completed",
   run_failed: "Run failed",
 };
 
 function activityDotClass(type: string) {
   if (type === "run_started") return "bg-cyan-glow/80";
   if (type === "run_failed") return "bg-danger/80";
-  if (type === "run_completed" || type === "run_terminal") return "bg-success/80";
+  if (type === "run_completed") return "bg-success/80";
   return "bg-text-4";
 }
 
 function ActivityFeed({ entries }: { entries: ActivityEntry[] }) {
   return (
-    <div className="rounded-md border border-border/50 bg-card">
+    <div className="rounded-md border border-border/50 bg-card" data-testid="activity-feed">
       <div className="flex items-center gap-2 px-4 py-2.5 border-b border-border/50">
         <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">
           Live activity
@@ -354,7 +353,7 @@ function ActivityFeed({ entries }: { entries: ActivityEntry[] }) {
       </div>
       <div className="divide-y divide-border/30 max-h-64 overflow-y-auto">
         {entries.map((entry) => (
-          <div key={entry.id} className="flex items-center gap-3 px-4 py-2.5">
+          <div key={entry.id} data-testid="activity-entry" className="flex items-center gap-3 px-4 py-2.5">
             <span
               className={cn("h-1.5 w-1.5 rounded-full shrink-0", activityDotClass(entry.type))}
             />

--- a/ui/src/features/jobs/JobsPage.tsx
+++ b/ui/src/features/jobs/JobsPage.tsx
@@ -333,12 +333,14 @@ const ACTIVITY_LABELS: Record<string, string> = {
   run_started: "Run started",
   run_completed: "Run completed",
   run_failed: "Run failed",
+  run_cancelled: "Run cancelled",
 };
 
 function activityDotClass(type: string) {
   if (type === "run_started") return "bg-cyan-glow/80";
   if (type === "run_failed") return "bg-danger/80";
   if (type === "run_completed") return "bg-success/80";
+  if (type === "run_cancelled") return "bg-warning/80";
   return "bg-text-4";
 }
 

--- a/ui/src/features/jobs/useJobsView.ts
+++ b/ui/src/features/jobs/useJobsView.ts
@@ -28,6 +28,13 @@ export interface ActivityEntry {
   timestamp: string;
 }
 
+interface PendingActivityEntry {
+  type: string;
+  jobId: string;
+  runId?: string;
+  timestamp: string;
+}
+
 const STATUS_FILTERS: StatusFilter[] = ["all", "running", "succeeded", "failed", "paused"];
 const SORT_KEYS: SortKey[] = ["alias", "status", "last_run"];
 
@@ -52,8 +59,11 @@ function writeUrlParams(status: StatusFilter, q: string, sort: SortKey) {
   window.history.replaceState(null, "", url);
 }
 
-type BackendJobRun = { status: string; duration?: number };
-type JobWithLastRuns = Job & { last_runs?: BackendJobRun[] };
+function activityKey(e: CaesiumEvent, jobId: string, runId?: string) {
+  if (runId) return `${e.type}:${runId}`;
+  if (e.sequence !== undefined) return `${e.type}:sequence:${e.sequence}`;
+  return `${e.type}:${jobId}:${e.timestamp}`;
+}
 
 export function useJobsView() {
   const queryClient = useQueryClient();
@@ -65,6 +75,9 @@ export function useJobsView() {
   const [sort, setSortState] = useState<SortKey>(initial.sort);
   const [activity, setActivity] = useState<ActivityEntry[]>([]);
   const activityIdRef = useRef(0);
+  const activityKeysRef = useRef(new Set<string>());
+  const jobAliasesRef = useRef(new Map<string, string>());
+  const pendingActivityRef = useRef<PendingActivityEntry[]>([]);
 
   const setStatusFilter = useCallback((f: StatusFilter) => setStatusFilterState(f), []);
   const setSearch = useCallback((s: string) => setSearchState(s), []);
@@ -79,6 +92,57 @@ export function useJobsView() {
     queryFn: api.getJobs,
     refetchInterval: streamHealthy ? false : 15000,
   });
+
+  const appendActivity = useCallback((draft: PendingActivityEntry, alias: string) => {
+    setActivity((prev) => {
+      const entry: ActivityEntry = {
+        id: String(++activityIdRef.current),
+        type: draft.type,
+        jobId: draft.jobId,
+        jobAlias: alias,
+        runId: draft.runId,
+        timestamp: draft.timestamp,
+      };
+      return [entry, ...prev].slice(0, 20);
+    });
+  }, []);
+
+  useEffect(() => {
+    const aliases = new Map<string, string>();
+    jobs?.forEach((job) => aliases.set(job.id, job.alias));
+    jobAliasesRef.current = aliases;
+
+    if (pendingActivityRef.current.length === 0) return;
+
+    const ready: Array<{ draft: PendingActivityEntry; alias: string }> = [];
+    const pending: PendingActivityEntry[] = [];
+    pendingActivityRef.current.forEach((draft) => {
+      const alias = aliases.get(draft.jobId);
+      if (alias) {
+        ready.push({ draft, alias });
+      } else {
+        pending.push(draft);
+      }
+    });
+    pendingActivityRef.current = pending;
+
+    if (ready.length === 0) return;
+
+    setActivity((prev) => {
+      const entries = ready
+        .slice()
+        .reverse()
+        .map(({ draft, alias }) => ({
+          id: String(++activityIdRef.current),
+          type: draft.type,
+          jobId: draft.jobId,
+          jobAlias: alias,
+          runId: draft.runId,
+          timestamp: draft.timestamp,
+        }));
+      return [...entries, ...prev].slice(0, 20);
+    });
+  }, [jobs]);
 
   useEffect(() => {
     const onConnection = (healthy: boolean) => setStreamHealthy(healthy);
@@ -106,22 +170,31 @@ export function useJobsView() {
         );
       }
 
-      const alias =
-        run?.job_alias ??
-        queryClient.getQueryData<Job[]>(["jobs"])?.find((j) => j.id === jobID)?.alias ??
-        jobID;
+      const payloadAlias = run?.job_alias?.trim();
+      const cachedAlias =
+        jobAliasesRef.current.get(jobID) ??
+        queryClient.getQueryData<Job[]>(["jobs"])?.find((j) => j.id === jobID)?.alias;
+      const alias = payloadAlias || cachedAlias;
+      const runId = e.run_id ?? run?.id;
+      const key = activityKey(e, jobID, runId);
 
-      setActivity((prev) => {
-        const entry: ActivityEntry = {
-          id: String(++activityIdRef.current),
-          type: e.type,
-          jobId: jobID,
-          jobAlias: alias,
-          runId: e.run_id ?? run?.id,
-          timestamp: e.timestamp ?? new Date().toISOString(),
-        };
-        return [entry, ...prev].slice(0, 20);
-      });
+      if (activityKeysRef.current.has(key)) return;
+      activityKeysRef.current.add(key);
+
+      const draft: PendingActivityEntry = {
+        type: e.type,
+        jobId: jobID,
+        runId,
+        timestamp: e.timestamp ?? new Date().toISOString(),
+      };
+
+      if (alias) {
+        appendActivity(draft, alias);
+        return;
+      }
+
+      pendingActivityRef.current.push(draft);
+      queryClient.invalidateQueries({ queryKey: ["jobs"] });
     };
 
     const onPauseEvent = (e: CaesiumEvent) => {
@@ -153,7 +226,7 @@ export function useJobsView() {
     };
 
     events.subscribeConnection(onConnection);
-    ["run_started", "run_completed", "run_failed", "run_terminal"].forEach((t) =>
+    ["run_started", "run_completed", "run_failed"].forEach((t) =>
       events.subscribe(t, onRunEvent),
     );
     ["job_paused", "job_unpaused"].forEach((t) => events.subscribe(t, onPauseEvent));
@@ -161,13 +234,13 @@ export function useJobsView() {
 
     return () => {
       events.unsubscribeConnection(onConnection);
-      ["run_started", "run_completed", "run_failed", "run_terminal"].forEach((t) =>
+      ["run_started", "run_completed", "run_failed"].forEach((t) =>
         events.unsubscribe(t, onRunEvent),
       );
       ["job_paused", "job_unpaused"].forEach((t) => events.unsubscribe(t, onPauseEvent));
       events.unsubscribe("task_cached", onTaskCached);
     };
-  }, [queryClient]);
+  }, [appendActivity, queryClient]);
 
   const counts = useMemo<JobCounts>(() => {
     if (!jobs) return { all: 0, running: 0, succeeded: 0, failed: 0, paused: 0 };
@@ -218,7 +291,7 @@ export function useJobsView() {
 
     return sorted.map((job) => ({
       ...job,
-      lastRuns: ((job as JobWithLastRuns).last_runs ?? [])
+      lastRuns: (job.last_runs ?? [])
         .slice(-14)
         .map((r) => ({ status: r.status, duration: r.duration ?? null })),
     }));

--- a/ui/src/features/jobs/useJobsView.ts
+++ b/ui/src/features/jobs/useJobsView.ts
@@ -37,6 +37,9 @@ interface PendingActivityEntry {
 
 const STATUS_FILTERS: StatusFilter[] = ["all", "running", "succeeded", "failed", "paused"];
 const SORT_KEYS: SortKey[] = ["alias", "status", "last_run"];
+const ACTIVITY_LIMIT = 20;
+const ACTIVITY_KEY_LIMIT = 100;
+const RUN_ACTIVITY_EVENTS = ["run_started", "run_completed", "run_failed", "run_cancelled"] as const;
 
 function readUrlParams(): { status: StatusFilter; q: string; sort: SortKey } {
   const params = new URLSearchParams(window.location.search);
@@ -63,6 +66,17 @@ function activityKey(e: CaesiumEvent, jobId: string, runId?: string) {
   if (runId) return `${e.type}:${runId}`;
   if (e.sequence !== undefined) return `${e.type}:sequence:${e.sequence}`;
   return `${e.type}:${jobId}:${e.timestamp}`;
+}
+
+function rememberActivityKey(keys: Set<string>, key: string) {
+  if (keys.has(key)) return false;
+  keys.add(key);
+  while (keys.size > ACTIVITY_KEY_LIMIT) {
+    const oldest = keys.values().next().value;
+    if (oldest === undefined) break;
+    keys.delete(oldest);
+  }
+  return true;
 }
 
 export function useJobsView() {
@@ -103,7 +117,7 @@ export function useJobsView() {
         runId: draft.runId,
         timestamp: draft.timestamp,
       };
-      return [entry, ...prev].slice(0, 20);
+      return [entry, ...prev].slice(0, ACTIVITY_LIMIT);
     });
   }, []);
 
@@ -140,7 +154,7 @@ export function useJobsView() {
           runId: draft.runId,
           timestamp: draft.timestamp,
         }));
-      return [...entries, ...prev].slice(0, 20);
+      return [...entries, ...prev].slice(0, ACTIVITY_LIMIT);
     });
   }, [jobs]);
 
@@ -178,8 +192,7 @@ export function useJobsView() {
       const runId = e.run_id ?? run?.id;
       const key = activityKey(e, jobID, runId);
 
-      if (activityKeysRef.current.has(key)) return;
-      activityKeysRef.current.add(key);
+      if (!rememberActivityKey(activityKeysRef.current, key)) return;
 
       const draft: PendingActivityEntry = {
         type: e.type,
@@ -226,17 +239,13 @@ export function useJobsView() {
     };
 
     events.subscribeConnection(onConnection);
-    ["run_started", "run_completed", "run_failed"].forEach((t) =>
-      events.subscribe(t, onRunEvent),
-    );
+    RUN_ACTIVITY_EVENTS.forEach((t) => events.subscribe(t, onRunEvent));
     ["job_paused", "job_unpaused"].forEach((t) => events.subscribe(t, onPauseEvent));
     events.subscribe("task_cached", onTaskCached);
 
     return () => {
       events.unsubscribeConnection(onConnection);
-      ["run_started", "run_completed", "run_failed"].forEach((t) =>
-        events.unsubscribe(t, onRunEvent),
-      );
+      RUN_ACTIVITY_EVENTS.forEach((t) => events.unsubscribe(t, onRunEvent));
       ["job_paused", "job_unpaused"].forEach((t) => events.unsubscribe(t, onPauseEvent));
       events.unsubscribe("task_cached", onTaskCached);
     };

--- a/ui/src/features/jobs/useNavCounts.ts
+++ b/ui/src/features/jobs/useNavCounts.ts
@@ -25,19 +25,19 @@ export function useNavCounts(): NavCounts {
   const results = useQueries({
     queries: [
       {
-        queryKey: ["nav-counts", "jobs"],
+        queryKey: ["jobs"],
         queryFn: api.getJobs,
         refetchInterval: REFETCH_MS,
         staleTime: REFETCH_MS / 2,
       },
       {
-        queryKey: ["nav-counts", "triggers"],
+        queryKey: ["triggers"],
         queryFn: api.getTriggers,
         refetchInterval: REFETCH_MS,
         staleTime: REFETCH_MS / 2,
       },
       {
-        queryKey: ["nav-counts", "atoms"],
+        queryKey: ["atoms"],
         queryFn: api.getAtoms,
         refetchInterval: REFETCH_MS,
         staleTime: REFETCH_MS / 2,

--- a/ui/src/lib/__tests__/events.test.ts
+++ b/ui/src/lib/__tests__/events.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // Mock EventSource before importing events module
 class MockEventSource {
   url: string;
-  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: (() => void) | null = null;
   onerror: (() => void) | null = null;
   close = vi.fn();
   private eventListeners: Record<string, ((event: MessageEvent) => void)[]> = {};
@@ -18,6 +18,11 @@ class MockEventSource {
       this.eventListeners[type] = [];
     }
     this.eventListeners[type].push(listener);
+  }
+
+  emit(type: string, payload: unknown) {
+    const event = { data: JSON.stringify(payload) } as MessageEvent;
+    this.eventListeners[type]?.forEach((listener) => listener(event));
   }
 
   static instances: MockEventSource[] = [];
@@ -57,13 +62,9 @@ describe('EventManager', () => {
     const handler = vi.fn();
     events.subscribe('run_started', handler);
 
-    // Simulate an SSE event by triggering addEventListener callback
+    // Simulate the named SSE events emitted by the server.
     const es = MockEventSource.instances[0];
-    // The EventManager subscribes via addEventListener and onmessage
-    // Use the onmessage handler to simulate a generic event
-    es.onmessage?.({
-      data: JSON.stringify({ type: 'run_started', timestamp: '2024-01-01T00:00:00Z' }),
-    } as MessageEvent);
+    es.emit('run_started', { type: 'run_started', timestamp: '2024-01-01T00:00:00Z' });
 
     expect(handler).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'run_started' })
@@ -77,9 +78,7 @@ describe('EventManager', () => {
     events.unsubscribe('run_started', handler);
 
     const es = MockEventSource.instances[0];
-    es.onmessage?.({
-      data: JSON.stringify({ type: 'run_started', timestamp: '2024-01-01T00:00:00Z' }),
-    } as MessageEvent);
+    es.emit('run_started', { type: 'run_started', timestamp: '2024-01-01T00:00:00Z' });
 
     expect(handler).not.toHaveBeenCalled();
   });

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -16,6 +16,12 @@ export interface Job {
   updated_at: string;
   trigger?: Trigger;
   latest_run?: JobRun;
+  last_runs?: JobLastRun[];
+}
+
+export interface JobLastRun {
+  status: string;
+  duration?: number | null;
 }
 
 export interface JobRun {

--- a/ui/src/lib/events.ts
+++ b/ui/src/lib/events.ts
@@ -45,7 +45,7 @@ class EventManager {
 
     const eventTypes = [
       "job_created", "job_deleted", "job_paused", "job_unpaused",
-      "run_started", "run_completed", "run_failed", "run_terminal",
+      "run_started", "run_completed", "run_failed", "run_cancelled", "run_terminal",
       "task_started", "task_succeeded", "task_failed", "task_skipped", "task_retrying", "task_cached",
       "task_ready", "task_claimed", "task_lease_expired",
       "incident_opened", "incident_status_changed", "agent_action_recorded", "approval_requested",

--- a/ui/src/lib/events.ts
+++ b/ui/src/lib/events.ts
@@ -64,15 +64,6 @@ class EventManager {
       });
     });
 
-    this.eventSource.onmessage = (message) => {
-      try {
-        const event = JSON.parse(message.data) as CaesiumEvent;
-        this.emit(event);
-      } catch (err) {
-        console.error("Failed to parse SSE message", err);
-      }
-    };
-
     this.eventSource.onerror = () => {
       this.connected = false;
       this.lastErrorAt = Date.now();

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -8,7 +8,13 @@ import { Toaster } from '@/components/ui/sonner'
 import { ThemeProvider } from './components/theme-provider'
 import { AuthGate } from './features/auth/AuthGate'
 
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 15_000,
+    },
+  },
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- **B1**: Live Activity now drops the duplicate generic `run_terminal` event (a successful run no longer shows "Run completed" twice; a failed run no longer shows a contradictory red "Run failed" + green "Run completed" pair), resolves the job alias on a cache-cold start (no raw UUIDs), and removes the dead `onmessage` handler in `events.ts` (server emits only named SSE events) — with the `events.test.ts` simulation corrected to drive named events.
- **B2**: a global React Query `staleTime` (15s) plus nav-count hooks sharing the canonical `["jobs"]`/`["triggers"]`/`["atoms"]` keys collapse the redundant `/v1/jobs`×4 + duplicate triggers/atoms/health fetches into one in-flight request each.
- **B3**: the ⌘K palette replaces cmdk's subsequence scoring with stricter word/substring matching (alias + short-id) and indexes triggers and atoms as their own groups.
- **B4**: `/v1/jobs` returns a bounded `last_runs` history array (`[{status, duration?}]`, ≤10, oldest→newest) via **one batched `ROW_NUMBER()` window query** (not N+1); the HISTORY sparkline now renders. Ships with `test/job_list_history_test.go` asserting the field through the live server.

## Test plan
- [ ] GHA CI: `ui-test` (vitest incl. palette + events; tsc), `build-and-integration-test` (`test/job_list_history_test.go`), `ui-e2e` (Live Activity coverage in `jobs-management.spec.ts`).

_Diff cosmetically includes the W1-H1 e2e-helper (stacked branch); collapses once #300 merges first._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
