### PR TITLE
Propagate event-trigger cancellation into run start; bound bridge test cleanup

### DIFF
--- a/internal/run/store.go
+++ b/internal/run/store.go
@@ -279,6 +279,7 @@ type admissionResult struct {
 }
 
 type startRunRequest struct {
+	ctx              context.Context
 	jobID            uuid.UUID
 	triggerID        *uuid.UUID
 	backfillID       *uuid.UUID
@@ -842,6 +843,15 @@ func metricJobAlias(jobID uuid.UUID, alias string) string {
 }
 
 func (s *Store) startRun(req startRunRequest) (*JobRun, error) {
+	ctx := req.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	conn := s.db.WithContext(ctx)
+
 	model, err := newStartRunModel(req)
 	if err != nil {
 		return nil, err
@@ -851,10 +861,10 @@ func (s *Store) startRun(req startRunRequest) (*JobRun, error) {
 		pendingEvents []event.Event
 		admission     admissionResult
 	)
-	if err := withStoreBusyRetry(func() error {
+	if err := withStoreBusyRetryContext(ctx, func() error {
 		attemptEvents := make([]event.Event, 0, 3)
 		attemptAdmission := admissionResult{decision: admissionNoPolicy}
-		err := s.db.Transaction(func(tx *gorm.DB) error {
+		err := conn.Transaction(func(tx *gorm.DB) error {
 			priority, err := startPriorityTx(tx, req.jobID, req.priorityOverride)
 			if err != nil {
 				return err
@@ -947,7 +957,7 @@ func (s *Store) startRun(req startRunRequest) (*JobRun, error) {
 	if s.leaseStore != nil {
 		vars := env.Variables()
 		if _, leaseErr := s.leaseStore.AcquireLease(
-			context.Background(),
+			ctx,
 			model.ID,
 			vars.NodeAddress,
 			vars.RunLeaseTTL,
@@ -966,7 +976,7 @@ func (s *Store) startRun(req startRunRequest) (*JobRun, error) {
 		s.startedMu.Unlock()
 	}
 
-	return s.loadRun(model.ID)
+	return s.loadRunWithDB(conn, model.ID)
 }
 
 func (s *Store) mutateTaskExecutionDescriptor(runID, taskID uuid.UUID, mutate func(*models.TaskExecutionDescriptor)) error {
@@ -1038,8 +1048,13 @@ func mergeDescriptorSecretRefs(existing, updates []models.TaskExecutionSecretRef
 }
 
 func (s *Store) Start(jobID uuid.UUID, triggerID *uuid.UUID, opts ...StartOption) (*JobRun, error) {
+	return s.StartWithContext(context.Background(), jobID, triggerID, opts...)
+}
+
+func (s *Store) StartWithContext(ctx context.Context, jobID uuid.UUID, triggerID *uuid.UUID, opts ...StartOption) (*JobRun, error) {
 	startOpts := startOptionsFrom(opts)
 	return s.startRun(startRunRequest{
+		ctx:              ctx,
 		jobID:            jobID,
 		triggerID:        triggerID,
 		params:           startOpts.Params,
@@ -1076,11 +1091,12 @@ func (s *Store) StartForBackfill(jobID, backfillID uuid.UUID, params map[string]
 // StartQueuedRun creates a fresh JobRun from an already-claimed run_queue row.
 // If a slot disappears between dequeue and insert, the caller should release the
 // queue row so a later drain can retry it.
-func (s *Store) StartQueuedRun(_ context.Context, queued *models.RunQueue) (*JobRun, error) {
+func (s *Store) StartQueuedRun(ctx context.Context, queued *models.RunQueue) (*JobRun, error) {
 	if queued == nil {
 		return nil, errors.New("run: queued run is nil")
 	}
 	return s.startRun(startRunRequest{
+		ctx:              ctx,
 		jobID:            queued.JobID,
 		params:           decodeRunParams(queued.Params),
 		priorityOverride: PriorityLabel(queued.Priority),
@@ -4326,8 +4342,18 @@ func (c *dbWriteCounts) commit() {
 }
 
 func withStoreBusyRetry(fn func() error) error {
+	return withStoreBusyRetryContext(context.Background(), fn)
+}
+
+func withStoreBusyRetryContext(ctx context.Context, fn func() error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var err error
 	for attempt := 0; ; attempt++ {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
 		err = fn()
 		if err == nil || !isStoreContentionErr(err) {
 			return err
@@ -4337,7 +4363,23 @@ func withStoreBusyRetry(fn func() error) error {
 		}
 
 		metrics.DBBusyRetriesTotal.Inc()
-		time.Sleep(jitterStoreBusyRetryBackoff(storeBusyRetryBackoffs[attempt]))
+		if sleepErr := sleepStoreBusyRetry(ctx, jitterStoreBusyRetryBackoff(storeBusyRetryBackoffs[attempt])); sleepErr != nil {
+			return sleepErr
+		}
+	}
+}
+
+func sleepStoreBusyRetry(ctx context.Context, backoff time.Duration) error {
+	if backoff <= 0 {
+		return ctx.Err()
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
 	}
 }
 

--- a/internal/trigger/event/event.go
+++ b/internal/trigger/event/event.go
@@ -178,6 +178,11 @@ func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]str
 				continue
 			}
 			outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Error: err.Error()})
+			// A cancelled fire context fails every remaining start the same
+			// way — abort the loop instead of appending redundant errors.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return outcomes, ctxErr
+			}
 			continue
 		}
 		if runRecord == nil {

--- a/internal/trigger/event/event.go
+++ b/internal/trigger/event/event.go
@@ -131,6 +131,9 @@ func (t *EventTrigger) Fire(ctx context.Context) error {
 }
 
 func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]string) ([]FireOutcome, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	log.Info("trigger firing", "id", t.id, "type", models.TriggerTypeEvent)
 
 	mergedParams := t.config.mergedParams(params)
@@ -160,7 +163,7 @@ func (t *EventTrigger) FireWithParams(ctx context.Context, params map[string]str
 		}
 
 		runtimeParams := cloneParams(mergedParams)
-		runRecord, err := t.runStoreFactory().Start(jobModel.ID, &t.id, runstorage.WithStartParams(runtimeParams))
+		runRecord, err := t.runStoreFactory().StartWithContext(ctx, jobModel.ID, &t.id, runstorage.WithStartParams(runtimeParams))
 		if err != nil {
 			if errors.Is(err, runstorage.ErrRunSkipped) {
 				outcomes = append(outcomes, FireOutcome{JobID: jobModel.ID, Skipped: true, SkipReason: "max concurrency reached"})

--- a/internal/trigger/event/router_test.go
+++ b/internal/trigger/event/router_test.go
@@ -214,7 +214,16 @@ func TestLifecycleBridgeRoutesRunCompletedWithJobAliasAndDepth(t *testing.T) {
 	}()
 	t.Cleanup(func() {
 		cancel()
-		require.NoError(t, <-errCh)
+		// Bounded wait: a regression that stops the bridge honoring
+		// cancellation should fail here in seconds with a clear message,
+		// not hold the package open to the 600s go-test timeout. 5s gives
+		// a loaded -race arm64 runner room to finish the in-flight route.
+		select {
+		case err := <-errCh:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("lifecycle bridge did not exit after context cancellation")
+		}
 	})
 
 	runID := uuid.New()


### PR DESCRIPTION
## Summary
Root-cause + fix for the intermittent `internal/trigger/event` **600s package hang** (and its 0.00s-failure sibling) that red-lighted `unit-test`/`unit-test-arm64` on ~1/3 of recent pushes:

**The blocking chain**: `TestLifecycleBridgeRoutesRunCompletedWithJobAliasAndDepth` runs `RunLifecycleBridge` in a goroutine and its `t.Cleanup` did an **unbounded** `<-errCh`. The bridge routes synchronously via `Route → FireWithParams → run.Store.Start`, and that run-start path **ignored the context** — so when run-start DB work stalled under CI contention, `cancel()` could not unblock the goroutine and the cleanup held the package open to the 10-minute go-test timeout.

**The fix (minimal, behavior-preserving for existing callers):**
- `run.Store.StartWithContext` — `Start` delegates with `context.Background()`; ctx threads through the start transaction (`WithContext`), lease acquisition, and the busy-retry loop (`withStoreBusyRetryContext` + ctx-aware backoff sleep).
- `FireWithParams` passes its ctx into run-start (nil normalized to Background). Note: a caller-cancelled ctx now aborts the fire mid-flight (transaction rolls back) — e.g. client disconnect on the ingest path.
- `StartQueuedRun` honors its previously-ignored `ctx` param; on a shutdown-cancel the dequeuer's existing release-claim error path applies.
- Test cleanup gets a **5s watchdog**: a regression fails in seconds with "lifecycle bridge did not exit after context cancellation" instead of hanging 600s.

**Eliminated hypotheses** (with code evidence): bus publish deadlock (buffered, drop-on-full), cross-test bus leakage (per-test bus), unclosed `for range` (bridge selects on ctx), require-in-goroutine (goroutine only sends), sqlite `cache=shared` (already removed in QW-2).

## Test plan
- [ ] GHA CI `unit-test` + `unit-test-arm64` (-race, containerized). The flake is intermittent (~1/3), so a single green run is weak evidence — I'll rerun the unit-test jobs a few times on this PR before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
