### PR TITLE
Flag newly unsatisfiable required keys when additionalProperties stays false

### DIFF
--- a/pkg/jobdef/schemacompat/compat.go
+++ b/pkg/jobdef/schemacompat/compat.go
@@ -422,11 +422,13 @@ func compareAdditionalProperties(findings *[]Finding, path schemaPath, oldSchema
 		))
 		return
 	}
-	if oldFalse || !newFalse {
+	if !newFalse {
 		return
 	}
 
 	newProps := schemaProperties(newSchema)
+	oldProps := schemaProperties(oldSchema)
+	oldRequired := requiredSet(oldSchema)
 	// Only the NEW schema's required set matters here: a key required by the
 	// old schema but dropped by the new one is compareRequired's finding
 	// (required-removed), not an additionalProperties tightening.
@@ -434,6 +436,17 @@ func compareAdditionalProperties(findings *[]Finding, path schemaPath, oldSchema
 	for _, key := range sortedSetKeys(required) {
 		if _, ok := newProps[key]; ok {
 			continue
+		}
+		if oldFalse {
+			// The old schema was already additionalProperties: false. Flag only
+			// NEWLY unsatisfiable keys — a key that was already
+			// required-outside-properties is a pre-existing invariant, not a
+			// change introduced by this revision.
+			_, wasRequired := oldRequired[key]
+			_, hadProp := oldProps[key]
+			if wasRequired && !hadProp {
+				continue
+			}
 		}
 		*findings = append(*findings, finding(
 			FindingKindAdditionalPropertiesTightened,

--- a/pkg/jobdef/schemacompat/compat_test.go
+++ b/pkg/jobdef/schemacompat/compat_test.go
@@ -278,6 +278,43 @@ func TestCompareAddedRequiredPropertyIsSilentlyCompatible(t *testing.T) {
 	require.Empty(t, findings)
 }
 
+// When BOTH schemas carry additionalProperties: false, a key newly added to
+// required but absent from properties makes the new schema unsatisfiable —
+// that must be a breaking finding, while a key that was ALREADY
+// required-outside-properties in the old schema is a pre-existing invariant
+// and stays silent. Regression for the post-merge review finding on W1-α.
+func TestCompareBothAdditionalPropertiesFalse(t *testing.T) {
+	oldSchema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"id": map[string]any{"type": "string"},
+		},
+	}
+	newSchema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"name"},
+		"properties": map[string]any{
+			"id": map[string]any{"type": "string"},
+		},
+	}
+	findings := Compare(oldSchema, newSchema)
+	requireContainsFinding(t, findings, FindingKindAdditionalPropertiesTightened, "properties.name", VerdictBreaking)
+
+	// Same shape, but the unsatisfiable key predates this revision: silent.
+	preExisting := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []any{"name"},
+		"properties": map[string]any{
+			"id": map[string]any{"type": "string"},
+		},
+	}
+	findings = Compare(preExisting, preExisting)
+	require.Empty(t, findings)
+}
+
 func TestSatisfies(t *testing.T) {
 	cases := []struct {
 		name        string


### PR DESCRIPTION
## Summary
Fix-forward for a post-merge greptile finding on #320 (the bot re-reviewed after the review-fix push, past the merge):

- `compareAdditionalProperties` early-returned when BOTH old and new schemas carried `additionalProperties: false`, so a key newly added to `required` but absent from `properties` yielded **zero findings** despite making the new schema unsatisfiable (it can never accept any object).
- The guard is now `if !newFalse`: whenever the new schema is closed, its required set is scanned; with `oldFalse`, keys that were already required-outside-properties in the old schema are skipped as pre-existing invariants rather than re-flagged.
- `TestCompareBothAdditionalPropertiesFalse` pins both halves (newly unsatisfiable → breaking; pre-existing invariant → silent).

## Test plan
- [x] Host `go vet` + `go test ./pkg/jobdef/schemacompat/` (pure Go).
- [ ] Full matrix — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
