### PR TITLE
Enforce contracts at apply time with acks and a 409 surface (contract-enforcement W2-γ)

### DIFF
--- a/api/rest/controller/jobdef/apply.go
+++ b/api/rest/controller/jobdef/apply.go
@@ -49,6 +49,12 @@ func Apply(c *echo.Context) error {
 
 		aliases = append(aliases, def.Metadata.Alias)
 		if _, err := importer.ApplyWithOptions(ctx, def, opts); err != nil {
+			if errors.Is(err, internaljobdef.ErrContractBreak) {
+				if payload, ok := internaljobdef.ContractBreakResponse(err); ok {
+					return c.JSON(http.StatusConflict, payload)
+				}
+				return echo.NewHTTPError(http.StatusConflict, err.Error())
+			}
 			if errors.Is(err, internaljobdef.ErrDuplicateJob) || errors.Is(err, internaljobdef.ErrProvenanceConflict) || errors.Is(err, internaljobdef.ErrJobRunning) {
 				return echo.NewHTTPError(http.StatusConflict, err.Error())
 			}

--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -200,7 +200,7 @@ transaction that persists the producer — so racing applies serialize on the st
 and there is no TOCTOU window. Breaking findings without a valid ack → HTTP 409.
 Plus the two-sided intentional-break escape hatch.
 
-- [ ] C1. Add the `ContractAck` GORM model (dataset/edge-set digest, actor, reason,
+- [x] C1. Add the `ContractAck` GORM model (dataset/edge-set digest, actor, reason,
       created/expires) + register it in the `All` slice (`internal/models/models.go`,
       appended after `LineageDataset`); add `CAESIUM_CONTRACT_ENFORCEMENT` (`""` off /
       `warn` / `fail`, mirroring `metadata.schemaValidation`'s tri-state) and
@@ -217,6 +217,7 @@ Plus the two-sided intentional-break escape hatch.
       `api/rest/controller/jobdef/apply.go`, `internal/contract/enforce.go`,
       `internal/metrics/metrics.go`.
       Depends on: A1 + B1.
+      Note: W2-γ landed the catalog-only `ContractAck` model, `CAESIUM_CONTRACT_ENFORCEMENT`/`CAESIUM_CONTRACT_DEPRECATION_WINDOW`, fail/warn apply-time enforcement inside the importer transaction, the HTTP 409 payload, `caesium_contract_breaks_blocked_total{dataset}`, and the paramMapping + happy-path integration scenarios. The C1 edge-set digest is `sha256` hex over JSON `{version:1, subject, edges[]}`, with `edges[]` sorted by producer, consumer, edge ID, path, and detail and carrying edge class, dataset/output key, consumer team, path/detail, and verdict.
 - [ ] C2. Add the intentional-break escape hatch: `caesium job apply
       --allow-breaking dataset=<name> [--reason ...]` records a `ContractAck` row
       (actor, edge-set digest, `deprecationUntil`); during the window the enforcement
@@ -337,6 +338,7 @@ precedent: backend REST/CLI first, UI consumes it). New feature dir gated by the
       deferred to W2: the `CAESIUM_CONTRACT_DEPRECATION_WINDOW` bound and the `test/`
       fixture helpers land alongside the C/D scenarios that use them (helpers now
       would be unused code; the window depends on C2's actual expiry-test shape).
+      W2-γ added the deferred `test/` fixture helpers alongside the apply-time enforcement scenarios that use them; expiry-specific helpers remain deferred to C2's ack lifecycle.
 
 ## Navigational / Organizational Improvements
 

--- a/helm/caesium/ci/test-values-k8s.yaml
+++ b/helm/caesium/ci/test-values-k8s.yaml
@@ -33,6 +33,10 @@ config:
     # Enable freshness so dataset-state integration scenarios exercise the live evaluator.
     - name: CAESIUM_FRESHNESS_ENABLED
       value: "true"
+    # Enable contract enforcement so the apply-time 409 scenarios run here too
+    # (mirrors the justfile lanes and the ci.yml docker-run server blocks).
+    - name: CAESIUM_CONTRACT_ENFORCEMENT
+      value: fail
 
 kubernetes:
   engine:

--- a/internal/contract/enforce.go
+++ b/internal/contract/enforce.go
@@ -1,0 +1,395 @@
+package contract
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/internal/models"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
+	"github.com/caesium-cloud/caesium/pkg/log"
+	"gorm.io/gorm"
+)
+
+const (
+	EnforcementModeOff  = ""
+	EnforcementModeWarn = "warn"
+	EnforcementModeFail = "fail"
+)
+
+var (
+	ErrContractBreakBlocked = errors.New("contract breaking change blocked")
+	outputKeyDetailPattern  = regexp.MustCompile(`(?:output key|key) "([^"]+)"`)
+)
+
+// EnforcementError is returned when fail-mode enforcement sees an unacknowledged
+// breaking edge set.
+type EnforcementError struct {
+	Response EnforcementResponse
+}
+
+func (e *EnforcementError) Error() string {
+	if strings.TrimSpace(e.Response.Message) != "" {
+		return e.Response.Message
+	}
+	return ErrContractBreakBlocked.Error()
+}
+
+func (e *EnforcementError) Unwrap() error {
+	return ErrContractBreakBlocked
+}
+
+// EnforcementResponse is the stable machine-readable 409 payload consumed by
+// CLI, REST, and future UI surfaces.
+type EnforcementResponse struct {
+	Error    string            `json:"error"`
+	Message  string            `json:"message"`
+	Findings []ContractFinding `json:"findings"`
+}
+
+// ContractFinding names one impacted consumer for a breaking contract edge.
+type ContractFinding struct {
+	Subject           string `json:"subject"`
+	Dataset           string `json:"dataset,omitempty"`
+	OutputKey         string `json:"output_key,omitempty"`
+	Producer          string `json:"producer"`
+	Consumer          string `json:"consumer"`
+	ConsumerTeam      string `json:"consumer_team,omitempty"`
+	TeamAttribution   string `json:"team_attribution,omitempty"`
+	EdgeClass         string `json:"edge_class"`
+	Path              string `json:"path"`
+	Detail            string `json:"detail"`
+	Verdict           string `json:"verdict"`
+	EdgeID            string `json:"edge_id"`
+	EdgeSetDigest     string `json:"edge_set_digest"`
+	Acknowledged      bool   `json:"acknowledged"`
+	AcknowledgementID string `json:"acknowledgement_id,omitempty"`
+}
+
+type breakingGroup struct {
+	subject  string
+	findings []ContractFinding
+	digest   string
+}
+
+type digestInput struct {
+	Version int             `json:"version"`
+	Subject string          `json:"subject"`
+	Edges   []digestFinding `json:"edges"`
+}
+
+type digestFinding struct {
+	EdgeID       string `json:"edge_id"`
+	EdgeClass    string `json:"edge_class"`
+	Dataset      string `json:"dataset,omitempty"`
+	OutputKey    string `json:"output_key,omitempty"`
+	Producer     string `json:"producer"`
+	Consumer     string `json:"consumer"`
+	ConsumerTeam string `json:"consumer_team,omitempty"`
+	Path         string `json:"path"`
+	Detail       string `json:"detail"`
+	Verdict      string `json:"verdict"`
+}
+
+// EnforceApply derives the merged contract graph for incoming definitions and
+// applies warn/fail enforcement. Off-mode returns before graph derivation so the
+// apply path is fully inert when CAESIUM_CONTRACT_ENFORCEMENT is unset.
+func EnforceApply(ctx context.Context, db *gorm.DB, incoming []schema.Definition, mode string, now time.Time) error {
+	mode = normalizeMode(mode)
+	if mode == EnforcementModeOff {
+		return nil
+	}
+	if mode != EnforcementModeWarn && mode != EnforcementModeFail {
+		return fmt.Errorf("unsupported contract enforcement mode %q", mode)
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	graph, err := NewGORMDeriver(db).DeriveGraph(ctx, incoming)
+	if err != nil {
+		return err
+	}
+	return EvaluateGraph(ctx, db, graph, mode, now)
+}
+
+// EvaluateGraph applies enforcement to an already-derived graph. It is split
+// out so tests and future lint/diff surfaces can reuse the exact digest logic.
+func EvaluateGraph(ctx context.Context, db *gorm.DB, graph Graph, mode string, now time.Time) error {
+	mode = normalizeMode(mode)
+	if mode == EnforcementModeOff {
+		return nil
+	}
+	if mode != EnforcementModeWarn && mode != EnforcementModeFail {
+		return fmt.Errorf("unsupported contract enforcement mode %q", mode)
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	groups, err := breakingGroupsFromGraph(graph)
+	if err != nil {
+		return err
+	}
+	if len(groups) == 0 {
+		return nil
+	}
+
+	if mode == EnforcementModeWarn {
+		for _, group := range groups {
+			log.Warn("contract breaking change detected in warn mode",
+				"subject", group.subject,
+				"edge_set_digest", group.digest,
+				"findings", len(group.findings),
+			)
+		}
+		return nil
+	}
+
+	blocked := make([]ContractFinding, 0)
+	for _, group := range groups {
+		ackID, ok, err := validAckForDigest(ctx, db, group.digest, now)
+		if err != nil {
+			return err
+		}
+		if ok {
+			for idx := range group.findings {
+				group.findings[idx].Acknowledged = true
+				group.findings[idx].AcknowledgementID = ackID
+			}
+			log.Warn("contract breaking change allowed by active acknowledgement",
+				"subject", group.subject,
+				"edge_set_digest", group.digest,
+				"acknowledgement_id", ackID,
+				"findings", len(group.findings),
+			)
+			continue
+		}
+
+		metrics.ContractBreaksBlockedTotal.WithLabelValues(group.subject).Inc()
+		blocked = append(blocked, group.findings...)
+	}
+	if len(blocked) == 0 {
+		return nil
+	}
+	sortContractFindings(blocked)
+	return &EnforcementError{
+		Response: EnforcementResponse{
+			Error:    "contract_breaking_change",
+			Message:  contractBreakMessage(blocked),
+			Findings: blocked,
+		},
+	}
+}
+
+func breakingGroupsFromGraph(graph Graph) ([]breakingGroup, error) {
+	nodesByID := make(map[string]Node, len(graph.Nodes))
+	for _, node := range graph.Nodes {
+		nodesByID[node.ID] = node
+	}
+
+	grouped := map[string]*breakingGroup{}
+	for _, edge := range graph.Edges {
+		if edge.Verdict != schemacompat.VerdictBreaking {
+			continue
+		}
+		for _, finding := range edge.Findings {
+			if finding.Verdict != schemacompat.VerdictBreaking {
+				continue
+			}
+			cf := contractFindingFromEdge(edge, finding, nodesByID)
+			key := cf.Producer + "\x00" + cf.Subject
+			group := grouped[key]
+			if group == nil {
+				group = &breakingGroup{subject: cf.Subject}
+				grouped[key] = group
+			}
+			group.findings = append(group.findings, cf)
+		}
+	}
+
+	groups := make([]breakingGroup, 0, len(grouped))
+	for _, group := range grouped {
+		sortContractFindings(group.findings)
+		digest, err := edgeSetDigest(group.subject, group.findings)
+		if err != nil {
+			return nil, err
+		}
+		group.digest = digest
+		for idx := range group.findings {
+			group.findings[idx].EdgeSetDigest = digest
+		}
+		groups = append(groups, *group)
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].subject == groups[j].subject {
+			return groups[i].digest < groups[j].digest
+		}
+		return groups[i].subject < groups[j].subject
+	})
+	return groups, nil
+}
+
+func contractFindingFromEdge(edge Edge, finding schemacompat.Finding, nodesByID map[string]Node) ContractFinding {
+	producer := strings.TrimPrefix(strings.TrimSpace(edge.From), "job:")
+	consumer := strings.TrimPrefix(strings.TrimSpace(edge.To), "job:")
+	consumerTeam := strings.TrimSpace(nodesByID[edge.To].Labels["team"])
+	teamAttribution := ""
+	if consumerTeam == "" {
+		teamAttribution = "deferred: metadata.labels.team not set"
+	}
+
+	dataset := datasetKey(edge.Dataset)
+	outputKey := ""
+	subject := dataset
+	if subject == "" {
+		outputKey = outputKeyFromDetail(finding.Detail)
+		if outputKey != "" {
+			subject = producer + ".output." + outputKey
+		} else {
+			subject = producer + ".contract"
+		}
+	}
+
+	return ContractFinding{
+		Subject:         subject,
+		Dataset:         dataset,
+		OutputKey:       outputKey,
+		Producer:        producer,
+		Consumer:        consumer,
+		ConsumerTeam:    consumerTeam,
+		TeamAttribution: teamAttribution,
+		EdgeClass:       string(edge.Class),
+		Path:            finding.Path,
+		Detail:          finding.Detail,
+		Verdict:         string(finding.Verdict),
+		EdgeID:          edge.ID,
+	}
+}
+
+func outputKeyFromDetail(detail string) string {
+	matches := outputKeyDetailPattern.FindStringSubmatch(detail)
+	if len(matches) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(matches[1])
+}
+
+func edgeSetDigest(subject string, findings []ContractFinding) (string, error) {
+	input := digestInput{
+		Version: 1,
+		Subject: subject,
+		Edges:   make([]digestFinding, 0, len(findings)),
+	}
+	for _, finding := range findings {
+		input.Edges = append(input.Edges, digestFinding{
+			EdgeID:       finding.EdgeID,
+			EdgeClass:    finding.EdgeClass,
+			Dataset:      finding.Dataset,
+			OutputKey:    finding.OutputKey,
+			Producer:     finding.Producer,
+			Consumer:     finding.Consumer,
+			ConsumerTeam: finding.ConsumerTeam,
+			Path:         finding.Path,
+			Detail:       finding.Detail,
+			Verdict:      finding.Verdict,
+		})
+	}
+	sort.Slice(input.Edges, func(i, j int) bool {
+		left := input.Edges[i]
+		right := input.Edges[j]
+		for _, cmp := range []int{
+			strings.Compare(left.Producer, right.Producer),
+			strings.Compare(left.Consumer, right.Consumer),
+			strings.Compare(left.EdgeID, right.EdgeID),
+			strings.Compare(left.Path, right.Path),
+			strings.Compare(left.Detail, right.Detail),
+		} {
+			if cmp < 0 {
+				return true
+			}
+			if cmp > 0 {
+				return false
+			}
+		}
+		return false
+	})
+
+	payload, err := json.Marshal(input)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func validAckForDigest(ctx context.Context, db *gorm.DB, digest string, now time.Time) (string, bool, error) {
+	if db == nil {
+		return "", false, nil
+	}
+	var ack models.ContractAck
+	err := db.WithContext(ctx).
+		Where("edge_set_digest = ?", digest).
+		Where("expires_at > ?", now).
+		Order("expires_at DESC").
+		First(&ack).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	return ack.ID.String(), true, nil
+}
+
+func contractBreakMessage(findings []ContractFinding) string {
+	parts := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		team := "team attribution deferred: metadata.labels.team not set"
+		if finding.ConsumerTeam != "" {
+			team = "team: " + finding.ConsumerTeam
+		}
+		subject := finding.Subject
+		if finding.OutputKey != "" {
+			subject = "output key " + finding.OutputKey
+		}
+		parts = append(parts, fmt.Sprintf("%s from %s consumed by %s (%s)", subject, finding.Producer, finding.Consumer, team))
+	}
+	sort.Strings(parts)
+	return fmt.Sprintf("contract enforcement blocked %d breaking finding(s): %s", len(findings), strings.Join(parts, "; "))
+}
+
+func sortContractFindings(findings []ContractFinding) {
+	sort.Slice(findings, func(i, j int) bool {
+		left := findings[i]
+		right := findings[j]
+		for _, cmp := range []int{
+			strings.Compare(left.Subject, right.Subject),
+			strings.Compare(left.Producer, right.Producer),
+			strings.Compare(left.Consumer, right.Consumer),
+			strings.Compare(left.Path, right.Path),
+			strings.Compare(left.Detail, right.Detail),
+		} {
+			if cmp < 0 {
+				return true
+			}
+			if cmp > 0 {
+				return false
+			}
+		}
+		return false
+	})
+}
+
+func normalizeMode(mode string) string {
+	return strings.ToLower(strings.TrimSpace(mode))
+}

--- a/internal/contract/enforce_test.go
+++ b/internal/contract/enforce_test.go
@@ -1,0 +1,90 @@
+package contract
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/internal/models"
+	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestEvaluateGraphFailModeBlocksAndNamesConsumerTeam(t *testing.T) {
+	graph := breakingInferenceGraph()
+	err := EvaluateGraph(context.Background(), nil, graph, EnforcementModeFail, time.Now().UTC())
+
+	var enforcementErr *EnforcementError
+	require.ErrorAs(t, err, &enforcementErr)
+	require.True(t, errors.Is(err, ErrContractBreakBlocked))
+	require.Equal(t, "contract_breaking_change", enforcementErr.Response.Error)
+	require.Contains(t, enforcementErr.Response.Message, "customer_id")
+	require.Contains(t, enforcementErr.Response.Message, "consumer")
+	require.Contains(t, enforcementErr.Response.Message, "team: reporting")
+	require.Len(t, enforcementErr.Response.Findings, 1)
+
+	finding := enforcementErr.Response.Findings[0]
+	require.Equal(t, "producer.output.customer_id", finding.Subject)
+	require.Equal(t, "customer_id", finding.OutputKey)
+	require.Equal(t, "producer", finding.Producer)
+	require.Equal(t, "consumer", finding.Consumer)
+	require.Equal(t, "reporting", finding.ConsumerTeam)
+	require.Equal(t, "inferred", finding.EdgeClass)
+	require.NotEmpty(t, finding.EdgeSetDigest)
+}
+
+func TestEvaluateGraphAcknowledgementAllowsMatchingDigest(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	graph := breakingInferenceGraph()
+
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ContractAck{}))
+
+	err = EvaluateGraph(context.Background(), db, graph, EnforcementModeFail, now)
+	var enforcementErr *EnforcementError
+	require.ErrorAs(t, err, &enforcementErr)
+	digest := enforcementErr.Response.Findings[0].EdgeSetDigest
+
+	require.NoError(t, db.Create(&models.ContractAck{
+		ID:            uuid.New(),
+		Dataset:       enforcementErr.Response.Findings[0].Subject,
+		EdgeSetDigest: digest,
+		Actor:         "integration-test",
+		Reason:        "planned migration",
+		CreatedAt:     now.Add(-time.Minute),
+		ExpiresAt:     now.Add(time.Hour),
+	}).Error)
+
+	require.NoError(t, EvaluateGraph(context.Background(), db, graph, EnforcementModeFail, now))
+}
+
+func TestEvaluateGraphWarnModeDoesNotBlock(t *testing.T) {
+	require.NoError(t, EvaluateGraph(context.Background(), nil, breakingInferenceGraph(), EnforcementModeWarn, time.Now().UTC()))
+}
+
+func breakingInferenceGraph() Graph {
+	return Graph{
+		Nodes: []Node{
+			{ID: "job:producer", Kind: NodeKindJob, Alias: "producer"},
+			{ID: "job:consumer", Kind: NodeKindJob, Alias: "consumer", Labels: map[string]string{"team": "reporting"}},
+		},
+		Edges: []Edge{{
+			ID:      "edge:inferred:job:producer->job:consumer",
+			From:    "job:producer",
+			To:      "job:consumer",
+			Class:   EdgeClassInferred,
+			Verdict: schemacompat.VerdictBreaking,
+			Findings: []schemacompat.Finding{{
+				Kind:    schemacompat.FindingKindRequirementUnsatisfied,
+				Path:    "trigger.configuration.paramMapping.customer",
+				Detail:  `paramMapping "customer" references $.tasks[0].output.customer_id output key "customer_id" from producer producer step "export", but that key is missing from the step outputSchema`,
+				Verdict: schemacompat.VerdictBreaking,
+			}},
+		}},
+	}
+}

--- a/internal/jobdef/importer.go
+++ b/internal/jobdef/importer.go
@@ -15,10 +15,12 @@ import (
 	"sync"
 	"time"
 
+	contractenforce "github.com/caesium-cloud/caesium/internal/contract"
 	"github.com/caesium-cloud/caesium/internal/freshness"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/dqlite"
+	"github.com/caesium-cloud/caesium/pkg/env"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/jsonmap"
 	"github.com/caesium-cloud/caesium/pkg/jsonutil"
@@ -32,6 +34,7 @@ var (
 	ErrDuplicateJob       = errors.New("job alias already exists")
 	ErrProvenanceConflict = errors.New("job definition provenance conflict")
 	ErrJobRunning         = errors.New("job has a running run")
+	ErrContractBreak      = contractenforce.ErrContractBreakBlocked
 
 	importerBusyRetryBackoffs = []time.Duration{
 		10 * time.Millisecond,
@@ -156,6 +159,9 @@ func (i *Importer) ApplyWithOptions(ctx context.Context, def *schema.Definition,
 			if err := i.reconcileDatasetDeclarationsTx(tx, jobModel, def); err != nil {
 				return err
 			}
+			if err := i.enforceContractsTx(ctx, tx, def); err != nil {
+				return err
+			}
 			if err := i.softDeleteAtomsTx(tx, retiredAtomIDs); err != nil {
 				return err
 			}
@@ -175,6 +181,24 @@ func (i *Importer) ApplyWithOptions(ctx context.Context, def *schema.Definition,
 	notifyTriggerMutationBestEffort(ctx, "apply")
 
 	return result, nil
+}
+
+// ContractBreakResponse returns the stable 409 payload for an apply-time
+// contract enforcement error.
+func ContractBreakResponse(err error) (any, bool) {
+	var enforcementErr *contractenforce.EnforcementError
+	if !errors.As(err, &enforcementErr) {
+		return nil, false
+	}
+	return enforcementErr.Response, true
+}
+
+func (i *Importer) enforceContractsTx(ctx context.Context, tx *gorm.DB, def *schema.Definition) error {
+	mode := env.Variables().ContractEnforcement
+	if strings.TrimSpace(mode) == "" {
+		return nil
+	}
+	return contractenforce.EnforceApply(ctx, tx, []schema.Definition{*def}, mode, time.Now().UTC())
 }
 
 // PruneMissing retires active jobs that are absent from the desired alias set.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -269,6 +269,14 @@ var (
 		[]string{"dataset", "status"},
 	)
 
+	ContractBreaksBlockedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_contract_breaks_blocked_total",
+			Help: "Total apply-time contract breaks blocked by dataset or output-key subject.",
+		},
+		[]string{"dataset"},
+	)
+
 	// Auth metrics
 
 	AuthRequestsTotal = prometheus.NewCounterVec(
@@ -586,6 +594,7 @@ func Register() {
 			DatasetStalenessSeconds,
 			DatasetDerivationsTotal,
 			FreshnessViolationsTotal,
+			ContractBreaksBlockedTotal,
 			AuthRequestsTotal,
 			AuthFailuresTotal,
 			AuthKeyAgeSeconds,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -45,6 +45,7 @@ func (s *MetricsSuite) SetupTest() {
 		SSOLoginsTotal,
 		SSOLoginDurationSeconds,
 		SSOLogoutsTotal,
+		ContractBreaksBlockedTotal,
 	)
 }
 
@@ -292,6 +293,13 @@ func (s *MetricsSuite) TestSSOLogoutsTotalIncrements() {
 
 	val = metrictestutil.CounterValue(s.T(), SSOLogoutsTotal, "error")
 	s.GreaterOrEqual(val, float64(2))
+}
+
+func (s *MetricsSuite) TestContractBreaksBlockedTotalIncrements() {
+	ContractBreaksBlockedTotal.WithLabelValues("producer.output.customer_id").Inc()
+
+	val := metrictestutil.CounterValue(s.T(), ContractBreaksBlockedTotal, "producer.output.customer_id")
+	s.GreaterOrEqual(val, float64(1))
 }
 
 func (s *MetricsSuite) gaugeValue(vec *prometheus.GaugeVec, labels ...string) float64 {

--- a/internal/models/contract_ack.go
+++ b/internal/models/contract_ack.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ContractAck records an intentional, time-bounded acknowledgement of a
+// breaking contract edge set. It is a low-volume catalog table; run hot paths
+// must not depend on it.
+type ContractAck struct {
+	ID uuid.UUID `gorm:"type:uuid;primaryKey" json:"id"`
+
+	// Dataset is the human-readable contract subject: an OpenLineage dataset
+	// identity when present, otherwise the producer output-key subject for an
+	// inferred event-trigger edge.
+	Dataset string `gorm:"type:text;not null;index:idx_contract_ack_dataset_digest,priority:1" json:"dataset"`
+	// EdgeSetDigest is a deterministic digest over the breaking edge set the
+	// ack covers. C2's --allow-breaking path writes this exact value.
+	EdgeSetDigest string `gorm:"type:text;not null;index:idx_contract_ack_dataset_digest,priority:2;index" json:"edge_set_digest"`
+
+	Actor  string `gorm:"type:text;not null;default:''" json:"actor"`
+	Reason string `gorm:"type:text;not null;default:''" json:"reason"`
+
+	CreatedAt time.Time `gorm:"not null" json:"created_at"`
+	ExpiresAt time.Time `gorm:"not null;index" json:"expires_at"`
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -17,6 +17,7 @@ var All = []interface{}{
 	&JobRun{},
 	&TaskRun{},
 	&LineageDataset{},
+	&ContractAck{},
 	&TaskCache{},
 	&CallbackRun{},
 	&ExecutionEvent{},

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -54,6 +54,14 @@ func validate() error {
 	default:
 		return fmt.Errorf("CAESIUM_WAKEUP_FANOUT_MODE must be one of: full, gossip")
 	}
+	switch strings.ToLower(strings.TrimSpace(variables.ContractEnforcement)) {
+	case "", "warn", "fail":
+	default:
+		return fmt.Errorf("CAESIUM_CONTRACT_ENFORCEMENT must be one of: \"\", warn, fail")
+	}
+	if variables.ContractDeprecationWindow <= 0 {
+		return fmt.Errorf("CAESIUM_CONTRACT_DEPRECATION_WINDOW must be greater than 0")
+	}
 
 	// Agent-in-the-loop master gate (D1 security precondition). Caesium defaults
 	// to CAESIUM_AUTH_MODE=none, which attaches NO auth middleware at all — every
@@ -180,6 +188,8 @@ type Environment struct {
 	FreshnessEnabled               bool          `envconfig:"FRESHNESS_ENABLED" default:"false"`
 	FreshnessEvalInterval          time.Duration `envconfig:"FRESHNESS_EVAL_INTERVAL" default:"1m"`
 	FreshnessMaxDerivationsPerTick int           `envconfig:"FRESHNESS_MAX_DERIVATIONS_PER_TICK" default:"50"`
+	ContractEnforcement            string        `envconfig:"CONTRACT_ENFORCEMENT" default:""`
+	ContractDeprecationWindow      time.Duration `envconfig:"CONTRACT_DEPRECATION_WINDOW" default:"336h"`
 
 	// Notification Watcher
 	NotificationWatcherInterval time.Duration `envconfig:"NOTIFICATION_WATCHER_INTERVAL" default:"15s"`

--- a/test/contract_enforcement_test.go
+++ b/test/contract_enforcement_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	jobdefsvc "github.com/caesium-cloud/caesium/api/rest/service/jobdef"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+)
+
+func (s *IntegrationTestSuite) TestContractEnforcementRejectsRemovedParamMappingOutputKey() {
+	suffix := time.Now().UnixNano()
+	producer := fmt.Sprintf("integration-contract-producer-%d", suffix)
+	consumer := fmt.Sprintf("integration-contract-consumer-%d", suffix)
+
+	dir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"customer_id", "row_count"}),
+		consumer: contractConsumerManifest(consumer, producer, "reporting", "customer", "customer_id"),
+	})
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	status, body := s.postContractApplyManifest(contractProducerManifest(producer, []string{"row_count"}))
+	s.Equal(http.StatusConflict, status, string(body))
+	s.Contains(string(body), "contract_breaking_change")
+	s.Contains(string(body), "customer_id")
+	s.Contains(string(body), consumer)
+	s.Contains(string(body), "reporting")
+
+	brokenDir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"row_count"}),
+	})
+	defer os.RemoveAll(brokenDir)
+	output, err := s.runCLIExpectError("job", "apply", "--path", brokenDir, "--server", s.caesiumURL)
+	s.Require().Error(err)
+	s.Contains(output, "customer_id")
+	s.Contains(output, consumer)
+}
+
+func (s *IntegrationTestSuite) TestContractEnforcementAllowsNonBreakingProducerApply() {
+	suffix := time.Now().UnixNano()
+	producer := fmt.Sprintf("integration-contract-happy-producer-%d", suffix)
+	consumer := fmt.Sprintf("integration-contract-happy-consumer-%d", suffix)
+
+	dir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"customer_id", "row_count"}),
+		consumer: contractConsumerManifest(consumer, producer, "analytics", "customer", "customer_id"),
+	})
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	status, body := s.postContractApplyManifest(contractProducerManifest(producer, []string{"customer_id", "row_count", "customer_segment"}))
+	s.Equal(http.StatusOK, status, string(body))
+	s.Require().NotNil(s.requireJobByAlias(producer))
+}
+
+func (s *IntegrationTestSuite) writeContractManifests(files map[string]string) string {
+	s.T().Helper()
+
+	dir, err := os.MkdirTemp("", "caesium-contract-*")
+	s.Require().NoError(err)
+	for name, contents := range files {
+		path := filepath.Join(dir, name+".job.yaml")
+		s.Require().NoError(os.WriteFile(path, []byte(strings.TrimSpace(s.injectEngine(contents))), 0o644))
+	}
+	return dir
+}
+
+func (s *IntegrationTestSuite) postContractApplyManifest(manifest string) (int, []byte) {
+	s.T().Helper()
+
+	def, err := schema.Parse([]byte(s.injectEngine(manifest)))
+	s.Require().NoError(err)
+	payload, err := json.Marshal(jobdefsvc.ApplyRequest{Definitions: []schema.Definition{*def}})
+	s.Require().NoError(err)
+
+	resp, err := s.doJSONRequest(http.MethodPost, s.caesiumURL+"/v1/jobdefs/apply", bytes.NewReader(payload))
+	s.Require().NoError(err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	s.Require().NoError(err)
+	return resp.StatusCode, body
+}
+
+func contractProducerManifest(alias string, outputKeys []string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  labels:
+    team: producer-team
+trigger:
+  type: cron
+  configuration:
+    cron: "0 0 1 1 *"
+steps:
+  - name: export
+    image: alpine:3.23
+    command: ["sh", "-c", "echo contract producer"]
+    outputSchema:
+      type: object
+      required: [%s]
+      properties:
+%s
+`, alias, strings.Join(outputKeys, ", "), contractOutputSchemaProperties(outputKeys))
+}
+
+func contractOutputSchemaProperties(keys []string) string {
+	var b strings.Builder
+	for _, key := range keys {
+		fmt.Fprintf(&b, "        %s:\n          type: string\n", key)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func contractConsumerManifest(alias, producerAlias, team, paramName, outputKey string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  labels:
+    team: %s
+trigger:
+  type: event
+  configuration:
+    events:
+      - type: run_completed
+        source: caesium
+        filter:
+          job_alias: %s
+    paramMapping:
+      %s: "$.tasks[0].output.%s"
+steps:
+  - name: consume
+    image: alpine:3.23
+    command: ["sh", "-c", "echo contract consumer"]
+`, alias, team, producerAlias, paramName, outputKey)
+}


### PR DESCRIPTION
## Summary
C1 (+ the W1-η-deferred harness helpers) of the contract-enforcement plan:

- `ContractAck` GORM model (digest, actor, reason, created/expires) registered after `LineageDataset` — catalog table, deliberately NOT hot-path.
- `CAESIUM_CONTRACT_ENFORCEMENT` tri-state (`""` fully inert / `warn` / `fail`) + `CAESIUM_CONTRACT_DEPRECATION_WINDOW` (336h default) in `pkg/env`.
- Enforcement runs INSIDE `ApplyWithOptions`'s transaction (persisted consumers read under the same txn — no TOCTOU): breaking findings without an unexpired matching ack → structured **HTTP 409** naming dataset/output key, consumers, and team attribution.
- Edge-set digest: SHA-256 over canonical-sorted JSON `{version:1, subject, edges[]}` — documented for C2's `--allow-breaking` writer.
- `caesium_contract_breaks_blocked_total{dataset}` + testutil assertion.
- Integration scenarios (live server already boots `enforcement=fail` via W1-η): paramMapping-inferred removed-output-key apply → rejected naming the consumer; non-breaking apply → succeeds.

## Test plan
- [x] Host `go test`: internal/contract, internal/models, pkg/env, internal/metrics (agent + orchestrator).
- [ ] importer/apply + integration scenarios — GHA CI (dqlite CGO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
