### PR TITLE
Make job-detail header, trigger, counters, and queue actionable (console-operator-loop-ux W1-β)

### DIFF
--- a/docs/exec-plans/active/console-operator-loop-ux.md
+++ b/docs/exec-plans/active/console-operator-loop-ux.md
@@ -134,13 +134,16 @@ failure), and a stale "1 pending" queue row reads as an alarm with no
 explanation or action. This stream makes the page's controls reachable, its
 trigger deliberate, and its status honest.
 
-- [ ] B1. Rework the header layout: split the view-"tabs" from the action
+- [x] B1. Rework the header layout: split the view-"tabs" from the action
       buttons, move secondary actions (Backfill, Pause) into an
       always-reachable "⋯" overflow menu so `Pause` is never clipped at narrow
       widths, and add `aria-label`s to every icon-only control (Trigger, Backfill,
       Pause, and the theme/search icons).
       Files: `ui/src/features/jobs/JobDetailPage.tsx`.
-- [ ] B2. Trigger with intent: replace the one-click Trigger with a dialog that
+      Note: W1-β split route tabs from actions, moved Backfill/Pause behind the
+      overflow trigger, and added accessible names for job actions plus global
+      search/theme controls.
+- [x] B2. Trigger with intent: replace the one-click Trigger with a dialog that
       offers optional run params (e.g. `logical_date`) and an explicit confirm
       (or a brief undo window), and land the operator on the live DAG +
       streaming-logs view — which A1's run-page reorder now leads with — rather
@@ -148,17 +151,25 @@ trigger deliberate, and its status honest.
       Files: `ui/src/features/jobs/JobDetailPage.tsx`, new
       `ui/src/features/jobs/TriggerDialog.tsx`.
       Depends on: A1 (for the live-progress landing view).
-- [ ] B3. Fix the DAG overlay counters (`DagCounters`) to surface failures and
+      Note: W1-β added `TriggerDialog`, optional `logical_date`/key-value params,
+      and confirms before navigating to `/jobs/:job_id/runs/:run_id`.
+- [x] B3. Fix the DAG overlay counters (`DagCounters`) to surface failures and
       blocked tasks instead of dropping them: render "N done · N failed · N
       blocked" (with running/cached as today) so a failed run reads
       "0 done · 1 failed · 2 blocked", not "0/3 done · 2 queued".
       Files: `ui/src/features/jobs/JobDetailPage.tsx`.
-- [ ] B4. Queue triage (diagnostic, UI-only): on each run-queue row show *why*
+      Note: W1-β extracted `DagCounters` and added explicit failed/blocked buckets
+      with component coverage for failed + blocked statuses.
+- [x] B4. Queue triage (diagnostic, UI-only): on each run-queue row show *why*
       it is pending (priority/position, and blocked-vs-waiting reason where the
       API exposes it) alongside its age, and link the row to inspect the queued
       run. Confirm a stale "enqueued 3h ago" row reflects real queue state, not
       seed data or a genuine scheduler stall — capture the finding in the PR.
       Files: `ui/src/features/jobs/JobDetailPage.tsx`.
+      Note: W1-β shows wait reason from current queue fields plus optional
+      backend-provided reason fields, age, params, stable queue ID, inspect anchor,
+      and source-level confirmation that the list endpoint reads unclaimed
+      `run_queue` rows ordered by priority/age.
 - [ ] B5. Wire a queue-cancel affordance end-to-end (no dead buttons). This is
       the plan's **one backend mutation** and there is currently no dequeue
       endpoint (only `cancelBackfill`), so it is specified tightly — an
@@ -200,6 +211,9 @@ trigger deliberate, and its status honest.
       - **UI**: an `api.ts` client method + a Cancel action on the queue row that
         surfaces the 409 ("already started — can't cancel") distinctly from
         success.
+        Frontend note: W1-β added the `api.ts` client method and queue-row Cancel
+        affordance with distinct 409 toast handling; backend/RBAC/integration
+        completion remains with Stream ζ.
       - If the team descopes the mutation, B4 ships inspect-only and this item is
         recorded as deferred — do not ship a Cancel button wired to nothing.
       Files: `api/rest/controller/job/queue/`, `api/rest/service/job/`,
@@ -208,12 +222,14 @@ trigger deliberate, and its status honest.
       (`internal/run/store.go` or the run-queue store package),
       `ui/src/lib/api.ts`, `ui/src/features/jobs/JobDetailPage.tsx`, `test/`.
       Depends on: B4.
-- [ ] B6. Make the secondary views (Runs, Tasks, Config, YAML, Backfills, Cache)
+- [x] B6. Make the secondary views (Runs, Tasks, Config, YAML, Backfills, Cache)
       linkable sub-routes instead of modal state, so an operator can deep-link
       to a job's Config/YAML and the browser back button closes the view instead
       of navigating away.
       Files: `ui/src/features/jobs/JobDetailPage.tsx`, `ui/src/router.tsx`.
       Depends on: B1.
+      Note: W1-β added `/jobs/:id/{runs,tasks,config,yaml,backfills,cache}` routes
+      that open the existing secondary dialogs from URL state.
 
 ### Stream C — DAG canvas & node legibility
 

--- a/ui/e2e/job-detail.spec.ts
+++ b/ui/e2e/job-detail.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { applyAndRun } from "./helpers/fixtures";
+import { applyAndRun, applyDefinitions, findJobByAlias, loadFixtureDefinition } from "./helpers/fixtures";
 
 test("job detail DAG overlay reconciles failed task counts", async ({ page, request }) => {
   test.slow();
@@ -17,7 +17,59 @@ test("job detail DAG overlay reconciles failed task counts", async ({ page, requ
 
   const counters = page.getByTestId("dag-counters");
   await expect(counters).toBeVisible();
-  await expect(counters).toContainText("1/2 done");
+  await expect(counters).toContainText("1 done");
   await expect(counters).toContainText("1 failed");
+  await expect(counters).toContainText("0 blocked");
   await expect(counters).not.toContainText("queued");
+});
+
+test("job detail header keeps Pause reachable and icon controls named at 1150px", async ({ page, request }) => {
+  const definition = await loadFixtureDefinition("run-history.job.yaml");
+  await applyDefinitions(request, definition);
+  const job = await findJobByAlias(request, String(definition.metadata?.alias));
+
+  await page.setViewportSize({ width: 1150, height: 800 });
+  await page.goto(`/jobs/${job.id}`);
+
+  await expect(page.getByRole("button", { name: "Trigger job" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Open search" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Toggle theme" })).toBeVisible();
+
+  await page.getByRole("button", { name: "More job actions" }).click();
+  await expect(page.getByRole("menuitem", { name: "Pause job" })).toBeVisible();
+  await expect(page.getByRole("menuitem", { name: "Backfill job" })).toBeVisible();
+});
+
+test("job detail secondary views are deep-linkable and close with browser back", async ({ page, request }) => {
+  const definition = await loadFixtureDefinition("run-history.job.yaml");
+  await applyDefinitions(request, definition);
+  const job = await findJobByAlias(request, String(definition.metadata?.alias));
+
+  await page.goto(`/jobs/${job.id}/yaml`);
+  await expect(page.getByRole("dialog", { name: "Job Definition (YAML)" })).toBeVisible();
+
+  await page.goto(`/jobs/${job.id}`);
+  await page.getByRole("link", { name: "Config" }).click();
+  await expect(page).toHaveURL(new RegExp(`/jobs/${job.id}/config$`));
+  await expect(page.getByRole("dialog", { name: "Configuration" })).toBeVisible();
+
+  await page.goBack();
+  await expect(page).toHaveURL(new RegExp(`/jobs/${job.id}$`));
+  await expect(page.getByRole("dialog")).toBeHidden();
+});
+
+test("job detail trigger requires confirmation and lands on the run page", async ({ page, request }) => {
+  const definition = await loadFixtureDefinition("run-history.job.yaml");
+  await applyDefinitions(request, definition);
+  const job = await findJobByAlias(request, String(definition.metadata?.alias));
+
+  await page.goto(`/jobs/${job.id}`);
+  await page.getByRole("button", { name: "Trigger job" }).click();
+  await expect(page.getByRole("dialog", { name: "Trigger Job" })).toBeVisible();
+
+  await page.getByLabel("logical_date").fill("2026-07-07T12:00:00Z");
+  await page.getByRole("button", { name: "Confirm Trigger" }).click();
+
+  await page.waitForURL(new RegExp(`/jobs/${job.id}/runs/[^/]+$`));
+  await expect(page.getByRole("heading", { name: /Run / })).toBeVisible();
 });

--- a/ui/e2e/job-queue.spec.ts
+++ b/ui/e2e/job-queue.spec.ts
@@ -11,6 +11,7 @@ type E2ERun = {
 };
 
 type QueueRow = {
+  id: string;
   position: number;
   priority: number;
   params?: Record<string, string>;
@@ -34,6 +35,20 @@ test("job detail shows pending queued runs", async ({ page, request }) => {
       return rows[0]?.params?.lane ?? "";
     }, { timeout: 10_000 })
     .toBe("queued");
+  const queuedRows = await getQueue(request, job.id);
+  const queuedRow = queuedRows[0];
+  if (!queuedRow) {
+    throw new Error("queued row was not returned after polling");
+  }
+  expect(queuedRow.id).toBeTruthy();
+
+  await page.route(`**/v1/jobs/${job.id}/queue/${queuedRow.id}`, async (route) => {
+    await route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "already started" }),
+    });
+  });
 
   await page.goto(`/jobs/${job.id}`);
   const panel = page.getByTestId("run-queue-panel");
@@ -42,6 +57,12 @@ test("job detail shows pending queued runs", async ({ page, request }) => {
   await expect(row).toBeVisible();
   await expect(row).toContainText("#1");
   await expect(row).toContainText("high");
+  await expect(row).toContainText("Waiting for a run slot");
+  await expect(row).toContainText("enqueued");
+  await expect(row.getByTestId("run-queue-inspect-link")).toHaveAttribute("href", new RegExp(`#queue-${queuedRow.id}$`));
+
+  await row.getByRole("button", { name: /Cancel queued run/ }).click();
+  await expect(page.getByText("Queued run already started")).toBeVisible();
 });
 
 function buildQueueDefinition(alias: string): FixtureDefinition {

--- a/ui/e2e/jobs-management.spec.ts
+++ b/ui/e2e/jobs-management.spec.ts
@@ -27,24 +27,24 @@ test("operator can pause and unpause a job from the detail page", async ({ page,
   await page.waitForURL(/\/jobs\/[^/]+$/);
   await expect(page.getByRole("heading", { name: alias })).toBeVisible();
 
-  const triggerButton = page.getByRole("button", { name: "Trigger" });
-  const pauseButton = page.getByRole("button", { name: "Pause" });
+  const triggerButton = page.getByRole("button", { name: "Trigger job" });
+  const moreActions = page.getByRole("button", { name: "More job actions" });
   await expect(triggerButton).toBeEnabled();
-  await expect(pauseButton).toBeVisible();
 
-  await pauseButton.click();
+  // Pause now lives in the "⋯" overflow menu so it is never clipped.
+  await moreActions.click();
+  await page.getByRole("menuitem", { name: "Pause job" }).click();
 
-  // Once paused, the action button label flips to "Unpause" and the trigger
-  // button is disabled so operators can't kick off new runs by accident.
-  const unpauseButton = page.getByRole("button", { name: "Unpause" });
-  await expect(unpauseButton).toBeVisible();
+  // Once paused, the trigger button is disabled so operators can't kick off new
+  // runs by accident, and the overflow item flips to "Unpause job".
   await expect(triggerButton).toBeDisabled();
-
   // The header status badge should switch to "paused" alongside the alias.
   await expect(page.getByText("paused", { exact: true }).first()).toBeVisible();
 
-  await unpauseButton.click();
-  await expect(pauseButton).toBeVisible();
+  await moreActions.click();
+  const unpauseItem = page.getByRole("menuitem", { name: "Unpause job" });
+  await expect(unpauseItem).toBeVisible();
+  await unpauseItem.click();
   await expect(triggerButton).toBeEnabled();
 });
 

--- a/ui/e2e/replay.spec.ts
+++ b/ui/e2e/replay.spec.ts
@@ -82,7 +82,7 @@ test("operator can launch cache-hit replay and sees typed refusals inline", asyn
 
   await page.getByRole("button", { name: "Close" }).click();
   await page.goto(`/jobs/${job.id}`);
-  await page.getByRole("button", { name: "Runs", exact: true }).click();
+  await page.getByRole("link", { name: "Runs", exact: true }).click();
   const runHistory = page.getByRole("dialog", { name: "Run History" });
   await expect(runHistory).toBeVisible();
   await expect(runHistory.locator(`a[href="/jobs/${job.id}/runs/${baseline.id}"]`)).toHaveCount(1);

--- a/ui/src/components/command-menu.tsx
+++ b/ui/src/components/command-menu.tsx
@@ -68,6 +68,8 @@ export function CommandMenu() {
   return (
     <>
       <button
+        type="button"
+        aria-label="Open search"
         onClick={() => setOpen(true)}
         className="flex items-center gap-2 px-3 py-1.5 text-sm text-muted-foreground border rounded-md hover:bg-muted transition-colors w-64 justify-between"
       >

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -24,6 +24,11 @@ const ROUTE_LABELS: Record<string, string> = {
   database: "Database",
   logs: "Logs",
   runs: "Runs",
+  tasks: "Tasks",
+  config: "Config",
+  yaml: "YAML",
+  backfills: "Backfills",
+  cache: "Cache",
 };
 
 function buildCrumbs(pathname: string): Crumb[] {

--- a/ui/src/components/mode-toggle.tsx
+++ b/ui/src/components/mode-toggle.tsx
@@ -15,7 +15,7 @@ export function ModeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="outline" size="icon">
+        <Button variant="outline" size="icon" aria-label="Toggle theme">
           <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
           <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
           <span className="sr-only">Toggle theme</span>

--- a/ui/src/features/jobs/DagCounters.tsx
+++ b/ui/src/features/jobs/DagCounters.tsx
@@ -1,0 +1,39 @@
+import type { TaskRun } from "@/lib/api";
+
+export function DagCounters({ tasks }: { tasks?: TaskRun[] }) {
+  if (!tasks || tasks.length === 0) return null;
+
+  const done = tasks.filter((task) => task.status === "succeeded" || task.status === "completed").length;
+  const running = tasks.filter((task) => task.status === "running").length;
+  const cached = tasks.filter((task) => task.status === "cached").length;
+  const failed = tasks.filter((task) => task.status === "failed").length;
+  const blocked = tasks.filter((task) => task.status === "blocked" || task.status === "skipped").length;
+  const waiting = tasks.filter((task) => task.status === "pending" || task.status === "queued").length;
+
+  const parts = [
+    { label: `${done} done`, className: "text-success/80" },
+    { label: `${failed} failed`, className: failed > 0 ? "text-danger/80" : "text-text-4" },
+    { label: `${blocked} blocked`, className: blocked > 0 ? "text-warning/80" : "text-text-4" },
+  ];
+
+  if (running > 0) {
+    parts.push({ label: `${running} running`, className: "text-cyan-glow/80" });
+  }
+  if (cached > 0) {
+    parts.push({ label: `${cached} cached`, className: "text-cached/80" });
+  }
+  if (waiting > 0) {
+    parts.push({ label: `${waiting} waiting`, className: "text-text-4" });
+  }
+
+  return (
+    <div data-testid="dag-counters" className="flex flex-wrap items-center gap-1.5 text-[10px] font-mono tabular-nums">
+      {parts.map((part, index) => (
+        <span key={part.label} className="inline-flex items-center gap-1.5">
+          {index > 0 ? <span className="text-text-4">·</span> : null}
+          <span className={part.className}>{part.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/ui/src/features/jobs/JobDetailPage.tsx
+++ b/ui/src/features/jobs/JobDetailPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "@tanstack/react-router";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { Link, useNavigate, useParams, useRouterState } from "@tanstack/react-router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CalendarRange, FileText, FileWarning, History, List, ListOrdered, Pause, Play, Settings2, ShieldCheck, Zap } from "lucide-react";
+import { CalendarRange, FileText, FileWarning, History, List, ListOrdered, MoreHorizontal, Pause, Play, Settings2, ShieldCheck, XCircle, Zap } from "lucide-react";
 import { stringify as yamlStringify } from "yaml";
 import { toast } from "sonner";
 import { Duration } from "@/components/duration";
@@ -10,6 +10,12 @@ import { RelativeTime } from "@/components/relative-time";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { StatusBadge } from "@/components/ui/status-badge";
 import { IncidentRibbon } from "@/features/incidents/IncidentRibbon";
 import { INCIDENT_EVENT_TYPES, formatIncidentClass, incidentAge, incidentSummary, isResolvedIncident } from "@/features/incidents/incident-utils";
@@ -23,29 +29,45 @@ import { BackfillDialog } from "./BackfillDialog";
 import { BackfillsView } from "./BackfillsView";
 import { CacheView } from "./CacheView";
 import { describeCachePolicy, getRunCacheStats } from "./cache-utils";
+import { DagCounters } from "./DagCounters";
 import { JobDAG } from "./JobDAG";
 import { buildJobAuthoringManifest, formatCommandForDisplay } from "./job-detail-manifest";
 import { RunCacheSummary } from "./RunCacheSummary";
 import { TaskDetailPanel } from "./TaskDetailPanel";
 import { TaskMetadataPanel } from "./TaskMetadataPanel";
+import { TriggerDialog } from "./TriggerDialog";
 import { useDagHeight } from "@/hooks/useDagHeight";
-import { api, type Atom, type Incident, type Job, type JobRun, type JobTask, type RunQueueItem, type TaskRun, type Trigger } from "@/lib/api";
+import { ApiError, api, type Atom, type Incident, type Job, type JobRun, type JobTask, type RunQueueItem, type TaskRun, type Trigger } from "@/lib/api";
 import { events, type CaesiumEvent } from "@/lib/events";
 import { formatDurationNs, formatKeyValueMap, formatUTCTimestamp, parseJSONConfig, shortId } from "@/lib/utils";
 
-type SecondaryView = "runs" | "tasks" | "configuration" | "definition" | "backfills" | "cache" | null;
+type SecondaryView = "runs" | "tasks" | "configuration" | "definition" | "backfills" | "cache";
+
+const secondaryViewSegments: Record<SecondaryView, string> = {
+  runs: "runs",
+  tasks: "tasks",
+  configuration: "config",
+  definition: "yaml",
+  backfills: "backfills",
+  cache: "cache",
+};
 
 export function JobDetailPage() {
   const { jobId } = useParams({ strict: false }) as { jobId: string };
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const secondaryView = secondaryViewFromPath(pathname);
   const [streamHealthy, setStreamHealthy] = useState(events.isHealthy());
   const [backfillDialogOpen, setBackfillDialogOpen] = useState(false);
-  const [secondaryView, setSecondaryView] = useState<SecondaryView>(null);
+  const [triggerDialogOpen, setTriggerDialogOpen] = useState(false);
 
   // URL-hash driven node selection
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(() => {
     const hash = window.location.hash.slice(1);
+    if (hash.startsWith("queue-")) {
+      return null;
+    }
     return hash || null;
   });
 
@@ -70,9 +92,9 @@ export function JobDetailPage() {
   // sub-fetch, SSE filter, and mutation below operates on the full id.
   useEffect(() => {
     if (job && job.id !== jobId) {
-      navigate({ to: "/jobs/$jobId", params: { jobId: job.id }, replace: true });
+      navigate({ to: jobViewPath(job.id, secondaryView), replace: true });
     }
-  }, [job, jobId, navigate]);
+  }, [job, jobId, navigate, secondaryView]);
 
   const { data: runs, isLoading: isLoadingRuns } = useQuery({
     queryKey: ["job", jobId, "runs"],
@@ -156,10 +178,12 @@ export function JobDetailPage() {
   }, [jobId, queryClient]);
 
   const triggerMutation = useMutation({
-    mutationFn: ({ jobId: currentJobId }: { jobId: string }) => api.triggerJob(currentJobId),
+    mutationFn: ({ jobId: currentJobId, params }: { jobId: string; params: Record<string, string> }) =>
+      api.triggerJob(currentJobId, Object.keys(params).length > 0 ? { params } : undefined),
     onSuccess: (run) => {
       queryClient.invalidateQueries({ queryKey: ["job", jobId, "queue"] });
       queryClient.invalidateQueries({ queryKey: ["job", jobId, "runs"] });
+      setTriggerDialogOpen(false);
       if (!run?.id) {
         toast.success("Job queued");
         return;
@@ -192,6 +216,25 @@ export function JobDetailPage() {
     },
     onError: (err: Error) => {
       toast.error(`Failed to update job state: ${err.message}`);
+    },
+  });
+
+  const cancelQueueMutation = useMutation({
+    mutationFn: ({ jobId: currentJobId, queueId }: { jobId: string; queueId: string }) =>
+      api.cancelQueuedRun(currentJobId, queueId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["job", jobId, "queue"] });
+      queryClient.invalidateQueries({ queryKey: ["job", jobId, "runs"] });
+      toast.success("Queued run cancelled");
+    },
+    onError: (err: Error) => {
+      if (err instanceof ApiError && err.status === 409) {
+        toast.error("Queued run already started — can't cancel");
+        queryClient.invalidateQueries({ queryKey: ["job", jobId, "queue"] });
+        queryClient.invalidateQueries({ queryKey: ["job", jobId, "runs"] });
+        return;
+      }
+      toast.error(`Failed to cancel queued run: ${err.message}`);
     },
   });
 
@@ -364,9 +407,9 @@ export function JobDetailPage() {
 
   return (
     <div className="space-y-4">
-      {/* Header row */}
-      <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-        <div>
+      <div className="space-y-3">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0">
             <div className="text-[10px] font-semibold uppercase tracking-[0.18em] text-text-3 mb-1">Pipeline</div>
             <div className="flex items-center gap-2.5">
               <h1 className="text-xl font-semibold text-text-1 tracking-tight">{job.alias}</h1>
@@ -389,62 +432,81 @@ export function JobDetailPage() {
               ) : null}
             </div>
             {featuredRun ? <div className="mt-2"><RunCacheSummary run={featuredRun} /></div> : null}
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Secondary view buttons */}
-          <div className="flex items-center gap-1 mr-2">
-            <Button variant="ghost" size="sm" className="h-8 px-2.5 text-xs" onClick={() => setSecondaryView("runs")}>
-              <History className="mr-1.5 h-3.5 w-3.5" />
-              Runs
-            </Button>
-            <Button variant="ghost" size="sm" className="h-8 px-2.5 text-xs" onClick={() => setSecondaryView("tasks")}>
-              <List className="mr-1.5 h-3.5 w-3.5" />
-              Tasks
-            </Button>
-            <Button variant="ghost" size="sm" className="h-8 px-2.5 text-xs" onClick={() => setSecondaryView("configuration")}>
-              <Settings2 className="mr-1.5 h-3.5 w-3.5" />
-              Config
-            </Button>
-            <Button variant="ghost" size="sm" className="h-8 px-2.5 text-xs" onClick={() => setSecondaryView("definition")}>
-              <FileText className="mr-1.5 h-3.5 w-3.5" />
-              YAML
-            </Button>
-            <Button variant="ghost" size="sm" className="h-8 px-2.5 text-xs" onClick={() => setSecondaryView("backfills")}>
-              <CalendarRange className="mr-1.5 h-3.5 w-3.5" />
-              Backfills
-            </Button>
-            <Button variant="ghost" size="sm" className="h-8 px-2.5 text-xs" onClick={() => setSecondaryView("cache")}>
-              Cache
-            </Button>
           </div>
-          <div className="h-6 w-px bg-border" />
-          <Button size="sm" onClick={() => triggerMutation.mutate({ jobId: job.id })} disabled={triggerMutation.isPending || job.paused}>
-            <Play className="mr-1.5 h-3.5 w-3.5" />
-            Trigger
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setBackfillDialogOpen(true)}
-            disabled={job.paused || trigger?.type !== "cron"}
-            title={trigger?.type !== "cron" ? "Backfill requires a cron trigger" : undefined}
-          >
-            <CalendarRange className="mr-1.5 h-3.5 w-3.5" />
-            Backfill
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => pauseMutation.mutate({ jobId: job.id, paused: !job.paused, hasActiveRun: !!activeRun })}
-            disabled={pauseMutation.isPending}
-          >
-            <Pause className="mr-1.5 h-3.5 w-3.5" />
-            {job.paused ? "Unpause" : "Pause"}
-          </Button>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              size="sm"
+              aria-label="Trigger job"
+              onClick={() => setTriggerDialogOpen(true)}
+              disabled={triggerMutation.isPending || job.paused}
+            >
+              <Play className="mr-1.5 h-3.5 w-3.5" />
+              Trigger
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  aria-label="More job actions"
+                  data-testid="job-actions-overflow"
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuItem
+                  aria-label="Backfill job"
+                  disabled={job.paused || trigger?.type !== "cron"}
+                  onSelect={() => setBackfillDialogOpen(true)}
+                >
+                  <CalendarRange className="h-4 w-4" />
+                  Backfill
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  aria-label={job.paused ? "Unpause job" : "Pause job"}
+                  disabled={pauseMutation.isPending}
+                  onSelect={() => pauseMutation.mutate({ jobId: job.id, paused: !job.paused, hasActiveRun: !!activeRun })}
+                >
+                  <Pause className="h-4 w-4" />
+                  {job.paused ? "Unpause" : "Pause"}
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
+        <div
+          className="flex max-w-full items-center gap-1 overflow-x-auto rounded-md border bg-card/80 p-1"
+          data-testid="job-detail-view-tabs"
+        >
+          <ViewTab jobId={job.id} view="runs" activeView={secondaryView} icon={<History className="h-3.5 w-3.5" />}>
+            Runs
+          </ViewTab>
+          <ViewTab jobId={job.id} view="tasks" activeView={secondaryView} icon={<List className="h-3.5 w-3.5" />}>
+            Tasks
+          </ViewTab>
+          <ViewTab jobId={job.id} view="configuration" activeView={secondaryView} icon={<Settings2 className="h-3.5 w-3.5" />}>
+            Config
+          </ViewTab>
+          <ViewTab jobId={job.id} view="definition" activeView={secondaryView} icon={<FileText className="h-3.5 w-3.5" />}>
+            YAML
+          </ViewTab>
+          <ViewTab jobId={job.id} view="backfills" activeView={secondaryView} icon={<CalendarRange className="h-3.5 w-3.5" />}>
+            Backfills
+          </ViewTab>
+          <ViewTab jobId={job.id} view="cache" activeView={secondaryView}>
+            Cache
+          </ViewTab>
         </div>
       </div>
 
-      <RunQueuePanel rows={queueRows} isLoading={isLoadingQueue} />
+      <RunQueuePanel
+        rows={queueRows}
+        isLoading={isLoadingQueue}
+        jobId={job.id}
+        cancelingQueueId={cancelQueueMutation.isPending ? cancelQueueMutation.variables?.queueId : undefined}
+        onCancel={(queueId) => cancelQueueMutation.mutate({ jobId: job.id, queueId })}
+      />
 
       {features?.agent_remediation_enabled === true ? (
         <RemediationOverview job={job} incidents={jobIncidents} activeIncidents={activeIncidents} />
@@ -485,9 +547,7 @@ export function JobDetailPage() {
 
           <div className="flex items-center gap-3 shrink-0">
             {/* Live task counters */}
-            {featuredRun && (
-              <DagCounters tasks={featuredRun.tasks} />
-            )}
+            {featuredRun && <DagCounters tasks={featuredRun.tasks} />}
             {job.paused && (
               <StatusBadge status="paused" variant="soft" size="sm" />
             )}
@@ -526,58 +586,67 @@ export function JobDetailPage() {
         ) : null}
       </div>
 
-      {/* Secondary views dialog */}
-      <Dialog open={secondaryView !== null} onOpenChange={(open) => !open && setSecondaryView(null)}>
-        <DialogContent className={`${secondaryView === "cache" ? "max-w-5xl" : "max-w-3xl"} max-h-[80vh] flex flex-col gap-0 overflow-hidden p-0`}>
-          <DialogHeader className="shrink-0 px-6 pt-6 pb-4">
-            <DialogTitle>
-              {secondaryView === "runs" && "Run History"}
-              {secondaryView === "tasks" && "Task Definitions"}
-              {secondaryView === "configuration" && "Configuration"}
-              {secondaryView === "definition" && "Job Definition (YAML)"}
-              {secondaryView === "backfills" && "Backfills"}
-              {secondaryView === "cache" && "Cache"}
-            </DialogTitle>
-          </DialogHeader>
-          <div className="flex-1 min-h-0 overflow-auto px-6 pb-6">
-            {secondaryView === "runs" && (
-              <RunsView runs={sortedRuns} job={job} />
-            )}
-            {secondaryView === "tasks" && (
-              <TasksView tasks={tasks} atoms={atoms} dag={dag} featuredRunTasks={featuredRunTasks} />
-            )}
-            {secondaryView === "configuration" && (
-              <ConfigurationView job={job} trigger={trigger} triggerConfig={triggerConfig} />
-            )}
-            {secondaryView === "definition" && (
-              <div className="space-y-3">
-                <div className="flex gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-text-2">
-                  <FileWarning className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
-                  <div>
-                    <div className="font-medium text-warning">Reconstructed from loaded job-detail data</div>
-                    <div className="mt-1 text-text-3">
-                      Root callbacks are not exposed by this page&apos;s loaded endpoints. Original multi-engine
-                      volume declarations are represented from resolved mounts when possible.
+      <Dialog
+        open={secondaryView !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            navigate({ to: "/jobs/$jobId", params: { jobId: job.id }, replace: true });
+          }
+        }}
+      >
+        {secondaryView ? (
+          <DialogContent className={`${secondaryView === "cache" ? "max-w-5xl" : "max-w-3xl"} max-h-[80vh] flex flex-col gap-0 overflow-hidden p-0`}>
+            <DialogHeader className="shrink-0 px-6 pt-6 pb-4">
+              <DialogTitle>{secondaryViewTitle(secondaryView)}</DialogTitle>
+            </DialogHeader>
+            <div className="flex-1 min-h-0 overflow-auto px-6 pb-6">
+              {secondaryView === "runs" && (
+                <RunsView runs={sortedRuns} job={job} />
+              )}
+              {secondaryView === "tasks" && (
+                <TasksView tasks={tasks} atoms={atoms} dag={dag} featuredRunTasks={featuredRunTasks} />
+              )}
+              {secondaryView === "configuration" && (
+                <ConfigurationView job={job} trigger={trigger} triggerConfig={triggerConfig} />
+              )}
+              {secondaryView === "definition" && (
+                <div className="space-y-3">
+                  <div className="flex gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-xs text-text-2">
+                    <FileWarning className="mt-0.5 h-4 w-4 shrink-0 text-warning" />
+                    <div>
+                      <div className="font-medium text-warning">Reconstructed from loaded job-detail data</div>
+                      <div className="mt-1 text-text-3">
+                        Root callbacks are not exposed by this page&apos;s loaded endpoints. Original multi-engine
+                        volume declarations are represented from resolved mounts when possible.
+                      </div>
                     </div>
                   </div>
+                  <pre className="overflow-auto rounded-md border bg-muted p-4 text-xs">
+                    {yamlStringify(jobManifest)}
+                  </pre>
                 </div>
-                <pre className="overflow-auto rounded-md border bg-muted p-4 text-xs">
-                  {yamlStringify(jobManifest)}
-                </pre>
-              </div>
-            )}
-            {secondaryView === "backfills" && (
-              <BackfillsView jobId={jobId} />
-            )}
-            {secondaryView === "cache" && (
-              <CacheView jobId={jobId} job={job} featuredRun={featuredRun} tasks={tasks} />
-            )}
-          </div>
-        </DialogContent>
+              )}
+              {secondaryView === "backfills" && (
+                <BackfillsView jobId={job.id} />
+              )}
+              {secondaryView === "cache" && (
+                <CacheView jobId={job.id} job={job} featuredRun={featuredRun} tasks={tasks} />
+              )}
+            </div>
+          </DialogContent>
+        ) : null}
       </Dialog>
 
+      <TriggerDialog
+        open={triggerDialogOpen}
+        onOpenChange={setTriggerDialogOpen}
+        disabled={job.paused}
+        isPending={triggerMutation.isPending}
+        onConfirm={(params) => triggerMutation.mutate({ jobId: job.id, params })}
+      />
+
       <BackfillDialog
-        jobId={jobId}
+        jobId={job.id}
         open={backfillDialogOpen}
         onOpenChange={setBackfillDialogOpen}
         disabled={job.paused}
@@ -586,29 +655,19 @@ export function JobDetailPage() {
   );
 }
 
-/* ── DAG live counters ── */
-
-function DagCounters({ tasks }: { tasks?: TaskRun[] }) {
-  if (!tasks || tasks.length === 0) return null;
-  const done = tasks.filter((t) => t.status === "succeeded" || t.status === "completed").length;
-  const running = tasks.filter((t) => t.status === "running").length;
-  const cached = tasks.filter((t) => t.status === "cached").length;
-  const failed = tasks.filter((t) => t.status === "failed").length;
-  const queued = tasks.filter((t) => t.status === "pending" || t.status === "queued").length;
-  const total = tasks.length;
-
-  return (
-    <div data-testid="dag-counters" className="flex items-center gap-3 text-[10px] font-mono tabular-nums">
-      <span className="text-success/80">{done}/{total} done</span>
-      {running > 0 && <span className="text-cyan-glow/80">{running} active</span>}
-      {cached > 0 && <span className="text-cached/80">{cached} cached</span>}
-      {failed > 0 && <span className="text-danger/80">{failed} failed</span>}
-      {queued > 0 && <span className="text-text-4">{queued} queued</span>}
-    </div>
-  );
-}
-
-function RunQueuePanel({ rows, isLoading }: { rows?: RunQueueItem[]; isLoading: boolean }) {
+function RunQueuePanel({
+  rows,
+  isLoading,
+  jobId,
+  cancelingQueueId,
+  onCancel,
+}: {
+  rows?: RunQueueItem[];
+  isLoading: boolean;
+  jobId: string;
+  cancelingQueueId?: string;
+  onCancel: (queueId: string) => void;
+}) {
   const hasRows = (rows?.length ?? 0) > 0;
   if (!hasRows && !isLoading) {
     return null;
@@ -630,19 +689,52 @@ function RunQueuePanel({ rows, isLoading }: { rows?: RunQueueItem[]; isLoading: 
           {rows?.map((row) => (
             <div
               key={row.id}
+              id={`queue-${row.id}`}
               data-testid="run-queue-row"
-              className="grid gap-2 px-3 py-2 text-xs md:grid-cols-[72px_96px_minmax(160px,1fr)_minmax(160px,1.4fr)] md:items-center"
+              className="grid gap-3 px-3 py-2 text-xs md:grid-cols-[minmax(120px,0.8fr)_minmax(220px,1.4fr)_minmax(160px,1fr)_auto] md:items-center"
             >
-              <span className="font-mono text-text-3">#{row.position}</span>
-              <Badge variant="outline" className="w-fit font-mono text-[10px]">
-                {formatPriority(row.priority)}
-              </Badge>
-              <span className="text-text-3">
-                enqueued <RelativeTime date={row.enqueued_at} />
-              </span>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-text-3">#{row.position}</span>
+                  <Badge variant="outline" className="w-fit font-mono text-[10px]">
+                    {formatPriority(row.priority)}
+                  </Badge>
+                </div>
+                <div className="mt-1 font-mono text-[10px] text-text-4">{shortId(row.id)}</div>
+              </div>
+              <div className="min-w-0">
+                <div className="truncate text-text-2" title={queuePendingReason(row)}>
+                  {queuePendingReason(row)}
+                </div>
+                <div className="mt-1 text-text-3">
+                  enqueued <RelativeTime date={row.enqueued_at} />
+                </div>
+              </div>
               <span className="min-w-0 truncate font-mono text-text-2" title={formatQueueParams(row.params)}>
                 {formatQueueParams(row.params)}
               </span>
+              <div className="flex items-center justify-end gap-1">
+                <a
+                  href={`/jobs/${encodeURIComponent(jobId)}#queue-${row.id}`}
+                  className="rounded-md px-2 py-1 text-xs text-cyan-glow hover:bg-cyan-glow/10"
+                  aria-label={`Inspect queued run ${shortId(row.id)}`}
+                  data-testid="run-queue-inspect-link"
+                >
+                  Inspect
+                </a>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2 text-xs text-danger hover:text-danger"
+                  aria-label={`Cancel queued run ${shortId(row.id)}`}
+                  disabled={cancelingQueueId === row.id}
+                  onClick={() => onCancel(row.id)}
+                >
+                  <XCircle className="mr-1 h-3.5 w-3.5" />
+                  {cancelingQueueId === row.id ? "Canceling" : "Cancel"}
+                </Button>
+              </div>
             </div>
           ))}
         </div>
@@ -652,6 +744,38 @@ function RunQueuePanel({ rows, isLoading }: { rows?: RunQueueItem[]; isLoading: 
         </div>
       )}
     </div>
+  );
+}
+
+function ViewTab({
+  jobId,
+  view,
+  activeView,
+  icon,
+  children,
+}: {
+  jobId: string;
+  view: SecondaryView;
+  activeView: SecondaryView | null;
+  icon?: ReactNode;
+  children: ReactNode;
+}) {
+  const isActive = activeView === view;
+  return (
+    <Button
+      asChild
+      variant={isActive ? "secondary" : "ghost"}
+      size="sm"
+      className="h-8 shrink-0 px-2.5 text-xs"
+    >
+      <Link
+        to={jobViewPath(jobId, view)}
+        aria-current={isActive ? "page" : undefined}
+      >
+        {icon}
+        {children}
+      </Link>
+    </Button>
   );
 }
 
@@ -941,6 +1065,48 @@ function incidentMatchesTask(incident: Incident, taskId: string, taskName?: stri
   return incident.task_id === taskId || incident.task_name === taskId || Boolean(taskName && incident.task_name === taskName);
 }
 
+function secondaryViewFromPath(pathname: string): SecondaryView | null {
+  const lastSegment = pathname.split("/").filter(Boolean).at(-1);
+  switch (lastSegment) {
+    case "runs":
+      return "runs";
+    case "tasks":
+      return "tasks";
+    case "config":
+      return "configuration";
+    case "yaml":
+      return "definition";
+    case "backfills":
+      return "backfills";
+    case "cache":
+      return "cache";
+    default:
+      return null;
+  }
+}
+
+function jobViewPath(jobId: string, view: SecondaryView | null): string {
+  const base = `/jobs/${encodeURIComponent(jobId)}`;
+  return view ? `${base}/${secondaryViewSegments[view]}` : base;
+}
+
+function secondaryViewTitle(view: SecondaryView): string {
+  switch (view) {
+    case "runs":
+      return "Run History";
+    case "tasks":
+      return "Task Definitions";
+    case "configuration":
+      return "Configuration";
+    case "definition":
+      return "Job Definition (YAML)";
+    case "backfills":
+      return "Backfills";
+    case "cache":
+      return "Cache";
+  }
+}
+
 function renderRunStatus(status: string) {
   const variant =
     status === "succeeded" || status === "completed"
@@ -996,4 +1162,15 @@ function formatQueueParams(params?: Record<string, string>) {
     .sort()
     .map((key) => `${key}=${params[key]}`)
     .join(", ");
+}
+
+function queuePendingReason(row: RunQueueItem) {
+  const explicitReason = row.pending_reason ?? row.wait_reason ?? row.blocked_reason ?? row.reason;
+  if (row.blocked === true) {
+    return explicitReason ? `Blocked: ${explicitReason}` : "Blocked by scheduler policy";
+  }
+  if (explicitReason) {
+    return explicitReason;
+  }
+  return `Waiting for a run slot; ${formatPriority(row.priority)} priority at position #${row.position}`;
 }

--- a/ui/src/features/jobs/TriggerDialog.tsx
+++ b/ui/src/features/jobs/TriggerDialog.tsx
@@ -107,7 +107,7 @@ export function TriggerDialog({
           ) : null}
 
           <DialogFooter>
-            <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)} disabled={isPending}>
+            <Button type="button" variant="outline" size="sm" onClick={() => handleOpenChange(false)} disabled={isPending}>
               Cancel
             </Button>
             <Button type="submit" size="sm" disabled={isPending || disabled}>

--- a/ui/src/features/jobs/TriggerDialog.tsx
+++ b/ui/src/features/jobs/TriggerDialog.tsx
@@ -1,0 +1,145 @@
+import { useMemo, useState, type FormEvent } from "react";
+import { Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+interface TriggerDialogProps {
+  open: boolean;
+  disabled?: boolean;
+  isPending?: boolean;
+  onConfirm: (params: Record<string, string>) => void;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function TriggerDialog({
+  open,
+  disabled,
+  isPending,
+  onConfirm,
+  onOpenChange,
+}: TriggerDialogProps) {
+  const [logicalDate, setLogicalDate] = useState("");
+  const [paramLines, setParamLines] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setLogicalDate("");
+      setParamLines("");
+      setValidationError(null);
+    }
+    onOpenChange(next);
+  }
+
+  const inputClassName = useMemo(
+    () =>
+      "w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm text-foreground " +
+      "focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50",
+    [],
+  );
+  const labelClassName = "block text-xs uppercase tracking-wide text-muted-foreground mb-1";
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setValidationError(null);
+
+    const parsed = parseParamLines(paramLines);
+    if (parsed.error) {
+      setValidationError(parsed.error);
+      return;
+    }
+
+    const params = { ...parsed.params };
+    const trimmedLogicalDate = logicalDate.trim();
+    if (trimmedLogicalDate) {
+      params.logical_date = trimmedLogicalDate;
+    }
+
+    onConfirm(params);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Trigger Job</DialogTitle>
+          <DialogDescription>
+            Confirm a manual run and optionally pass run parameters.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4 pt-1">
+          <div>
+            <label htmlFor="trigger-logical-date" className={labelClassName}>
+              logical_date
+            </label>
+            <input
+              id="trigger-logical-date"
+              value={logicalDate}
+              onChange={(event) => setLogicalDate(event.target.value)}
+              disabled={isPending || disabled}
+              className={inputClassName}
+              placeholder="2026-07-07T12:00:00Z"
+            />
+          </div>
+          <div>
+            <label htmlFor="trigger-extra-params" className={labelClassName}>
+              Additional params
+            </label>
+            <textarea
+              id="trigger-extra-params"
+              value={paramLines}
+              onChange={(event) => setParamLines(event.target.value)}
+              disabled={isPending || disabled}
+              className={`${inputClassName} min-h-24 font-mono text-xs`}
+              placeholder="key=value"
+            />
+          </div>
+
+          {validationError ? (
+            <p className="text-xs text-destructive">{validationError}</p>
+          ) : null}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)} disabled={isPending}>
+              Cancel
+            </Button>
+            <Button type="submit" size="sm" disabled={isPending || disabled}>
+              <Play className="mr-1.5 h-3.5 w-3.5" />
+              {isPending ? "Triggering..." : "Confirm Trigger"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function parseParamLines(raw: string): { params: Record<string, string>; error?: string } {
+  const params: Record<string, string> = {};
+  const lines = raw.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
+    if (!line) continue;
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex <= 0) {
+      return { params: {}, error: `Line ${index + 1} must be key=value` };
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const value = line.slice(separatorIndex + 1).trim();
+    if (!key) {
+      return { params: {}, error: `Line ${index + 1} is missing a key` };
+    }
+    params[key] = value;
+  }
+
+  return { params };
+}

--- a/ui/src/features/jobs/__tests__/DagCounters.test.tsx
+++ b/ui/src/features/jobs/__tests__/DagCounters.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DagCounters } from "../DagCounters";
+import type { TaskRun } from "@/lib/api";
+
+function task(status: string): TaskRun {
+  return {
+    id: `${status}-task`,
+    job_run_id: "run-1",
+    task_id: `${status}-task`,
+    atom_id: "atom-1",
+    engine: "docker",
+    image: "alpine:3.23",
+    command: ["true"],
+    status,
+    created_at: "2026-07-07T00:00:00Z",
+    updated_at: "2026-07-07T00:00:00Z",
+  };
+}
+
+describe("DagCounters", () => {
+  it("surfaces failed and blocked buckets explicitly", () => {
+    render(<DagCounters tasks={[task("failed"), task("skipped"), task("blocked")]} />);
+
+    expect(screen.getByTestId("dag-counters")).toHaveTextContent("0 done · 1 failed · 2 blocked");
+    expect(screen.getByTestId("dag-counters")).not.toHaveTextContent("queued");
+  });
+
+  it("keeps running and cached counts visible", () => {
+    render(<DagCounters tasks={[task("succeeded"), task("running"), task("cached"), task("pending")]} />);
+
+    const counters = screen.getByTestId("dag-counters");
+    expect(counters).toHaveTextContent("1 done");
+    expect(counters).toHaveTextContent("1 running");
+    expect(counters).toHaveTextContent("1 cached");
+    expect(counters).toHaveTextContent("1 waiting");
+  });
+});

--- a/ui/src/features/jobs/__tests__/DagCounters.test.tsx
+++ b/ui/src/features/jobs/__tests__/DagCounters.test.tsx
@@ -22,8 +22,11 @@ describe("DagCounters", () => {
   it("surfaces failed and blocked buckets explicitly", () => {
     render(<DagCounters tasks={[task("failed"), task("skipped"), task("blocked")]} />);
 
-    expect(screen.getByTestId("dag-counters")).toHaveTextContent("0 done · 1 failed · 2 blocked");
-    expect(screen.getByTestId("dag-counters")).not.toHaveTextContent("queued");
+    const counters = screen.getByTestId("dag-counters");
+    expect(counters).toHaveTextContent("0 done");
+    expect(counters).toHaveTextContent("1 failed");
+    expect(counters).toHaveTextContent("2 blocked");
+    expect(counters).not.toHaveTextContent("queued");
   });
 
   it("keeps running and cached counts visible", () => {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -118,6 +118,11 @@ export interface RunQueueItem {
   priority: number;
   params?: Record<string, string>;
   enqueued_at: string;
+  blocked?: boolean;
+  reason?: string;
+  pending_reason?: string;
+  wait_reason?: string;
+  blocked_reason?: string;
 }
 
 export interface Atom {
@@ -528,7 +533,8 @@ export type ApiErrorKind =
   | "replay_conflict"
   | "replay_request_too_large"
   | "replay_safe_refusal"
-  | "replay_refused";
+  | "replay_refused"
+  | "queue_cancel_conflict";
 
 export interface FieldChange {
   field: string;
@@ -985,6 +991,10 @@ function replayErrorKind(status: number, message: string): ApiErrorKind | undefi
   }
 }
 
+function queueCancelErrorKind(status: number): ApiErrorKind | undefined {
+  return status === 409 ? "queue_cancel_conflict" : undefined;
+}
+
 function queryString(params: Record<string, string | number | boolean | undefined>): string {
   const query = new URLSearchParams();
   Object.entries(params).forEach(([key, value]) => {
@@ -1071,6 +1081,12 @@ export const api = {
     return request<JobRun[]>(`/jobs/${jobId}/runs${suffix}`);
   },
   getJobQueue: (jobId: string) => request<RunQueueItem[]>(`/jobs/${encodeURIComponent(jobId)}/queue`),
+  cancelQueuedRun: (jobId: string, queueId: string) =>
+    request<void>(
+      `/jobs/${encodeURIComponent(jobId)}/queue/${encodeURIComponent(queueId)}`,
+      { method: "DELETE" },
+      queueCancelErrorKind,
+    ),
   getJobRun: (jobId: string, runId: string) => request<JobRun>(`/jobs/${jobId}/runs/${runId}`),
   getRunDiff: (jobId: string, left: string, right: string) =>
     request<RunDiff>(
@@ -1173,7 +1189,7 @@ export const api = {
       body: JSON.stringify({ definitions: parseJobDefinitions(yaml) }),
     }),
   triggerJob: (jobId: string, body?: TriggerRunRequest) =>
-    request<JobRun>(`/jobs/${jobId}/run`, {
+    request<JobRun | undefined>(`/jobs/${encodeURIComponent(jobId)}/run`, {
       method: "POST",
       body: body ? JSON.stringify(body) : undefined,
     }),

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -43,6 +43,42 @@ const jobDetailRoute = createRoute({
   component: JobDetailPage,
 });
 
+const jobRunsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "jobs/$jobId/runs",
+  component: JobDetailPage,
+});
+
+const jobTasksRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "jobs/$jobId/tasks",
+  component: JobDetailPage,
+});
+
+const jobConfigRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "jobs/$jobId/config",
+  component: JobDetailPage,
+});
+
+const jobYamlRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "jobs/$jobId/yaml",
+  component: JobDetailPage,
+});
+
+const jobBackfillsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "jobs/$jobId/backfills",
+  component: JobDetailPage,
+});
+
+const jobCacheRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "jobs/$jobId/cache",
+  component: JobDetailPage,
+});
+
 const blameRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "jobs/$jobId/blame",
@@ -192,6 +228,12 @@ const routeTree = rootRoute.addChildren([
   indexRoute,
   jobsRoute,
   jobDetailRoute,
+  jobRunsRoute,
+  jobTasksRoute,
+  jobConfigRoute,
+  jobYamlRoute,
+  jobBackfillsRoute,
+  jobCacheRoute,
   blameRoute,
   runDiffRoute,
   runDetailRoute,


### PR DESCRIPTION
## Summary
- **B1**: header splits view-tabs from actions; Backfill/Pause move into an always-reachable `⋯` overflow menu so `Pause` is never clipped at ≤1150px; `aria-label`s on all icon-only controls (Trigger/Backfill/Pause/theme/search).
- **B2**: new `TriggerDialog` — optional run params (`logical_date` + extra) with an explicit confirm; lands on the live run view (sibling W1-α leads it with live progress) instead of the attestation view. Reset moved to the `onOpenChange` handler (no setState-in-effect).
- **B3**: DAG counters (extracted to `DagCounters.tsx`) surface failed AND blocked tasks — "N done · N failed · N blocked" — building on the bug-sweep failed-count work.
- **B4**: queue rows show why-pending (priority/position/age) with an inspect link; confirmed the queue list reads real unclaimed `run_queue` rows (no seed/static path).
- **B6**: secondary views (Runs/Tasks/Config/YAML/Backfills/Cache) are deep-linkable sub-routes; back button closes the view.
- **Cancel UI**: `api.cancelQueuedRun(jobId, queueId)` → `DELETE /v1/jobs/:id/queue/:queue_id`; a 409 shows "Queued run already started — can't cancel" distinctly from success. Backend is W1-ζ (#311).

## Test plan
- [x] eslint + tsc + vite build (orchestrator local)
- [ ] GHA CI: ui-lint, ui-test, ui-e2e. Depends on #311 (ζ) for the live Cancel endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
