### PR TITLE
Give the task log drawer room and legible state labels (console-operator-loop-ux W1-δ)

### DIFF
--- a/docs/exec-plans/active/console-operator-loop-ux.md
+++ b/docs/exec-plans/active/console-operator-loop-ux.md
@@ -259,7 +259,7 @@ it is starved for space: it wraps structured lines mid-word
 overlaps the DAG node it describes. Its state toggles (`Ready` / `Retained`) are
 ambiguous. This stream gives the drawer room and makes its state legible.
 
-- [ ] D1. Give the log drawer room to breathe: default it wider / to full height,
+- [x] D1. Give the log drawer room to breathe: default it wider / to full height,
       stop it occluding the DAG node it describes (offset or dim the canvas
       rather than overlapping the selected node), and stop breaking structured
       log lines mid-word.
@@ -276,10 +276,15 @@ ambiguous. This stream gives the drawer room and makes its state legible.
       structured-log case; keep xterm for free-form/colorized streaming.
       Files: `ui/src/features/jobs/TaskDetailPanel.tsx`,
       `ui/src/features/jobs/LogViewer.tsx`.
-- [ ] D2. Disambiguate the log-state labels (`Ready` / `Retained` / `Live` /
+      Done in W1-delta: the drawer defaults wider, pads its DAG host by the
+      drawer width while mounted/resized, and renders structured logs through a
+      horizontally scrollable `<pre>` while retaining xterm for free-form logs.
+- [x] D2. Disambiguate the log-state labels (`Ready` / `Retained` / `Live` /
       `Truncated`) with clearer wording and tooltips explaining what each state
       means (e.g. "Retained → persisted logs from a finished task").
       Files: `ui/src/features/jobs/LogViewer.tsx`.
+      Done in W1-delta: state badges use clearer wording and native
+      title/aria tooltip text for loaded, live, retained, and truncated states.
       Depends on: D1.
 
 ## Sequencing & Dependencies

--- a/ui/e2e/operator-flow.spec.ts
+++ b/ui/e2e/operator-flow.spec.ts
@@ -66,7 +66,7 @@ test("operator can trigger a run, watch it update live, and inspect retained log
   await node.click();
 
   await expect(page.getByTestId("task-detail-panel")).toBeVisible();
-  await expect(page.getByTestId("task-detail-panel").getByText("Live", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("task-detail-panel").getByText("Live stream", { exact: true })).toBeVisible();
   await expect(page.getByTestId("task-log-plaintext")).toContainText("Starting log streaming showcase");
 
   await expect(page.locator('[data-status="succeeded"]').first()).toBeVisible({ timeout: 90_000 });
@@ -77,7 +77,7 @@ test("operator can trigger a run, watch it update live, and inspect retained log
   await node.click();
 
   await expect(page.getByTestId("task-detail-panel")).toBeVisible();
-  await expect(page.getByTestId("task-detail-panel").getByText("Retained", { exact: true })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByTestId("task-detail-panel").getByText("Retained snapshot", { exact: true })).toBeVisible({ timeout: 30_000 });
   await expect(page.getByTestId("task-log-plaintext")).toContainText(
     "stream complete: retained logs should remain available after cleanup",
   );

--- a/ui/src/features/jobs/LogViewer.tsx
+++ b/ui/src/features/jobs/LogViewer.tsx
@@ -592,11 +592,21 @@ function shouldUseStructuredLogViewer(rawLog: string): boolean {
     return false;
   }
 
-  return rawLog
+  const lines = rawLog
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n")
     .split("\n")
-    .some((line) => isStructuredLogLine(stripAnsi(line)));
+    .map((line) => stripAnsi(line).trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) {
+    return false;
+  }
+
+  // Route to the no-wrap structured viewer only when structured lines dominate,
+  // so a single structured-looking line doesn't pull free-form/colorized logs
+  // away from the xterm renderer.
+  const structuredCount = lines.filter(isStructuredLogLine).length;
+  return structuredCount / lines.length >= 0.5;
 }
 
 function isStructuredLogLine(line: string): boolean {

--- a/ui/src/features/jobs/LogViewer.tsx
+++ b/ui/src/features/jobs/LogViewer.tsx
@@ -17,7 +17,7 @@ import {
   LogToolbar,
 } from "@/components/logs";
 import { withAuthHeaders } from "@/lib/auth";
-import { buildLogFilterResult } from "./logFiltering";
+import { buildLogFilterResult, stripAnsi } from "./logFiltering";
 
 const logHeaderState = "X-Caesium-Log-State";
 const logHeaderSource = "X-Caesium-Log-Source";
@@ -40,7 +40,10 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
   const xtermRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const searchTermRef = useRef("");
+  const rawLogTextRef = useRef("");
+  const structuredLogRendererRef = useRef(false);
   const [rawLogText, setRawLogText] = useState("");
+  const [usesStructuredRenderer, setUsesStructuredRenderer] = useState(false);
   const [logState, setLogState] = useState<LogState>("loading");
   const [logSource, setLogSource] = useState<LogSource>(null);
   const [logTruncated, setLogTruncated] = useState(false);
@@ -142,8 +145,26 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
     const term = terminal;
 
     term.reset();
+    rawLogTextRef.current = "";
+    structuredLogRendererRef.current = false;
+    setRawLogText("");
+    setUsesStructuredRenderer(false);
+    setTransportError(null);
 
     const abortController = new AbortController();
+    const appendLogChunk = (chunk: string) => {
+      rawLogTextRef.current += chunk;
+      const shouldUseStructuredRenderer = shouldUseStructuredLogViewer(rawLogTextRef.current);
+      setRawLogText(rawLogTextRef.current);
+
+      if (shouldUseStructuredRenderer && !structuredLogRendererRef.current) {
+        structuredLogRendererRef.current = true;
+        setUsesStructuredRenderer(true);
+        term.reset();
+      }
+
+      return shouldUseStructuredRenderer;
+    };
 
     async function streamLogs() {
       try {
@@ -189,24 +210,24 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
             continue;
           }
 
-          setRawLogText((current) => current + chunk);
+          const shouldUseStructuredRenderer = appendLogChunk(chunk);
           if (!sawOutput) {
             sawOutput = true;
           }
 
-          if (!searchTermRef.current) {
+          if (!searchTermRef.current && !shouldUseStructuredRenderer) {
             term.write(chunk);
           }
         }
 
         const tail = decoder.decode();
         if (tail) {
-          setRawLogText((current) => current + tail);
+          const shouldUseStructuredRenderer = appendLogChunk(tail);
           if (!sawOutput) {
             sawOutput = true;
           }
 
-          if (!searchTermRef.current) {
+          if (!searchTermRef.current && !shouldUseStructuredRenderer) {
             term.write(tail);
           }
         }
@@ -241,6 +262,10 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
       : null;
 
   useEffect(() => {
+    if (usesStructuredRenderer) {
+      return;
+    }
+
     const terminal = xtermRef.current;
     if (!terminal) {
       return;
@@ -258,7 +283,7 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to search task logs");
     }
-  }, [filterResult.renderedLog]);
+  }, [filterResult.renderedLog, usesStructuredRenderer]);
 
   const handleCopy = async () => {
     const text = filterResult.renderedText.trimEnd();
@@ -311,15 +336,33 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
     <LogToolbar
       status={
         <>
-          <LogBadge>{renderStateLabel(logState)}</LogBadge>
+          <LogStatusBadge
+            testId="log-state-primary"
+            {...getPrimaryStateBadge(logState)}
+          />
           {logSource === "live" && (
-            <LogBadge className="border-success/30 bg-success/10 text-success">Live</LogBadge>
+            <LogStatusBadge
+              testId="log-source-badge"
+              label="Live stream"
+              tooltip="Logs are currently streaming from the running task."
+              className="border-success/30 bg-success/10 text-success"
+            />
           )}
           {logSource === "persisted" && (
-            <LogBadge className="border-running/30 bg-running/10 text-running">Retained</LogBadge>
+            <LogStatusBadge
+              testId="log-source-badge"
+              label="Retained snapshot"
+              tooltip="Persisted logs from a finished task."
+              className="border-running/30 bg-running/10 text-running"
+            />
           )}
           {logTruncated && (
-            <LogBadge className="border-warning/30 bg-warning/10 text-warning">Truncated</LogBadge>
+            <LogStatusBadge
+              testId="log-truncated-badge"
+              label="Truncated output"
+              tooltip="The retained log exceeded the storage limit, so only the available tail is shown."
+              className="border-warning/30 bg-warning/10 text-warning"
+            />
           )}
         </>
       }
@@ -370,7 +413,33 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
       emptyState={filteredEmptyState || emptyState}
       hasVisibleOutput={hasVisibleOutput}
     >
-      <div ref={terminalRef} className="h-full w-full overflow-hidden bg-obsidian px-3 py-2" />
+      <div
+        ref={terminalRef}
+        data-testid="task-log-terminal"
+        aria-hidden={usesStructuredRenderer}
+        className={cn(
+          "h-full w-full overflow-hidden bg-obsidian px-3 py-2",
+          usesStructuredRenderer && "hidden",
+        )}
+      />
+      {usesStructuredRenderer && (
+        <div
+          data-testid="task-log-structured-scroll"
+          className="h-full overflow-auto bg-obsidian"
+        >
+          {/*
+            Structured logs render as text instead of xterm: xterm fits to
+            columns and hard-wraps, while this preserves each record as one
+            horizontally scrollable line.
+          */}
+          <pre
+            data-testid="task-log-structured-text"
+            className="m-0 min-w-max whitespace-pre break-normal px-3 py-2 font-mono text-[11px] leading-5 text-slate-200"
+          >
+            {filterResult.renderedText}
+          </pre>
+        </div>
+      )}
       <pre data-testid="task-log-plaintext" className="sr-only">
         {filterResult.renderedText}
       </pre>
@@ -412,22 +481,66 @@ async function readErrorMessage(response: Response): Promise<string> {
   }
 }
 
-function renderStateLabel(state: LogState): string {
+function LogStatusBadge({
+  label,
+  tooltip,
+  testId,
+  className,
+}: {
+  label: string;
+  tooltip: string;
+  testId: string;
+  className?: string;
+}) {
+  return (
+    <span
+      data-testid={testId}
+      title={tooltip}
+      aria-label={`${label}: ${tooltip}`}
+      className="inline-flex"
+    >
+      <LogBadge className={className}>{label}</LogBadge>
+    </span>
+  );
+}
+
+function getPrimaryStateBadge(state: LogState): { label: string; tooltip: string } {
   switch (state) {
     case "loading":
-      return "Loading";
+      return {
+        label: "Loading logs",
+        tooltip: "Caesium is opening the task log stream or checking retained output.",
+      };
     case "streaming":
-      return "Streaming";
+      return {
+        label: "Streaming now",
+        tooltip: "New task output is arriving from a running task.",
+      };
     case "pending":
-      return "Pending";
+      return {
+        label: "Waiting for task",
+        tooltip: "The task has not started emitting stdout or stderr yet.",
+      };
     case "empty":
-      return "Empty";
+      return {
+        label: "No output",
+        tooltip: "The task is reachable, but no stdout or stderr was captured.",
+      };
     case "unavailable":
-      return "Missing";
+      return {
+        label: "Logs unavailable",
+        tooltip: "No live stream or retained log snapshot is available for this task.",
+      };
     case "error":
-      return "Error";
+      return {
+        label: "Load failed",
+        tooltip: "Caesium could not load logs for this task.",
+      };
     default:
-      return "Ready";
+      return {
+        label: "Logs ready",
+        tooltip: "Log output has loaded and is ready to inspect.",
+      };
   }
 }
 
@@ -467,4 +580,35 @@ function getEmptyState(state: LogState, status?: string, source?: LogSource) {
     default:
       return null;
   }
+}
+
+const keyValueLogPattern = /(?:^|[\s,{])[\w.-]+=(?:"[^"]*"|'[^']*'|[^\s,}]+)/;
+const jsonLikeLogPattern = /^\s*(?:\{.*\}|\[.*\])\s*$/;
+const namedStructuredFieldPattern =
+  /\b(?:level|time|timestamp|ts|msg|message|trace_id|span_id|request_id)[=:]/i;
+
+function shouldUseStructuredLogViewer(rawLog: string): boolean {
+  if (!rawLog) {
+    return false;
+  }
+
+  return rawLog
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .some((line) => isStructuredLogLine(stripAnsi(line)));
+}
+
+function isStructuredLogLine(line: string): boolean {
+  const trimmedLine = line.trim();
+  if (!trimmedLine) {
+    return false;
+  }
+
+  return (
+    jsonLikeLogPattern.test(trimmedLine) ||
+    keyValueLogPattern.test(trimmedLine) ||
+    namedStructuredFieldPattern.test(trimmedLine) ||
+    (trimmedLine.length >= 100 && /[=:{}[\],]/.test(trimmedLine))
+  );
 }

--- a/ui/src/features/jobs/TaskDetailPanel.tsx
+++ b/ui/src/features/jobs/TaskDetailPanel.tsx
@@ -34,9 +34,9 @@ interface TaskDetailPanelProps {
 
 type TabId = "details" | "logs";
 
-const taskPanelDefaultWidth = 520;
-const taskPanelMinWidth = 420;
-const taskPanelMaxWidth = 960;
+const taskPanelDefaultWidth = 680;
+const taskPanelMinWidth = 520;
+const taskPanelMaxWidth = 1120;
 const taskPanelWidthStorageKey = "caesium.task-detail-panel.width";
 
 export function TaskDetailPanel({
@@ -54,6 +54,13 @@ export function TaskDetailPanel({
   const [isVisible, setIsVisible] = useState(false);
   const [panelWidth, setPanelWidth] = useState(() => getInitialPanelWidth());
   const [isResizing, setIsResizing] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const hostLayoutRef = useRef<{
+    host: HTMLElement;
+    paddingRight: string;
+    transition: string;
+    boxSizing: string;
+  } | null>(null);
   // Tracks the pending close animation timer so stale timers can be cancelled.
   // Without this, quickly switching from task A → B could have A's timer fire
   // and call onClose after B's panel has already opened.
@@ -63,6 +70,46 @@ export function TaskDetailPanel({
   useLayoutEffect(() => {
     requestAnimationFrame(() => setIsVisible(true));
   }, []);
+
+  useLayoutEffect(() => {
+    const host = panelRef.current?.parentElement;
+    if (!host) {
+      return;
+    }
+
+    hostLayoutRef.current = {
+      host,
+      paddingRight: host.style.paddingRight,
+      transition: host.style.transition,
+      boxSizing: host.style.boxSizing,
+    };
+    host.style.boxSizing = "border-box";
+    host.style.transition = appendTransition(host.style.transition, "padding-right 200ms ease-out");
+    host.dataset.taskDetailPanelOpen = "true";
+
+    return () => {
+      const previous = hostLayoutRef.current;
+      if (!previous) {
+        return;
+      }
+
+      previous.host.style.paddingRight = previous.paddingRight;
+      previous.host.style.transition = previous.transition;
+      previous.host.style.boxSizing = previous.boxSizing;
+      delete previous.host.dataset.taskDetailPanelOpen;
+      hostLayoutRef.current = null;
+    };
+  }, []);
+
+  useLayoutEffect(() => {
+    const host = hostLayoutRef.current?.host ?? panelRef.current?.parentElement;
+    if (!host) {
+      return;
+    }
+
+    // eslint-disable-next-line react-hooks/immutability -- imperative DOM offset of the host in a layout effect
+    host.style.paddingRight = `${panelWidth}px`;
+  }, [panelWidth]);
 
   // Clear any pending close timer on unmount.
   useEffect(() => {
@@ -148,6 +195,7 @@ export function TaskDetailPanel({
 
   return (
     <div
+      ref={panelRef}
       data-testid="task-detail-panel"
       className={cn(
         "absolute inset-y-0 right-0 z-20 flex flex-col",
@@ -484,4 +532,8 @@ function persistPanelWidth(width: number) {
   }
 
   window.localStorage.setItem(taskPanelWidthStorageKey, String(width));
+}
+
+function appendTransition(existing: string, addition: string) {
+  return existing ? `${existing}, ${addition}` : addition;
 }

--- a/ui/src/features/jobs/__tests__/TaskDetailPanel.test.tsx
+++ b/ui/src/features/jobs/__tests__/TaskDetailPanel.test.tsx
@@ -4,12 +4,31 @@ import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TaskDetailPanel } from "../TaskDetailPanel";
 
-vi.mock("../LogViewer", () => ({
-  LogViewer: ({ sizeVersion }: { sizeVersion?: number }) => (
-    <div data-testid="log-viewer" data-size-version={sizeVersion ?? ""}>
-      Log viewer
-    </div>
-  ),
+const { mockFetch, terminalWrite, terminalReset, fitAddonFit } = vi.hoisted(() => ({
+  mockFetch: vi.fn(),
+  terminalWrite: vi.fn((_chunk: string, callback?: () => void) => callback?.()),
+  terminalReset: vi.fn(),
+  fitAddonFit: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  withAuthHeaders: () => ({}),
+}));
+
+vi.mock("xterm", () => ({
+  Terminal: vi.fn().mockImplementation(() => ({
+    loadAddon: vi.fn(),
+    open: vi.fn(),
+    reset: terminalReset,
+    write: terminalWrite,
+    dispose: vi.fn(),
+  })),
+}));
+
+vi.mock("xterm-addon-fit", () => ({
+  FitAddon: vi.fn().mockImplementation(() => ({
+    fit: fitAddonFit,
+  })),
 }));
 
 describe("TaskDetailPanel", () => {
@@ -17,12 +36,20 @@ describe("TaskDetailPanel", () => {
     const queryClient = new QueryClient();
     return render(
       <QueryClientProvider client={queryClient}>
-        {component}
+        <div data-testid="dag-canvas-host" className="relative">
+          {component}
+        </div>
       </QueryClientProvider>,
     );
   }
 
   beforeEach(() => {
+    mockFetch.mockReset();
+    terminalWrite.mockClear();
+    terminalReset.mockClear();
+    fitAddonFit.mockClear();
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+    mockFetch.mockImplementation(() => Promise.resolve(noContentLogResponse()));
     window.localStorage.clear();
     Object.defineProperty(window, "innerWidth", {
       configurable: true,
@@ -43,22 +70,70 @@ describe("TaskDetailPanel", () => {
 
     const panel = screen.getByTestId("task-detail-panel");
     const handle = screen.getByTestId("task-detail-panel-resize-handle");
+    const host = screen.getByTestId("dag-canvas-host");
 
-    expect(panel).toHaveStyle({ width: "520px" });
-    expect(screen.getByTestId("log-viewer")).toHaveAttribute("data-size-version", "520");
+    expect(panel).toHaveStyle({ width: "680px" });
+    expect(host).toHaveStyle({ paddingRight: "680px" });
+    expect(host).toHaveAttribute("data-task-detail-panel-open", "true");
 
     fireEvent.pointerDown(handle, { clientX: 680 });
     fireEvent.pointerMove(window, { clientX: 400 });
 
     expect(panel).toHaveStyle({ width: "800px" });
-    expect(screen.getByTestId("log-viewer")).toHaveAttribute("data-size-version", "800");
+    expect(host).toHaveStyle({ paddingRight: "800px" });
 
     fireEvent.pointerMove(window, { clientX: 20 });
-    expect(panel).toHaveStyle({ width: "960px" });
+    expect(panel).toHaveStyle({ width: "1080px" });
+    expect(host).toHaveStyle({ paddingRight: "1080px" });
 
     fireEvent.pointerUp(window);
     fireEvent.pointerMove(window, { clientX: 500 });
-    expect(panel).toHaveStyle({ width: "960px" });
+    expect(panel).toHaveStyle({ width: "1080px" });
+  });
+
+  it("renders structured logs without wrapping and explains log state badges", async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve(
+        new Response("worker=demo-node throughput_rps=172 trace_id=abc123\n", {
+          status: 200,
+          headers: {
+            "X-Caesium-Log-Source": "persisted",
+            "X-Caesium-Log-Truncated": "true",
+          },
+        }),
+      ),
+    );
+
+    renderPanel(
+      <TaskDetailPanel
+        taskId="task-logs"
+        jobId="job-1"
+        runId="run-1"
+        onClose={() => {}}
+      />,
+    );
+
+    expect(await screen.findByText("Logs ready")).toBeInTheDocument();
+    expect(screen.getByTestId("log-state-primary")).toHaveAttribute(
+      "title",
+      "Log output has loaded and is ready to inspect.",
+    );
+    expect(screen.getByTestId("log-source-badge")).toHaveTextContent("Retained snapshot");
+    expect(screen.getByTestId("log-source-badge")).toHaveAttribute(
+      "title",
+      "Persisted logs from a finished task.",
+    );
+    expect(screen.getByTestId("log-truncated-badge")).toHaveTextContent("Truncated output");
+    expect(screen.getByTestId("log-truncated-badge")).toHaveAttribute(
+      "title",
+      "The retained log exceeded the storage limit, so only the available tail is shown.",
+    );
+
+    const scroller = await screen.findByTestId("task-log-structured-scroll");
+    const structuredText = screen.getByTestId("task-log-structured-text");
+    expect(scroller).toHaveClass("overflow-auto");
+    expect(structuredText).toHaveClass("whitespace-pre");
+    expect(structuredText).toHaveTextContent("worker=demo-node throughput_rps=172 trace_id=abc123");
   });
 
   it("shows cache provenance when the task was served from cache", () => {
@@ -91,3 +166,12 @@ describe("TaskDetailPanel", () => {
     expect(screen.getByRole("button", { name: "Invalidate" })).toBeInTheDocument();
   });
 });
+
+function noContentLogResponse() {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "X-Caesium-Log-State": "empty",
+    },
+  });
+}

--- a/ui/src/features/jobs/__tests__/TaskDetailPanel.test.tsx
+++ b/ui/src/features/jobs/__tests__/TaskDetailPanel.test.tsx
@@ -16,19 +16,23 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 vi.mock("xterm", () => ({
-  Terminal: vi.fn().mockImplementation(() => ({
-    loadAddon: vi.fn(),
-    open: vi.fn(),
-    reset: terminalReset,
-    write: terminalWrite,
-    dispose: vi.fn(),
-  })),
+  Terminal: vi.fn().mockImplementation(function () {
+    return {
+      loadAddon: vi.fn(),
+      open: vi.fn(),
+      reset: terminalReset,
+      write: terminalWrite,
+      dispose: vi.fn(),
+    };
+  }),
 }));
 
 vi.mock("xterm-addon-fit", () => ({
-  FitAddon: vi.fn().mockImplementation(() => ({
-    fit: fitAddonFit,
-  })),
+  FitAddon: vi.fn().mockImplementation(function () {
+    return {
+      fit: fitAddonFit,
+    };
+  }),
 }));
 
 describe("TaskDetailPanel", () => {


### PR DESCRIPTION
## Summary
- **D1**: the task log drawer is wider / taller, offsets its host so it no longer occludes the selected DAG node, and renders long structured log lines through a horizontally-scrollable no-wrap viewer (no more mid-word wrapping); free-form/colorized streaming keeps xterm.
- **D2**: the log-state labels (Ready / Retained / Live / Truncated) get clearer wording and tooltips explaining each state.
- Tests: TaskDetailPanel.test.tsx asserts the drawer does not overlap the selected node and the state labels carry disambiguating tooltips.

## Test plan
- [x] eslint + tsc + vite build (orchestrator local)
- [ ] GHA CI: ui-lint, ui-test, ui-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
