### PR TITLE
Improve DAG node legibility: task-name-first, trivial-graph fit (console-operator-loop-ux W1-γ)

### DIFF
--- a/docs/exec-plans/active/console-operator-loop-ux.md
+++ b/docs/exec-plans/active/console-operator-loop-ux.md
@@ -226,12 +226,14 @@ render dangling input/output handles on nodes with no edges. And a "React Flow"
 attribution watermark shows bottom-right on every DAG, which reads as unbranded
 for a product surface.
 
-- [ ] C1. Promote the task name to the node's primary line — the full task name
+- [x] C1. Promote the task name to the node's primary line — the full task name
       with `text-overflow: ellipsis` + a `title` tooltip — and demote the image
       to a secondary line; stop `shortId`-truncating the label so operators scan
       the identifier they came for.
       Files: `ui/src/features/jobs/components/TaskNode.tsx`.
-- [ ] C2. Handle trivial and disconnected graphs: tighten zoom-to-fit (or render
+      Note (W1-γ): `TaskNode` now renders the task label as the primary
+      truncated/title line and moves the image to secondary metadata.
+- [x] C2. Handle trivial and disconnected graphs: tighten zoom-to-fit (or render
       a compact card) for single-node DAGs so one node no longer floats in an
       empty canvas, and hide the input/output `Handle`s on nodes with no incident
       edges (pass edge-degree into the node and render handles conditionally).
@@ -239,7 +241,10 @@ for a product surface.
       `ui/src/features/jobs/components/TaskNode.tsx`,
       `ui/src/features/jobs/components/BranchNode.tsx`.
       Depends on: C1.
-- [ ] C3. Hide the React Flow attribution watermark on every DAG
+      Note (W1-γ): `JobDAG` passes incoming/outgoing/total edge degree into DAG
+      nodes, isolated nodes hide handles, and single-node DAGs use tighter
+      `fitViewOptions`.
+- [ ] C3. (Deferred 2026-07-07 — the operator chose to keep the on-canvas watermark; no React Flow Pro subscription / OSS exception is confirmed. C1/C2 shipped without it.) Hide the React Flow attribution watermark on every DAG
       (`proOptions={{ hideAttribution: true }}` on the `ReactFlow` element) and
       drop the now-dead `.react-flow__attribution` styling.
       **Licensing gate**: xyflow's terms ask that you either keep the "React
@@ -250,6 +255,9 @@ for a product surface.
       lightweight "Powered by React Flow" credit in an About/footer surface
       rather than the on-canvas watermark, which still de-clutters the DAG.
       Files: `ui/src/features/jobs/JobDAG.tsx`, `ui/src/index.css`.
+      Note (W1-γ): implemented on-canvas attribution hiding; orchestrator still
+      needs to confirm the Pro/OSS exception stance or add the fallback footer
+      credit before publication.
 
 ### Stream D — Task log drawer
 

--- a/ui/src/features/jobs/JobDAG.tsx
+++ b/ui/src/features/jobs/JobDAG.tsx
@@ -100,6 +100,12 @@ interface EdgeDetailsState {
   contractSchema?: Record<string, unknown>;
 }
 
+interface NodeEdgeDegree {
+  incoming: number;
+  outgoing: number;
+  total: number;
+}
+
 export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, taskRunData, onNodeClick, selectedTaskId }: JobDAGProps) {
     const [selectedEdge, setSelectedEdge] = useState<EdgeDetailsState | null>(null);
     const resolvedTaskStatus = useMemo(() => {
@@ -117,6 +123,21 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
 
         return statusByTask;
     }, [taskMetadata, taskStatus]);
+
+    const edgeDegreeByNode = useMemo(() => {
+        const degreeByNode = new Map<string, NodeEdgeDegree>();
+
+        (dag.nodes ?? []).forEach((node) => {
+            degreeByNode.set(node.id, { incoming: 0, outgoing: 0, total: 0 });
+        });
+
+        (dag.edges ?? []).forEach((edge) => {
+            incrementEdgeDegree(degreeByNode, edge.from, 'outgoing');
+            incrementEdgeDegree(degreeByNode, edge.to, 'incoming');
+        });
+
+        return degreeByNode;
+    }, [dag.edges, dag.nodes]);
 
     const initialNodes: Node[] = useMemo(() => {
         if (!dag.nodes) return [];
@@ -141,11 +162,12 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
                   error: meta?.error,
                   rateLimitRetryAfter: meta?.rate_limit_retry_after,
                   taskType: n.type,
+                  edgeDegree: edgeDegreeByNode.get(n.id) ?? { incoming: 0, outgoing: 0, total: 0 },
                 },
                 position: { x: 0, y: 0 }
             }
         });
-    }, [dag, atoms, taskDefinitions, resolvedTaskStatus, taskMetadata, selectedTaskId]);
+    }, [dag, atoms, taskDefinitions, resolvedTaskStatus, taskMetadata, selectedTaskId, edgeDegreeByNode]);
 
     const initialEdges: Edge[] = useMemo(() => {
         if (!dag.edges) return [];
@@ -211,6 +233,15 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
         [initialNodes, initialEdges]
     );
 
+    const isSingleNodeDAG = layoutedNodes.length === 1 && layoutedEdges.length === 0;
+    const fitViewOptions = useMemo(
+      () => ({
+        padding: isSingleNodeDAG ? 0.06 : 0.2,
+        maxZoom: isSingleNodeDAG ? 2.2 : 1.5,
+      }),
+      [isSingleNodeDAG]
+    );
+
     const handleNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
       onNodeClick?.(node.id);
     }, [onNodeClick]);
@@ -225,9 +256,9 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
           edgeTypes={edgeTypes}
           onNodeClick={handleNodeClick}
           fitView
-          fitViewOptions={{ padding: 0.2 }}
+          fitViewOptions={fitViewOptions}
           minZoom={0.1}
-          maxZoom={1.5}
+          maxZoom={isSingleNodeDAG ? 2.2 : 1.5}
         >
           <Background gap={20} />
           <Controls />
@@ -249,6 +280,13 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
       </Dialog>
     </>
   );
+}
+
+function incrementEdgeDegree(degreeByNode: Map<string, NodeEdgeDegree>, nodeId: string, direction: 'incoming' | 'outgoing') {
+    const degree = degreeByNode.get(nodeId) ?? { incoming: 0, outgoing: 0, total: 0 };
+    degree[direction] += 1;
+    degree.total += 1;
+    degreeByNode.set(nodeId, degree);
 }
 
 function normalizeTaskStatus(status?: string) {

--- a/ui/src/features/jobs/__tests__/JobDAG.test.tsx
+++ b/ui/src/features/jobs/__tests__/JobDAG.test.tsx
@@ -8,15 +8,27 @@ vi.mock("reactflow", () => {
     nodes = [],
     edges = [],
     onNodeClick,
+    fitViewOptions,
+    maxZoom,
+    proOptions,
   }: {
     nodes?: Array<Record<string, unknown>>;
     edges?: Array<Record<string, unknown>>;
     onNodeClick?: (event: React.MouseEvent, node: Record<string, unknown>) => void;
+    fitViewOptions?: Record<string, unknown>;
+    maxZoom?: number;
+    proOptions?: { hideAttribution?: boolean };
   }) => (
-    <div data-testid="reactflow-mock">
+    <div
+      data-testid="reactflow-mock"
+      data-fit-view-padding={String(fitViewOptions?.padding ?? "")}
+      data-fit-view-max-zoom={String(fitViewOptions?.maxZoom ?? "")}
+      data-max-zoom={String(maxZoom ?? "")}
+    >
       {nodes.map((node) => {
         const id = String(node.id);
         const data = (node.data ?? {}) as Record<string, unknown>;
+        const edgeDegree = (data.edgeDegree ?? {}) as Record<string, unknown>;
         return (
           <button
             key={id}
@@ -25,6 +37,9 @@ vi.mock("reactflow", () => {
             data-node-type={String(node.type)}
             data-status={String(data.status ?? "")}
             data-selected={String(Boolean(data.isSelected))}
+            data-edge-incoming={String(edgeDegree.incoming ?? "")}
+            data-edge-outgoing={String(edgeDegree.outgoing ?? "")}
+            data-edge-total={String(edgeDegree.total ?? "")}
             onClick={(event) => onNodeClick?.(event, node)}
           >
             {String(data.label ?? id)}
@@ -50,6 +65,9 @@ vi.mock("reactflow", () => {
           />
         );
       })}
+      {proOptions?.hideAttribution ? null : (
+        <div className="react-flow__attribution">React Flow</div>
+      )}
     </div>
   );
 
@@ -181,6 +199,23 @@ describe("JobDAG", () => {
     expect(screen.getByTestId("node-task-1")).toHaveTextContent("extract");
   });
 
+  it("tightens single-node DAGs and passes zero edge degree", () => {
+    const dag: JobDAGResponse = {
+      job_id: "job-1",
+      nodes: [{ id: "task-1", atom_id: "atom-1" }],
+      edges: [],
+    };
+
+    render(<JobDAG dag={dag} atoms={atoms} />);
+
+    expect(screen.getByTestId("reactflow-mock")).toHaveAttribute("data-fit-view-padding", "0.06");
+    expect(screen.getByTestId("reactflow-mock")).toHaveAttribute("data-fit-view-max-zoom", "2.2");
+    expect(screen.getByTestId("reactflow-mock")).toHaveAttribute("data-max-zoom", "2.2");
+    expect(screen.getByTestId("node-task-1")).toHaveAttribute("data-edge-incoming", "0");
+    expect(screen.getByTestId("node-task-1")).toHaveAttribute("data-edge-outgoing", "0");
+    expect(screen.getByTestId("node-task-1")).toHaveAttribute("data-edge-total", "0");
+  });
+
   it("marks output-bearing contract edges and skipped branch paths", () => {
     const dag: JobDAGResponse = {
       job_id: "job-1",
@@ -220,6 +255,10 @@ describe("JobDAG", () => {
     );
 
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-output-count", "2");
+    expect(screen.getByTestId("node-task-1")).toHaveAttribute("data-edge-incoming", "0");
+    expect(screen.getByTestId("node-task-1")).toHaveAttribute("data-edge-outgoing", "1");
+    expect(screen.getByTestId("node-task-2")).toHaveAttribute("data-edge-incoming", "1");
+    expect(screen.getByTestId("node-task-2")).toHaveAttribute("data-edge-outgoing", "0");
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-contract-defined", "true");
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-stroke", "hsl(var(--text-3))");
     expect(screen.getByTestId("edge-task-1-task-2")).toHaveAttribute("data-dasharray", "6 3");

--- a/ui/src/features/jobs/components/BranchNode.tsx
+++ b/ui/src/features/jobs/components/BranchNode.tsx
@@ -21,6 +21,7 @@ import { Duration } from '@/components/duration';
 export const BranchNode = memo(({ data }: NodeProps) => {
   const { label, atom, status, isSelected, startedAt, completedAt, engine, command, error } = data;
   const taskLabel = typeof label === 'string' ? label : '';
+  const { showTargetHandle, showSourceHandle } = getHandleVisibility(data.edgeDegree);
 
   const getStatusIcon = () => {
     switch (status) {
@@ -101,7 +102,14 @@ export const BranchNode = memo(({ data }: NodeProps) => {
         isSelected ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''
       )}
     >
-      <Handle type="target" position={Position.Left} className="h-3 w-3 border-2 border-dag-bg bg-gold" />
+      {showTargetHandle ? (
+        <Handle
+          data-testid="branch-node-target-handle"
+          type="target"
+          position={Position.Left}
+          className="h-3 w-3 border-2 border-dag-bg bg-gold"
+        />
+      ) : null}
 
       <div className="flex h-full flex-col gap-2">
         {/* Row 1: Image & Status */}
@@ -187,9 +195,38 @@ export const BranchNode = memo(({ data }: NodeProps) => {
         </div>
       </div>
 
-      <Handle type="source" position={Position.Right} className="h-3 w-3 border-2 border-dag-bg bg-gold" />
+      {showSourceHandle ? (
+        <Handle
+          data-testid="branch-node-source-handle"
+          type="source"
+          position={Position.Right}
+          className="h-3 w-3 border-2 border-dag-bg bg-gold"
+        />
+      ) : null}
     </div>
   );
 });
 
 BranchNode.displayName = 'BranchNode';
+
+function getHandleVisibility(edgeDegree: unknown) {
+  if (!isEdgeDegree(edgeDegree)) {
+    return {
+      showTargetHandle: true,
+      showSourceHandle: true,
+    };
+  }
+
+  return {
+    showTargetHandle: readEdgeCount(edgeDegree.incoming) > 0,
+    showSourceHandle: readEdgeCount(edgeDegree.outgoing) > 0,
+  };
+}
+
+function isEdgeDegree(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readEdgeCount(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}

--- a/ui/src/features/jobs/components/TaskNode.tsx
+++ b/ui/src/features/jobs/components/TaskNode.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
 import { isRecord } from '@/lib/typeGuards';
-import { cn, formatUTCTimestamp, shortId } from '@/lib/utils';
+import { cn, formatUTCTimestamp } from '@/lib/utils';
 import {
   Activity,
   CheckCircle2,
@@ -26,6 +26,7 @@ export const TaskNode = memo(({ data }: NodeProps) => {
   const { label, atom, status, isSelected, startedAt, completedAt, engine, command, error, rateLimitRetryAfter } = data;
   const taskLabel = typeof label === 'string' ? label : '';
   const runtimeHints = getRuntimeHints(atom?.spec);
+  const { showTargetHandle, showSourceHandle } = getHandleVisibility(data.edgeDegree);
 
   const getStatusIcon = () => {
     switch (status) {
@@ -110,20 +111,30 @@ export const TaskNode = memo(({ data }: NodeProps) => {
         isSelected ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : ''
       )}
     >
-      <Handle type="target" position={Position.Left} className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan" />
+      {showTargetHandle ? (
+        <Handle
+          data-testid="task-node-target-handle"
+          type="target"
+          position={Position.Left}
+          className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan"
+        />
+      ) : null}
 
       <div className="flex h-full flex-col gap-2">
-        {/* Row 1: Image & Status */}
         <div className="flex min-h-[44px] items-start justify-between gap-3">
-          <div className="flex items-center gap-2 overflow-hidden">
+          <div className="flex min-w-0 items-center gap-2 overflow-hidden">
             <div className="rounded-lg border border-caesium-cyan/20 bg-muted p-1.5 shadow-inner shadow-caesium-cyan/10">
               {getEngineIcon()}
             </div>
-            <div className="flex flex-col min-w-0">
-              <span className="text-[11px] font-bold truncate text-foreground" title={atom?.image}>
-                {shortImage(atom?.image)}
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span
+                data-testid="task-node-label"
+                className="block truncate text-[13px] font-bold leading-5 text-foreground"
+                title={taskLabel}
+              >
+                {taskLabel}
               </span>
-              <div className="flex items-center gap-1">
+              <div className="mt-0.5 flex min-w-0 items-center gap-1">
                 {isShell && (
                   <span className="rounded border border-caesium-cyan/40 bg-caesium-cyan/15 px-1 text-[8px] font-black tracking-tighter text-caesium-cyan">
                     SHELL
@@ -149,8 +160,12 @@ export const TaskNode = memo(({ data }: NodeProps) => {
                     SA
                   </span>
                 )}
-                <span className="truncate text-[9px] font-mono text-muted-foreground">
-                  {shortId(taskLabel)}
+                <span
+                  data-testid="task-node-image"
+                  className="truncate text-[9px] font-mono text-muted-foreground"
+                  title={atom?.image}
+                >
+                  {shortImage(atom?.image)}
                 </span>
               </div>
             </div>
@@ -238,7 +253,14 @@ export const TaskNode = memo(({ data }: NodeProps) => {
         </div>
       </div>
 
-      <Handle type="source" position={Position.Right} className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan" />
+      {showSourceHandle ? (
+        <Handle
+          data-testid="task-node-source-handle"
+          type="source"
+          position={Position.Right}
+          className="h-3 w-3 border-2 border-dag-bg bg-caesium-cyan"
+        />
+      ) : null}
     </div>
   );
 });
@@ -250,6 +272,24 @@ function formatRetryAfter(value: unknown) {
     return 'the current window resets';
   }
   return formatUTCTimestamp(value, value);
+}
+
+function getHandleVisibility(edgeDegree: unknown) {
+  if (!isRecord(edgeDegree)) {
+    return {
+      showTargetHandle: true,
+      showSourceHandle: true,
+    };
+  }
+
+  return {
+    showTargetHandle: readEdgeCount(edgeDegree.incoming) > 0,
+    showSourceHandle: readEdgeCount(edgeDegree.outgoing) > 0,
+  };
+}
+
+function readEdgeCount(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 function getRuntimeHints(spec: unknown) {

--- a/ui/src/features/jobs/components/__tests__/TaskNode.test.tsx
+++ b/ui/src/features/jobs/components/__tests__/TaskNode.test.tsx
@@ -36,6 +36,28 @@ describe('TaskNode', () => {
     expect(screen.getByTestId('status-icon-succeeded')).toBeInTheDocument();
   });
 
+  it('renders the full task name as the primary truncated line', () => {
+    const taskName = 'bootstrap-operator-live-state-collector';
+
+    renderTaskNode({
+      label: taskName,
+      status: 'pending',
+      atom: { image: 'alpine:3.23', engine: 'docker', command: [] },
+      engine: 'docker',
+      command: [],
+    });
+
+    const primaryLabel = screen.getByTestId('task-node-label');
+    expect(primaryLabel).toHaveTextContent(taskName);
+    expect(primaryLabel).toHaveAttribute('title', taskName);
+    expect(primaryLabel).toHaveClass('truncate');
+    expect(screen.queryByText('bootstra')).not.toBeInTheDocument();
+
+    const imageLabel = screen.getByTestId('task-node-image');
+    expect(imageLabel).toHaveTextContent('alpine:3.23');
+    expect(imageLabel).toHaveClass('truncate');
+  });
+
   it('renders task with failed status and shows error info', () => {
     renderTaskNode({
       label: 'task-def456',
@@ -121,6 +143,20 @@ describe('TaskNode', () => {
 
     expect(screen.queryByText('IN')).not.toBeInTheDocument();
     expect(screen.queryByText('OUT')).not.toBeInTheDocument();
+  });
+
+  it('hides dangling handles on nodes with no incident edges', () => {
+    renderTaskNode({
+      label: 'single-task',
+      status: 'pending',
+      atom: { image: 'alpine:3.23', engine: 'docker', command: [] },
+      engine: 'docker',
+      command: [],
+      edgeDegree: { incoming: 0, outgoing: 0, total: 0 },
+    });
+
+    expect(screen.queryByTestId('task-node-target-handle')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('task-node-source-handle')).not.toBeInTheDocument();
   });
 
   it('renders runtime badges for resolved volumes and Kubernetes identity', () => {


### PR DESCRIPTION
## Summary
- **C1**: the task name is now the node's primary line (full name, `text-overflow: ellipsis` + `title` tooltip); the image drops to a secondary line and is no longer shortId-truncated.
- **C2**: single-node DAGs zoom-to-fit tightly (no lone node floating in an empty canvas), and input/output handles are hidden on nodes with no incident edges (edge-degree threaded into TaskNode/BranchNode).
- **C3 (deferred)**: watermark removal is NOT shipped — per operator decision the on-canvas React Flow attribution is kept (no Pro/OSS exception confirmed). index.css + proOptions reverted; C3 unchecked in the plan.
- Tests: `TaskNode.test.tsx` / `JobDAG.test.tsx` cover the name-first line and single-node fit + zero-edge handles.

## Test plan
- [x] eslint + tsc + vite build + vitest (JobDAG, TaskNode) — orchestrator local
- [ ] GHA CI: ui-lint, ui-test, ui-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
