### PR TITLE
Add race-safe RBAC-gated queue-cancel endpoint (console-operator-loop-ux W1-ζ/B5)

### DIFF
--- a/api/middleware/auth.go
+++ b/api/middleware/auth.go
@@ -385,6 +385,8 @@ func auditActionForRoute(method, routePath string) string {
 		return auth.ActionRunTrigger
 	case "GET /v1/jobs/:id/queue":
 		return auth.ActionRunQueueRead
+	case "DELETE /v1/jobs/:id/queue/:id":
+		return auth.ActionRunQueueCancel
 	case "POST /v1/jobs/:id/runs/:id/retry":
 		return auth.ActionRunRetry
 	case "POST /v1/jobs/:id/backfill":

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -459,9 +459,17 @@ func TestAuthRejectsBadSessionCSRFRecordsFailureAndAudit(t *testing.T) {
 func requireAuditReason(t *testing.T, entry models.AuditLog, want string) {
 	t.Helper()
 
+	requireAuditMetadata(t, entry, map[string]any{"reason": want})
+}
+
+func requireAuditMetadata(t *testing.T, entry models.AuditLog, want map[string]any) {
+	t.Helper()
+
 	var metadata map[string]any
 	require.NoError(t, json.Unmarshal(entry.Metadata, &metadata))
-	require.Equal(t, want, metadata["reason"])
+	for key, value := range want {
+		require.Equal(t, value, metadata[key], "audit metadata %s", key)
+	}
 }
 
 func TestMiddlewareRejectsExpiredKey(t *testing.T) {
@@ -683,6 +691,117 @@ func TestMiddlewareScopedJobRouteRejectsOutOfScopeAlias(t *testing.T) {
 	he, ok := err.(*echo.HTTPError)
 	require.True(t, ok)
 	require.Equal(t, http.StatusForbidden, he.Code)
+}
+
+func TestMiddlewareScopedQueueCancelAllowsInScopeOperatorAndAudits(t *testing.T) {
+	db, svc, auditor, limiter, _ := setupAuth(t)
+	jobID, _, _ := seedJobFixtures(t, db, "alpha")
+	queueID := uuid.New()
+	key := createKey(t, svc, models.RoleOperator, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/jobs/"+jobID.String()+"/queue/"+queueID.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs/:id/queue/:queue_id", Method: http.MethodDelete},
+		echo.PathValues{
+			{Name: "id", Value: jobID.String()},
+			{Name: "queue_id", Value: queueID.String()},
+		},
+		func(c *echo.Context) error {
+			return c.NoContent(http.StatusNoContent)
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, rec.Code)
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Action: auth.ActionRunQueueCancel, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	require.Equal(t, auth.OutcomeSuccess, entries[0].Outcome)
+	require.Equal(t, "job", entries[0].ResourceType)
+	require.Equal(t, "alpha", entries[0].ResourceID)
+	requireAuditMetadata(t, entries[0], map[string]any{
+		"method": "DELETE",
+		"path":   "/v1/jobs/:id/queue/:id",
+	})
+}
+
+func TestMiddlewareScopedQueueCancelRejectsOutOfScopeOperator(t *testing.T) {
+	db, svc, auditor, limiter, _ := setupAuth(t)
+	jobID, _, _ := seedJobFixtures(t, db, "alpha")
+	queueID := uuid.New()
+	key := createKey(t, svc, models.RoleOperator, &models.KeyScope{Jobs: []string{"beta"}})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/jobs/"+jobID.String()+"/queue/"+queueID.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs/:id/queue/:queue_id", Method: http.MethodDelete},
+		echo.PathValues{
+			{Name: "id", Value: jobID.String()},
+			{Name: "queue_id", Value: queueID.String()},
+		},
+		nil,
+	)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Action: auth.ActionAuthDenied, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	requireAuditMetadata(t, entries[0], map[string]any{
+		"reason":     "insufficient_scope",
+		"policy_key": "DELETE /v1/jobs/:id/queue/:id",
+	})
+}
+
+func TestMiddlewareQueueCancelRequiresOperator(t *testing.T) {
+	db, svc, auditor, limiter, _ := setupAuth(t)
+	jobID, _, _ := seedJobFixtures(t, db, "alpha")
+	queueID := uuid.New()
+	key := createKey(t, svc, models.RoleViewer, nil)
+
+	req := httptest.NewRequest(http.MethodDelete, "/v1/jobs/"+jobID.String()+"/queue/"+queueID.String(), nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/jobs/:id/queue/:queue_id", Method: http.MethodDelete},
+		echo.PathValues{
+			{Name: "id", Value: jobID.String()},
+			{Name: "queue_id", Value: queueID.String()},
+		},
+		nil,
+	)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+
+	entries, err := auditor.Query(&auth.AuditQueryRequest{Action: auth.ActionAuthDenied, Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	requireAuditMetadata(t, entries[0], map[string]any{
+		"reason":        "insufficient_role",
+		"required_role": string(models.RoleOperator),
+		"policy_key":    "DELETE /v1/jobs/:id/queue/:id",
+	})
 }
 
 func TestMiddlewareScopedRunRouteAllowsInScopeAlias(t *testing.T) {

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -82,6 +82,7 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		g.GET("/jobs/:id/tasks", job.Tasks)
 		g.GET("/jobs/:id/dag", job.DAG)
 		g.GET("/jobs/:id/queue", jobqueue.List)
+		g.DELETE("/jobs/:id/queue/:queue_id", jobqueue.Delete)
 		g.GET("/jobs/:id/runs", run.List)
 		g.GET("/jobs/:id/runs/diff", rundiffctrl.Get)
 		g.GET("/jobs/:id/runs/:run_id", run.Get)

--- a/api/rest/controller/job/queue/delete.go
+++ b/api/rest/controller/job/queue/delete.go
@@ -32,6 +32,9 @@ func Delete(c *echo.Context) error {
 	}
 
 	if err := svc.CancelQueuedRun(jobID, queueID); err != nil {
+		if errors.Is(err, runstorage.ErrQueuedRunNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "queued run not found")
+		}
 		if errors.Is(err, runstorage.ErrQueuedRunUnavailable) {
 			return echo.NewHTTPError(http.StatusConflict, "queued run already started")
 		}

--- a/api/rest/controller/job/queue/delete.go
+++ b/api/rest/controller/job/queue/delete.go
@@ -1,0 +1,42 @@
+package queue
+
+import (
+	"errors"
+	"net/http"
+
+	jsvc "github.com/caesium-cloud/caesium/api/rest/service/job"
+	runstorage "github.com/caesium-cloud/caesium/internal/run"
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"gorm.io/gorm"
+)
+
+func Delete(c *echo.Context) error {
+	ctx := c.Request().Context()
+
+	jobID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+	queueID, err := uuid.Parse(c.Param("queue_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "bad request").Wrap(err)
+	}
+
+	svc := jsvc.Service(ctx)
+	if _, err = svc.Get(jobID); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return echo.ErrNotFound
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	if err := svc.CancelQueuedRun(jobID, queueID); err != nil {
+		if errors.Is(err, runstorage.ErrQueuedRunUnavailable) {
+			return echo.NewHTTPError(http.StatusConflict, "queued run already started")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "internal server error").Wrap(err)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}

--- a/api/rest/service/job/job.go
+++ b/api/rest/service/job/job.go
@@ -27,6 +27,7 @@ type Job interface {
 	Get(uuid.UUID) (*models.Job, error)
 	GetByIDPrefix(string) (*models.Job, error)
 	Queue(uuid.UUID) ([]QueueItem, error)
+	CancelQueuedRun(uuid.UUID, uuid.UUID) error
 	Create(*CreateRequest) (*models.Job, error)
 	Delete(uuid.UUID) error
 	SetPaused(id uuid.UUID, paused bool) (*models.Job, error)
@@ -371,6 +372,10 @@ func (j *jobService) Queue(id uuid.UUID) ([]QueueItem, error) {
 		})
 	}
 	return items, nil
+}
+
+func (j *jobService) CancelQueuedRun(jobID, queueID uuid.UUID) error {
+	return runstorage.NewStore(j.db.WithContext(j.ctx)).CancelQueuedRun(j.ctx, jobID, queueID)
 }
 
 func decodeQueueParams(raw []byte) (map[string]string, error) {

--- a/docs/exec-plans/active/console-operator-loop-ux.md
+++ b/docs/exec-plans/active/console-operator-loop-ux.md
@@ -159,7 +159,7 @@ trigger deliberate, and its status honest.
       run. Confirm a stale "enqueued 3h ago" row reflects real queue state, not
       seed data or a genuine scheduler stall — capture the finding in the PR.
       Files: `ui/src/features/jobs/JobDetailPage.tsx`.
-- [ ] B5. Wire a queue-cancel affordance end-to-end (no dead buttons). This is
+- [x] B5. Wire a queue-cancel affordance end-to-end (no dead buttons). This is
       the plan's **one backend mutation** and there is currently no dequeue
       endpoint (only `cancelBackfill`), so it is specified tightly — an
       under-specified version risks a Cancel button that 403s under auth, is
@@ -207,6 +207,12 @@ trigger deliberate, and its status honest.
       `api/auth_rbac_policy_completeness_test.go`, the run-queue store
       (`internal/run/store.go` or the run-queue store package),
       `ui/src/lib/api.ts`, `ui/src/features/jobs/JobDetailPage.tsx`, `test/`.
+      W1-zeta backend note: `DELETE /v1/jobs/:id/queue/:queue_id` is bound
+      group-relative as `/jobs/:id/queue/:queue_id`, carries normalized
+      Operator RBAC policy key `DELETE /v1/jobs/:id/queue/:id`, and deletes only
+      unclaimed `run_queue` rows (`claimed_by = ''`); zero affected rows return
+      409. Integration coverage exercises clean unclaimed cancel and claimed-row
+      conflict.
       Depends on: B4.
 - [ ] B6. Make the secondary views (Runs, Tasks, Config, YAML, Backfills, Cache)
       linkable sub-routes instead of modal state, so an operator can deep-link

--- a/internal/auth/audit.go
+++ b/internal/auth/audit.go
@@ -37,6 +37,7 @@ const (
 	ActionRunTrigger         = "run.trigger"
 	ActionRunRetry           = "run.retry"
 	ActionRunQueueRead       = "run_queue.read"
+	ActionRunQueueCancel     = "run_queue.cancel"
 	ActionBackfill           = "run.backfill"
 	ActionJobdefApply        = "jobdef.apply"
 	ActionCachePrune         = "cache.prune"

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -114,6 +114,7 @@ var endpointPolicy = map[string]models.Role{
 	"PUT /v1/jobs/:id/unpause":              models.RoleOperator,
 	"POST /v1/jobdefs/apply":                models.RoleOperator,
 	"POST /v1/cache/prune":                  models.RoleOperator,
+	"DELETE /v1/jobs/:id/queue/:id":         models.RoleOperator,
 	"DELETE /v1/jobs/:id/cache":             models.RoleOperator,
 	"DELETE /v1/jobs/:id/cache/:id":         models.RoleOperator,
 	"PUT /v1/jobs/:id/backfills/:id/cancel": models.RoleOperator,

--- a/internal/run/concurrency_test.go
+++ b/internal/run/concurrency_test.go
@@ -193,6 +193,41 @@ func TestEnqueueRunEvictsOldestWhenDepthExceeded(t *testing.T) {
 	require.NotEqual(t, oldestID, rows[1].ID)
 }
 
+func TestCancelQueuedRunDeletesOnlyUnclaimedRows(t *testing.T) {
+	db := testutil.OpenTestDB(t)
+	t.Cleanup(func() { testutil.CloseDB(db) })
+
+	store := NewStore(db)
+	job := createConcurrencyJob(t, db, "queue-cancel", jobdef.ConcurrencyStrategyQueue, 1)
+	unclaimedID := uuid.New()
+	claimedID := uuid.New()
+	now := time.Now().UTC()
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        unclaimedID,
+		JobID:     job.ID,
+		Priority:  PriorityNormalValue,
+		CreatedAt: now,
+	}).Error)
+	require.NoError(t, db.Create(&models.RunQueue{
+		ID:        claimedID,
+		JobID:     job.ID,
+		Priority:  PriorityNormalValue,
+		ClaimedBy: "node-a/race",
+		ClaimedAt: &now,
+		CreatedAt: now,
+	}).Error)
+
+	require.NoError(t, store.CancelQueuedRun(context.Background(), job.ID, unclaimedID))
+	var count int64
+	require.NoError(t, db.Model(&models.RunQueue{}).Where("id = ?", unclaimedID).Count(&count).Error)
+	require.Zero(t, count)
+
+	err := store.CancelQueuedRun(context.Background(), job.ID, claimedID)
+	require.ErrorIs(t, err, ErrQueuedRunUnavailable)
+	require.NoError(t, db.Model(&models.RunQueue{}).Where("id = ? AND claimed_by = ?", claimedID, "node-a/race").Count(&count).Error)
+	require.EqualValues(t, 1, count)
+}
+
 func createConcurrencyJob(t *testing.T, db *gorm.DB, alias, strategy string, maxRuns int) *models.Job {
 	t.Helper()
 	now := time.Now().UTC()

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -242,6 +242,7 @@ var (
 	ErrRunSkipped               = errors.New("run: skipped by concurrency policy")
 	ErrRunQueued                = errors.New("run: queued by concurrency policy")
 	ErrQueuedRunUnavailable     = errors.New("run: queued run already claimed or unavailable")
+	ErrQueuedRunNotFound        = errors.New("run: queued run not found")
 	ErrMaxConcurrentRunsReached = errors.New("run: max concurrent runs reached")
 	// ErrJobPaused is returned by RetryFromFailureAdmitted when an agent-initiated
 	// retry is refused because the job is paused. A human pause outranks an agent
@@ -3803,6 +3804,16 @@ func (s *Store) CancelQueuedRun(ctx context.Context, jobID, queueID uuid.UUID) e
 		return result.Error
 	}
 	if result.RowsAffected == 0 {
+		// The conditional delete matched no unclaimed row: distinguish a missing
+		// queued run (404) from one the dequeuer has already claimed (409).
+		var count int64
+		if err := s.db.WithContext(ctx).Model(&models.RunQueue{}).
+			Where("id = ? AND job_id = ?", queueID, jobID).Count(&count).Error; err != nil {
+			return err
+		}
+		if count == 0 {
+			return ErrQueuedRunNotFound
+		}
 		return ErrQueuedRunUnavailable
 	}
 	if err := s.observeRunQueueDepth(jobID); err != nil {

--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -241,6 +241,7 @@ var (
 	ErrTaskClaimMismatch        = errors.New("run: task claim mismatch")
 	ErrRunSkipped               = errors.New("run: skipped by concurrency policy")
 	ErrRunQueued                = errors.New("run: queued by concurrency policy")
+	ErrQueuedRunUnavailable     = errors.New("run: queued run already claimed or unavailable")
 	ErrMaxConcurrentRunsReached = errors.New("run: max concurrent runs reached")
 	// ErrJobPaused is returned by RetryFromFailureAdmitted when an agent-initiated
 	// retry is refused because the job is paused. A human pause outranks an agent
@@ -3790,6 +3791,22 @@ func (s *Store) ReleaseQueuedRun(ctx context.Context, queueID uuid.UUID, claimed
 		if observeErr := s.observeRunQueueDepth(queued.JobID); observeErr != nil {
 			log.Warn("run queue: failed to observe depth after release", "job_id", queued.JobID, "error", observeErr)
 		}
+	}
+	return nil
+}
+
+func (s *Store) CancelQueuedRun(ctx context.Context, jobID, queueID uuid.UUID) error {
+	result := s.db.WithContext(ctx).
+		Where("id = ? AND job_id = ? AND claimed_by = ''", queueID, jobID).
+		Delete(&models.RunQueue{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return ErrQueuedRunUnavailable
+	}
+	if err := s.observeRunQueueDepth(jobID); err != nil {
+		log.Warn("run queue: failed to observe depth after cancel", "job_id", jobID, "queue_id", queueID, "error", err)
 	}
 	return nil
 }

--- a/test/job_queue_cancel_test.go
+++ b/test/job_queue_cancel_test.go
@@ -1,0 +1,141 @@
+//go:build integration
+
+package test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestJobQueueCancelEndpointDeletesUnclaimedRowOnly() {
+	job := s.applyConcurrencyJob("queue", `sleep 6`)
+	firstStatus, firstRunID := s.postConcurrencyRun(job.ID)
+	s.Equal(http.StatusAccepted, firstStatus)
+	s.Require().NotEmpty(firstRunID)
+
+	secondStatus, secondRunID := s.postConcurrencyRun(job.ID)
+	s.Equal(http.StatusAccepted, secondStatus)
+	s.Empty(secondRunID, "queued admission should not create a run synchronously")
+
+	queued := s.requireQueuedRun(job.ID)
+
+	status, body := s.deleteQueuedRun(job.ID, queued.ID)
+	s.Equal(http.StatusNoContent, status, body)
+
+	s.requireQueueEmpty(job.ID)
+	runs := s.fetchRuns(job.ID)
+	s.Require().Len(runs, 1, "cancelled queued row must not create a JobRun")
+	s.Equal(firstRunID, runs[0].ID)
+
+	s.Equal("succeeded", s.awaitRunStatus(job.ID, firstRunID, runTimeout, "succeeded").Status)
+	runs = s.fetchRuns(job.ID)
+	s.Require().Len(runs, 1, "cancelled queued row must not start after the active run drains")
+	s.Equal(firstRunID, runs[0].ID)
+}
+
+func (s *IntegrationTestSuite) TestJobQueueCancelEndpointConflictsWithClaimedRow() {
+	if s.engineType == "kubernetes" {
+		s.T().Skipf("claimed run_queue race setup writes run_queue directly; dqlite binds to POD_IP under CAESIUM_TEST_ENGINE=%s and is not port-forward-reachable; covered on the docker + podman lanes", s.engineType)
+	}
+
+	job := s.applyConcurrencyJob("queue", `sleep 6`)
+	firstStatus, firstRunID := s.postConcurrencyRun(job.ID)
+	s.Equal(http.StatusAccepted, firstStatus)
+	s.Require().NotEmpty(firstRunID)
+
+	secondStatus, secondRunID := s.postConcurrencyRun(job.ID)
+	s.Equal(http.StatusAccepted, secondStatus)
+	s.Empty(secondRunID, "queued admission should not create a run synchronously")
+
+	queued := s.requireQueuedRun(job.ID)
+	claimOwner := "cancel-race/e2e"
+	s.setQueuedRunClaim(job.ID, queued.ID, claimOwner, time.Now().UTC())
+
+	status, body := s.deleteQueuedRun(job.ID, queued.ID)
+	s.Equal(http.StatusConflict, status, body)
+	s.Contains(body, "queued run already started")
+
+	s.setQueuedRunClaim(job.ID, queued.ID, claimOwner, time.Now().UTC().Add(-5*time.Minute))
+	s.Equal("succeeded", s.awaitRunStatus(job.ID, firstRunID, runTimeout, "succeeded").Status)
+
+	var queuedRunID string
+	s.Require().Eventually(func() bool {
+		for _, run := range s.fetchRuns(job.ID) {
+			if run.ID != firstRunID {
+				queuedRunID = run.ID
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, time.Second, "claimed row must remain available for the dequeuer after cancel returns 409")
+	s.Require().NotEmpty(queuedRunID)
+	s.Equal("succeeded", s.awaitRunStatus(job.ID, queuedRunID, runTimeout, "succeeded").Status)
+}
+
+func (s *IntegrationTestSuite) requireQueuedRun(jobID string) queueCLIItem {
+	s.T().Helper()
+
+	var (
+		rows []queueCLIItem
+		err  error
+	)
+	s.Require().Eventually(func() bool {
+		rows, err = s.tryFetchQueue(jobID)
+		return err == nil && len(rows) > 0
+	}, 10*time.Second, 250*time.Millisecond, "expected queued run for job %s", jobID)
+	s.Require().NoError(err)
+	return rows[0]
+}
+
+func (s *IntegrationTestSuite) requireQueueEmpty(jobID string) {
+	s.T().Helper()
+
+	var (
+		rows []queueCLIItem
+		err  error
+	)
+	s.Require().Eventually(func() bool {
+		rows, err = s.tryFetchQueue(jobID)
+		return err == nil && len(rows) == 0
+	}, 10*time.Second, 250*time.Millisecond, "expected queue to be empty for job %s", jobID)
+	s.Require().NoError(err)
+}
+
+func (s *IntegrationTestSuite) tryFetchQueue(jobID string) ([]queueCLIItem, error) {
+	s.T().Helper()
+
+	var rows []queueCLIItem
+	err := s.tryGetJSON(fmt.Sprintf("/v1/jobs/%s/queue", jobID), &rows)
+	return rows, err
+}
+
+func (s *IntegrationTestSuite) deleteQueuedRun(jobID, queueID string) (int, string) {
+	s.T().Helper()
+
+	resp, err := s.doRequest(http.MethodDelete, fmt.Sprintf("%s/v1/jobs/%s/queue/%s", s.caesiumURL, jobID, queueID), nil)
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	return resp.StatusCode, string(body)
+}
+
+func (s *IntegrationTestSuite) setQueuedRunClaim(jobID, queueID, claimedBy string, claimedAt time.Time) {
+	s.T().Helper()
+
+	catalogDB := s.openIntegrationCatalogDB()
+	defer func() { s.Require().NoError(catalogDB.Close()) }()
+
+	result, err := catalogDB.ExecContext(s.T().Context(), `
+UPDATE run_queue
+SET claimed_by = ?, claimed_at = ?
+WHERE id = ? AND job_id = ?
+`, claimedBy, claimedAt, queueID, jobID)
+	s.Require().NoError(err)
+	affected, err := result.RowsAffected()
+	s.Require().NoError(err)
+	s.Equal(int64(1), affected)
+}


### PR DESCRIPTION
## Summary
- Adds `DELETE /v1/jobs/:id/queue/:queue_id` (`api/rest/controller/job/queue/delete.go` + `CancelQueuedRun` in the run store).
- **Race-safe**: conditional delete `WHERE id = ? AND job_id = ? AND claimed_by = ''`; if `RowsAffected == 0` (dequeuer already claimed it) the store returns `ErrQueuedRunUnavailable`, mapped to **409 Conflict** — a cancel never races a run already starting.
- **Auth**: explicit RBAC policy entry `DELETE /v1/jobs/:id/queue/:id` at `models.RoleOperator` (satisfies `TestAuthMiddlewareMountedRoutesHaveRBACPolicy`) + a `run_queue.cancel` scope action with scoped-key allow/deny/audit coverage.
- **Integration test** (`test/job_queue_cancel_test.go`): clean unclaimed cancel asserts the row is gone and **no JobRun is created**; the claimed-race asserts **409** then the run proceeds.
- Frontend Cancel button + `api.ts` client method land in the sibling W1-β stream.

## Test plan
- [ ] GHA CI: `lint`, `unit-test`, `build-and-integration-test` (the new cancel scenarios), RBAC completeness + scope tests. (Note: the claimed-race test uses `openIntegrationCatalogDB`, which is docker-lane; may skip on podman/k8s netns per existing lane behavior.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
