### PR TITLE
Lead run page with status/timeline/DAG, de-alarm receipt, order tasks (console-operator-loop-ux W1-α)

### DIFF
--- a/docs/exec-plans/active/console-operator-loop-ux.md
+++ b/docs/exec-plans/active/console-operator-loop-ux.md
@@ -95,19 +95,21 @@ is the universal "something's broken" signal, so every normal run looks
 alarming. This stream leads with what happened and reserves red for real
 failure.
 
-- [ ] A1. Reorder `RunDetailPage` so the run leads with status + execution
+- [x] A1. Reorder `RunDetailPage` so the run leads with status + execution
       timeline + DAG + per-task logs; move `ReceiptPanel` into a collapsed
       "Reproducibility" section (or dedicated tab) below the fold, so attestation
       is one interaction away rather than the first thing on the page.
       Files: `ui/src/features/jobs/RunDetailPage.tsx`.
-- [ ] A2. Reserve red for real failures in the receipt panel: render "not
+      Note: Run detail now renders timeline and interactive DAG/task logs before a collapsed Reproducibility receipt section.
+- [x] A2. Reserve red for real failures in the receipt panel: render "not
       attested", "caching disabled", "digest_pinned=false", and
       "degraded / unverifiable" as neutral, informational text (muted/secondary
       styling), not red/amber alarm badges. Keep red strictly for actual task
       failure or attestation *tampering* (a computed digest that does not match
       the recorded one).
       Files: `ui/src/features/jobs/ReceiptPanel.tsx`.
-- [ ] A3. Reconcile the run page's timeline-vs-DAG surfaces so they no longer
+      Note: Degraded/unverifiable and digest-pinned-off receipt states now use muted informational styling, with component/e2e coverage.
+- [x] A3. Reconcile the run page's timeline-vs-DAG surfaces so they no longer
       read as a duplicated DAG (the review flagged "the DAG is rendered twice —
       overlay up top, full DAG at bottom"). Label the execution-timeline gantt
       and the interactive DAG distinctly, and/or collapse the redundant surface;
@@ -115,11 +117,13 @@ failure.
       reconciliation in the PR and resolve as verified-not-a-bug.
       Files: `ui/src/features/jobs/RunDetailPage.tsx`.
       Depends on: A1.
-- [ ] A4. Order the run's task rows in execution order (by start time, breaking
+      Note: Verified one `JobDAG` on the run page; the separate SVG gantt is labeled Execution timeline and the graph is labeled Interactive DAG + task logs.
+- [x] A4. Order the run's task rows in execution order (by start time, breaking
       ties with DAG topological order) before rendering the timeline, so the
       task list reads top-to-bottom in the order things actually ran ("convert
       before list").
       Files: `ui/src/features/jobs/RunTimeline.tsx`.
+      Note: Timeline rows now sort by execution start time first and use the existing DAG topology as the tie-breaker.
 
 ### Stream B — Job-detail page: actionable header, intentional trigger, honest queue & counts
 

--- a/ui/e2e/receipt-verify.spec.ts
+++ b/ui/e2e/receipt-verify.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
 import { applyDefinitions, type FixtureDefinition } from "./helpers/fixtures";
 
 type E2EJob = {
@@ -74,7 +74,8 @@ test("operator can inspect receipts and verify a committed receipt against drift
   expect(committedReceipt.degraded).toBe(false);
 
   await page.goto(`/jobs/${pinnedJob.id}/runs/${pinnedRun.id}`);
-  await expect(page.getByTestId("receipt-panel")).toBeVisible({ timeout: 30_000 });
+  await expectRunRealityBeforeReceipt(page);
+  await openReproducibility(page);
   await expect(page.getByTestId("receipt-digest")).toContainText(committedReceipt.receipt_digest);
   await expect(page.getByTestId("receipt-task-row").filter({ hasText: "prepare" })).toContainText("digest_pinned=true");
   await expect(page.getByTestId("receipt-task-row").filter({ hasText: "render" })).toContainText("identity_hash");
@@ -105,12 +106,55 @@ test("operator can inspect receipts and verify a committed receipt against drift
   await waitForSucceededRun(request, unpinnedJob.id, unpinnedRun.id);
 
   await page.goto(`/jobs/${unpinnedJob.id}/runs/${unpinnedRun.id}`);
-  await expect(page.getByTestId("receipt-panel")).toBeVisible({ timeout: 30_000 });
+  await expectRunRealityBeforeReceipt(page);
+  await expect(page.getByTestId("run-timeline-task-row").first()).toHaveAttribute("data-task-name", "prepare");
+  await openReproducibility(page);
   await expect(page.getByTestId("receipt-degraded-status")).toContainText("degraded-unverifiable");
+  await expect(page.getByTestId("receipt-degraded-status")).not.toHaveClass(alarmClassPattern);
+  await expect(
+    page.getByTestId("receipt-task-digest-pinned-marker").filter({ hasText: "digest_pinned=false" }).first(),
+  ).not.toHaveClass(alarmClassPattern);
   await expect(page.getByTestId("receipt-task-unverifiable-marker").first()).toContainText("unverifiable");
+  await expect(page.getByTestId("receipt-task-unverifiable-marker").first()).not.toHaveClass(alarmClassPattern);
   await expect(page.getByTestId("receipt-task-degraded-reason").first()).toContainText("image not digest-pinned");
+  await expect(page.getByTestId("receipt-task-degraded-reason").first()).not.toHaveClass(alarmClassPattern);
   await expect(page.getByTestId("receipt-unverifiable-summary")).toContainText("Unverifiable tasks");
+  await expect(page.getByTestId("receipt-unverifiable-summary")).not.toHaveClass(alarmClassPattern);
 });
+
+const alarmClassPattern = /(?:bg|text|border)-(?:destructive|warning|danger)/;
+
+async function expectRunRealityBeforeReceipt(page: Page): Promise<void> {
+  await expect(page.getByTestId("run-execution-timeline-section")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("run-interactive-dag-section")).toBeVisible();
+  await expect(page.getByTestId("run-reproducibility-section")).toBeVisible();
+  await expect(page.getByTestId("receipt-panel")).toHaveCount(0);
+
+  const order = await page.evaluate(() => {
+    const timeline = document.querySelector('[data-testid="run-execution-timeline-section"]');
+    const dag = document.querySelector('[data-testid="run-interactive-dag-section"]');
+    const receipt = document.querySelector('[data-testid="run-reproducibility-section"]');
+    const isBefore = (first: Element | null, second: Element | null) =>
+      Boolean(first && second && (first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING));
+
+    return {
+      timelineBeforeDag: isBefore(timeline, dag),
+      dagBeforeReceipt: isBefore(dag, receipt),
+      timelineBeforeReceipt: isBefore(timeline, receipt),
+    };
+  });
+
+  expect(order).toEqual({
+    timelineBeforeDag: true,
+    dagBeforeReceipt: true,
+    timelineBeforeReceipt: true,
+  });
+}
+
+async function openReproducibility(page: Page): Promise<void> {
+  await page.getByTestId("run-reproducibility-toggle").click();
+  await expect(page.getByTestId("receipt-panel")).toBeVisible({ timeout: 30_000 });
+}
 
 function buildReceiptDefinition(alias: string, variant: string, pinDigests: boolean): ReceiptFixture {
   return {

--- a/ui/src/features/jobs/ReceiptPanel.tsx
+++ b/ui/src/features/jobs/ReceiptPanel.tsx
@@ -1,6 +1,6 @@
 import { type ChangeEvent, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { AlertTriangle, FileJson, Loader2, ShieldAlert, ShieldCheck, Upload } from "lucide-react";
+import { AlertTriangle, FileJson, Loader2, ShieldCheck, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,6 +13,11 @@ interface ReceiptPanelProps {
   jobId: string;
   runId: string;
 }
+
+const RECEIPT_INFO_BADGE_CLASS =
+  "border-border/60 bg-muted/40 text-text-3 shadow-none hover:bg-muted/50";
+const RECEIPT_INFO_PANEL_CLASS =
+  "rounded-md border border-border/60 bg-muted/25 p-3 text-xs text-text-3";
 
 export function ReceiptPanel({ jobId, runId }: ReceiptPanelProps) {
   const [committedReceiptText, setCommittedReceiptText] = useState("");
@@ -137,8 +142,12 @@ function ReceiptSkeleton() {
 
 function ReceiptStatus({ receipt }: { receipt: Receipt }) {
   return receipt.degraded === true ? (
-    <Badge data-testid="receipt-degraded-status" variant="destructive" className="h-fit gap-1.5">
-      <ShieldAlert className="h-3.5 w-3.5" />
+    <Badge
+      data-testid="receipt-degraded-status"
+      variant="secondary"
+      className={cn("h-fit gap-1.5", RECEIPT_INFO_BADGE_CLASS)}
+    >
+      <FileJson className="h-3.5 w-3.5" />
       degraded-unverifiable
     </Badge>
   ) : (
@@ -191,10 +200,7 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
               key={`${task.task_name}:${task.identity_hash}`}
               data-testid="receipt-task-row"
               data-task-name={task.task_name}
-              className={cn(
-                "rounded-md border bg-background/40 p-3",
-                task.degraded === true ? "border-warning/35" : "border-border/50",
-              )}
+              className="rounded-md border border-border/50 bg-background/40 p-3"
             >
               <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between">
                 <div className="min-w-0">
@@ -209,11 +215,19 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
                   </div>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  <Badge variant={task.digest_pinned ? "success" : "destructive"} className="text-[10px]">
+                  <Badge
+                    data-testid="receipt-task-digest-pinned-marker"
+                    variant={task.digest_pinned ? "success" : "secondary"}
+                    className={cn("text-[10px]", task.digest_pinned ? undefined : RECEIPT_INFO_BADGE_CLASS)}
+                  >
                     digest_pinned={String(task.digest_pinned)}
                   </Badge>
                   {task.degraded === true ? (
-                    <Badge data-testid="receipt-task-unverifiable-marker" variant="destructive" className="text-[10px]">
+                    <Badge
+                      data-testid="receipt-task-unverifiable-marker"
+                      variant="secondary"
+                      className={cn("text-[10px]", RECEIPT_INFO_BADGE_CLASS)}
+                    >
                       unverifiable
                     </Badge>
                   ) : null}
@@ -250,7 +264,7 @@ function ReceiptContent({ receipt }: { receipt: Receipt }) {
               {task.degraded_reason ? (
                 <div
                   data-testid="receipt-task-degraded-reason"
-                  className="mt-3 rounded-md border border-warning/25 bg-warning/10 p-2 text-xs text-warning"
+                  className="mt-3 rounded-md border border-border/60 bg-muted/25 p-2 text-xs text-text-3"
                 >
                   {task.degraded_reason}
                 </div>
@@ -271,13 +285,13 @@ function UnverifiableSummary({ tasks }: { tasks: string[] }) {
   return (
     <div
       data-testid="receipt-unverifiable-summary"
-      className="rounded-md border border-warning/25 bg-warning/10 p-3 text-xs text-warning"
+      className={RECEIPT_INFO_PANEL_CLASS}
     >
       <div className="flex items-start gap-2">
-        <ShieldAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+        <FileJson className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-3" />
         <div>
           <div className="font-semibold">This receipt is degraded-unverifiable.</div>
-          <div className="mt-1 text-warning/85">
+          <div className="mt-1 text-text-3">
             Unverifiable tasks:{" "}
             {tasks.map((task, index) => (
               <span key={`${task}:${index}`}>
@@ -375,6 +389,8 @@ function VerifyForm({
 
 function VerifyResultView({ result }: { result: VerifyResult }) {
   const verdict = verifyVerdict(result);
+  const isDegraded = verdict === "degraded-unverifiable";
+  const isDrift = !result.match && !isDegraded;
   const degradedTasks = result.degraded_tasks ?? [];
   const drifts = result.drifts ?? [];
 
@@ -383,17 +399,18 @@ function VerifyResultView({ result }: { result: VerifyResult }) {
       data-testid="receipt-verify-result"
       className={cn(
         "space-y-3 rounded-md border p-3",
-        verdict === "reproducible"
+        result.match
           ? "border-success/30 bg-success/10"
-          : verdict === "degraded-unverifiable"
-            ? "border-warning/30 bg-warning/10"
-            : "border-danger/30 bg-danger/10",
+          : isDrift
+            ? "border-danger/30 bg-danger/10"
+            : "border-border/60 bg-muted/25",
       )}
     >
       <div className="flex flex-wrap items-center gap-2">
         <Badge
           data-testid="receipt-verify-verdict"
-          variant={verdict === "reproducible" ? "success" : verdict === "degraded-unverifiable" ? "destructive" : "outline"}
+          variant={result.match ? "success" : isDrift ? "destructive" : "secondary"}
+          className={isDegraded ? RECEIPT_INFO_BADGE_CLASS : undefined}
         >
           {verdict}
         </Badge>
@@ -418,7 +435,7 @@ function VerifyResultView({ result }: { result: VerifyResult }) {
       </div>
 
       {degradedTasks.length > 0 ? (
-        <div className="rounded-md border border-warning/25 bg-warning/10 p-2 text-xs text-warning">
+        <div className="rounded-md border border-border/60 bg-muted/25 p-2 text-xs text-text-3">
           <span className="font-semibold">degraded_tasks </span>
           {degradedTasks.map((task, index) => (
             <span key={`${task}:${index}`}>

--- a/ui/src/features/jobs/RunDetailPage.tsx
+++ b/ui/src/features/jobs/RunDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, ArrowLeftRight, ChevronDown, ChevronRight, RotateCcw, Square, History } from "lucide-react";
+import { ArrowLeft, ArrowLeftRight, ChevronDown, ChevronRight, FileJson, RotateCcw, Square, History } from "lucide-react";
 import { toast } from "sonner";
 import { NotFoundState } from "@/components/not-found-state";
 import { RelativeTime } from "@/components/relative-time";
@@ -39,6 +39,7 @@ export function RunDetailPage() {
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [streamHealthy, setStreamHealthy] = useState(events.isHealthy());
   const [timelineOpen, setTimelineOpen] = useState(true);
+  const [reproducibilityOpen, setReproducibilityOpen] = useState(false);
   const [replayDialogOpen, setReplayDialogOpen] = useState(false);
   const principal = usePrincipal();
 
@@ -454,14 +455,14 @@ export function RunDetailPage() {
         testId="run-incident-ribbon"
       />
 
-      <ReceiptPanel jobId={jobId} runId={runId} />
-
       {/* Gantt timeline */}
-      <div className="rounded-md border border-border/50 bg-card overflow-hidden">
+      <div data-testid="run-execution-timeline-section" className="rounded-md border border-border/50 bg-card overflow-hidden">
         <button
           type="button"
           className="flex w-full items-center gap-2 px-4 py-2.5 text-left border-b border-border/50 hover:bg-obsidian/30 transition-colors"
           onClick={() => setTimelineOpen((o) => !o)}
+          aria-expanded={timelineOpen}
+          aria-controls="run-execution-timeline-body"
         >
           {timelineOpen ? (
             <ChevronDown className="h-3.5 w-3.5 text-text-3" />
@@ -479,7 +480,7 @@ export function RunDetailPage() {
           </span>
         </button>
         {timelineOpen && (
-          <div className="p-4">
+          <div id="run-execution-timeline-body" className="p-4">
             {run.tasks && run.tasks.length > 0 ? (
               <RunTimeline tasks={run.tasks} taskDefinitions={taskDefinitions} runStartedAt={run.started_at} />
             ) : (
@@ -489,6 +490,49 @@ export function RunDetailPage() {
             )}
           </div>
         )}
+      </div>
+
+      {/* Interactive DAG with task selection */}
+      <div data-testid="run-interactive-dag-section" className="overflow-hidden rounded-md border border-border/50 bg-card">
+        <div className="flex items-center gap-2 border-b border-border/50 px-4 py-2.5">
+          <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">
+            Interactive DAG + task logs
+          </span>
+          <span className="ml-auto text-[10px] text-text-4">
+            {dag?.nodes?.length ?? 0} nodes
+          </span>
+        </div>
+        <div
+          ref={dagContainerRef}
+          className="relative overflow-hidden bg-card"
+          style={{ height: dagHeight ? `${dagHeight}px` : "600px" }}
+        >
+          {dag && atoms ? (
+            <JobDAG
+              dag={dag}
+              atoms={atoms}
+              taskDefinitions={taskDefinitions}
+              taskMetadata={taskMetadata}
+              taskRunData={runTasks}
+              onNodeClick={(id) => setSelectedTaskId((prev) => (prev === id ? null : id))}
+              selectedTaskId={selectedTaskId}
+            />
+          ) : null}
+
+          {selectedTaskId ? (
+            <TaskDetailPanel
+              key={selectedTaskId}
+              taskId={selectedTaskId}
+              task={selectedTask}
+              runTask={selectedRunTask}
+              taskType={dag?.nodes?.find((n) => n.id === selectedTaskId)?.type}
+              jobId={jobId}
+              runId={runId}
+              incidents={selectedTaskIncidents}
+              onClose={() => setSelectedTaskId(null)}
+            />
+          ) : null}
+        </div>
       </div>
 
       {callbackRuns.length > 0 ? <CallbackRunsSection callbacks={callbackRuns} /> : null}
@@ -510,36 +554,30 @@ export function RunDetailPage() {
         </Card>
       ) : null}
 
-      {/* DAG with task selection */}
-      <div
-        ref={dagContainerRef}
-        className="relative overflow-hidden rounded-md border border-border/50 bg-card"
-        style={{ height: dagHeight ? `${dagHeight}px` : "600px" }}
-      >
-        {dag && atoms ? (
-          <JobDAG
-            dag={dag}
-            atoms={atoms}
-            taskDefinitions={taskDefinitions}
-            taskMetadata={taskMetadata}
-            taskRunData={runTasks}
-            onNodeClick={(id) => setSelectedTaskId((prev) => (prev === id ? null : id))}
-            selectedTaskId={selectedTaskId}
-          />
-        ) : null}
-
-        {selectedTaskId ? (
-          <TaskDetailPanel
-            key={selectedTaskId}
-            taskId={selectedTaskId}
-            task={selectedTask}
-            runTask={selectedRunTask}
-            taskType={dag?.nodes?.find((n) => n.id === selectedTaskId)?.type}
-            jobId={jobId}
-            runId={runId}
-            incidents={selectedTaskIncidents}
-            onClose={() => setSelectedTaskId(null)}
-          />
+      <div data-testid="run-reproducibility-section" className="overflow-hidden rounded-md border border-border/50 bg-card">
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 px-4 py-2.5 text-left hover:bg-obsidian/30 transition-colors"
+          onClick={() => setReproducibilityOpen((open) => !open)}
+          aria-expanded={reproducibilityOpen}
+          aria-controls="run-reproducibility-body"
+          data-testid="run-reproducibility-toggle"
+        >
+          {reproducibilityOpen ? (
+            <ChevronDown className="h-3.5 w-3.5 text-text-3" />
+          ) : (
+            <ChevronRight className="h-3.5 w-3.5 text-text-3" />
+          )}
+          <FileJson className="h-3.5 w-3.5 text-text-3" />
+          <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-text-3">
+            Reproducibility
+          </span>
+          <span className="ml-auto text-[10px] text-text-4">Receipt</span>
+        </button>
+        {reproducibilityOpen ? (
+          <div id="run-reproducibility-body" className="border-t border-border/50 p-4">
+            <ReceiptPanel jobId={jobId} runId={runId} />
+          </div>
         ) : null}
       </div>
     </div>

--- a/ui/src/features/jobs/RunTimeline.tsx
+++ b/ui/src/features/jobs/RunTimeline.tsx
@@ -29,7 +29,7 @@ export function RunTimeline({ tasks, taskDefinitions, runStartedAt }: Props) {
   const [now] = useState<number>(Date.now);
 
   // Only show tasks that have started
-  const startedTasks = orderTasksByDAG(
+  const startedTasks = orderTasksByExecution(
     tasks.filter(t => t.started_at || t.status === "cached"),
     taskDefinitions,
   );
@@ -108,7 +108,13 @@ export function RunTimeline({ tasks, taskDefinitions, runStartedAt }: Props) {
           const duration = end - start;
 
           return (
-            <g key={task.id}>
+            <g
+              key={task.id}
+              data-testid="run-timeline-task-row"
+              data-task-id={task.task_id}
+              data-task-name={label}
+              data-started-at={task.started_at ?? ""}
+            >
               {/* Task label */}
               <text
                 x={LABEL_W - 8}
@@ -217,22 +223,36 @@ export function RunTimeline({ tasks, taskDefinitions, runStartedAt }: Props) {
   );
 }
 
-function orderTasksByDAG(tasks: TaskRun[], taskDefinitions: Record<string, JobTask>): TaskRun[] {
+function orderTasksByExecution(tasks: TaskRun[], taskDefinitions: Record<string, JobTask>): TaskRun[] {
   if (tasks.length <= 1) return tasks;
 
+  const topoRank = taskTopologicalRanks(tasks, taskDefinitions);
+  const inputOrder = new Map(tasks.map((task, index) => [task.task_id, index]));
+
+  return [...tasks].sort((a, b) => {
+    const aStartedAt = executionTimestamp(a);
+    const bStartedAt = executionTimestamp(b);
+    if (aStartedAt !== bStartedAt) return aStartedAt - bStartedAt;
+
+    const aTopoRank = topoRank.get(a.task_id) ?? Number.POSITIVE_INFINITY;
+    const bTopoRank = topoRank.get(b.task_id) ?? Number.POSITIVE_INFINITY;
+    if (aTopoRank !== bTopoRank) return aTopoRank - bTopoRank;
+
+    return (inputOrder.get(a.task_id) ?? 0) - (inputOrder.get(b.task_id) ?? 0);
+  });
+}
+
+function taskTopologicalRanks(tasks: TaskRun[], taskDefinitions: Record<string, JobTask>): Map<string, number> {
   const taskByID = new Map<string, TaskRun>();
   const adjacency = new Map<string, Set<string>>();
   const indegree = new Map<string, number>();
-  const fallbackOrder = new Map<string, { timestamp: number; index: number }>();
+  const inputOrder = new Map<string, number>();
 
   tasks.forEach((task, index) => {
     taskByID.set(task.task_id, task);
     adjacency.set(task.task_id, new Set());
     indegree.set(task.task_id, 0);
-    fallbackOrder.set(task.task_id, {
-      timestamp: fallbackTimestamp(task),
-      index,
-    });
+    inputOrder.set(task.task_id, index);
   });
 
   tasks.forEach((task) => {
@@ -246,14 +266,11 @@ function orderTasksByDAG(tasks: TaskRun[], taskDefinitions: Record<string, JobTa
     indegree.set(nextID, (indegree.get(nextID) ?? 0) + 1);
   });
 
-  const compareByFallback = (a: TaskRun, b: TaskRun) => {
-    const aOrder = fallbackOrder.get(a.task_id) ?? { timestamp: Number.POSITIVE_INFINITY, index: 0 };
-    const bOrder = fallbackOrder.get(b.task_id) ?? { timestamp: Number.POSITIVE_INFINITY, index: 0 };
-    if (aOrder.timestamp !== bOrder.timestamp) return aOrder.timestamp - bOrder.timestamp;
-    return aOrder.index - bOrder.index;
+  const compareByInputOrder = (a: TaskRun, b: TaskRun) => {
+    return (inputOrder.get(a.task_id) ?? 0) - (inputOrder.get(b.task_id) ?? 0);
   };
 
-  const ready = tasks.filter((task) => (indegree.get(task.task_id) ?? 0) === 0).sort(compareByFallback);
+  const ready = tasks.filter((task) => (indegree.get(task.task_id) ?? 0) === 0).sort(compareByInputOrder);
   const ordered: TaskRun[] = [];
 
   while (ready.length > 0) {
@@ -268,21 +285,20 @@ function orderTasksByDAG(tasks: TaskRun[], taskDefinitions: Record<string, JobTa
       const nextTask = taskByID.get(nextID);
       if (nextTask && nextDegree === 0) {
         ready.push(nextTask);
-        ready.sort(compareByFallback);
+        ready.sort(compareByInputOrder);
       }
     }
   }
 
-  if (ordered.length === tasks.length) return ordered;
-
   const orderedIDs = new Set(ordered.map((task) => task.task_id));
   const unresolved = tasks
     .filter((task) => !orderedIDs.has(task.task_id))
-    .sort(compareByFallback);
-  return [...ordered, ...unresolved];
+    .sort(compareByInputOrder);
+
+  return new Map([...ordered, ...unresolved].map((task, index) => [task.task_id, index]));
 }
 
-function fallbackTimestamp(task: TaskRun): number {
+function executionTimestamp(task: TaskRun): number {
   const parsed = new Date(task.started_at ?? task.created_at).getTime();
   return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
 }

--- a/ui/src/features/jobs/__tests__/ReceiptPanel.test.tsx
+++ b/ui/src/features/jobs/__tests__/ReceiptPanel.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Receipt } from "@/lib/api";
+import { api } from "@/lib/api";
+import { ReceiptPanel } from "../ReceiptPanel";
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getReceipt: vi.fn(),
+    postVerify: vi.fn(),
+  },
+}));
+
+const alarmClassPattern = /(?:bg|text|border)-(?:destructive|warning|danger)/;
+
+describe("ReceiptPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders degraded unverifiable receipt state as informational", async () => {
+    vi.mocked(api.getReceipt).mockResolvedValue(degradedReceipt);
+
+    renderWithQueryClient(<ReceiptPanel jobId="job-1" runId="run-1" />);
+
+    const status = await screen.findByTestId("receipt-degraded-status");
+    expect(status).toHaveTextContent("degraded-unverifiable");
+    expectInformational(status);
+
+    const digestPinned = screen.getByTestId("receipt-task-digest-pinned-marker");
+    expect(digestPinned).toHaveTextContent("digest_pinned=false");
+    expectInformational(digestPinned);
+
+    const unverifiable = screen.getByTestId("receipt-task-unverifiable-marker");
+    expect(unverifiable).toHaveTextContent("unverifiable");
+    expectInformational(unverifiable);
+
+    expectInformational(screen.getByTestId("receipt-task-degraded-reason"));
+    expectInformational(screen.getByTestId("receipt-unverifiable-summary"));
+  });
+});
+
+function renderWithQueryClient(component: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      {component}
+    </QueryClientProvider>,
+  );
+}
+
+function expectInformational(element: HTMLElement) {
+  expect(element.className).not.toMatch(alarmClassPattern);
+}
+
+const degradedReceipt: Receipt = {
+  receipt_version: 1,
+  run_id: "run-1",
+  job_id: "job-1",
+  job_alias: "demo",
+  git_commit: "abc123",
+  manifest_content_hash: "manifest",
+  tasks: [
+    {
+      task_name: "extract",
+      identity_hash: "identity",
+      image: "busybox:latest",
+      digest_pinned: false,
+      degraded: true,
+      degraded_reason: "image not digest-pinned",
+    },
+  ],
+  degraded: true,
+  degraded_tasks: ["extract"],
+  receipt_digest: "sha256:receipt",
+};


### PR DESCRIPTION
## Summary
- **A1**: `RunDetailPage` leads with status + execution timeline + interactive DAG + per-task logs; `ReceiptPanel` moves into a collapsed "Reproducibility" section below the fold.
- **A2**: `ReceiptPanel` renders "not attested"/"caching disabled"/"digest_pinned=false"/"degraded" as neutral informational text — red is reserved for real task failure or attestation tampering; a SUCCEEDED run shows no red.
- **A3**: verified the run page renders a single `JobDAG`; the gantt timeline and the interactive DAG are now labeled distinctly (not a duplicated DAG).
- **A4**: task rows sort by execution start time with DAG topological rank as the tie-break.
- Tests: `receipt-verify.spec.ts` asserts timeline/DAG precede the receipt + neutral degraded styling; `ReceiptPanel.test.tsx` covers the neutral styling.

## Test plan
- [x] eslint + tsc + vite build (orchestrator local)
- [ ] GHA CI: ui-lint, ui-test, ui-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
