### PR TITLE
Add the contracts graph endpoint and lint/diff findings (contract-enforcement W2-δ)

### DIFF
--- a/api/auth_rbac_policy_completeness_test.go
+++ b/api/auth_rbac_policy_completeness_test.go
@@ -25,6 +25,7 @@ func TestAuthMiddlewareMountedRoutesHaveRBACPolicy(t *testing.T) {
 	t.Setenv("CAESIUM_AUTH_LDAP_ENABLED", "true")
 	t.Setenv("CAESIUM_LOG_CONSOLE_ENABLED", "true")
 	t.Setenv("CAESIUM_DATABASE_CONSOLE_ENABLED", "true")
+	t.Setenv("CAESIUM_CONTRACT_ENFORCEMENT", "fail")
 	require.NoError(t, env.Process())
 
 	vars := env.Variables()
@@ -64,6 +65,7 @@ func TestAuthMiddlewareMountedRoutesHaveRBACPolicy(t *testing.T) {
 	require.Contains(t, mounted, "GET /v1/auth/keys")
 	require.Contains(t, mounted, "GET /v1/logs/level")
 	require.Contains(t, mounted, "GET /v1/database/schema")
+	require.Contains(t, mounted, "GET /v1/contracts/graph")
 
 	sort.Strings(missing)
 	require.Empty(t, missing, "auth-middleware mounted routes missing endpointPolicy entries")

--- a/api/middleware/auth_scope.go
+++ b/api/middleware/auth_scope.go
@@ -22,6 +22,10 @@ const ContextKeyAllowedJobAliases = "auth.allowed_job_aliases"
 // integration tests assert against the single source of truth.
 const LineageImpactScopedDenyMessage = "lineage impact is a global cross-job query and requires an unscoped principal"
 
+// ContractsGraphScopedDenyMessage is the 403 reason returned to a scoped
+// principal on the global, cross-job /v1/contracts/graph route.
+const ContractsGraphScopedDenyMessage = "contracts graph is a global cross-job query and requires an unscoped principal"
+
 // EventsScopedDenyMessage is returned when a scoped principal attempts to open
 // the global event stream without a run_id filter. Scoped event subscriptions
 // must resolve to one run owner before any events are streamed.
@@ -142,6 +146,10 @@ func authorizeScope(c *echo.Context, svc *auth.Service, scopeJSON []byte, routeP
 	case "/v1/lineage/impact":
 		if c.Request().Method == http.MethodGet {
 			return nil, echo.NewHTTPError(http.StatusForbidden, LineageImpactScopedDenyMessage)
+		}
+	case "/v1/contracts/graph":
+		if c.Request().Method == http.MethodGet {
+			return nil, echo.NewHTTPError(http.StatusForbidden, ContractsGraphScopedDenyMessage)
 		}
 	case "/v1/events":
 		if c.Request().Method == http.MethodGet {

--- a/api/middleware/auth_test.go
+++ b/api/middleware/auth_test.go
@@ -918,6 +918,50 @@ func TestMiddlewareLineageImpactRejectsScopedViewerWithSpecificMessage(t *testin
 	require.Equal(t, authmw.LineageImpactScopedDenyMessage, he.Message)
 }
 
+func TestMiddlewareContractsGraphAllowsUnscopedViewer(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleViewer, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contracts/graph", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	rec, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/contracts/graph", Method: http.MethodGet},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestMiddlewareContractsGraphRejectsScopedViewerWithSpecificMessage(t *testing.T) {
+	_, svc, auditor, limiter, _ := setupAuth(t)
+	key := createKey(t, svc, models.RoleViewer, &models.KeyScope{Jobs: []string{"alpha"}})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/contracts/graph", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	_, err := callMiddleware(
+		t,
+		svc,
+		auditor,
+		limiter,
+		req,
+		&echo.RouteInfo{Path: "/v1/contracts/graph", Method: http.MethodGet},
+		nil,
+		nil,
+	)
+	require.Error(t, err)
+
+	he, ok := err.(*echo.HTTPError)
+	require.True(t, ok)
+	require.Equal(t, http.StatusForbidden, he.Code)
+	require.Equal(t, authmw.ContractsGraphScopedDenyMessage, he.Message)
+}
+
 func TestGetAuthKeyReturnsNilWhenNotSet(t *testing.T) {
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/api/rest/bind/bind.go
+++ b/api/rest/bind/bind.go
@@ -8,6 +8,7 @@ import (
 	authctrl "github.com/caesium-cloud/caesium/api/rest/controller/auth"
 	"github.com/caesium-cloud/caesium/api/rest/controller/backfill"
 	blamectrl "github.com/caesium-cloud/caesium/api/rest/controller/blame"
+	contractctrl "github.com/caesium-cloud/caesium/api/rest/controller/contract"
 	"github.com/caesium-cloud/caesium/api/rest/controller/database"
 	datasetctrl "github.com/caesium-cloud/caesium/api/rest/controller/dataset"
 	"github.com/caesium-cloud/caesium/api/rest/controller/event"
@@ -30,6 +31,7 @@ import (
 	"github.com/caesium-cloud/caesium/api/rest/controller/trigger"
 	"github.com/caesium-cloud/caesium/api/rest/controller/webhook"
 	whyctrl "github.com/caesium-cloud/caesium/api/rest/controller/why"
+	contractsvc "github.com/caesium-cloud/caesium/api/rest/service/contract"
 	"github.com/caesium-cloud/caesium/internal/auth"
 	internal_event "github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/pkg/env"
@@ -131,6 +133,11 @@ func Protected(g *echo.Group, bus internal_event.Bus) {
 		g.POST("/jobdefs/apply", jobdef.Apply)
 		g.POST("/jobdefs/lint", jobdef.Lint)
 		g.POST("/jobdefs/diff", jobdef.Diff)
+	}
+
+	// contracts
+	if contractsvc.Enabled() {
+		g.GET("/contracts/graph", contractctrl.Graph)
 	}
 
 	// datasets

--- a/api/rest/bind/bind_test.go
+++ b/api/rest/bind/bind_test.go
@@ -53,3 +53,24 @@ func TestAllProtectsRESTButLeavesWebhooksPublic(t *testing.T) {
 	require.Equal(t, http.StatusAccepted, webhookRec.Code)
 	require.Equal(t, 1, webhookCalls)
 }
+
+func TestProtectedGatesContractGraphRoute(t *testing.T) {
+	t.Setenv("CAESIUM_CONTRACT_ENFORCEMENT", "")
+	off := echo.New()
+	Protected(off.Group("/v1"), nil)
+	require.False(t, hasRoute(off, http.MethodGet, "/v1/contracts/graph"))
+
+	t.Setenv("CAESIUM_CONTRACT_ENFORCEMENT", "fail")
+	on := echo.New()
+	Protected(on.Group("/v1"), nil)
+	require.True(t, hasRoute(on, http.MethodGet, "/v1/contracts/graph"))
+}
+
+func hasRoute(e *echo.Echo, method, path string) bool {
+	for _, route := range e.Router().Routes() {
+		if route.Method == method && route.Path == path {
+			return true
+		}
+	}
+	return false
+}

--- a/api/rest/controller/contract/graph.go
+++ b/api/rest/controller/contract/graph.go
@@ -1,0 +1,25 @@
+package contract
+
+import (
+	"errors"
+	"net/http"
+
+	svc "github.com/caesium-cloud/caesium/api/rest/service/contract"
+	"github.com/labstack/echo/v5"
+)
+
+func Graph(c *echo.Context) error {
+	graph, err := svc.New(c.Request().Context()).Graph(c.QueryParam("dataset"), nil)
+	if err != nil {
+		switch {
+		case errors.Is(err, svc.ErrDisabled):
+			return echo.ErrNotFound
+		case errors.Is(err, svc.ErrInvalidDatasetFilter):
+			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+		default:
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to derive contract graph").Wrap(err)
+		}
+	}
+	svc.RecordFindings(*graph)
+	return c.JSON(http.StatusOK, graph)
+}

--- a/api/rest/controller/jobdef/diff.go
+++ b/api/rest/controller/jobdef/diff.go
@@ -3,6 +3,7 @@ package jobdef
 import (
 	"net/http"
 
+	contractsvc "github.com/caesium-cloud/caesium/api/rest/service/contract"
 	jobdiff "github.com/caesium-cloud/caesium/internal/jobdef/diff"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
@@ -14,9 +15,19 @@ type DiffRequest struct {
 }
 
 type DiffResponse struct {
-	Added    []jobdiff.JobSpec `json:"added"`
-	Removed  []jobdiff.JobSpec `json:"removed"`
-	Modified []jobdiff.Update  `json:"modified"`
+	Added    []DiffJobSpec `json:"added"`
+	Removed  []DiffJobSpec `json:"removed"`
+	Modified []DiffUpdate  `json:"modified"`
+}
+
+type DiffJobSpec struct {
+	jobdiff.JobSpec
+	ContractFindings []contractsvc.Finding `json:"contractFindings,omitempty"`
+}
+
+type DiffUpdate struct {
+	jobdiff.Update
+	ContractFindings []contractsvc.Finding `json:"contractFindings,omitempty"`
 }
 
 func Diff(c *echo.Context) error {
@@ -42,25 +53,54 @@ func Diff(c *echo.Context) error {
 
 	result := jobdiff.Compare(desired, specs)
 
-	// ensure non-nil slices for JSON serialization
-	added := result.Creates
-	if added == nil {
-		added = []jobdiff.JobSpec{}
-	}
-	removed := result.Deletes
-	if removed == nil {
-		removed = []jobdiff.JobSpec{}
-	}
-	modified := result.Updates
-	if modified == nil {
-		modified = []jobdiff.Update{}
+	var findingsByAlias map[string][]contractsvc.Finding
+	if contractsvc.Enabled() {
+		graph, err := contractsvc.New(ctx).Graph("", req.Definitions)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "failed to derive contract graph").Wrap(err)
+		}
+		contractsvc.RecordFindings(*graph)
+		findingsByAlias = make(map[string][]contractsvc.Finding, len(desired))
+		for alias := range desired {
+			if findings := contractsvc.FindingsForAlias(*graph, alias); len(findings) > 0 {
+				findingsByAlias[alias] = findings
+			}
+		}
 	}
 
 	resp := DiffResponse{
-		Added:    added,
-		Removed:  removed,
-		Modified: modified,
+		Added:    diffJobSpecs(result.Creates, findingsByAlias),
+		Removed:  diffJobSpecs(result.Deletes, findingsByAlias),
+		Modified: diffUpdates(result.Updates, findingsByAlias),
 	}
 
 	return c.JSON(http.StatusOK, resp)
+}
+
+func diffJobSpecs(specs []jobdiff.JobSpec, findingsByAlias map[string][]contractsvc.Finding) []DiffJobSpec {
+	if len(specs) == 0 {
+		return []DiffJobSpec{}
+	}
+	out := make([]DiffJobSpec, 0, len(specs))
+	for _, spec := range specs {
+		out = append(out, DiffJobSpec{
+			JobSpec:          spec,
+			ContractFindings: findingsByAlias[spec.Alias],
+		})
+	}
+	return out
+}
+
+func diffUpdates(updates []jobdiff.Update, findingsByAlias map[string][]contractsvc.Finding) []DiffUpdate {
+	if len(updates) == 0 {
+		return []DiffUpdate{}
+	}
+	out := make([]DiffUpdate, 0, len(updates))
+	for _, update := range updates {
+		out = append(out, DiffUpdate{
+			Update:           update,
+			ContractFindings: findingsByAlias[update.Alias],
+		})
+	}
+	return out
 }

--- a/api/rest/controller/jobdef/diff.go
+++ b/api/rest/controller/jobdef/diff.go
@@ -61,8 +61,9 @@ func Diff(c *echo.Context) error {
 		}
 		contractsvc.RecordFindings(*graph)
 		findingsByAlias = make(map[string][]contractsvc.Finding, len(desired))
+		allFindings := contractsvc.FindingsFromGraph(*graph)
 		for alias := range desired {
-			if findings := contractsvc.FindingsForAlias(*graph, alias); len(findings) > 0 {
+			if findings := contractsvc.FilterFindingsForAlias(allFindings, alias); len(findings) > 0 {
 				findingsByAlias[alias] = findings
 			}
 		}

--- a/api/rest/controller/jobdef/lint.go
+++ b/api/rest/controller/jobdef/lint.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	contractsvc "github.com/caesium-cloud/caesium/api/rest/service/contract"
 	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
@@ -27,9 +28,10 @@ type LintSummary struct {
 }
 
 type LintResponse struct {
-	Errors   []LintMessage `json:"errors"`
-	Warnings []LintMessage `json:"warnings"`
-	Summary  LintSummary   `json:"summary"`
+	Errors    []LintMessage                `json:"errors"`
+	Warnings  []LintMessage                `json:"warnings"`
+	Summary   LintSummary                  `json:"summary"`
+	Contracts *contractsvc.FindingsSummary `json:"contracts,omitempty"`
 }
 
 func Lint(c *echo.Context) error {
@@ -73,6 +75,16 @@ func Lint(c *echo.Context) error {
 	}
 
 	if len(resp.Errors) == 0 {
+		if contractsvc.Enabled() {
+			graph, err := contractsvc.New(c.Request().Context()).Graph("", req.Definitions)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusInternalServerError, "failed to derive contract graph").Wrap(err)
+			}
+			contractsvc.RecordFindings(*graph)
+			summary := contractsvc.SummaryFromGraph(*graph)
+			resp.Contracts = &summary
+		}
+
 		var allSteps []schema.Step
 		for _, def := range req.Definitions {
 			allSteps = append(allSteps, def.Steps...)

--- a/api/rest/service/contract/contract.go
+++ b/api/rest/service/contract/contract.go
@@ -1,0 +1,227 @@
+package contract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	internalcontract "github.com/caesium-cloud/caesium/internal/contract"
+	"github.com/caesium-cloud/caesium/internal/metrics"
+	"github.com/caesium-cloud/caesium/pkg/db"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
+	"gorm.io/gorm"
+)
+
+const enforcementEnv = "CAESIUM_CONTRACT_ENFORCEMENT"
+
+var (
+	ErrDisabled             = errors.New("contract enforcement is disabled")
+	ErrInvalidDatasetFilter = errors.New("dataset filter must be in namespace/name form")
+)
+
+type Service struct {
+	ctx context.Context
+	db  *gorm.DB
+}
+
+type Finding struct {
+	EdgeID    string                       `json:"edgeId,omitempty"`
+	EdgeClass internalcontract.EdgeClass   `json:"edgeClass,omitempty"`
+	From      string                       `json:"from,omitempty"`
+	To        string                       `json:"to,omitempty"`
+	Dataset   *internalcontract.DatasetRef `json:"dataset,omitempty"`
+	Kind      schemacompat.FindingKind     `json:"kind,omitempty"`
+	Path      string                       `json:"path,omitempty"`
+	Detail    string                       `json:"detail,omitempty"`
+	Verdict   schemacompat.Verdict         `json:"verdict"`
+}
+
+type FindingsSummary struct {
+	Breaking []Finding `json:"breaking"`
+	Warnings []Finding `json:"warnings"`
+	Edges    int       `json:"edges"`
+}
+
+func New(ctx context.Context) *Service {
+	return &Service{ctx: ctx, db: db.Connection()}
+}
+
+func (s *Service) WithDatabase(conn *gorm.DB) *Service {
+	cp := *s
+	cp.db = conn
+	return &cp
+}
+
+// EnforcementMode reads the W2-delta REST gate directly until C1's env accessor
+// lands in pkg/env and W3 can unify callers on that typed field.
+func EnforcementMode() string {
+	return strings.ToLower(strings.TrimSpace(os.Getenv(enforcementEnv)))
+}
+
+func Enabled() bool {
+	return EnforcementMode() != ""
+}
+
+func (s *Service) Graph(dataset string, incoming []schema.Definition) (*internalcontract.Graph, error) {
+	if !Enabled() {
+		return nil, ErrDisabled
+	}
+	filter, err := parseDatasetFilter(dataset)
+	if err != nil {
+		return nil, err
+	}
+	if s.ctx == nil {
+		s.ctx = context.Background()
+	}
+
+	graph, err := internalcontract.NewGORMDeriver(s.db).DeriveGraph(s.ctx, incoming)
+	if err != nil {
+		return nil, err
+	}
+	if filter != nil {
+		graph = filterGraphByDataset(graph, *filter)
+	}
+	return &graph, nil
+}
+
+func SummaryFromGraph(graph internalcontract.Graph) FindingsSummary {
+	summary := FindingsSummary{
+		Breaking: []Finding{},
+		Warnings: []Finding{},
+		Edges:    len(graph.Edges),
+	}
+	for _, finding := range FindingsFromGraph(graph) {
+		if finding.Verdict == schemacompat.VerdictBreaking {
+			summary.Breaking = append(summary.Breaking, finding)
+			continue
+		}
+		summary.Warnings = append(summary.Warnings, finding)
+	}
+	return summary
+}
+
+func FindingsForAlias(graph internalcontract.Graph, alias string) []Finding {
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return nil
+	}
+	nodeID := "job:" + alias
+	findings := make([]Finding, 0)
+	for _, finding := range FindingsFromGraph(graph) {
+		if finding.From == nodeID || finding.To == nodeID {
+			findings = append(findings, finding)
+		}
+	}
+	return findings
+}
+
+func FindingsFromGraph(graph internalcontract.Graph) []Finding {
+	findings := make([]Finding, 0)
+	for _, edge := range graph.Edges {
+		for _, edgeFinding := range edge.Findings {
+			findings = append(findings, Finding{
+				EdgeID:    edge.ID,
+				EdgeClass: edge.Class,
+				From:      edge.From,
+				To:        edge.To,
+				Dataset:   cloneDataset(edge.Dataset),
+				Kind:      edgeFinding.Kind,
+				Path:      edgeFinding.Path,
+				Detail:    edgeFinding.Detail,
+				Verdict:   edgeFinding.Verdict,
+			})
+		}
+	}
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Verdict != findings[j].Verdict {
+			return findings[i].Verdict < findings[j].Verdict
+		}
+		if findings[i].EdgeID != findings[j].EdgeID {
+			return findings[i].EdgeID < findings[j].EdgeID
+		}
+		if findings[i].Path != findings[j].Path {
+			return findings[i].Path < findings[j].Path
+		}
+		return findings[i].Detail < findings[j].Detail
+	})
+	return findings
+}
+
+func RecordFindings(graph internalcontract.Graph) {
+	for _, finding := range FindingsFromGraph(graph) {
+		metrics.ContractFindingsTotal.WithLabelValues(metricVerdict(finding.Verdict)).Inc()
+	}
+}
+
+func parseDatasetFilter(raw string) (*internalcontract.DatasetRef, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	parts := strings.Split(raw, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidDatasetFilter, raw)
+	}
+	ref := internalcontract.DatasetRef{
+		Namespace: strings.TrimSpace(parts[0]),
+		Name:      strings.TrimSpace(parts[1]),
+	}
+	if ref.Namespace == "" || ref.Name == "" {
+		return nil, fmt.Errorf("%w: %q", ErrInvalidDatasetFilter, raw)
+	}
+	return &ref, nil
+}
+
+func filterGraphByDataset(graph internalcontract.Graph, filter internalcontract.DatasetRef) internalcontract.Graph {
+	edges := make([]internalcontract.Edge, 0, len(graph.Edges))
+	neededNodeIDs := map[string]struct{}{}
+	for _, edge := range graph.Edges {
+		if !datasetMatches(edge.Dataset, filter) {
+			continue
+		}
+		edges = append(edges, edge)
+		neededNodeIDs[edge.From] = struct{}{}
+		neededNodeIDs[edge.To] = struct{}{}
+	}
+
+	nodes := make([]internalcontract.Node, 0, len(graph.Nodes))
+	for _, node := range graph.Nodes {
+		if _, ok := neededNodeIDs[node.ID]; ok {
+			nodes = append(nodes, node)
+			continue
+		}
+		if datasetMatches(node.Dataset, filter) {
+			nodes = append(nodes, node)
+		}
+	}
+
+	return internalcontract.Graph{Nodes: nodes, Edges: edges}
+}
+
+func datasetMatches(dataset *internalcontract.DatasetRef, filter internalcontract.DatasetRef) bool {
+	if dataset == nil {
+		return false
+	}
+	return strings.TrimSpace(dataset.Namespace) == filter.Namespace && strings.TrimSpace(dataset.Name) == filter.Name
+}
+
+func cloneDataset(dataset *internalcontract.DatasetRef) *internalcontract.DatasetRef {
+	if dataset == nil {
+		return nil
+	}
+	cp := *dataset
+	return &cp
+}
+
+func metricVerdict(verdict schemacompat.Verdict) string {
+	switch verdict {
+	case schemacompat.VerdictBreaking, schemacompat.VerdictCompatible, schemacompat.VerdictUnknown:
+		return string(verdict)
+	default:
+		return string(schemacompat.VerdictUnknown)
+	}
+}

--- a/api/rest/service/contract/contract.go
+++ b/api/rest/service/contract/contract.go
@@ -74,11 +74,14 @@ func (s *Service) Graph(dataset string, incoming []schema.Definition) (*internal
 	if err != nil {
 		return nil, err
 	}
-	if s.ctx == nil {
-		s.ctx = context.Background()
+	// Local fallback only — mutating s.ctx from a pointer receiver would be a
+	// latent race across concurrent requests sharing the service value.
+	ctx := s.ctx
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
-	graph, err := internalcontract.NewGORMDeriver(s.db).DeriveGraph(s.ctx, incoming)
+	graph, err := internalcontract.NewGORMDeriver(s.db).DeriveGraph(ctx, incoming)
 	if err != nil {
 		return nil, err
 	}
@@ -105,13 +108,21 @@ func SummaryFromGraph(graph internalcontract.Graph) FindingsSummary {
 }
 
 func FindingsForAlias(graph internalcontract.Graph, alias string) []Finding {
+	return FilterFindingsForAlias(FindingsFromGraph(graph), alias)
+}
+
+// FilterFindingsForAlias filters an already-materialized findings list, so
+// callers iterating many aliases compute FindingsFromGraph once. The node ID
+// comes from the graph package's canonical helper rather than a duplicated
+// format string.
+func FilterFindingsForAlias(all []Finding, alias string) []Finding {
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
 		return nil
 	}
-	nodeID := "job:" + alias
+	nodeID := internalcontract.JobNodeID(alias)
 	findings := make([]Finding, 0)
-	for _, finding := range FindingsFromGraph(graph) {
+	for _, finding := range all {
 		if finding.From == nodeID || finding.To == nodeID {
 			findings = append(findings, finding)
 		}

--- a/api/rest/service/system/system.go
+++ b/api/rest/service/system/system.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 
+	contractsvc "github.com/caesium-cloud/caesium/api/rest/service/contract"
 	"github.com/caesium-cloud/caesium/internal/models"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/caesium-cloud/caesium/pkg/dqlite"
@@ -34,11 +35,12 @@ type Node struct {
 }
 
 type Features struct {
-	DatabaseConsoleEnabled  bool   `json:"database_console_enabled"`
-	LogConsoleEnabled       bool   `json:"log_console_enabled"`
-	ExternalURL             string `json:"external_url,omitempty"`
-	AgentRemediationEnabled bool   `json:"agent_remediation_enabled"`
-	FreshnessEnabled        bool   `json:"freshness_enabled"`
+	DatabaseConsoleEnabled     bool   `json:"database_console_enabled"`
+	LogConsoleEnabled          bool   `json:"log_console_enabled"`
+	ExternalURL                string `json:"external_url,omitempty"`
+	AgentRemediationEnabled    bool   `json:"agent_remediation_enabled"`
+	FreshnessEnabled           bool   `json:"freshness_enabled"`
+	ContractEnforcementEnabled bool   `json:"contract_enforcement_enabled"`
 }
 
 type Service struct {
@@ -124,10 +126,11 @@ func (s *Service) Nodes() ([]Node, error) {
 func (s *Service) Features() (*Features, error) {
 	v := env.Variables()
 	return &Features{
-		DatabaseConsoleEnabled:  v.DatabaseConsoleEnabled,
-		LogConsoleEnabled:       v.LogConsoleEnabled,
-		ExternalURL:             v.APIExternalURL,
-		AgentRemediationEnabled: v.AgentRemediationEnabled,
-		FreshnessEnabled:        v.FreshnessEnabled,
+		DatabaseConsoleEnabled:     v.DatabaseConsoleEnabled,
+		LogConsoleEnabled:          v.LogConsoleEnabled,
+		ExternalURL:                v.APIExternalURL,
+		AgentRemediationEnabled:    v.AgentRemediationEnabled,
+		FreshnessEnabled:           v.FreshnessEnabled,
+		ContractEnforcementEnabled: contractsvc.Enabled(),
 	}, nil
 }

--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -240,7 +240,7 @@ The read/inspect surfaces over the graph and checker: the graph endpoint, the
 contract CLI, and contract findings folded into the existing lint/diff responses.
 Reuses the existing `api/rest/controller/jobdef/` controllers — do NOT fork them.
 
-- [ ] D1. Add `GET /v1/contracts/graph` (`[--dataset ns/name]` filter) computing the
+- [x] D1. Add `GET /v1/contracts/graph` (`[--dataset ns/name]` filter) computing the
       Stream B graph on demand, bound in `Protected()` of `api/rest/bind/bind.go`
       (alongside the existing `/jobdefs/*` routes at `bind.go:126-128`); fold contract
       findings into the existing lint/diff responses — `POST /v1/jobdefs/lint`
@@ -255,6 +255,17 @@ Reuses the existing `api/rest/controller/jobdef/` controllers — do NOT fork th
       `api/rest/controller/jobdef/lint.go`, `api/rest/controller/jobdef/diff.go`,
       `api/rest/service/system/system.go`, `internal/metrics/metrics.go`.
       Depends on: A1 + B1.
+      Note: W2-delta added the env-gated `GET /v1/contracts/graph` REST read through
+      a new `api/rest/service/contract` wrapper over `internal/contract.NewGORMDeriver`
+      with optional `dataset=ns/name` filtering, no route registration when
+      `CAESIUM_CONTRACT_ENFORCEMENT` is unset, and `GET /v1/system/features`
+      reporting `contract_enforcement_enabled` from the same raw env gate. Server
+      lint now adds optional `contracts: {breaking, warnings, edges}` and diff wraps
+      added/removed/modified entries with optional `contractFindings`, both omitted
+      when the gate is off. Added the read-only RBAC policy and scoped-key global-read
+      denial for `/v1/contracts/graph`, `caesium_contract_findings_total{verdict}`,
+      and an integration scenario that applies a producer/consumer pair, reads the
+      real graph endpoint, and verifies the feature flag.
 - [ ] D2. Add the `caesium contract` Cobra group — `caesium contract graph
       [--dataset ns/name] [--json]` (GET `/v1/contracts/graph`) and `caesium contract
       check --path jobs/ [--json]` (server-mode contract lint) — appended to the

--- a/internal/auth/rbac.go
+++ b/internal/auth/rbac.go
@@ -59,6 +59,7 @@ var endpointPolicy = map[string]models.Role{
 	"GET /v1/stats/summary":                     models.RoleViewer,
 	"GET /v1/system/features":                   models.RoleViewer,
 	"GET /v1/system/nodes":                      models.RoleViewer,
+	"GET /v1/contracts/graph":                   models.RoleViewer,
 	"GET /v1/triggers":                          models.RoleViewer,
 	"GET /v1/triggers/:id":                      models.RoleViewer,
 	"GET /v1/triggers/:id/events":               models.RoleViewer,

--- a/internal/auth/rbac_test.go
+++ b/internal/auth/rbac_test.go
@@ -97,6 +97,7 @@ func TestRequiredRoleBackfilledProtectedEndpoints(t *testing.T) {
 		{"GET", "/v1/stats/summary", models.RoleViewer},
 		{"GET", "/v1/system/features", models.RoleViewer},
 		{"GET", "/v1/system/nodes", models.RoleViewer},
+		{"GET", "/v1/contracts/graph", models.RoleViewer},
 		{"GET", "/v1/notifications/channels", models.RoleViewer},
 		{"GET", "/v1/notifications/channels/:id", models.RoleViewer},
 		{"GET", "/v1/notifications/policies", models.RoleViewer},

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -944,8 +944,15 @@ func mergeEdges(existing, incoming Edge) Edge {
 	return existing
 }
 
-func jobNodeID(alias string) string {
+// JobNodeID is the canonical graph node identifier for a job alias. Exported
+// so API layers filtering findings by job stay in sync with the graph's ID
+// convention instead of duplicating the format.
+func JobNodeID(alias string) string {
 	return "job:" + strings.TrimSpace(alias)
+}
+
+func jobNodeID(alias string) string {
+	return JobNodeID(alias)
 }
 
 func datasetNodeID(dataset DatasetRef) string {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -269,6 +269,14 @@ var (
 		[]string{"dataset", "status"},
 	)
 
+	ContractFindingsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "caesium_contract_findings_total",
+			Help: "Total contract findings surfaced by read paths, by bounded verdict.",
+		},
+		[]string{"verdict"},
+	)
+
 	// Auth metrics
 
 	AuthRequestsTotal = prometheus.NewCounterVec(
@@ -586,6 +594,7 @@ func Register() {
 			DatasetStalenessSeconds,
 			DatasetDerivationsTotal,
 			FreshnessViolationsTotal,
+			ContractFindingsTotal,
 			AuthRequestsTotal,
 			AuthFailuresTotal,
 			AuthKeyAgeSeconds,

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -42,6 +42,7 @@ func (s *MetricsSuite) SetupTest() {
 		EventTriggerMatchesTotal,
 		EventsIngestedTotal,
 		EventBridgeFailuresTotal,
+		ContractFindingsTotal,
 		SSOLoginsTotal,
 		SSOLoginDurationSeconds,
 		SSOLogoutsTotal,
@@ -248,6 +249,18 @@ func (s *MetricsSuite) TestEventBridgeFailuresTotalIncrements() {
 
 	val := metrictestutil.CounterValue(s.T(), EventBridgeFailuresTotal, "webhook")
 	s.GreaterOrEqual(val, float64(1))
+}
+
+func (s *MetricsSuite) TestContractFindingsTotalIncrements() {
+	ContractFindingsTotal.WithLabelValues("breaking").Inc()
+	ContractFindingsTotal.WithLabelValues("unknown").Inc()
+	ContractFindingsTotal.WithLabelValues("unknown").Inc()
+
+	val := metrictestutil.CounterValue(s.T(), ContractFindingsTotal, "breaking")
+	s.GreaterOrEqual(val, float64(1))
+
+	val = metrictestutil.CounterValue(s.T(), ContractFindingsTotal, "unknown")
+	s.GreaterOrEqual(val, float64(2))
 }
 
 func (s *MetricsSuite) TestSSOLoginsTotalIncrements() {

--- a/test/contracts_graph_test.go
+++ b/test/contracts_graph_test.go
@@ -1,0 +1,129 @@
+//go:build integration
+
+package test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestContractsGraphEndpointReportsInferredEdgeAndFeatureFlag() {
+	suffix := time.Now().UnixNano()
+	producerAlias := fmt.Sprintf("integration-contract-producer-%d", suffix)
+	consumerAlias := fmt.Sprintf("integration-contract-consumer-%d", suffix)
+
+	dir, err := os.MkdirTemp("", "caesium-contract-graph-*")
+	s.Require().NoError(err)
+	defer os.RemoveAll(dir)
+
+	producer := fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  labels:
+    team: data-platform
+trigger:
+  type: cron
+  configuration:
+    cron: "0 2 * * *"
+steps:
+  - name: export
+    image: alpine:3.23
+    command: ["sh", "-c", "echo export"]
+    outputSchema:
+      type: object
+      required: [row_count]
+      properties:
+        row_count:
+          type: integer
+`, producerAlias)
+
+	consumer := fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  labels:
+    team: reporting
+trigger:
+  type: event
+  configuration:
+    events:
+      - type: run_completed
+        source: caesium
+        filter:
+          job_alias: %s
+    paramMapping:
+      upstream_rows: "$.tasks[0].output.row_count"
+steps:
+  - name: load
+    image: alpine:3.23
+    command: ["sh", "-c", "echo load"]
+`, consumerAlias, producerAlias)
+
+	s.Require().NoError(os.WriteFile(filepath.Join(dir, "producer.job.yaml"), []byte(strings.TrimSpace(s.injectEngine(producer))), 0o644))
+	s.Require().NoError(os.WriteFile(filepath.Join(dir, "consumer.job.yaml"), []byte(strings.TrimSpace(s.injectEngine(consumer))), 0o644))
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	var features struct {
+		ContractEnforcementEnabled bool `json:"contract_enforcement_enabled"`
+	}
+	s.getJSON("/v1/system/features", &features)
+	s.True(features.ContractEnforcementEnabled)
+
+	var graph contractGraphResponse
+	s.getJSON("/v1/contracts/graph", &graph)
+
+	s.Contains(nodeAliases(graph.Nodes), producerAlias)
+	s.Contains(nodeAliases(graph.Nodes), consumerAlias)
+
+	var matched *contractGraphEdge
+	for i := range graph.Edges {
+		edge := &graph.Edges[i]
+		if edge.From == "job:"+producerAlias && edge.To == "job:"+consumerAlias && edge.Class == "inferred" {
+			matched = edge
+			break
+		}
+	}
+	s.Require().NotNil(matched, "expected inferred contract edge from %s to %s in %+v", producerAlias, consumerAlias, graph.Edges)
+	s.Equal("compatible", matched.Verdict)
+	s.Empty(matched.Findings)
+}
+
+type contractGraphResponse struct {
+	Nodes []contractGraphNode `json:"nodes"`
+	Edges []contractGraphEdge `json:"edges"`
+}
+
+type contractGraphNode struct {
+	ID    string `json:"id"`
+	Kind  string `json:"kind"`
+	Alias string `json:"alias"`
+}
+
+type contractGraphEdge struct {
+	ID       string                 `json:"id"`
+	From     string                 `json:"from"`
+	To       string                 `json:"to"`
+	Class    string                 `json:"class"`
+	Verdict  string                 `json:"verdict"`
+	Findings []contractGraphFinding `json:"findings"`
+}
+
+type contractGraphFinding struct {
+	Verdict string `json:"verdict"`
+	Path    string `json:"path"`
+}
+
+func nodeAliases(nodes []contractGraphNode) []string {
+	aliases := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		if node.Kind == "job" {
+			aliases = append(aliases, node.Alias)
+		}
+	}
+	return aliases
+}


### PR DESCRIPTION
## Summary
D1 of the contract-enforcement plan — the REST operator surface:

- `GET /v1/contracts/graph` (`?dataset=ns/name` filter) recomputing the derived graph per request; the route is only REGISTERED when `CAESIUM_CONTRACT_ENFORCEMENT` is set (unset ⇒ no route, per the plan's inertness criterion).
- `POST /v1/jobdefs/lint` gains `contracts: {breaking, warnings, edges}`; `POST /v1/jobdefs/diff` gains per-job `contractFindings` — omitted entirely when enforcement is unset (backward-compatible additive fields).
- `GET /v1/system/features` reports `contract_enforcement_enabled`.
- RBAC: Viewer-readable policy entry + scoped-principal denial (global cross-job query) + scope-action mapping; the completeness test covers the new route.
- `caesium_contract_findings_total{verdict}` with bounded labels.
- Live integration scenario: apply producer+consumer, GET the graph, assert the inferred edge + feature flag.
- Env read via a small `api/rest/service/contract` helper (raw env) to avoid cross-PR compile coupling with W2-γ's env.go field — W3 unifies (noted in-code).

## Test plan
- [x] Host `go test`: api/middleware, internal/auth, internal/metrics, internal/contract (agent + orchestrator).
- [ ] api/rest build + integration scenario — GHA CI (dqlite CGO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
