### PR TITLE
Add the contract graph deriver for inferred and evidence edges (contract-enforcement W1-β)

### DIFF
--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -154,7 +154,7 @@ versions) — derive the three edge classes. Edges are recomputed per request fr
 authoritative sources so they never go stale against jobdef edits. New package,
 read-only against existing tables.
 
-- [ ] B1. Add the `internal/contract` graph deriver for the two evidence-driven edge
+- [x] B1. Add the `internal/contract` graph deriver for the two evidence-driven edge
       classes: **inferred** — reuse `patternCanMatchCaesiumLifecycle` +
       `triggerChainPatternSourceAlias` (`internal/jobdef/trigger_cycle.go:293,236`)
       to find A→B trigger-chain edges, then statically parse B's `paramMapping`
@@ -171,6 +171,14 @@ read-only against existing tables.
       new `internal/contract/graph_test.go`.
       Depends on: A1 (edges reference the checker's `Finding` type for path-vs-schema
       verdicts).
+      Note: Added JSON-ready `Graph{Nodes, Edges}` types, `declared`/`inferred`/
+      `evidence` edge-class constants, a pure `DeriveGraph(DeriveInput)` API, and
+      a `Deriver` with GORM-backed readers that substitute incoming definitions
+      for persisted jobs. B1 covers inferred lifecycle `paramMapping` output-key
+      checks with `schemacompat.Finding` verdicts and lineage evidence edges with
+      warn-only `VerdictUnknown` plus `lastSeen`; tests cover missing keys,
+      unresolved task indexes, unknown scoped producers, ignored non-output paths,
+      job-id source filters, and evidence last-seen aggregation.
 - [ ] B2. Fold the **declared** edge class into the graph: match
       `datasets.produces`/`datasets.consumes` on dataset `name` across all merged
       jobs, attaching the producer's `schemaFrom: output` (resolved to that step's

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -3,6 +3,7 @@ package contract
 import (
 	"bytes"
 	"context"
+	"database/sql/driver"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -142,31 +143,48 @@ func (s GORMStore) ListContractEvidence(ctx context.Context) ([]EvidenceRecord, 
 		ConsumerJobAlias string    `gorm:"column:consumer_job_alias"`
 		Namespace        string    `gorm:"column:namespace"`
 		Name             string    `gorm:"column:name"`
-		LastSeen         time.Time `gorm:"column:last_seen"`
+		LastSeen         sqlTime   `gorm:"column:last_seen"`
 	}
 	var rows []evidenceRow
 
+	lineageJobDatasetAggregate := func() *gorm.DB {
+		return s.DB.WithContext(ctx).
+			Table("lineage_datasets AS ld").
+			Select(
+				"job_runs.job_id AS job_id," +
+					" jobs.alias AS job_alias," +
+					" ld.namespace AS namespace," +
+					" ld.name AS name," +
+					" ld.direction AS direction," +
+					" MAX(ld.created_at) AS last_seen",
+			).
+			Joins("JOIN task_runs ON task_runs.id = ld.task_run_id").
+			Joins("JOIN job_runs ON job_runs.id = task_runs.job_run_id").
+			Joins("JOIN jobs ON jobs.id = job_runs.job_id AND jobs.deleted_at IS NULL").
+			Group("job_runs.job_id, jobs.alias, ld.namespace, ld.name, ld.direction")
+	}
+
 	err := s.DB.WithContext(ctx).
-		Table("lineage_datasets AS producer_ld").
+		Table("(?) AS producer", lineageJobDatasetAggregate()).
 		Select(
-			"producer_job.id AS producer_job_id,"+
-				" producer_job.alias AS producer_job_alias,"+
-				" consumer_job.id AS consumer_job_id,"+
-				" consumer_job.alias AS consumer_job_alias,"+
-				" producer_ld.namespace AS namespace,"+
-				" producer_ld.name AS name,"+
-				" MAX(consumer_ld.created_at) AS last_seen",
+			"producer.job_id AS producer_job_id,"+
+				" producer.job_alias AS producer_job_alias,"+
+				" consumer.job_id AS consumer_job_id,"+
+				" consumer.job_alias AS consumer_job_alias,"+
+				" producer.namespace AS namespace,"+
+				" producer.name AS name,"+
+				" consumer.last_seen AS last_seen",
 		).
-		Joins("JOIN task_runs producer_task_run ON producer_task_run.id = producer_ld.task_run_id").
-		Joins("JOIN job_runs producer_job_run ON producer_job_run.id = producer_task_run.job_run_id").
-		Joins("JOIN jobs producer_job ON producer_job.id = producer_job_run.job_id AND producer_job.deleted_at IS NULL").
-		Joins("JOIN lineage_datasets consumer_ld ON consumer_ld.namespace = producer_ld.namespace AND consumer_ld.name = producer_ld.name AND consumer_ld.direction = 'input'").
-		Joins("JOIN task_runs consumer_task_run ON consumer_task_run.id = consumer_ld.task_run_id").
-		Joins("JOIN job_runs consumer_job_run ON consumer_job_run.id = consumer_task_run.job_run_id").
-		Joins("JOIN jobs consumer_job ON consumer_job.id = consumer_job_run.job_id AND consumer_job.deleted_at IS NULL").
-		Where("producer_ld.direction = ?", "output").
-		Where("producer_job.id <> consumer_job.id").
-		Group("producer_job.id, producer_job.alias, consumer_job.id, consumer_job.alias, producer_ld.namespace, producer_ld.name").
+		Joins(
+			"JOIN (?) AS consumer ON consumer.namespace = producer.namespace"+
+				" AND consumer.name = producer.name"+
+				" AND producer.direction = ?"+
+				" AND consumer.direction = ?"+
+				" AND producer.job_id <> consumer.job_id",
+			lineageJobDatasetAggregate(),
+			"output",
+			"input",
+		).
 		Scan(&rows).Error
 	if err != nil {
 		return nil, err
@@ -183,11 +201,62 @@ func (s GORMStore) ListContractEvidence(ctx context.Context) ([]EvidenceRecord, 
 				Namespace: strings.TrimSpace(row.Namespace),
 				Name:      strings.TrimSpace(row.Name),
 			},
-			LastSeen: row.LastSeen,
+			LastSeen: row.LastSeen.Time,
 		})
 	}
 	sortEvidence(records)
 	return records, nil
+}
+
+type sqlTime struct {
+	time.Time
+}
+
+func (t *sqlTime) Scan(value any) error {
+	switch v := value.(type) {
+	case time.Time:
+		t.Time = v
+		return nil
+	case string:
+		return t.scanString(v)
+	case []byte:
+		return t.scanString(string(v))
+	case nil:
+		t.Time = time.Time{}
+		return nil
+	default:
+		return fmt.Errorf("unsupported timestamp value %T", value)
+	}
+}
+
+func (t sqlTime) Value() (driver.Value, error) {
+	if t.Time.IsZero() {
+		return nil, nil
+	}
+	return t.Time, nil
+}
+
+func (t *sqlTime) scanString(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		t.Time = time.Time{}
+		return nil
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		"2006-01-02 15:04:05.999999999-07:00",
+		"2006-01-02 15:04:05.999999999Z07:00",
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02 15:04:05",
+	} {
+		parsed, err := time.Parse(layout, value)
+		if err == nil {
+			t.Time = parsed
+			return nil
+		}
+	}
+	return fmt.Errorf("parse timestamp %q", value)
 }
 
 // DeriveGraph derives a contract graph from already-loaded jobs and lineage
@@ -275,6 +344,7 @@ func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases ma
 		return nil, err
 	}
 
+	eligibleRows := make([]jobRow, 0, len(rows))
 	jobIDs := make([]uuid.UUID, 0, len(rows))
 	for _, row := range rows {
 		alias := strings.TrimSpace(row.Alias)
@@ -287,6 +357,8 @@ func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases ma
 		if _, replaced := incomingJobIDs[row.ID]; replaced {
 			continue
 		}
+		row.Alias = alias
+		eligibleRows = append(eligibleRows, row)
 		jobIDs = append(jobIDs, row.ID)
 	}
 
@@ -295,26 +367,15 @@ func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases ma
 		return nil, err
 	}
 
-	jobs := make([]Job, 0, len(rows))
-	for _, row := range rows {
-		alias := strings.TrimSpace(row.Alias)
-		if alias == "" {
-			continue
-		}
-		if _, replaced := incomingAliases[alias]; replaced {
-			continue
-		}
-		if _, replaced := incomingJobIDs[row.ID]; replaced {
-			continue
-		}
-
+	jobs := make([]Job, 0, len(eligibleRows))
+	for _, row := range eligibleRows {
 		cfg, err := parseJSONMap(row.Configuration)
 		if err != nil {
-			return nil, fmt.Errorf("existing trigger %s configuration: %w", alias, err)
+			return nil, fmt.Errorf("existing trigger %s configuration: %w", row.Alias, err)
 		}
 		jobs = append(jobs, Job{
 			ID:     row.ID,
-			Alias:  alias,
+			Alias:  row.Alias,
 			Labels: stringLabels(row.Labels),
 			Trigger: Trigger{
 				Type:          strings.TrimSpace(row.TriggerType),
@@ -581,7 +642,10 @@ func triggerChainPatternSourceAlias(pattern triggerChainPattern, aliasByJobID ma
 
 	resolvedAlias := aliasByJobID[sourceJobID]
 	if sourceAlias == "" {
-		return resolvedAlias, true
+		if resolvedAlias != "" {
+			return resolvedAlias, true
+		}
+		return sourceJobID, true
 	}
 	if resolvedAlias != "" && resolvedAlias != sourceAlias {
 		return "", true
@@ -761,10 +825,6 @@ func verdictForFindings(findings []schemacompat.Finding, defaultVerdict schemaco
 			return schemacompat.VerdictBreaking
 		case schemacompat.VerdictUnknown:
 			verdict = schemacompat.VerdictUnknown
-		case schemacompat.VerdictCompatible:
-			if verdict == "" {
-				verdict = schemacompat.VerdictCompatible
-			}
 		}
 	}
 	return verdict

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -1,0 +1,1014 @@
+package contract
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/event"
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
+	"github.com/google/uuid"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+var eventOutputPathPattern = regexp.MustCompile(`^\$\.tasks\[([0-9]+)\]\.output\.([^.\s\[\]]+)$`)
+
+// JobReader reads the merged job world used to derive contract graph edges.
+type JobReader interface {
+	ListContractJobs(ctx context.Context, incoming []schema.Definition) ([]Job, error)
+}
+
+// EvidenceReader reads lineage-observed job-level dataset flow edges.
+type EvidenceReader interface {
+	ListContractEvidence(ctx context.Context) ([]EvidenceRecord, error)
+}
+
+// Deriver loads authoritative sources and derives a contract graph on demand.
+type Deriver struct {
+	Jobs     JobReader
+	Evidence EvidenceReader
+}
+
+// GORMStore reads contract graph inputs from the existing GORM catalog.
+type GORMStore struct {
+	DB *gorm.DB
+}
+
+// NewGORMDeriver returns a Deriver backed by the existing GORM catalog tables.
+func NewGORMDeriver(db *gorm.DB) Deriver {
+	store := GORMStore{DB: db}
+	return Deriver{Jobs: store, Evidence: store}
+}
+
+// DeriveGraph loads the merged job world, lineage evidence, and returns the
+// derived contract graph. Incoming definitions replace persisted jobs with
+// matching aliases, mirroring trigger-chain validation.
+func (d Deriver) DeriveGraph(ctx context.Context, incoming []schema.Definition) (Graph, error) {
+	if d.Jobs == nil {
+		return Graph{}, errors.New("contract deriver requires a job reader")
+	}
+	jobs, err := d.Jobs.ListContractJobs(ctx, incoming)
+	if err != nil {
+		return Graph{}, err
+	}
+
+	var evidence []EvidenceRecord
+	if d.Evidence != nil {
+		evidence, err = d.Evidence.ListContractEvidence(ctx)
+		if err != nil {
+			return Graph{}, err
+		}
+	}
+
+	return DeriveGraph(DeriveInput{Jobs: jobs, Evidence: evidence})
+}
+
+// ListContractJobs returns incoming definitions plus persisted jobs not
+// replaced by those definitions.
+func (s GORMStore) ListContractJobs(ctx context.Context, incoming []schema.Definition) ([]Job, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	jobs := make([]Job, 0, len(incoming))
+	incomingAliases := make(map[string]struct{}, len(incoming))
+	incomingAliasIndexes := make(map[string]int, len(incoming))
+	for idx := range incoming {
+		job, err := jobFromDefinition(incoming[idx])
+		if err != nil {
+			return nil, fmt.Errorf("definition %d: %w", idx, err)
+		}
+		if _, ok := incomingAliases[job.Alias]; ok {
+			return nil, fmt.Errorf("duplicate job alias %q", job.Alias)
+		}
+		incomingAliases[job.Alias] = struct{}{}
+		incomingAliasIndexes[job.Alias] = len(jobs)
+		jobs = append(jobs, job)
+	}
+
+	if s.DB == nil {
+		sortJobs(jobs)
+		return jobs, nil
+	}
+
+	incomingJobIDs, err := s.existingJobIDsByAlias(ctx, incomingAliases)
+	if err != nil {
+		return nil, err
+	}
+	for alias, id := range incomingJobIDs {
+		if idx, ok := incomingAliasIndexes[alias]; ok {
+			jobs[idx].ID = id
+		}
+	}
+
+	incomingJobIDSet := make(map[uuid.UUID]struct{}, len(incomingJobIDs))
+	for _, id := range incomingJobIDs {
+		incomingJobIDSet[id] = struct{}{}
+	}
+
+	existing, err := s.persistedContractJobs(ctx, incomingAliases, incomingJobIDSet)
+	if err != nil {
+		return nil, err
+	}
+	jobs = append(jobs, existing...)
+	sortJobs(jobs)
+	return jobs, nil
+}
+
+// ListContractEvidence returns distinct job-level lineage evidence edges.
+func (s GORMStore) ListContractEvidence(ctx context.Context) ([]EvidenceRecord, error) {
+	if s.DB == nil {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	type evidenceRow struct {
+		ProducerJobID    uuid.UUID `gorm:"column:producer_job_id"`
+		ProducerJobAlias string    `gorm:"column:producer_job_alias"`
+		ConsumerJobID    uuid.UUID `gorm:"column:consumer_job_id"`
+		ConsumerJobAlias string    `gorm:"column:consumer_job_alias"`
+		Namespace        string    `gorm:"column:namespace"`
+		Name             string    `gorm:"column:name"`
+		LastSeen         time.Time `gorm:"column:last_seen"`
+	}
+	var rows []evidenceRow
+
+	err := s.DB.WithContext(ctx).
+		Table("lineage_datasets AS producer_ld").
+		Select(
+			"producer_job.id AS producer_job_id,"+
+				" producer_job.alias AS producer_job_alias,"+
+				" consumer_job.id AS consumer_job_id,"+
+				" consumer_job.alias AS consumer_job_alias,"+
+				" producer_ld.namespace AS namespace,"+
+				" producer_ld.name AS name,"+
+				" MAX(consumer_ld.created_at) AS last_seen",
+		).
+		Joins("JOIN task_runs producer_task_run ON producer_task_run.id = producer_ld.task_run_id").
+		Joins("JOIN job_runs producer_job_run ON producer_job_run.id = producer_task_run.job_run_id").
+		Joins("JOIN jobs producer_job ON producer_job.id = producer_job_run.job_id AND producer_job.deleted_at IS NULL").
+		Joins("JOIN lineage_datasets consumer_ld ON consumer_ld.namespace = producer_ld.namespace AND consumer_ld.name = producer_ld.name AND consumer_ld.direction = 'input'").
+		Joins("JOIN task_runs consumer_task_run ON consumer_task_run.id = consumer_ld.task_run_id").
+		Joins("JOIN job_runs consumer_job_run ON consumer_job_run.id = consumer_task_run.job_run_id").
+		Joins("JOIN jobs consumer_job ON consumer_job.id = consumer_job_run.job_id AND consumer_job.deleted_at IS NULL").
+		Where("producer_ld.direction = ?", "output").
+		Where("producer_job.id <> consumer_job.id").
+		Group("producer_job.id, producer_job.alias, consumer_job.id, consumer_job.alias, producer_ld.namespace, producer_ld.name").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]EvidenceRecord, 0, len(rows))
+	for _, row := range rows {
+		records = append(records, EvidenceRecord{
+			ProducerJobID:    row.ProducerJobID,
+			ProducerJobAlias: strings.TrimSpace(row.ProducerJobAlias),
+			ConsumerJobID:    row.ConsumerJobID,
+			ConsumerJobAlias: strings.TrimSpace(row.ConsumerJobAlias),
+			Dataset: DatasetRef{
+				Namespace: strings.TrimSpace(row.Namespace),
+				Name:      strings.TrimSpace(row.Name),
+			},
+			LastSeen: row.LastSeen,
+		})
+	}
+	sortEvidence(records)
+	return records, nil
+}
+
+// DeriveGraph derives a contract graph from already-loaded jobs and lineage
+// evidence. It performs no writes and stores no graph state.
+func DeriveGraph(input DeriveInput) (Graph, error) {
+	builder := newGraphBuilder()
+
+	jobs := append([]Job(nil), input.Jobs...)
+	evidence := append([]EvidenceRecord(nil), input.Evidence...)
+	sortJobs(jobs)
+
+	seenAliases := make(map[string]struct{}, len(jobs))
+	for idx := range jobs {
+		jobs[idx].Alias = strings.TrimSpace(jobs[idx].Alias)
+		if jobs[idx].Alias == "" {
+			return Graph{}, fmt.Errorf("job %d: alias is required", idx)
+		}
+		if _, exists := seenAliases[jobs[idx].Alias]; exists {
+			return Graph{}, fmt.Errorf("duplicate job alias %q", jobs[idx].Alias)
+		}
+		seenAliases[jobs[idx].Alias] = struct{}{}
+		builder.addJob(jobs[idx])
+	}
+
+	if err := deriveInferredEdges(builder, jobs); err != nil {
+		return Graph{}, err
+	}
+	deriveEvidenceEdges(builder, evidence)
+
+	return builder.graph(), nil
+}
+
+func (s GORMStore) existingJobIDsByAlias(ctx context.Context, incomingAliases map[string]struct{}) (map[string]uuid.UUID, error) {
+	if len(incomingAliases) == 0 {
+		return nil, nil
+	}
+
+	aliases := make([]string, 0, len(incomingAliases))
+	for alias := range incomingAliases {
+		aliases = append(aliases, alias)
+	}
+
+	var rows []struct {
+		ID    uuid.UUID
+		Alias string
+	}
+	err := s.DB.WithContext(ctx).
+		Table("jobs").
+		Select("id, alias").
+		Where("deleted_at IS NULL").
+		Where("alias IN ?", aliases).
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	ids := make(map[string]uuid.UUID, len(rows))
+	for _, row := range rows {
+		alias := strings.TrimSpace(row.Alias)
+		if alias == "" || row.ID == uuid.Nil {
+			continue
+		}
+		ids[alias] = row.ID
+	}
+	return ids, nil
+}
+
+func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases map[string]struct{}, incomingJobIDs map[uuid.UUID]struct{}) ([]Job, error) {
+	type jobRow struct {
+		ID            uuid.UUID         `gorm:"column:id"`
+		Alias         string            `gorm:"column:alias"`
+		Labels        datatypes.JSONMap `gorm:"column:labels"`
+		TriggerType   string            `gorm:"column:trigger_type"`
+		Configuration string            `gorm:"column:configuration"`
+	}
+	var rows []jobRow
+
+	err := s.DB.WithContext(ctx).
+		Table("jobs").
+		Select("jobs.id, jobs.alias, jobs.labels, triggers.type AS trigger_type, triggers.configuration").
+		Joins("JOIN triggers ON triggers.id = jobs.trigger_id AND triggers.deleted_at IS NULL").
+		Where("jobs.deleted_at IS NULL").
+		Find(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+
+	jobIDs := make([]uuid.UUID, 0, len(rows))
+	for _, row := range rows {
+		alias := strings.TrimSpace(row.Alias)
+		if alias == "" {
+			continue
+		}
+		if _, replaced := incomingAliases[alias]; replaced {
+			continue
+		}
+		if _, replaced := incomingJobIDs[row.ID]; replaced {
+			continue
+		}
+		jobIDs = append(jobIDs, row.ID)
+	}
+
+	stepsByJobID, err := s.persistedContractSteps(ctx, jobIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs := make([]Job, 0, len(rows))
+	for _, row := range rows {
+		alias := strings.TrimSpace(row.Alias)
+		if alias == "" {
+			continue
+		}
+		if _, replaced := incomingAliases[alias]; replaced {
+			continue
+		}
+		if _, replaced := incomingJobIDs[row.ID]; replaced {
+			continue
+		}
+
+		cfg, err := parseJSONMap(row.Configuration)
+		if err != nil {
+			return nil, fmt.Errorf("existing trigger %s configuration: %w", alias, err)
+		}
+		jobs = append(jobs, Job{
+			ID:     row.ID,
+			Alias:  alias,
+			Labels: stringLabels(row.Labels),
+			Trigger: Trigger{
+				Type:          strings.TrimSpace(row.TriggerType),
+				Configuration: cfg,
+			},
+			Steps: stepsByJobID[row.ID],
+		})
+	}
+	return jobs, nil
+}
+
+func (s GORMStore) persistedContractSteps(ctx context.Context, jobIDs []uuid.UUID) (map[uuid.UUID][]Step, error) {
+	stepsByJobID := make(map[uuid.UUID][]Step, len(jobIDs))
+	if len(jobIDs) == 0 {
+		return stepsByJobID, nil
+	}
+
+	var tasks []models.Task
+	if err := s.DB.WithContext(ctx).
+		Where("job_id IN ?", jobIDs).
+		Order("job_id ASC").
+		Order("position ASC").
+		Order("created_at ASC").
+		Find(&tasks).Error; err != nil {
+		return nil, err
+	}
+
+	for _, task := range tasks {
+		outputSchema, err := parseJSONMapBytes(task.OutputSchema)
+		if err != nil {
+			return nil, fmt.Errorf("task %s output_schema: %w", task.Name, err)
+		}
+		stepsByJobID[task.JobID] = append(stepsByJobID[task.JobID], Step{
+			Name:         strings.TrimSpace(task.Name),
+			OutputSchema: outputSchema,
+		})
+	}
+	return stepsByJobID, nil
+}
+
+func jobFromDefinition(def schema.Definition) (Job, error) {
+	alias := strings.TrimSpace(def.Metadata.Alias)
+	if alias == "" {
+		return Job{}, errors.New("metadata.alias is required")
+	}
+
+	steps := make([]Step, 0, len(def.Steps))
+	for _, step := range def.Steps {
+		steps = append(steps, Step{
+			Name:         strings.TrimSpace(step.Name),
+			OutputSchema: cloneAnyMap(step.OutputSchema),
+		})
+	}
+
+	return Job{
+		Alias:  alias,
+		Labels: cloneStringMap(def.Metadata.Labels),
+		Trigger: Trigger{
+			Type:          strings.TrimSpace(def.Trigger.Type),
+			Configuration: cloneAnyMap(def.Trigger.Configuration),
+		},
+		Steps: steps,
+	}, nil
+}
+
+func deriveInferredEdges(builder *graphBuilder, jobs []Job) error {
+	jobsByAlias := make(map[string]Job, len(jobs))
+	aliasByJobID := make(map[string]string, len(jobs))
+	knownAliases := make([]string, 0, len(jobs))
+	for _, job := range jobs {
+		jobsByAlias[job.Alias] = job
+		knownAliases = append(knownAliases, job.Alias)
+		if job.ID != uuid.Nil {
+			aliasByJobID[job.ID.String()] = job.Alias
+		}
+	}
+	sort.Strings(knownAliases)
+
+	pairs := make(map[inferredPair]struct{})
+	for _, consumer := range jobs {
+		if consumer.Trigger.Type != schema.TriggerEvent && consumer.Trigger.Type != string(models.TriggerTypeEvent) {
+			continue
+		}
+
+		outputRefs, err := outputParamMappingRefs(consumer.Trigger.Configuration)
+		if err != nil {
+			return fmt.Errorf("definition %s: %w", consumer.Alias, err)
+		}
+		if len(outputRefs) == 0 {
+			continue
+		}
+
+		patterns, err := triggerChainPatterns(consumer.Trigger.Configuration)
+		if err != nil {
+			return fmt.Errorf("definition %s: %w", consumer.Alias, err)
+		}
+		for _, pattern := range patterns {
+			if !patternCanMatchCaesiumLifecycle(pattern) {
+				continue
+			}
+			sourceAlias, scoped := triggerChainPatternSourceAlias(pattern, aliasByJobID)
+			if scoped {
+				addInferredPair(pairs, sourceAlias, consumer.Alias)
+				continue
+			}
+			for _, alias := range knownAliases {
+				addInferredPair(pairs, alias, consumer.Alias)
+			}
+		}
+	}
+
+	orderedPairs := make([]inferredPair, 0, len(pairs))
+	for p := range pairs {
+		orderedPairs = append(orderedPairs, p)
+	}
+	sort.Slice(orderedPairs, func(i, j int) bool {
+		if orderedPairs[i].from == orderedPairs[j].from {
+			return orderedPairs[i].to < orderedPairs[j].to
+		}
+		return orderedPairs[i].from < orderedPairs[j].from
+	})
+
+	for _, p := range orderedPairs {
+		consumer := jobsByAlias[p.to]
+		outputRefs, err := outputParamMappingRefs(consumer.Trigger.Configuration)
+		if err != nil {
+			return fmt.Errorf("definition %s: %w", consumer.Alias, err)
+		}
+		producer, ok := jobsByAlias[p.from]
+		if !ok {
+			findings := unknownProducerFindings(p.from, consumer, outputRefs)
+			builder.addJob(Job{Alias: p.from})
+			builder.addEdge(Edge{
+				From:     jobNodeID(p.from),
+				To:       jobNodeID(consumer.Alias),
+				Class:    EdgeClassInferred,
+				Verdict:  schemacompat.VerdictUnknown,
+				Findings: findings,
+			})
+			continue
+		}
+		findings := inferredFindings(producer, outputRefs)
+		builder.addEdge(Edge{
+			From:     jobNodeID(producer.Alias),
+			To:       jobNodeID(consumer.Alias),
+			Class:    EdgeClassInferred,
+			Verdict:  verdictForFindings(findings, schemacompat.VerdictCompatible),
+			Findings: findings,
+		})
+	}
+	return nil
+}
+
+type inferredPair struct {
+	from string
+	to   string
+}
+
+func addInferredPair(pairs map[inferredPair]struct{}, from, to string) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	if from == "" || to == "" || from == to {
+		return
+	}
+	pairs[inferredPair{from: from, to: to}] = struct{}{}
+}
+
+func deriveEvidenceEdges(builder *graphBuilder, records []EvidenceRecord) {
+	sortEvidence(records)
+	for _, record := range records {
+		producerAlias := strings.TrimSpace(record.ProducerJobAlias)
+		consumerAlias := strings.TrimSpace(record.ConsumerJobAlias)
+		if producerAlias == "" || consumerAlias == "" || producerAlias == consumerAlias {
+			continue
+		}
+		dataset := DatasetRef{
+			Namespace: strings.TrimSpace(record.Dataset.Namespace),
+			Name:      strings.TrimSpace(record.Dataset.Name),
+		}
+		if dataset.Namespace == "" && dataset.Name == "" {
+			continue
+		}
+
+		builder.addJob(Job{ID: record.ProducerJobID, Alias: producerAlias})
+		builder.addJob(Job{ID: record.ConsumerJobID, Alias: consumerAlias})
+		builder.addDataset(dataset)
+
+		lastSeen := record.LastSeen
+		builder.addEdge(Edge{
+			From:     jobNodeID(producerAlias),
+			To:       jobNodeID(consumerAlias),
+			Class:    EdgeClassEvidence,
+			Verdict:  schemacompat.VerdictUnknown,
+			Dataset:  &dataset,
+			LastSeen: &lastSeen,
+		})
+	}
+}
+
+type triggerChainPattern struct {
+	eventType string
+	source    string
+	filter    map[string]string
+}
+
+func triggerChainPatterns(cfg map[string]any) ([]triggerChainPattern, error) {
+	rawEvents, ok := cfg["events"]
+	if !ok || rawEvents == nil {
+		return nil, nil
+	}
+	events, ok := rawEvents.([]any)
+	if !ok {
+		return nil, fmt.Errorf("trigger.configuration.events must be a list")
+	}
+
+	patterns := make([]triggerChainPattern, 0, len(events))
+	for idx, rawEvent := range events {
+		eventMap, ok := rawEvent.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("trigger.configuration.events[%d] must be an object", idx)
+		}
+		pattern := triggerChainPattern{filter: map[string]string{}}
+		pattern.eventType, _ = eventMap["type"].(string)
+		pattern.source, _ = eventMap["source"].(string)
+		if rawFilter, ok := eventMap["filter"]; ok && rawFilter != nil {
+			filter, ok := rawFilter.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("trigger.configuration.events[%d].filter must be an object", idx)
+			}
+			for key, value := range filter {
+				if stringValue, ok := value.(string); ok {
+					pattern.filter[key] = stringValue
+				}
+			}
+		}
+		patterns = append(patterns, pattern)
+	}
+	return patterns, nil
+}
+
+func patternCanMatchCaesiumLifecycle(pattern triggerChainPattern) bool {
+	source := strings.TrimSpace(pattern.source)
+	if source != "" && source != "caesium" {
+		return false
+	}
+	for _, lifecycleType := range []event.Type{event.TypeRunCompleted, event.TypeRunFailed, event.TypeRunTerminal} {
+		if matchesTriggerChainEventType(pattern.eventType, string(lifecycleType)) {
+			return true
+		}
+	}
+	return false
+}
+
+func triggerChainPatternSourceAlias(pattern triggerChainPattern, aliasByJobID map[string]string) (string, bool) {
+	sourceAlias := strings.TrimSpace(pattern.filter["job_alias"])
+	sourceJobID := strings.TrimSpace(pattern.filter["job_id"])
+
+	if sourceAlias == "" && sourceJobID == "" {
+		return "", false
+	}
+	if sourceJobID == "" {
+		return sourceAlias, true
+	}
+
+	resolvedAlias := aliasByJobID[sourceJobID]
+	if sourceAlias == "" {
+		return resolvedAlias, true
+	}
+	if resolvedAlias != "" && resolvedAlias != sourceAlias {
+		return "", true
+	}
+	return sourceAlias, true
+}
+
+func matchesTriggerChainEventType(patternValue, eventType string) bool {
+	patternValue = strings.TrimSpace(patternValue)
+	eventType = strings.TrimSpace(eventType)
+	if patternValue == "" || eventType == "" {
+		return false
+	}
+	if !strings.ContainsAny(patternValue, "*?[") {
+		return patternValue == eventType
+	}
+	matched, err := path.Match(patternValue, eventType)
+	return err == nil && matched
+}
+
+type outputRef struct {
+	paramName string
+	jsonPath  string
+	stepIndex int
+	key       string
+}
+
+func outputParamMappingRefs(cfg map[string]any) ([]outputRef, error) {
+	mapping, err := paramMapping(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(mapping) == 0 {
+		return nil, nil
+	}
+
+	params := make([]string, 0, len(mapping))
+	for param := range mapping {
+		params = append(params, param)
+	}
+	sort.Strings(params)
+
+	refs := make([]outputRef, 0, len(mapping))
+	for _, param := range params {
+		jsonPath := strings.TrimSpace(mapping[param])
+		match := eventOutputPathPattern.FindStringSubmatch(jsonPath)
+		if len(match) != 3 {
+			continue
+		}
+		stepIndex, err := strconv.Atoi(match[1])
+		if err != nil {
+			continue
+		}
+		refs = append(refs, outputRef{
+			paramName: param,
+			jsonPath:  jsonPath,
+			stepIndex: stepIndex,
+			key:       match[2],
+		})
+	}
+	return refs, nil
+}
+
+func paramMapping(cfg map[string]any) (map[string]string, error) {
+	rawMapping, ok := cfg["paramMapping"]
+	if !ok || rawMapping == nil {
+		return nil, nil
+	}
+
+	switch mapping := rawMapping.(type) {
+	case map[string]string:
+		out := make(map[string]string, len(mapping))
+		for key, value := range mapping {
+			out[key] = value
+		}
+		return out, nil
+	case map[string]any:
+		out := make(map[string]string, len(mapping))
+		for key, value := range mapping {
+			stringValue, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("trigger.configuration.paramMapping[%q] must be a string", key)
+			}
+			out[key] = stringValue
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("trigger.configuration.paramMapping must be a map of string keys and values")
+	}
+}
+
+func inferredFindings(producer Job, refs []outputRef) []schemacompat.Finding {
+	findings := make([]schemacompat.Finding, 0)
+	for _, ref := range refs {
+		if ref.stepIndex >= 0 && ref.stepIndex < len(producer.Steps) {
+			step := producer.Steps[ref.stepIndex]
+			if outputSchemaHasProperty(step.OutputSchema, ref.key) {
+				continue
+			}
+			findings = append(findings, schemacompat.Finding{
+				Kind:    schemacompat.FindingKindRequirementUnsatisfied,
+				Path:    paramMappingFindingPath(ref.paramName),
+				Detail:  fmt.Sprintf("paramMapping %q references %s output key %q from producer %s step %q, but that key is missing from the step outputSchema", ref.paramName, ref.jsonPath, ref.key, producer.Alias, step.Name),
+				Verdict: schemacompat.VerdictBreaking,
+			})
+			continue
+		}
+
+		foundInUnion := producerOutputSchemaUnionHasProperty(producer, ref.key)
+		kind := schemacompat.FindingKindRequirementUnknown
+		detail := fmt.Sprintf("paramMapping %q references %s, but tasks[%d] cannot be resolved to a producer step in %s; key %q was found in the producer outputSchema union", ref.paramName, ref.jsonPath, ref.stepIndex, producer.Alias, ref.key)
+		if !foundInUnion {
+			kind = schemacompat.FindingKindRequirementUnsatisfied
+			detail = fmt.Sprintf("paramMapping %q references %s, but tasks[%d] cannot be resolved to a producer step in %s and key %q is missing from every producer step outputSchema", ref.paramName, ref.jsonPath, ref.stepIndex, producer.Alias, ref.key)
+		}
+		findings = append(findings, schemacompat.Finding{
+			Kind:    kind,
+			Path:    paramMappingFindingPath(ref.paramName),
+			Detail:  detail,
+			Verdict: schemacompat.VerdictUnknown,
+		})
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Path == findings[j].Path {
+			return findings[i].Detail < findings[j].Detail
+		}
+		return findings[i].Path < findings[j].Path
+	})
+	return findings
+}
+
+func unknownProducerFindings(producerAlias string, consumer Job, refs []outputRef) []schemacompat.Finding {
+	findings := make([]schemacompat.Finding, 0, len(refs))
+	for _, ref := range refs {
+		findings = append(findings, schemacompat.Finding{
+			Kind:    schemacompat.FindingKindRequirementUnknown,
+			Path:    paramMappingFindingPath(ref.paramName),
+			Detail:  fmt.Sprintf("paramMapping %q on %s references %s from producer %s, but that producer is not present in the merged job set; cannot prove the output key %q exists", ref.paramName, consumer.Alias, ref.jsonPath, producerAlias, ref.key),
+			Verdict: schemacompat.VerdictUnknown,
+		})
+	}
+	return findings
+}
+
+func paramMappingFindingPath(paramName string) string {
+	return "trigger.configuration.paramMapping." + paramName
+}
+
+func outputSchemaHasProperty(outputSchema map[string]any, key string) bool {
+	key = strings.TrimSpace(key)
+	if key == "" || len(outputSchema) == 0 {
+		return false
+	}
+	props, ok := outputSchema["properties"].(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = props[key]
+	return ok
+}
+
+func producerOutputSchemaUnionHasProperty(producer Job, key string) bool {
+	for _, step := range producer.Steps {
+		if outputSchemaHasProperty(step.OutputSchema, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func verdictForFindings(findings []schemacompat.Finding, defaultVerdict schemacompat.Verdict) schemacompat.Verdict {
+	verdict := defaultVerdict
+	for _, finding := range findings {
+		switch finding.Verdict {
+		case schemacompat.VerdictBreaking:
+			return schemacompat.VerdictBreaking
+		case schemacompat.VerdictUnknown:
+			verdict = schemacompat.VerdictUnknown
+		case schemacompat.VerdictCompatible:
+			if verdict == "" {
+				verdict = schemacompat.VerdictCompatible
+			}
+		}
+	}
+	return verdict
+}
+
+type graphBuilder struct {
+	nodes map[string]Node
+	edges map[string]Edge
+}
+
+func newGraphBuilder() *graphBuilder {
+	return &graphBuilder{
+		nodes: map[string]Node{},
+		edges: map[string]Edge{},
+	}
+}
+
+func (b *graphBuilder) addJob(job Job) {
+	alias := strings.TrimSpace(job.Alias)
+	if alias == "" {
+		return
+	}
+	id := jobNodeID(alias)
+	node := Node{
+		ID:     id,
+		Kind:   NodeKindJob,
+		Alias:  alias,
+		Labels: cloneStringMap(job.Labels),
+	}
+	if existing, ok := b.nodes[id]; ok {
+		if len(existing.Labels) == 0 && len(node.Labels) > 0 {
+			existing.Labels = node.Labels
+			b.nodes[id] = existing
+		}
+		return
+	}
+	b.nodes[id] = node
+}
+
+func (b *graphBuilder) addDataset(dataset DatasetRef) {
+	dataset.Namespace = strings.TrimSpace(dataset.Namespace)
+	dataset.Name = strings.TrimSpace(dataset.Name)
+	if dataset.Namespace == "" && dataset.Name == "" {
+		return
+	}
+	id := datasetNodeID(dataset)
+	if _, ok := b.nodes[id]; ok {
+		return
+	}
+	ref := dataset
+	b.nodes[id] = Node{
+		ID:      id,
+		Kind:    NodeKindDataset,
+		Dataset: &ref,
+	}
+}
+
+func (b *graphBuilder) addEdge(edge Edge) {
+	if strings.TrimSpace(edge.From) == "" || strings.TrimSpace(edge.To) == "" || edge.Class == "" {
+		return
+	}
+	edge.From = strings.TrimSpace(edge.From)
+	edge.To = strings.TrimSpace(edge.To)
+	edge.ID = edgeID(edge)
+
+	if existing, ok := b.edges[edge.ID]; ok {
+		b.edges[edge.ID] = mergeEdges(existing, edge)
+		return
+	}
+	b.edges[edge.ID] = edge
+}
+
+func (b *graphBuilder) graph() Graph {
+	nodes := make([]Node, 0, len(b.nodes))
+	for _, node := range b.nodes {
+		nodes = append(nodes, node)
+	}
+	sort.Slice(nodes, func(i, j int) bool {
+		if nodes[i].Kind == nodes[j].Kind {
+			return nodes[i].ID < nodes[j].ID
+		}
+		return nodes[i].Kind < nodes[j].Kind
+	})
+
+	edges := make([]Edge, 0, len(b.edges))
+	for _, edge := range b.edges {
+		edges = append(edges, edge)
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].Class == edges[j].Class {
+			if edges[i].From == edges[j].From {
+				if edges[i].To == edges[j].To {
+					return datasetKey(edges[i].Dataset) < datasetKey(edges[j].Dataset)
+				}
+				return edges[i].To < edges[j].To
+			}
+			return edges[i].From < edges[j].From
+		}
+		return edges[i].Class < edges[j].Class
+	})
+
+	return Graph{Nodes: nodes, Edges: edges}
+}
+
+func mergeEdges(existing, incoming Edge) Edge {
+	if incoming.Verdict == schemacompat.VerdictBreaking || existing.Verdict == "" {
+		existing.Verdict = incoming.Verdict
+	} else if incoming.Verdict == schemacompat.VerdictUnknown && existing.Verdict != schemacompat.VerdictBreaking {
+		existing.Verdict = schemacompat.VerdictUnknown
+	}
+
+	existing.Findings = append(existing.Findings, incoming.Findings...)
+	if incoming.LastSeen != nil && (existing.LastSeen == nil || incoming.LastSeen.After(*existing.LastSeen)) {
+		lastSeen := *incoming.LastSeen
+		existing.LastSeen = &lastSeen
+	}
+	return existing
+}
+
+func jobNodeID(alias string) string {
+	return "job:" + strings.TrimSpace(alias)
+}
+
+func datasetNodeID(dataset DatasetRef) string {
+	return "dataset:" + datasetKey(&dataset)
+}
+
+func datasetKey(dataset *DatasetRef) string {
+	if dataset == nil {
+		return ""
+	}
+	return strings.TrimSpace(dataset.Namespace) + "/" + strings.TrimSpace(dataset.Name)
+}
+
+func edgeID(edge Edge) string {
+	key := string(edge.Class) + ":" + edge.From + "->" + edge.To
+	if edge.Dataset != nil {
+		key += ":" + datasetKey(edge.Dataset)
+	}
+	return "edge:" + key
+}
+
+func parseJSONMap(raw string) (map[string]any, error) {
+	return parseJSONMapBytes([]byte(raw))
+}
+
+func parseJSONMapBytes(raw []byte) (map[string]any, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
+		return nil, nil
+	}
+	var out map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func stringLabels(labels datatypes.JSONMap) map[string]string {
+	if len(labels) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(labels))
+	for key, value := range labels {
+		stringValue, ok := value.(string)
+		if !ok {
+			continue
+		}
+		out[key] = stringValue
+	}
+	return out
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneAnyMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		switch typed := value.(type) {
+		case map[string]any:
+			out[key] = cloneAnyMap(typed)
+		case []any:
+			out[key] = cloneAnySlice(typed)
+		default:
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func cloneAnySlice(in []any) []any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]any, len(in))
+	for idx, value := range in {
+		switch typed := value.(type) {
+		case map[string]any:
+			out[idx] = cloneAnyMap(typed)
+		case []any:
+			out[idx] = cloneAnySlice(typed)
+		default:
+			out[idx] = value
+		}
+	}
+	return out
+}
+
+func sortJobs(jobs []Job) {
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].Alias < jobs[j].Alias
+	})
+}
+
+func sortEvidence(records []EvidenceRecord) {
+	sort.Slice(records, func(i, j int) bool {
+		left := records[i]
+		right := records[j]
+		if left.ProducerJobAlias == right.ProducerJobAlias {
+			if left.ConsumerJobAlias == right.ConsumerJobAlias {
+				if left.Dataset.Namespace == right.Dataset.Namespace {
+					if left.Dataset.Name == right.Dataset.Name {
+						return left.LastSeen.Before(right.LastSeen)
+					}
+					return left.Dataset.Name < right.Dataset.Name
+				}
+				return left.Dataset.Namespace < right.Dataset.Namespace
+			}
+			return left.ConsumerJobAlias < right.ConsumerJobAlias
+		}
+		return left.ProducerJobAlias < right.ProducerJobAlias
+	})
+}

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -230,7 +230,7 @@ func (t *sqlTime) Scan(value any) error {
 }
 
 func (t sqlTime) Value() (driver.Value, error) {
-	if t.Time.IsZero() {
+	if t.IsZero() {
 		return nil, nil
 	}
 	return t.Time, nil

--- a/internal/contract/graph.go
+++ b/internal/contract/graph.go
@@ -1,0 +1,103 @@
+// Package contract derives the cross-job contract graph from authoritative
+// job, trigger, and lineage sources.
+package contract
+
+import (
+	"time"
+
+	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
+	"github.com/google/uuid"
+)
+
+// NodeKind identifies the kind of graph node.
+type NodeKind string
+
+const (
+	// NodeKindJob is a Caesium job node.
+	NodeKindJob NodeKind = "job"
+	// NodeKindDataset is an OpenLineage dataset node.
+	NodeKindDataset NodeKind = "dataset"
+)
+
+// EdgeClass identifies how a contract graph edge was derived.
+type EdgeClass string
+
+const (
+	// EdgeClassDeclared marks an edge declared through dataset produces/consumes blocks.
+	EdgeClassDeclared EdgeClass = "declared"
+	// EdgeClassInferred marks an edge inferred from lifecycle trigger chains and paramMapping paths.
+	EdgeClassInferred EdgeClass = "inferred"
+	// EdgeClassEvidence marks an edge observed from lineage input/output rows.
+	EdgeClassEvidence EdgeClass = "evidence"
+)
+
+// DatasetRef identifies a dataset by its OpenLineage namespace/name pair.
+type DatasetRef struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// Graph is the JSON-ready contract graph returned by read surfaces.
+type Graph struct {
+	Nodes []Node `json:"nodes"`
+	Edges []Edge `json:"edges"`
+}
+
+// Node is a job or dataset graph node.
+type Node struct {
+	ID      string            `json:"id"`
+	Kind    NodeKind          `json:"kind"`
+	Alias   string            `json:"alias,omitempty"`
+	Labels  map[string]string `json:"labels,omitempty"`
+	Dataset *DatasetRef       `json:"dataset,omitempty"`
+}
+
+// Edge is a derived relationship between two graph nodes.
+type Edge struct {
+	ID       string                 `json:"id"`
+	From     string                 `json:"from"`
+	To       string                 `json:"to"`
+	Class    EdgeClass              `json:"class"`
+	Verdict  schemacompat.Verdict   `json:"verdict,omitempty"`
+	Findings []schemacompat.Finding `json:"findings,omitempty"`
+	Dataset  *DatasetRef            `json:"dataset,omitempty"`
+	LastSeen *time.Time             `json:"lastSeen,omitempty"`
+}
+
+// Job is the compact job definition surface needed to derive B1 graph edges.
+type Job struct {
+	ID      uuid.UUID
+	Alias   string
+	Labels  map[string]string
+	Trigger Trigger
+	Steps   []Step
+}
+
+// Trigger is the compact trigger surface needed for trigger-chain inference.
+type Trigger struct {
+	Type          string
+	Configuration map[string]any
+}
+
+// Step is the compact step surface needed for output-schema path checks.
+type Step struct {
+	Name         string
+	OutputSchema map[string]any
+}
+
+// EvidenceRecord is one distinct lineage-observed producer/dataset/consumer edge.
+type EvidenceRecord struct {
+	ProducerJobID    uuid.UUID
+	ProducerJobAlias string
+	ConsumerJobID    uuid.UUID
+	ConsumerJobAlias string
+	Dataset          DatasetRef
+	LastSeen         time.Time
+}
+
+// DeriveInput is the pure input surface for graph derivation. Callers that
+// already have the merged job world can use DeriveGraph directly.
+type DeriveInput struct {
+	Jobs     []Job
+	Evidence []EvidenceRecord
+}

--- a/internal/contract/graph_test.go
+++ b/internal/contract/graph_test.go
@@ -1,6 +1,7 @@
 package contract
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -8,6 +9,8 @@ import (
 	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestDeriveGraphInferredEdgeReportsMissingMappedOutput(t *testing.T) {
@@ -128,6 +131,62 @@ func TestDeriveGraphInferredUnknownProducerAliasWarns(t *testing.T) {
 	require.Contains(t, edge.Findings[0].Detail, "not present in the merged job set")
 }
 
+func TestDeriveGraphUnscopedLifecyclePatternFansOutToKnownJobs(t *testing.T) {
+	producerA := Job{
+		Alias: "producer-a",
+		Steps: []Step{{
+			Name:         "extract",
+			OutputSchema: outputSchemaWithProperties("row_count"),
+		}},
+	}
+	producerB := Job{
+		Alias: "producer-b",
+		Steps: []Step{{
+			Name:         "extract",
+			OutputSchema: outputSchemaWithProperties("row_count"),
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Trigger: eventTriggerWithFilter(map[string]any{}, map[string]string{
+			"rows": "$.tasks[0].output.row_count",
+		}),
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producerA, producerB, consumer}})
+	require.NoError(t, err)
+
+	edgeA := requireEdge(t, graph, EdgeClassInferred, "job:producer-a", "job:consumer", "")
+	require.Equal(t, schemacompat.VerdictCompatible, edgeA.Verdict)
+	require.Empty(t, edgeA.Findings)
+
+	edgeB := requireEdge(t, graph, EdgeClassInferred, "job:producer-b", "job:consumer", "")
+	require.Equal(t, schemacompat.VerdictCompatible, edgeB.Verdict)
+	require.Empty(t, edgeB.Findings)
+	require.Len(t, graph.Edges, 2)
+}
+
+func TestDeriveGraphUnknownJobIDFilterWarns(t *testing.T) {
+	missingJobID := uuid.New()
+	consumer := Job{
+		Alias: "consumer",
+		Trigger: eventTriggerWithFilter(map[string]any{"job_id": missingJobID.String()}, map[string]string{
+			"rows": "$.tasks[0].output.row_count",
+		}),
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassInferred, "job:"+missingJobID.String(), "job:consumer", "")
+	require.Equal(t, schemacompat.VerdictUnknown, edge.Verdict)
+	require.Len(t, edge.Findings, 1)
+	require.Equal(t, schemacompat.FindingKindRequirementUnknown, edge.Findings[0].Kind)
+	require.Contains(t, edge.Findings[0].Detail, missingJobID.String())
+	require.Contains(t, edge.Findings[0].Detail, "not present in the merged job set")
+	requireJobNode(t, graph, missingJobID.String())
+}
+
 func TestDeriveGraphEvidenceEdgesAggregateLastSeen(t *testing.T) {
 	producerID := uuid.New()
 	consumerID := uuid.New()
@@ -166,6 +225,34 @@ func TestDeriveGraphEvidenceEdgesAggregateLastSeen(t *testing.T) {
 	require.NotNil(t, edge.LastSeen)
 	require.Equal(t, newer, *edge.LastSeen)
 	requireDatasetNode(t, graph, "lake/customers")
+}
+
+func TestGORMStoreListContractEvidenceAggregatesBeforeJoining(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	createContractEvidenceTables(t, db)
+
+	producerJobID := uuid.New()
+	consumerJobID := uuid.New()
+	insertEvidenceJob(t, db, producerJobID, "producer")
+	insertEvidenceJob(t, db, consumerJobID, "consumer")
+
+	olderConsumerSeen := time.Date(2026, 7, 7, 10, 0, 0, 0, time.UTC)
+	newerConsumerSeen := olderConsumerSeen.Add(2 * time.Hour)
+	insertEvidenceDataset(t, db, producerJobID, "lake", "customers", "output", olderConsumerSeen.Add(-2*time.Hour))
+	insertEvidenceDataset(t, db, producerJobID, "lake", "customers", "output", olderConsumerSeen.Add(-time.Hour))
+	insertEvidenceDataset(t, db, consumerJobID, "lake", "customers", "input", olderConsumerSeen)
+	insertEvidenceDataset(t, db, consumerJobID, "lake", "customers", "input", newerConsumerSeen)
+
+	records, err := (GORMStore{DB: db}).ListContractEvidence(context.Background())
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, producerJobID, records[0].ProducerJobID)
+	require.Equal(t, "producer", records[0].ProducerJobAlias)
+	require.Equal(t, consumerJobID, records[0].ConsumerJobID)
+	require.Equal(t, "consumer", records[0].ConsumerJobAlias)
+	require.Equal(t, DatasetRef{Namespace: "lake", Name: "customers"}, records[0].Dataset)
+	require.WithinDuration(t, newerConsumerSeen, records[0].LastSeen, time.Second)
 }
 
 func TestDeriveGraphInferredEdgeResolvesJobIDFilter(t *testing.T) {
@@ -255,4 +342,44 @@ func requireDatasetNode(t *testing.T, graph Graph, dataset string) {
 		}
 	}
 	t.Fatalf("dataset node %q not found in %#v", dataset, graph.Nodes)
+}
+
+func requireJobNode(t *testing.T, graph Graph, alias string) {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.Kind == NodeKindJob && node.Alias == alias {
+			return
+		}
+	}
+	t.Fatalf("job node %q not found in %#v", alias, graph.Nodes)
+}
+
+func createContractEvidenceTables(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec("CREATE TABLE jobs (id text PRIMARY KEY, alias text NOT NULL, deleted_at datetime)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE job_runs (id text PRIMARY KEY, job_id text NOT NULL)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE task_runs (id text PRIMARY KEY, job_run_id text NOT NULL)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE lineage_datasets (id text PRIMARY KEY, task_run_id text NOT NULL, namespace text NOT NULL, name text NOT NULL, direction text NOT NULL, created_at datetime NOT NULL)").Error)
+}
+
+func insertEvidenceJob(t *testing.T, db *gorm.DB, jobID uuid.UUID, alias string) {
+	t.Helper()
+	require.NoError(t, db.Exec("INSERT INTO jobs (id, alias, deleted_at) VALUES (?, ?, NULL)", jobID, alias).Error)
+}
+
+func insertEvidenceDataset(t *testing.T, db *gorm.DB, jobID uuid.UUID, namespace, name, direction string, createdAt time.Time) {
+	t.Helper()
+	jobRunID := uuid.New()
+	taskRunID := uuid.New()
+	require.NoError(t, db.Exec("INSERT INTO job_runs (id, job_id) VALUES (?, ?)", jobRunID, jobID).Error)
+	require.NoError(t, db.Exec("INSERT INTO task_runs (id, job_run_id) VALUES (?, ?)", taskRunID, jobRunID).Error)
+	require.NoError(t, db.Exec(
+		"INSERT INTO lineage_datasets (id, task_run_id, namespace, name, direction, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		uuid.New(),
+		taskRunID,
+		namespace,
+		name,
+		direction,
+		createdAt,
+	).Error)
 }

--- a/internal/contract/graph_test.go
+++ b/internal/contract/graph_test.go
@@ -1,0 +1,258 @@
+package contract
+
+import (
+	"testing"
+	"time"
+
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeriveGraphInferredEdgeReportsMissingMappedOutput(t *testing.T) {
+	producer := Job{
+		Alias: "producer",
+		Steps: []Step{{
+			Name:         "extract",
+			OutputSchema: outputSchemaWithProperties("row_count"),
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Trigger: eventTrigger("producer", map[string]string{
+			"rows":     "$.tasks[0].output.row_count",
+			"customer": "$.tasks[0].output.customer_id",
+			"run_id":   "$.run_id",
+		}),
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassInferred, "job:producer", "job:consumer", "")
+	require.Equal(t, schemacompat.VerdictBreaking, edge.Verdict)
+	require.Len(t, edge.Findings, 1)
+	require.Equal(t, schemacompat.FindingKindRequirementUnsatisfied, edge.Findings[0].Kind)
+	require.Equal(t, schemacompat.VerdictBreaking, edge.Findings[0].Verdict)
+	require.Equal(t, "trigger.configuration.paramMapping.customer", edge.Findings[0].Path)
+	require.Contains(t, edge.Findings[0].Detail, "customer_id")
+}
+
+func TestDeriveGraphInferredUnresolvedIndexDegradesToUnknown(t *testing.T) {
+	tests := []struct {
+		name         string
+		outputKey    string
+		producerKeys []string
+		wantKind     schemacompat.FindingKind
+	}{
+		{
+			name:         "key found in producer union",
+			outputKey:    "customer_id",
+			producerKeys: []string{"customer_id"},
+			wantKind:     schemacompat.FindingKindRequirementUnknown,
+		},
+		{
+			name:         "key missing from producer union",
+			outputKey:    "customer_id",
+			producerKeys: []string{"row_count"},
+			wantKind:     schemacompat.FindingKindRequirementUnsatisfied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			producer := Job{
+				Alias: "producer",
+				Steps: []Step{{
+					Name:         "extract",
+					OutputSchema: outputSchemaWithProperties(tt.producerKeys...),
+				}},
+			}
+			consumer := Job{
+				Alias: "consumer",
+				Trigger: eventTrigger("producer", map[string]string{
+					"customer": "$.tasks[3].output." + tt.outputKey,
+				}),
+			}
+
+			graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+			require.NoError(t, err)
+
+			edge := requireEdge(t, graph, EdgeClassInferred, "job:producer", "job:consumer", "")
+			require.Equal(t, schemacompat.VerdictUnknown, edge.Verdict)
+			require.Len(t, edge.Findings, 1)
+			require.Equal(t, tt.wantKind, edge.Findings[0].Kind)
+			require.Equal(t, schemacompat.VerdictUnknown, edge.Findings[0].Verdict)
+			require.Contains(t, edge.Findings[0].Detail, "cannot be resolved")
+		})
+	}
+}
+
+func TestDeriveGraphIgnoresParamMappingsOutsideTaskOutputPaths(t *testing.T) {
+	producer := Job{
+		Alias: "producer",
+		Steps: []Step{{
+			Name:         "extract",
+			OutputSchema: outputSchemaWithProperties("row_count"),
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Trigger: eventTrigger("producer", map[string]string{
+			"run_id": "$.run_id",
+			"root":   "$",
+		}),
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+	require.NoError(t, err)
+	require.Empty(t, graph.Edges)
+}
+
+func TestDeriveGraphInferredUnknownProducerAliasWarns(t *testing.T) {
+	consumer := Job{
+		Alias: "consumer",
+		Trigger: eventTrigger("missing-producer", map[string]string{
+			"rows": "$.tasks[0].output.row_count",
+		}),
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassInferred, "job:missing-producer", "job:consumer", "")
+	require.Equal(t, schemacompat.VerdictUnknown, edge.Verdict)
+	require.Len(t, edge.Findings, 1)
+	require.Equal(t, schemacompat.FindingKindRequirementUnknown, edge.Findings[0].Kind)
+	require.Contains(t, edge.Findings[0].Detail, "not present in the merged job set")
+}
+
+func TestDeriveGraphEvidenceEdgesAggregateLastSeen(t *testing.T) {
+	producerID := uuid.New()
+	consumerID := uuid.New()
+	older := time.Date(2026, 7, 7, 10, 0, 0, 0, time.UTC)
+	newer := older.Add(2 * time.Hour)
+
+	graph, err := DeriveGraph(DeriveInput{
+		Jobs: []Job{
+			{ID: producerID, Alias: "producer"},
+			{ID: consumerID, Alias: "consumer"},
+		},
+		Evidence: []EvidenceRecord{
+			{
+				ProducerJobID:    producerID,
+				ProducerJobAlias: "producer",
+				ConsumerJobID:    consumerID,
+				ConsumerJobAlias: "consumer",
+				Dataset:          DatasetRef{Namespace: "lake", Name: "customers"},
+				LastSeen:         older,
+			},
+			{
+				ProducerJobID:    producerID,
+				ProducerJobAlias: "producer",
+				ConsumerJobID:    consumerID,
+				ConsumerJobAlias: "consumer",
+				Dataset:          DatasetRef{Namespace: "lake", Name: "customers"},
+				LastSeen:         newer,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassEvidence, "job:producer", "job:consumer", "lake/customers")
+	require.Equal(t, schemacompat.VerdictUnknown, edge.Verdict)
+	require.Empty(t, edge.Findings)
+	require.NotNil(t, edge.LastSeen)
+	require.Equal(t, newer, *edge.LastSeen)
+	requireDatasetNode(t, graph, "lake/customers")
+}
+
+func TestDeriveGraphInferredEdgeResolvesJobIDFilter(t *testing.T) {
+	producerID := uuid.New()
+	producer := Job{
+		ID:    producerID,
+		Alias: "producer",
+		Steps: []Step{{
+			Name:         "extract",
+			OutputSchema: outputSchemaWithProperties("row_count"),
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Trigger: eventTriggerWithFilter(map[string]any{"job_id": producerID.String()}, map[string]string{
+			"rows": "$.tasks[0].output.row_count",
+		}),
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassInferred, "job:producer", "job:consumer", "")
+	require.Equal(t, schemacompat.VerdictCompatible, edge.Verdict)
+	require.Empty(t, edge.Findings)
+}
+
+func outputSchemaWithProperties(keys ...string) map[string]any {
+	properties := make(map[string]any, len(keys))
+	for _, key := range keys {
+		properties[key] = map[string]any{"type": "string"}
+	}
+	return map[string]any{
+		"type":       "object",
+		"properties": properties,
+	}
+}
+
+func eventTrigger(sourceAlias string, mapping map[string]string) Trigger {
+	filter := map[string]any{}
+	if sourceAlias != "" {
+		filter["job_alias"] = sourceAlias
+	}
+	return eventTriggerWithFilter(filter, mapping)
+}
+
+func eventTriggerWithFilter(filter map[string]any, mapping map[string]string) Trigger {
+	cfg := map[string]any{
+		"events": []any{
+			map[string]any{
+				"type":   "run_completed",
+				"source": "caesium",
+				"filter": filter,
+			},
+		},
+		"paramMapping": map[string]any{},
+	}
+	for key, value := range mapping {
+		cfg["paramMapping"].(map[string]any)[key] = value
+	}
+	return Trigger{
+		Type:          schema.TriggerEvent,
+		Configuration: cfg,
+	}
+}
+
+func requireEdge(t *testing.T, graph Graph, class EdgeClass, from, to, dataset string) Edge {
+	t.Helper()
+	for _, edge := range graph.Edges {
+		if edge.Class != class || edge.From != from || edge.To != to {
+			continue
+		}
+		if datasetKey(edge.Dataset) != dataset {
+			continue
+		}
+		return edge
+	}
+	t.Fatalf("edge %s %s -> %s dataset %q not found in %#v", class, from, to, dataset, graph.Edges)
+	return Edge{}
+}
+
+func requireDatasetNode(t *testing.T, graph Graph, dataset string) {
+	t.Helper()
+	for _, node := range graph.Nodes {
+		if node.Kind == NodeKindDataset && datasetKey(node.Dataset) == dataset {
+			return
+		}
+	}
+	t.Fatalf("dataset node %q not found in %#v", dataset, graph.Nodes)
+}


### PR DESCRIPTION
## Summary
B1 of the contract-enforcement plan — the derived (never stored) cross-job edge set the checker runs over:

- JSON-ready `Graph`/`Node`/`Edge`/`EdgeClass`/`DatasetRef` types with all three edge-class constants (`declared` reserved for B2/W2).
- **Inferred edges**: lifecycle trigger-chain A→B pairs (mirroring `trigger_cycle.go`'s lifecycle matching + source-alias resolution) whose `paramMapping` values statically parse as `$.tasks[<i>].output.<key>`; mapped keys are checked against the producer's step `outputSchema`s via `schemacompat` findings, degrading to warn when a positional index can't resolve.
- **Evidence edges**: distinct cross-job `(namespace, name)` pairs from lineage rows (`direction='output'` vs `'input'`), aggregated to job level with `lastSeen`; warn-only by design.
- `DeriveGraph(DeriveInput)` for callers holding the merged world + `NewGORMDeriver(db)` for server-side reads (incoming defs substituted by alias, preserving job IDs for trigger filters) — the C1/D1 consumption points.
- Pure unit coverage: missing output keys, unresolved indexes, unknown producers, ignored non-output paths, job-id filters, evidence aggregation.

## Test plan
- [x] Host `go vet` + `go test ./internal/contract/` — green (agent + orchestrator independently).
- [ ] Full matrix — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
