### PR TITLE
Polish console review nits: dedupe node helpers, SPA link, bounded log scan

### DIFF
--- a/ui/src/features/jobs/JobDAG.tsx
+++ b/ui/src/features/jobs/JobDAG.tsx
@@ -234,12 +234,13 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
     );
 
     const isSingleNodeDAG = layoutedNodes.length === 1 && layoutedEdges.length === 0;
+    const dagMaxZoom = isSingleNodeDAG ? 2.2 : 1.5;
     const fitViewOptions = useMemo(
       () => ({
         padding: isSingleNodeDAG ? 0.06 : 0.2,
-        maxZoom: isSingleNodeDAG ? 2.2 : 1.5,
+        maxZoom: dagMaxZoom,
       }),
-      [isSingleNodeDAG]
+      [isSingleNodeDAG, dagMaxZoom]
     );
 
     const handleNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
@@ -258,7 +259,7 @@ export function JobDAG({ dag, atoms, taskDefinitions, taskStatus, taskMetadata, 
           fitView
           fitViewOptions={fitViewOptions}
           minZoom={0.1}
-          maxZoom={isSingleNodeDAG ? 2.2 : 1.5}
+          maxZoom={dagMaxZoom}
         >
           <Background gap={20} />
           <Controls />

--- a/ui/src/features/jobs/JobDetailPage.tsx
+++ b/ui/src/features/jobs/JobDetailPage.tsx
@@ -714,14 +714,16 @@ function RunQueuePanel({
                 {formatQueueParams(row.params)}
               </span>
               <div className="flex items-center justify-end gap-1">
-                <a
-                  href={`/jobs/${encodeURIComponent(jobId)}#queue-${row.id}`}
+                <Link
+                  to="/jobs/$jobId"
+                  params={{ jobId }}
+                  hash={`queue-${row.id}`}
                   className="rounded-md px-2 py-1 text-xs text-cyan-glow hover:bg-cyan-glow/10"
                   aria-label={`Inspect queued run ${shortId(row.id)}`}
                   data-testid="run-queue-inspect-link"
                 >
                   Inspect
-                </a>
+                </Link>
                 <Button
                   type="button"
                   variant="ghost"

--- a/ui/src/features/jobs/LogViewer.tsx
+++ b/ui/src/features/jobs/LogViewer.tsx
@@ -152,12 +152,25 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
     setTransportError(null);
 
     const abortController = new AbortController();
+    // The structured-vs-freeform decision reads only the first
+    // structuredScanMaxChars of the log, so once that head is complete the
+    // NEGATIVE decision is final too — stop rescanning it on every chunk.
+    let structuredDecisionFinal = false;
     const appendLogChunk = (chunk: string) => {
       rawLogTextRef.current += chunk;
       // Once the structured renderer is locked in there is no way back, so skip
       // re-scanning the (growing) buffer on every subsequent chunk.
-      const shouldUseStructuredRenderer =
-        structuredLogRendererRef.current || shouldUseStructuredLogViewer(rawLogTextRef.current);
+      let shouldUseStructuredRenderer: boolean;
+      if (structuredLogRendererRef.current) {
+        shouldUseStructuredRenderer = true;
+      } else if (structuredDecisionFinal) {
+        shouldUseStructuredRenderer = false;
+      } else {
+        shouldUseStructuredRenderer = shouldUseStructuredLogViewer(rawLogTextRef.current);
+        if (!shouldUseStructuredRenderer && rawLogTextRef.current.length >= structuredScanMaxChars) {
+          structuredDecisionFinal = true;
+        }
+      }
       setRawLogText(rawLogTextRef.current);
 
       if (shouldUseStructuredRenderer && !structuredLogRendererRef.current) {

--- a/ui/src/features/jobs/LogViewer.tsx
+++ b/ui/src/features/jobs/LogViewer.tsx
@@ -154,7 +154,10 @@ export function LogViewer({ jobId, runId, taskId, error, status, sizeVersion }: 
     const abortController = new AbortController();
     const appendLogChunk = (chunk: string) => {
       rawLogTextRef.current += chunk;
-      const shouldUseStructuredRenderer = shouldUseStructuredLogViewer(rawLogTextRef.current);
+      // Once the structured renderer is locked in there is no way back, so skip
+      // re-scanning the (growing) buffer on every subsequent chunk.
+      const shouldUseStructuredRenderer =
+        structuredLogRendererRef.current || shouldUseStructuredLogViewer(rawLogTextRef.current);
       setRawLogText(rawLogTextRef.current);
 
       if (shouldUseStructuredRenderer && !structuredLogRendererRef.current) {
@@ -587,17 +590,26 @@ const jsonLikeLogPattern = /^\s*(?:\{.*\}|\[.*\])\s*$/;
 const namedStructuredFieldPattern =
   /\b(?:level|time|timestamp|ts|msg|message|trace_id|span_id|request_id)[=:]/i;
 
+// Bound the structured-log heuristic to the head of the buffer: the decision is
+// made from the first lines a task emits, so appends never rescan an unbounded
+// (and growing) log. 64 KB / 200 non-empty lines is far more than the heuristic
+// needs while keeping every call O(1) in the total log size.
+const structuredScanMaxChars = 64_000;
+const structuredScanMaxLines = 200;
+
 function shouldUseStructuredLogViewer(rawLog: string): boolean {
   if (!rawLog) {
     return false;
   }
 
   const lines = rawLog
+    .slice(0, structuredScanMaxChars)
     .replace(/\r\n/g, "\n")
     .replace(/\r/g, "\n")
     .split("\n")
     .map((line) => stripAnsi(line).trim())
-    .filter((line) => line.length > 0);
+    .filter((line) => line.length > 0)
+    .slice(0, structuredScanMaxLines);
   if (lines.length === 0) {
     return false;
   }

--- a/ui/src/features/jobs/components/BranchNode.tsx
+++ b/ui/src/features/jobs/components/BranchNode.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
 import { cn, shortId } from '@/lib/utils';
+import { getHandleVisibility } from './node-edges';
 import {
   Activity,
   CheckCircle2,
@@ -209,24 +210,3 @@ export const BranchNode = memo(({ data }: NodeProps) => {
 
 BranchNode.displayName = 'BranchNode';
 
-function getHandleVisibility(edgeDegree: unknown) {
-  if (!isEdgeDegree(edgeDegree)) {
-    return {
-      showTargetHandle: true,
-      showSourceHandle: true,
-    };
-  }
-
-  return {
-    showTargetHandle: readEdgeCount(edgeDegree.incoming) > 0,
-    showSourceHandle: readEdgeCount(edgeDegree.outgoing) > 0,
-  };
-}
-
-function isEdgeDegree(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function readEdgeCount(value: unknown) {
-  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
-}

--- a/ui/src/features/jobs/components/TaskNode.tsx
+++ b/ui/src/features/jobs/components/TaskNode.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { Handle, Position, type NodeProps } from 'reactflow';
 import { isRecord } from '@/lib/typeGuards';
 import { cn, formatUTCTimestamp } from '@/lib/utils';
+import { getHandleVisibility } from './node-edges';
 import {
   Activity,
   CheckCircle2,
@@ -272,24 +273,6 @@ function formatRetryAfter(value: unknown) {
     return 'the current window resets';
   }
   return formatUTCTimestamp(value, value);
-}
-
-function getHandleVisibility(edgeDegree: unknown) {
-  if (!isRecord(edgeDegree)) {
-    return {
-      showTargetHandle: true,
-      showSourceHandle: true,
-    };
-  }
-
-  return {
-    showTargetHandle: readEdgeCount(edgeDegree.incoming) > 0,
-    showSourceHandle: readEdgeCount(edgeDegree.outgoing) > 0,
-  };
-}
-
-function readEdgeCount(value: unknown) {
-  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
 }
 
 function getRuntimeHints(spec: unknown) {

--- a/ui/src/features/jobs/components/node-edges.ts
+++ b/ui/src/features/jobs/components/node-edges.ts
@@ -1,0 +1,26 @@
+// Shared edge-degree helpers for DAG node components (TaskNode, BranchNode).
+// JobDAG threads a per-node `edgeDegree` ({ incoming, outgoing, total }) into
+// node data; nodes hide their input/output handles when they have no incident
+// edges on that side.
+
+export function getHandleVisibility(edgeDegree: unknown) {
+  if (!isEdgeDegree(edgeDegree)) {
+    return {
+      showTargetHandle: true,
+      showSourceHandle: true,
+    };
+  }
+
+  return {
+    showTargetHandle: readEdgeCount(edgeDegree.incoming) > 0,
+    showSourceHandle: readEdgeCount(edgeDegree.outgoing) > 0,
+  };
+}
+
+function isEdgeDegree(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readEdgeCount(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}

--- a/ui/src/features/jobs/components/node-edges.ts
+++ b/ui/src/features/jobs/components/node-edges.ts
@@ -3,8 +3,10 @@
 // node data; nodes hide their input/output handles when they have no incident
 // edges on that side.
 
+import { isRecord } from '@/lib/typeGuards';
+
 export function getHandleVisibility(edgeDegree: unknown) {
-  if (!isEdgeDegree(edgeDegree)) {
+  if (!isRecord(edgeDegree)) {
     return {
       showTargetHandle: true,
       showSourceHandle: true,
@@ -15,10 +17,6 @@ export function getHandleVisibility(edgeDegree: unknown) {
     showTargetHandle: readEdgeCount(edgeDegree.incoming) > 0,
     showSourceHandle: readEdgeCount(edgeDegree.outgoing) > 0,
   };
-}
-
-function isEdgeDegree(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function readEdgeCount(value: unknown) {


### PR DESCRIPTION
## Summary
Consolidated non-blocking review follow-ups from the Console v2 bug-sweep and operator-loop plans:

- **Dedupe**: `getHandleVisibility`/`readEdgeCount` (duplicated verbatim in `TaskNode.tsx` + `BranchNode.tsx`) move to a shared `components/node-edges.ts`. (greptile #310)
- **Single-source `maxZoom`**: JobDAG computes `dagMaxZoom` once for both `fitViewOptions` and the `ReactFlow` prop. (greptile #310)
- **SPA navigation**: the queue-row Inspect anchor becomes a TanStack `Link` (`to=/jobs/$jobId` + `hash`), avoiding a full page reload; className/aria-label/test-id preserved. (gemini #314)
- **Bounded log scan**: `shouldUseStructuredLogViewer` samples only the first 64 KB / 200 non-empty lines, and `appendLogChunk` short-circuits once the structured renderer locks in — streaming appends no longer rescan the whole growing buffer. (gemini #313)

## Test plan
- [x] eslint + tsc + vite build + vitest (TaskNode, JobDAG, TaskDetailPanel — 20/20) locally
- [ ] GHA CI: ui-lint, ui-test, ui-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
