### PR TITLE
Enable contract enforcement on the integration server (contract-enforcement W1-η)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,7 @@ jobs:
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
+            -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -326,6 +327,7 @@ jobs:
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
+            -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             -e CAESIUM_AGENT_REMEDIATION_ENABLED=true \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
@@ -506,6 +508,7 @@ jobs:
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
+            -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
       - name: Extract caesium CLI

--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -298,7 +298,7 @@ precedent: backend REST/CLI first, UI consumes it). New feature dir gated by the
 
 ## Harness Strengthening
 
-- [ ] H-1. Enable the contract path on the live integration server so the Stream C/D
+- [x] H-1. Enable the contract path on the live integration server so the Stream C/D
       scenarios drive the real surface, not an internal call: set
       `CAESIUM_CONTRACT_ENFORCEMENT=fail` (and a short
       `CAESIUM_CONTRACT_DEPRECATION_WINDOW` if the ack-expiry test needs a tight
@@ -309,6 +309,14 @@ precedent: backend REST/CLI first, UI consumes it). New feature dir gated by the
       need (apply producer+consumer fixtures, `runCLIStdout` split-stream capture for
       `--json`).
       Files: `justfile`, `.github/workflows/ci.yml`, `test/` harness helpers.
+      Note: W1-η set `CAESIUM_CONTRACT_ENFORCEMENT=fail` on every server-boot site,
+      mirroring the `CAESIUM_FRESHNESS_ENABLED` precedent — all justfile lanes
+      (docker, distributed, agent, podman), the helm chart `config.extraEnv[2]`, and
+      the three ci.yml server blocks — so no lane drifts red when enforcement lands.
+      The env var is inert until C1 adds it to `pkg/env/env.go`. Deliberately
+      deferred to W2: the `CAESIUM_CONTRACT_DEPRECATION_WINDOW` bound and the `test/`
+      fixture helpers land alongside the C/D scenarios that use them (helpers now
+      would be unused code; the window depends on C2's actual expiry-test shape).
 
 ## Navigational / Organizational Improvements
 

--- a/justfile
+++ b/justfile
@@ -294,6 +294,7 @@ integration-test-podman: build
         -e CAESIUM_EVENT_INGEST_API_KEY={{ event_ingest_api_key }} \
         -e CAESIUM_LOG_LEVEL=debug \
         -e CAESIUM_FRESHNESS_ENABLED=true \
+        -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
     if docker run --rm --platform {{ platform }} \
@@ -335,6 +336,7 @@ integration-up: build-test
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
+        -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_RATE_LIMIT_PRUNER_ENABLED=true \
         -e CAESIUM_RATE_LIMIT_PRUNE_INTERVAL=500ms \
@@ -359,6 +361,7 @@ integration-up-distributed: build-test
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
+        -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_EXECUTION_MODE=distributed \
         -e CAESIUM_NODE_ADDRESS=127.0.0.1:9001 \
@@ -405,6 +408,7 @@ integration-up-agent: build-test build-triage-agent
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
+        -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         {{ local_image_ref }}:{{ tag }}-test start
 
@@ -444,6 +448,7 @@ ui-e2e: build-release
             -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
+            -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -481,6 +486,7 @@ ui-e2e-auth: build-release
         -e CAESIUM_OPEN_LINEAGE_ENABLED=true \
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
+        -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_AGENT_REMEDIATION_ENABLED=true \
         --user 0:0 {{ local_image_ref }}:{{ tag }} start >/dev/null
     tries=0
@@ -564,6 +570,8 @@ k8s-distributed: build-release k8s-registry-up
             --set config.extraEnv[0].value=distributed \
             --set config.extraEnv[1].name=CAESIUM_FRESHNESS_ENABLED \
             --set-string config.extraEnv[1].value=true \
+            --set config.extraEnv[2].name=CAESIUM_CONTRACT_ENFORCEMENT \
+            --set-string config.extraEnv[2].value=fail \
             --set kubernetes.engine.enabled=true \
             --set persistence.enabled=false \
             --wait


### PR DESCRIPTION
## Summary
H-1 of the contract-enforcement plan: pre-plumb `CAESIUM_CONTRACT_ENFORCEMENT=fail` into every server-boot site so the Stream C/D integration scenarios (W2) drive a live, gated surface in CI from day one:

- All justfile lanes — `integration-up`, distributed, agent, podman — mirroring the `CAESIUM_FRESHNESS_ENABLED` precedent line-for-line.
- Helm chart `config.extraEnv[2]` (k8s-distributed lane).
- The three ci.yml server blocks (ui-e2e, ui-e2e-auth, helm).
- **Inert today**: envconfig ignores unknown vars until C1 adds the field to `pkg/env/env.go` (W2).
- Deliberately deferred to W2: `CAESIUM_CONTRACT_DEPRECATION_WINDOW` tuning + `test/` fixture helpers (land with the scenarios that use them, avoiding unused-code lint).

## Test plan
- [x] `just --summary` parses; ci.yml YAML-parses.
- [ ] GHA CI (the integration lanes themselves prove the env is accepted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
