### PR TITLE
Unify not-found states and normalize wall-clock timestamps to UTC (console-v2-bug-sweep W2-α)

### DIFF
--- a/docs/exec-plans/active/console-v2-bug-sweep.md
+++ b/docs/exec-plans/active/console-v2-bug-sweep.md
@@ -341,7 +341,7 @@ sequenced after them (see `## Sequencing & Dependencies`).
       `ui/src/features/system/SystemPage.tsx` (~138 `SysKpi`).
       Notes: W1-zeta relabelled the existing Nodes KPI sub-text to
       "Tracked nodes", keeping the displayed node count honest.
-- [ ] F2. Unify the app's not-found states (issue #17 is "two inconsistent
+- [x] F2. Unify the app's not-found states (issue #17 is "two inconsistent
       404s"). (a) Add a catch-all `NotFoundComponent` (or `*` route) so unknown
       SPA paths render a coherent 404 instead of a bare/empty fallback. (b)
       Normalize the two existing per-resource not-found renders, which are
@@ -355,7 +355,10 @@ sequenced after them (see `## Sequencing & Dependencies`).
       component under `ui/src/components/`. (Note: `/api/*` paths hitting the
       SPA is expected — the real API prefix is `/v1`, which `api/ui.go` already
       excludes from the SPA fallback; no backend change needed.)
-- [ ] F3. Make wall-clock timestamps consistently labelled. Bare
+      Notes: W2-alpha added a shared `NotFoundState`, wired the root route
+      not-found component, and reused it for missing jobs/runs plus navigation
+      e2e coverage.
+- [x] F3. Make wall-clock timestamps consistently labelled. Bare
       `toLocaleString()` renders unlabelled **local** time (e.g. "Jul 2, 2026,
       10:00 AM") right next to the UTC header clock, mixing zones without
       labels. Add one shared timestamp helper/component that emits a
@@ -371,6 +374,9 @@ sequenced after them (see `## Sequencing & Dependencies`).
       `ui/src/features/jobs/components/TaskNode.tsx`,
       `ui/src/features/stats/components/TrendChart.tsx`.
       Depends on: C, D (shares `JobDetailPage.tsx` / `RunDetailPage.tsx`).
+      Notes: W2-alpha added `formatUTCTimestamp`, replaced wall-clock local
+      timestamp formatting with labelled UTC output, and added deterministic
+      vitest coverage.
 - [x] F4. Resolve short-id deep links. The list displays an 8-char id but
       `GET /v1/jobs/:id` calls `uuid.Parse` (`api/rest/controller/job/get.go`
       ~24) and 400s on anything that isn't a full UUID, so a hand-typed/shared

--- a/ui/e2e/navigation.spec.ts
+++ b/ui/e2e/navigation.spec.ts
@@ -26,3 +26,12 @@ test("sidebar navigates between every primary control-plane page", async ({ page
     await expect(page.getByRole("heading", { name: item.heading })).toBeVisible();
   }
 });
+
+test("unknown console routes render the shared not-found state", async ({ page }) => {
+  await page.goto("/definitely-missing-console-route");
+
+  await expect(page.getByTestId("not-found-state")).toBeVisible();
+  await expect(page.getByText("404")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Page not found" })).toBeVisible();
+  await expect(page.getByRole("link", { name: "Back to jobs" })).toBeVisible();
+});

--- a/ui/src/components/not-found-state.tsx
+++ b/ui/src/components/not-found-state.tsx
@@ -1,0 +1,41 @@
+import { Link } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface NotFoundStateProps {
+  title?: string;
+  subtitle?: string;
+  className?: string;
+}
+
+export function NotFoundState({
+  title = "Page not found",
+  subtitle = "The route you opened does not exist in the Caesium console.",
+  className,
+}: NotFoundStateProps) {
+  return (
+    <section
+      aria-label="Not found"
+      data-testid="not-found-state"
+      className={cn(
+        "flex min-h-[50vh] flex-col items-center justify-center gap-4 px-5 py-16 text-center",
+        className,
+      )}
+    >
+      <div className="rounded-md border border-border/70 bg-muted/40 px-3 py-1.5 font-mono text-xs font-semibold tracking-[0.2em] text-text-3">
+        404
+      </div>
+      <div className="space-y-1.5">
+        <h1 className="text-lg font-semibold text-text-1">{title}</h1>
+        <p className="max-w-sm text-[13px] text-text-3">{subtitle}</p>
+      </div>
+      <Button asChild variant="outline" size="sm">
+        <Link to="/jobs">Back to jobs</Link>
+      </Button>
+    </section>
+  );
+}
+
+export function ConsoleNotFound() {
+  return <NotFoundState />;
+}

--- a/ui/src/features/incidents/incident-utils.ts
+++ b/ui/src/features/incidents/incident-utils.ts
@@ -1,5 +1,5 @@
 import type { AgentAction, AgentSession, Incident, Job } from "@/lib/api";
-import { shortId } from "@/lib/utils";
+import { formatUTCTimestamp, shortId } from "@/lib/utils";
 
 export const INCIDENT_EVENT_TYPES = [
   "incident_opened",
@@ -57,9 +57,7 @@ export function incidentSummary(incident: Incident): string {
 
 export function formatDateTime(value?: string): string {
   if (!value) return "unknown";
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-  return parsed.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+  return formatUTCTimestamp(value, value);
 }
 
 export function formatDurationMs(ms: number): string {

--- a/ui/src/features/jobs/BackfillsView.tsx
+++ b/ui/src/features/jobs/BackfillsView.tsx
@@ -5,7 +5,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { RelativeTime } from "@/components/relative-time";
 import { api, type Backfill } from "@/lib/api";
-import { shortId } from "@/lib/utils";
+import { formatUTCTimestamp, shortId } from "@/lib/utils";
 
 interface BackfillsViewProps {
   jobId: string;
@@ -34,11 +34,7 @@ function renderBackfillStatus(backfill: Backfill) {
 }
 
 function formatDateRange(start: string, end: string): string {
-  const fmt = (s: string) =>
-    new Date(s).toLocaleString(undefined, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    });
+  const fmt = (s: string) => formatUTCTimestamp(s, s);
   return `${fmt(start)} → ${fmt(end)}`;
 }
 

--- a/ui/src/features/jobs/JobDetailPage.tsx
+++ b/ui/src/features/jobs/JobDetailPage.tsx
@@ -5,6 +5,7 @@ import { CalendarRange, FileText, FileWarning, History, List, ListOrdered, Pause
 import { stringify as yamlStringify } from "yaml";
 import { toast } from "sonner";
 import { Duration } from "@/components/duration";
+import { NotFoundState } from "@/components/not-found-state";
 import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -30,7 +31,7 @@ import { TaskMetadataPanel } from "./TaskMetadataPanel";
 import { useDagHeight } from "@/hooks/useDagHeight";
 import { api, type Atom, type Incident, type Job, type JobRun, type JobTask, type RunQueueItem, type TaskRun, type Trigger } from "@/lib/api";
 import { events, type CaesiumEvent } from "@/lib/events";
-import { formatDurationNs, formatKeyValueMap, parseJSONConfig, shortId } from "@/lib/utils";
+import { formatDurationNs, formatKeyValueMap, formatUTCTimestamp, parseJSONConfig, shortId } from "@/lib/utils";
 
 type SecondaryView = "runs" | "tasks" | "configuration" | "definition" | "backfills" | "cache" | null;
 
@@ -345,7 +346,12 @@ export function JobDetailPage() {
   }
 
   if (!job) {
-    return <div className="p-8">Job not found</div>;
+    return (
+      <NotFoundState
+        title="Job not found"
+        subtitle="The requested job could not be found or is no longer available."
+      />
+    );
   }
 
   const selectedTask = selectedTaskId ? taskDefinitions[selectedTaskId] : undefined;
@@ -746,7 +752,7 @@ function RunsView({ runs, job }: { runs: JobRun[]; job: Job }) {
         >
           <div className="space-y-1">
             <div className="flex items-center gap-2">
-              <span className="font-medium">{new Date(run.started_at).toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" })}</span>
+              <span className="font-medium">{formatUTCTimestamp(run.started_at, run.started_at)}</span>
               {run.params && Object.keys(run.params).length > 0 ? (
                 <Badge variant="outline">{Object.keys(run.params).length} params</Badge>
               ) : null}

--- a/ui/src/features/jobs/LineageGraph.tsx
+++ b/ui/src/features/jobs/LineageGraph.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/features/datasets/freshness-utils";
 import { api, type DatasetState, type ImpactNode } from "@/lib/api";
 import { usePrincipal } from "@/lib/auth";
-import { cn, shortId } from "@/lib/utils";
+import { cn, formatUTCTimestamp, shortId } from "@/lib/utils";
 
 const lineageRouteApi = getRouteApi("/lineage");
 const nodeWidth = 320;
@@ -693,7 +693,7 @@ const LineageDatasetNode = memo(({ data }: NodeProps<LineageNodeData>) => {
             ) : null}
             {data.lastSeen ? (
               <div className="truncate font-mono text-[10px]" title={data.lastSeen}>
-                {new Date(data.lastSeen).toLocaleString()}
+                {formatUTCTimestamp(data.lastSeen, data.lastSeen)}
               </div>
             ) : null}
             {data.freshnessReason ? (

--- a/ui/src/features/jobs/RunDetailPage.tsx
+++ b/ui/src/features/jobs/RunDetailPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, ArrowLeftRight, ChevronDown, ChevronRight, RotateCcw, Square, History } from "lucide-react";
 import { toast } from "sonner";
+import { NotFoundState } from "@/components/not-found-state";
 import { RelativeTime } from "@/components/relative-time";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -20,7 +21,7 @@ import { useDagHeight } from "@/hooks/useDagHeight";
 import { api, type Atom, type CallbackRun, type Incident, type JobRun, type JobTask, type TaskRun } from "@/lib/api";
 import { usePrincipal } from "@/lib/auth";
 import { events, type CaesiumEvent } from "@/lib/events";
-import { shortId } from "@/lib/utils";
+import { formatUTCTimestamp, shortId } from "@/lib/utils";
 import { getRunCacheStats } from "./cache-utils";
 import { JobDAG } from "./JobDAG";
 import { ReceiptPanel } from "./ReceiptPanel";
@@ -267,7 +268,14 @@ export function RunDetailPage() {
     );
   }
 
-  if (!run) return <div className="p-8 text-text-3">Run not found</div>;
+  if (!run) {
+    return (
+      <NotFoundState
+        title="Run not found"
+        subtitle="The requested run could not be found or is no longer available."
+      />
+    );
+  }
 
   const selectedTask = selectedTaskId ? taskDefinitions[selectedTaskId] : undefined;
   const selectedRunTask = selectedTaskId ? runTasks[selectedTaskId] : undefined;
@@ -549,7 +557,7 @@ function runSortTimestamp(run: JobRun): number {
 
 function formatRunTimestamp(run: JobRun): string {
   const parsed = parseTimestamp(run.started_at) ?? parseTimestamp(run.created_at);
-  return parsed !== undefined ? new Date(parsed).toLocaleString() : "Unknown start time";
+  return parsed !== undefined ? formatUTCTimestamp(parsed, "Unknown start time") : "Unknown start time";
 }
 
 function parseTimestamp(value: string | undefined): number | undefined {

--- a/ui/src/features/jobs/RunDiffView.tsx
+++ b/ui/src/features/jobs/RunDiffView.tsx
@@ -7,7 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { Skeleton } from "@/components/ui/skeleton";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { api, type FieldChange, type RunDiffTask, type RunDiffVerdict, type WhyTrigger } from "@/lib/api";
-import { cn, shortId } from "@/lib/utils";
+import { cn, formatUTCTimestamp, shortId } from "@/lib/utils";
 
 export interface RunDiffViewProps {
   jobId: string;
@@ -102,7 +102,7 @@ export function RunDiffView({ jobId, leftRunId, rightRunId }: RunDiffViewProps) 
           <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-text-3">
             <span className="font-mono text-text-4 text-[10px]">{diff.jobId}</span>
             <span className="text-text-4">·</span>
-            <span>{new Date(diff.generatedAt).toLocaleString()}</span>
+            <span>{formatUTCTimestamp(diff.generatedAt, diff.generatedAt)}</span>
           </div>
         </div>
         <div className="flex w-fit max-w-full items-start gap-1.5 rounded-md border border-primary/30 bg-primary/5 px-2.5 py-1.5 text-xs font-medium text-primary">

--- a/ui/src/features/jobs/TaskDetailPanel.tsx
+++ b/ui/src/features/jobs/TaskDetailPanel.tsx
@@ -11,7 +11,7 @@ import {
   TimerReset,
 } from "lucide-react";
 import { toast } from "sonner";
-import { cn, formatDurationNs, formatKeyValueMap } from "@/lib/utils";
+import { cn, formatDurationNs, formatKeyValueMap, formatUTCTimestamp } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -290,10 +290,10 @@ export function TaskDetailPanel({
                         </Link>
                       ) : null}
                       {runTask?.cache_created_at ? (
-                        <span>cached {new Date(runTask.cache_created_at).toLocaleString()}</span>
+                        <span>cached {formatUTCTimestamp(runTask.cache_created_at, runTask.cache_created_at)}</span>
                       ) : null}
                       {runTask?.cache_expires_at ? (
-                        <span>expires {new Date(runTask.cache_expires_at).toLocaleString()}</span>
+                        <span>expires {formatUTCTimestamp(runTask.cache_expires_at, runTask.cache_expires_at)}</span>
                       ) : null}
                     </div>
                   </div>
@@ -459,11 +459,7 @@ function formatAttempts(runTask?: TaskRun): string {
 }
 
 function formatRetryAfter(value: string): string {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  return parsed.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+  return formatUTCTimestamp(value, value);
 }
 
 function getInitialPanelWidth() {

--- a/ui/src/features/jobs/TaskMetadataPanel.tsx
+++ b/ui/src/features/jobs/TaskMetadataPanel.tsx
@@ -1,5 +1,5 @@
 import type { JobTask, TaskRun } from "@/lib/api";
-import { formatDurationNs, formatKeyValueMap } from "@/lib/utils";
+import { formatDurationNs, formatKeyValueMap, formatUTCTimestamp } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { isTaskCached } from "./cache-utils";
@@ -35,8 +35,8 @@ export function TaskMetadataPanel({ task, runTask, taskType, framed = true }: Ta
         <MetadataRow label="Node Selector" value={formatKeyValueMap((task?.node_selector || runTask?.node_selector) as Record<string, unknown>)} />
         <MetadataRow label="Outstanding Predecessors" value={String(runTask?.outstanding_predecessors ?? 0)} mono />
         {runTask?.cache_origin_run_id ? <MetadataRow label="Source Run" value={runTask.cache_origin_run_id} mono /> : null}
-        {runTask?.cache_created_at ? <MetadataRow label="Cached At" value={new Date(runTask.cache_created_at).toLocaleString()} /> : null}
-        {runTask?.cache_expires_at ? <MetadataRow label="Cache Expires" value={new Date(runTask.cache_expires_at).toLocaleString()} /> : null}
+        {runTask?.cache_created_at ? <MetadataRow label="Cached At" value={formatUTCTimestamp(runTask.cache_created_at, runTask.cache_created_at)} /> : null}
+        {runTask?.cache_expires_at ? <MetadataRow label="Cache Expires" value={formatUTCTimestamp(runTask.cache_expires_at, runTask.cache_expires_at)} /> : null}
         {runTask?.error ? <MetadataRow label="Error" value={runTask.error} className="md:col-span-2" /> : null}
         {runTask?.output && Object.keys(runTask.output).length > 0 ? (
           <div className="md:col-span-2">
@@ -83,11 +83,7 @@ function formatAttempts(runTask?: TaskRun): string {
 }
 
 function formatRetryAfter(value: string): string {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  return parsed.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+  return formatUTCTimestamp(value, value);
 }
 
 interface MetadataRowProps {

--- a/ui/src/features/jobs/TaskWhyView.tsx
+++ b/ui/src/features/jobs/TaskWhyView.tsx
@@ -15,7 +15,7 @@ import {
   type WhyTrigger,
   type WhyVerdict,
 } from "@/lib/api";
-import { cn, shortId } from "@/lib/utils";
+import { cn, formatUTCTimestamp, shortId } from "@/lib/utils";
 
 interface TaskWhyViewProps {
   jobId: string;
@@ -461,5 +461,5 @@ function formatVerdict(verdict: WhyVerdict) {
 }
 
 function formatDateTime(value: string) {
-  return new Date(value).toLocaleString();
+  return formatUTCTimestamp(value, value);
 }

--- a/ui/src/features/jobs/components/TaskNode.tsx
+++ b/ui/src/features/jobs/components/TaskNode.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
 import { isRecord } from '@/lib/typeGuards';
-import { cn, shortId } from '@/lib/utils';
+import { cn, formatUTCTimestamp, shortId } from '@/lib/utils';
 import {
   Activity,
   CheckCircle2,
@@ -249,11 +249,7 @@ function formatRetryAfter(value: unknown) {
   if (typeof value !== 'string' || value.trim() === '') {
     return 'the current window resets';
   }
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return value;
-  }
-  return parsed.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+  return formatUTCTimestamp(value, value);
 }
 
 function getRuntimeHints(spec: unknown) {

--- a/ui/src/features/stats/components/TrendChart.tsx
+++ b/ui/src/features/stats/components/TrendChart.tsx
@@ -10,6 +10,9 @@ import {
   Legend,
 } from 'recharts';
 import type { DailyStats } from '@/lib/api';
+import { formatUTCTimestamp } from '@/lib/utils';
+
+const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 interface TrendChartProps {
   data: DailyStats[];
@@ -17,17 +20,11 @@ interface TrendChartProps {
 
 function formatDateLabel(value: string) {
   if (value.includes('T')) {
-    const date = new Date(value);
-    return new Intl.DateTimeFormat(undefined, {
-      hour: 'numeric',
-    }).format(date);
+    return formatUTCTimestamp(value, value);
   }
   const [year, month, day] = value.split('-').map(Number);
   if (!year || !month || !day) return value;
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-  }).format(new Date(year, month - 1, day));
+  return `${MONTH_LABELS[month - 1] ?? String(month)} ${day}`;
 }
 
 export function TrendChart({ data }: TrendChartProps) {

--- a/ui/src/features/stats/components/TrendChart.tsx
+++ b/ui/src/features/stats/components/TrendChart.tsx
@@ -10,7 +10,6 @@ import {
   Legend,
 } from 'recharts';
 import type { DailyStats } from '@/lib/api';
-import { formatUTCTimestamp } from '@/lib/utils';
 
 const MONTH_LABELS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -20,7 +19,14 @@ interface TrendChartProps {
 
 function formatDateLabel(value: string) {
   if (value.includes('T')) {
-    return formatUTCTimestamp(value, value);
+    // Intraday tick: keep a compact UTC hour (e.g. "10 AM") so 24 hourly ticks
+    // don't overlap on the axis; the full UTC timestamp is far too wide here.
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) return value;
+    const hour = parsed.getUTCHours();
+    const suffix = hour < 12 ? 'AM' : 'PM';
+    const hour12 = hour % 12 === 0 ? 12 : hour % 12;
+    return `${hour12} ${suffix}`;
   }
   const [year, month, day] = value.split('-').map(Number);
   if (!year || !month || !day) return value;

--- a/ui/src/lib/__tests__/utils.test.ts
+++ b/ui/src/lib/__tests__/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { formatUTCTimestamp } from "../utils";
+
+describe("formatUTCTimestamp", () => {
+  it("formats a fixed instant as a labelled UTC wall-clock timestamp", () => {
+    expect(formatUTCTimestamp(Date.UTC(2026, 6, 2, 10, 0, 5))).toBe(
+      "2026-07-02 10:00:05 UTC",
+    );
+  });
+
+  it("returns the fallback for invalid timestamps", () => {
+    expect(formatUTCTimestamp("not-a-date", "unavailable")).toBe("unavailable");
+  });
+});

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -60,3 +60,23 @@ export function shortId(value?: string | null, length = 8): string {
 
   return value.slice(0, length)
 }
+
+function padUTC(value: number): string {
+  return String(value).padStart(2, "0")
+}
+
+export function formatUTCTimestamp(
+  value: string | number | Date,
+  fallback = "Unknown time",
+): string {
+  const date = value instanceof Date ? value : new Date(value)
+  if (!Number.isFinite(date.getTime())) {
+    return fallback
+  }
+
+  return [
+    `${date.getUTCFullYear()}-${padUTC(date.getUTCMonth() + 1)}-${padUTC(date.getUTCDate())}`,
+    `${padUTC(date.getUTCHours())}:${padUTC(date.getUTCMinutes())}:${padUTC(date.getUTCSeconds())}`,
+    "UTC",
+  ].join(" ")
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, createRoute, createRouter, redirect } from "@tanstack/react-router";
 import { AppShell } from "./components/layout/AppShell";
+import { ConsoleNotFound } from "./components/not-found-state";
 import { AtomsPage } from "./features/atoms/AtomsPage";
 import { DatabaseConsolePage } from "./features/database/DatabaseConsolePage";
 import { DatasetsPage } from "./features/datasets/DatasetsPage";
@@ -21,6 +22,7 @@ import { normalizeStatusFilter } from "./features/datasets/freshness-utils";
 
 const rootRoute = createRootRoute({
   component: AppShell,
+  notFoundComponent: ConsoleNotFound,
 });
 
 const indexRoute = createRoute({


### PR DESCRIPTION
## Summary
- **F2**: unifies the app not-found states — a root `notFoundComponent` catch-all for unknown SPA routes plus a shared `NotFoundState` component reused by the per-resource "Job not found" / "Run not found" renders (previously inconsistently styled).
- **F3**: adds `formatUTCTimestamp` (shared, UTC, labelled date+time) and replaces the bare `toLocaleString()` local-time call sites across 11 run/task/lineage/stats files so wall-clock timestamps are consistently UTC-labelled next to the header clock.
- Vitest for the timestamp helper; a `navigation.spec.ts` e2e asserting the unknown-route 404. Closes Stream F (F2/F3); Streams A–E already merged.

## Test plan
- [x] eslint + tsc + vite build (orchestrator, local)
- [ ] GHA CI: ui-lint, ui-test, ui-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
