### PR TITLE
Address post-merge review nits for console-v2-bug-sweep (review-followups)

### DIFF
--- a/api/rest/service/job/job.go
+++ b/api/rest/service/job/job.go
@@ -202,7 +202,7 @@ func (j *jobService) GetByIDPrefix(rawID string) (*models.Job, error) {
 }
 
 func isCanonicalUUIDPrefix(prefix string) bool {
-	if len(prefix) > 36 {
+	if len(prefix) == 0 || len(prefix) > 36 {
 		return false
 	}
 	for i, r := range prefix {
@@ -225,7 +225,7 @@ func isHexRune(r rune) bool {
 }
 
 func (j *jobService) attachLatestRun(job *models.Job) {
-	runStore := runstorage.NewStore(j.db)
+	runStore := runstorage.NewStore(j.db.WithContext(j.ctx))
 	if latest, err := runStore.Latest(job.ID); err == nil && latest != nil {
 		job.LatestRun = &models.JobRun{
 			ID:            latest.ID,

--- a/ui/e2e/helpers/fixtures.ts
+++ b/ui/e2e/helpers/fixtures.ts
@@ -167,11 +167,11 @@ export async function triggerJob(
 ): Promise<void> {
   const options = normalizeTriggerJobOptions(params);
   const job = await getJob(request, jobId);
-  if (!job.trigger_id) {
-    throw new Error(`job ${jobId} did not include trigger_id`);
-  }
 
   if (job.trigger?.type === "http") {
+    if (!job.trigger_id) {
+      throw new Error(`job ${jobId} did not include trigger_id`);
+    }
     await fireHTTPTrigger(request, jobId, job.trigger_id, options);
     return;
   }

--- a/ui/src/features/jobs/RunDetailPage.tsx
+++ b/ui/src/features/jobs/RunDetailPage.tsx
@@ -574,7 +574,7 @@ function CallbackRunsSection({ callbacks }: { callbacks: CallbackRun[] }) {
       </CardHeader>
       <CardContent className="space-y-2">
         {callbacks.map((callback) => {
-          const failed = callback.status.toLowerCase() === "failed";
+          const failed = callback.status?.toLowerCase() === "failed";
           return (
             <div
               key={callback.id}

--- a/ui/src/lib/__tests__/utils.test.ts
+++ b/ui/src/lib/__tests__/utils.test.ts
@@ -11,4 +11,10 @@ describe("formatUTCTimestamp", () => {
   it("returns the fallback for invalid timestamps", () => {
     expect(formatUTCTimestamp("not-a-date", "unavailable")).toBe("unavailable");
   });
+
+  it("returns the fallback for null, undefined, or empty input", () => {
+    expect(formatUTCTimestamp(null, "unavailable")).toBe("unavailable");
+    expect(formatUTCTimestamp(undefined, "unavailable")).toBe("unavailable");
+    expect(formatUTCTimestamp("", "unavailable")).toBe("unavailable");
+  });
 });

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -66,9 +66,12 @@ function padUTC(value: number): string {
 }
 
 export function formatUTCTimestamp(
-  value: string | number | Date,
+  value: string | number | Date | null | undefined,
   fallback = "Unknown time",
 ): string {
+  if (value === null || value === undefined || value === "") {
+    return fallback
+  }
   const date = value instanceof Date ? value : new Date(value)
   if (!Number.isFinite(date.getTime())) {
     return fallback


### PR DESCRIPTION
## Summary
Consolidated follow-ups for non-blocking greptile/gemini findings on the merged Console v2 bug-sweep PRs:

- `isCanonicalUUIDPrefix("")` now returns false (previously true via an empty loop), so the helper is robust independent of its caller. (#302)
- `attachLatestRun` threads the request-scoped context into the run store (`j.db.WithContext(j.ctx)`) for timeout/cancellation/tracing propagation. (#302)
- `RunDetailPage` callback status uses optional chaining (`callback.status?.toLowerCase()`) to avoid a TypeError on a null/undefined status. (#304)
- `formatUTCTimestamp` returns the fallback for null/undefined/empty input instead of rendering the 1970 epoch; adds vitest coverage for those cases. (#307)
- `fixtures.ts triggerJob` only requires `trigger_id` on the HTTP-fire path (defensive; the cron path uses /jobs/:id/run). (#302)

## Test plan
- [x] eslint + tsc + vite build + vitest utils (orchestrator, local)
- [x] gofmt clean; `j.ctx` matches the existing WithContext pattern
- [ ] GHA CI: lint, unit-test, integration, ui-lint/ui-test/ui-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
