### PR TITLE
Fold declared contract edges into the graph (contract-enforcement W2-β)

### DIFF
--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -179,7 +179,7 @@ read-only against existing tables.
       warn-only `VerdictUnknown` plus `lastSeen`; tests cover missing keys,
       unresolved task indexes, unknown scoped producers, ignored non-output paths,
       job-id source filters, and evidence last-seen aggregation.
-- [ ] B2. Fold the **declared** edge class into the graph: match
+- [x] B2. Fold the **declared** edge class into the graph: match
       `datasets.produces`/`datasets.consumes` on dataset `name` across all merged
       jobs, attaching the producer's `schemaFrom: output` (resolved to that step's
       `outputSchema`) or inline `schema`, and each consumer's required `schema`.
@@ -190,6 +190,19 @@ read-only against existing tables.
       the comparison target), so a coordinated migration passes without an ack.
       Files: `internal/contract/derive.go`, `internal/contract/graph_test.go`.
       Depends on: B1 + E1 (the `datasets` schema fields the declared edges read).
+      Note: Added declared job-to-job dataset edges over merged `produces`/`consumes`
+      names, resolving inline producer schemas or `schemaFrom: output` to the step
+      `outputSchema` and carrying producer/previous-producer/consumer schemas on the
+      edge. Added additive `Job.Incoming`, compact produced/consumed dataset fields,
+      `ProducerSchemaRecord`, `DeriveInput.PreviousProducerSchemas`, and an optional
+      `ProducerSchemaReader` so incoming producer schemas compare against persisted
+      old schemas without breaking existing callers. Consumer schema requirements run
+      through `schemacompat.Satisfies`; schema-less consumers use producer old-vs-new
+      `Compare`; coordinated producer+consumer batch migrations use the incoming
+      consumer requirement as the target. Tests cover `schemaFrom: output`, inline
+      schemas, name-level edges, breaking requirements, schema-less consumer compare
+      behavior, coordinated migration, unknown previous schemas, and the GORM
+      previous-producer schema reader.
 
 ### Stream C — Apply-time enforcement, acks & break notifications
 

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -35,10 +35,16 @@ type EvidenceReader interface {
 	ListContractEvidence(ctx context.Context) ([]EvidenceRecord, error)
 }
 
+// ProducerSchemaReader reads persisted producer schemas replaced by an incoming batch.
+type ProducerSchemaReader interface {
+	ListContractProducerSchemas(ctx context.Context, incoming []schema.Definition) ([]ProducerSchemaRecord, error)
+}
+
 // Deriver loads authoritative sources and derives a contract graph on demand.
 type Deriver struct {
-	Jobs     JobReader
-	Evidence EvidenceReader
+	Jobs            JobReader
+	Evidence        EvidenceReader
+	ProducerSchemas ProducerSchemaReader
 }
 
 // GORMStore reads contract graph inputs from the existing GORM catalog.
@@ -49,7 +55,7 @@ type GORMStore struct {
 // NewGORMDeriver returns a Deriver backed by the existing GORM catalog tables.
 func NewGORMDeriver(db *gorm.DB) Deriver {
 	store := GORMStore{DB: db}
-	return Deriver{Jobs: store, Evidence: store}
+	return Deriver{Jobs: store, Evidence: store, ProducerSchemas: store}
 }
 
 // DeriveGraph loads the merged job world, lineage evidence, and returns the
@@ -72,7 +78,15 @@ func (d Deriver) DeriveGraph(ctx context.Context, incoming []schema.Definition) 
 		}
 	}
 
-	return DeriveGraph(DeriveInput{Jobs: jobs, Evidence: evidence})
+	var previousProducerSchemas []ProducerSchemaRecord
+	if d.ProducerSchemas != nil {
+		previousProducerSchemas, err = d.ProducerSchemas.ListContractProducerSchemas(ctx, incoming)
+		if err != nil {
+			return Graph{}, err
+		}
+	}
+
+	return DeriveGraph(DeriveInput{Jobs: jobs, Evidence: evidence, PreviousProducerSchemas: previousProducerSchemas})
 }
 
 // ListContractJobs returns incoming definitions plus persisted jobs not
@@ -125,6 +139,84 @@ func (s GORMStore) ListContractJobs(ctx context.Context, incoming []schema.Defin
 	jobs = append(jobs, existing...)
 	sortJobs(jobs)
 	return jobs, nil
+}
+
+// ListContractProducerSchemas returns resolved persisted producer schemas for
+// jobs that the incoming batch is replacing.
+func (s GORMStore) ListContractProducerSchemas(ctx context.Context, incoming []schema.Definition) ([]ProducerSchemaRecord, error) {
+	if s.DB == nil || len(incoming) == 0 {
+		return nil, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	incomingAliases := make(map[string]struct{}, len(incoming))
+	for idx := range incoming {
+		alias := strings.TrimSpace(incoming[idx].Metadata.Alias)
+		if alias == "" {
+			return nil, fmt.Errorf("definition %d: metadata.alias is required", idx)
+		}
+		incomingAliases[alias] = struct{}{}
+	}
+
+	incomingJobIDs, err := s.existingJobIDsByAlias(ctx, incomingAliases)
+	if err != nil {
+		return nil, err
+	}
+	if len(incomingJobIDs) == 0 {
+		return nil, nil
+	}
+
+	jobIDs := make([]uuid.UUID, 0, len(incomingJobIDs))
+	aliasByJobID := make(map[uuid.UUID]string, len(incomingJobIDs))
+	for alias, id := range incomingJobIDs {
+		jobIDs = append(jobIDs, id)
+		aliasByJobID[id] = alias
+	}
+	sort.Slice(jobIDs, func(i, j int) bool {
+		return aliasByJobID[jobIDs[i]] < aliasByJobID[jobIDs[j]]
+	})
+
+	stepsByJobID, err := s.persistedContractSteps(ctx, jobIDs)
+	if err != nil {
+		return nil, err
+	}
+	declsByJobID, err := s.persistedDatasetDeclarations(ctx, jobIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	records := make([]ProducerSchemaRecord, 0)
+	for _, jobID := range jobIDs {
+		alias := aliasByJobID[jobID]
+		stepsByName := make(map[string]Step, len(stepsByJobID[jobID]))
+		for _, step := range stepsByJobID[jobID] {
+			stepsByName[strings.TrimSpace(step.Name)] = step
+		}
+		for _, decl := range declsByJobID[jobID] {
+			if decl.Direction != models.DatasetDirectionProduces {
+				continue
+			}
+			name := strings.TrimSpace(decl.Name)
+			if name == "" {
+				continue
+			}
+			stepName := strings.TrimSpace(decl.StepName)
+			record := ProducerSchemaRecord{
+				JobAlias: alias,
+				StepName: stepName,
+				Dataset:  datasetRefFromName(name),
+			}
+			if step, ok := stepsByName[stepName]; ok && len(step.OutputSchema) > 0 {
+				record.Schema = cloneAnyMap(step.OutputSchema)
+				record.SchemaKnown = true
+			}
+			records = append(records, record)
+		}
+	}
+	sortProducerSchemaRecords(records)
+	return records, nil
 }
 
 // ListContractEvidence returns distinct job-level lineage evidence edges.
@@ -281,6 +373,7 @@ func DeriveGraph(input DeriveInput) (Graph, error) {
 		builder.addJob(jobs[idx])
 	}
 
+	deriveDeclaredEdges(builder, jobs, input.PreviousProducerSchemas)
 	if err := deriveInferredEdges(builder, jobs); err != nil {
 		return Graph{}, err
 	}
@@ -366,6 +459,10 @@ func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases ma
 	if err != nil {
 		return nil, err
 	}
+	declsByJobID, err := s.persistedDatasetDeclarations(ctx, jobIDs)
+	if err != nil {
+		return nil, err
+	}
 
 	jobs := make([]Job, 0, len(eligibleRows))
 	for _, row := range eligibleRows {
@@ -373,6 +470,7 @@ func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases ma
 		if err != nil {
 			return nil, fmt.Errorf("existing trigger %s configuration: %w", row.Alias, err)
 		}
+		steps := attachPersistedDatasetDeclarations(stepsByJobID[row.ID], declsByJobID[row.ID])
 		jobs = append(jobs, Job{
 			ID:     row.ID,
 			Alias:  row.Alias,
@@ -381,7 +479,7 @@ func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases ma
 				Type:          strings.TrimSpace(row.TriggerType),
 				Configuration: cfg,
 			},
-			Steps: stepsByJobID[row.ID],
+			Steps: steps,
 		})
 	}
 	return jobs, nil
@@ -416,6 +514,28 @@ func (s GORMStore) persistedContractSteps(ctx context.Context, jobIDs []uuid.UUI
 	return stepsByJobID, nil
 }
 
+func (s GORMStore) persistedDatasetDeclarations(ctx context.Context, jobIDs []uuid.UUID) (map[uuid.UUID][]models.DatasetDeclaration, error) {
+	declsByJobID := make(map[uuid.UUID][]models.DatasetDeclaration, len(jobIDs))
+	if len(jobIDs) == 0 {
+		return declsByJobID, nil
+	}
+
+	var decls []models.DatasetDeclaration
+	if err := s.DB.WithContext(ctx).
+		Where("job_id IN ?", jobIDs).
+		Order("job_id ASC").
+		Order("step_name ASC").
+		Order("name ASC").
+		Find(&decls).Error; err != nil {
+		return nil, err
+	}
+
+	for _, decl := range decls {
+		declsByJobID[decl.JobID] = append(declsByJobID[decl.JobID], decl)
+	}
+	return declsByJobID, nil
+}
+
 func jobFromDefinition(def schema.Definition) (Job, error) {
 	alias := strings.TrimSpace(def.Metadata.Alias)
 	if alias == "" {
@@ -427,18 +547,365 @@ func jobFromDefinition(def schema.Definition) (Job, error) {
 		steps = append(steps, Step{
 			Name:         strings.TrimSpace(step.Name),
 			OutputSchema: cloneAnyMap(step.OutputSchema),
+			Produces:     producedDatasetsFromDefinition(step.Datasets),
+			Consumes:     consumedDatasetsFromDefinition(step.Datasets),
 		})
 	}
 
 	return Job{
-		Alias:  alias,
-		Labels: cloneStringMap(def.Metadata.Labels),
+		Alias:    alias,
+		Labels:   cloneStringMap(def.Metadata.Labels),
+		Incoming: true,
 		Trigger: Trigger{
 			Type:          strings.TrimSpace(def.Trigger.Type),
 			Configuration: cloneAnyMap(def.Trigger.Configuration),
 		},
 		Steps: steps,
 	}, nil
+}
+
+func producedDatasetsFromDefinition(datasets *schema.StepDatasets) []ProducedDataset {
+	if datasets == nil || len(datasets.Produces) == 0 {
+		return nil
+	}
+	out := make([]ProducedDataset, 0, len(datasets.Produces))
+	for _, produced := range datasets.Produces {
+		name := strings.TrimSpace(produced.Name)
+		if name == "" {
+			continue
+		}
+		out = append(out, ProducedDataset{
+			Name:       name,
+			Schema:     cloneAnyMap(produced.Schema),
+			SchemaFrom: strings.TrimSpace(produced.SchemaFrom),
+			Version:    produced.Version,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func consumedDatasetsFromDefinition(datasets *schema.StepDatasets) []ConsumedDataset {
+	if datasets == nil || len(datasets.Consumes) == 0 {
+		return nil
+	}
+	out := make([]ConsumedDataset, 0, len(datasets.Consumes))
+	for _, consumed := range datasets.Consumes {
+		name := strings.TrimSpace(consumed.Name)
+		if name == "" {
+			continue
+		}
+		out = append(out, ConsumedDataset{
+			Name:   name,
+			Schema: cloneAnyMap(consumed.Schema),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func attachPersistedDatasetDeclarations(steps []Step, decls []models.DatasetDeclaration) []Step {
+	if len(steps) == 0 || len(decls) == 0 {
+		return steps
+	}
+
+	stepIndexByName := make(map[string]int, len(steps))
+	for idx := range steps {
+		stepIndexByName[strings.TrimSpace(steps[idx].Name)] = idx
+	}
+
+	for _, decl := range decls {
+		name := strings.TrimSpace(decl.Name)
+		if name == "" {
+			continue
+		}
+		stepName := strings.TrimSpace(decl.StepName)
+		idx, ok := stepIndexByName[stepName]
+		if !ok {
+			continue
+		}
+		switch decl.Direction {
+		case models.DatasetDirectionProduces:
+			produced := ProducedDataset{Name: name}
+			if len(steps[idx].OutputSchema) > 0 {
+				produced.SchemaFrom = schema.DatasetSchemaFromOutput
+			}
+			steps[idx].Produces = append(steps[idx].Produces, produced)
+		case models.DatasetDirectionConsumes:
+			steps[idx].Consumes = append(steps[idx].Consumes, ConsumedDataset{Name: name})
+		}
+	}
+
+	for idx := range steps {
+		sort.Slice(steps[idx].Produces, func(i, j int) bool {
+			return steps[idx].Produces[i].Name < steps[idx].Produces[j].Name
+		})
+		sort.Slice(steps[idx].Consumes, func(i, j int) bool {
+			return steps[idx].Consumes[i].Name < steps[idx].Consumes[j].Name
+		})
+	}
+	return steps
+}
+
+type declaredProducer struct {
+	job         Job
+	step        Step
+	dataset     DatasetRef
+	schema      map[string]any
+	schemaKnown bool
+}
+
+type declaredConsumer struct {
+	job         Job
+	step        Step
+	dataset     DatasetRef
+	schema      map[string]any
+	schemaKnown bool
+}
+
+func deriveDeclaredEdges(builder *graphBuilder, jobs []Job, previousSchemas []ProducerSchemaRecord) {
+	previousByKey := make(map[producerSchemaKey]ProducerSchemaRecord, len(previousSchemas))
+	for _, record := range previousSchemas {
+		key := producerSchemaKeyFor(record.JobAlias, record.StepName, record.Dataset)
+		if key.jobAlias == "" || key.datasetName == "" {
+			continue
+		}
+		previousByKey[key] = record
+	}
+
+	producersByDataset := map[string][]declaredProducer{}
+	consumersByDataset := map[string][]declaredConsumer{}
+
+	for _, job := range jobs {
+		for _, step := range job.Steps {
+			for _, produced := range step.Produces {
+				dataset := datasetRefFromName(produced.Name)
+				if dataset.Name == "" {
+					continue
+				}
+				producerSchema, schemaKnown := resolveProducedDatasetSchema(step, produced)
+				producersByDataset[dataset.Name] = append(producersByDataset[dataset.Name], declaredProducer{
+					job:         job,
+					step:        step,
+					dataset:     dataset,
+					schema:      producerSchema,
+					schemaKnown: schemaKnown,
+				})
+			}
+			for _, consumed := range step.Consumes {
+				dataset := datasetRefFromName(consumed.Name)
+				if dataset.Name == "" {
+					continue
+				}
+				consumerSchema := cloneAnyMap(consumed.Schema)
+				consumersByDataset[dataset.Name] = append(consumersByDataset[dataset.Name], declaredConsumer{
+					job:         job,
+					step:        step,
+					dataset:     dataset,
+					schema:      consumerSchema,
+					schemaKnown: len(consumerSchema) > 0,
+				})
+			}
+		}
+	}
+
+	datasetNames := make([]string, 0, len(producersByDataset))
+	for name := range producersByDataset {
+		if len(consumersByDataset[name]) > 0 {
+			datasetNames = append(datasetNames, name)
+		}
+	}
+	sort.Strings(datasetNames)
+
+	for _, datasetName := range datasetNames {
+		producers := producersByDataset[datasetName]
+		consumers := consumersByDataset[datasetName]
+		sortDeclaredProducers(producers)
+		sortDeclaredConsumers(consumers)
+
+		for _, producer := range producers {
+			builder.addDataset(producer.dataset)
+			previous, previousExists := previousByKey[producerSchemaKeyFor(producer.job.Alias, producer.step.Name, producer.dataset)]
+			compareFindings, previousSchema := declaredCompareFindings(producer, previous, previousExists)
+			for _, consumer := range consumers {
+				if producer.job.Alias == consumer.job.Alias {
+					continue
+				}
+				dataset := producer.dataset
+				findings := declaredEdgeFindings(compareFindings, producer, consumer)
+				builder.addEdge(Edge{
+					From:                   jobNodeID(producer.job.Alias),
+					To:                     jobNodeID(consumer.job.Alias),
+					Class:                  EdgeClassDeclared,
+					Verdict:                verdictForFindings(findings, schemacompat.VerdictCompatible),
+					Findings:               findings,
+					Dataset:                &dataset,
+					ProducerSchema:         cloneAnyMap(producer.schema),
+					PreviousProducerSchema: cloneAnyMap(previousSchema),
+					ConsumerSchema:         cloneAnyMap(consumer.schema),
+				})
+			}
+		}
+	}
+}
+
+func resolveProducedDatasetSchema(step Step, produced ProducedDataset) (map[string]any, bool) {
+	if len(produced.Schema) > 0 {
+		return cloneAnyMap(produced.Schema), true
+	}
+	if strings.TrimSpace(produced.SchemaFrom) == schema.DatasetSchemaFromOutput && len(step.OutputSchema) > 0 {
+		return cloneAnyMap(step.OutputSchema), true
+	}
+	return nil, false
+}
+
+func declaredCompareFindings(producer declaredProducer, previous ProducerSchemaRecord, previousExists bool) ([]schemacompat.Finding, map[string]any) {
+	var findings []schemacompat.Finding
+	var previousSchema map[string]any
+	if producer.job.Incoming && previousExists {
+		if !previous.SchemaKnown {
+			findings = append(findings, schemacompat.Finding{
+				Kind:    schemacompat.FindingKindRequirementUnknown,
+				Detail:  fmt.Sprintf("persisted producer schema for dataset %q on %s/%s is unavailable; cannot compare old producer schema to the incoming schema", producer.dataset.Name, producer.job.Alias, producer.step.Name),
+				Verdict: schemacompat.VerdictUnknown,
+			})
+			return prefixFindings(findings, declaredProduceFindingPath(producer.dataset)), nil
+		}
+		previousSchema = cloneAnyMap(previous.Schema)
+	} else if producer.schemaKnown {
+		previousSchema = cloneAnyMap(producer.schema)
+	}
+
+	if producer.job.Incoming && previousExists && previous.SchemaKnown {
+		findings = append(findings, schemacompat.Compare(previousSchema, schemaForCompare(producer.schema, producer.schemaKnown))...)
+	}
+	return prefixFindings(findings, declaredProduceFindingPath(producer.dataset)), previousSchema
+}
+
+func declaredEdgeFindings(compareFindings []schemacompat.Finding, producer declaredProducer, consumer declaredConsumer) []schemacompat.Finding {
+	findings := make([]schemacompat.Finding, 0, len(compareFindings))
+	if !consumer.schemaKnown {
+		findings = append(findings, compareFindings...)
+		return sortedFindings(findings)
+	}
+
+	requirementFindings := schemacompat.Satisfies(schemaForCompare(producer.schema, producer.schemaKnown), consumer.schema)
+	findings = append(findings, prefixFindings(requirementFindings, declaredConsumeFindingPath(consumer.dataset))...)
+	for _, finding := range compareFindings {
+		if finding.Verdict != schemacompat.VerdictBreaking {
+			findings = append(findings, finding)
+		}
+	}
+	return sortedFindings(findings)
+}
+
+func schemaForCompare(schema map[string]any, known bool) map[string]any {
+	if !known {
+		return nil
+	}
+	return schema
+}
+
+func datasetRefFromName(name string) DatasetRef {
+	return DatasetRef{Name: strings.TrimSpace(name)}
+}
+
+func declaredProduceFindingPath(dataset DatasetRef) string {
+	return "datasets.produces." + strings.TrimSpace(dataset.Name) + ".schema"
+}
+
+func declaredConsumeFindingPath(dataset DatasetRef) string {
+	return "datasets.consumes." + strings.TrimSpace(dataset.Name) + ".schema"
+}
+
+func prefixFindings(findings []schemacompat.Finding, prefix string) []schemacompat.Finding {
+	if len(findings) == 0 {
+		return nil
+	}
+	out := make([]schemacompat.Finding, 0, len(findings))
+	prefix = strings.TrimSuffix(strings.TrimSpace(prefix), ".")
+	for _, finding := range findings {
+		if prefix != "" {
+			finding.Path = prefixFindingPath(prefix, finding.Path)
+		}
+		out = append(out, finding)
+	}
+	return sortedFindings(out)
+}
+
+func prefixFindingPath(prefix, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return prefix
+	}
+	return prefix + "." + path
+}
+
+func sortedFindings(findings []schemacompat.Finding) []schemacompat.Finding {
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Path == findings[j].Path {
+			if findings[i].Kind == findings[j].Kind {
+				return findings[i].Detail < findings[j].Detail
+			}
+			return findings[i].Kind < findings[j].Kind
+		}
+		return findings[i].Path < findings[j].Path
+	})
+	return findings
+}
+
+type producerSchemaKey struct {
+	jobAlias    string
+	stepName    string
+	datasetName string
+}
+
+func producerSchemaKeyFor(jobAlias, stepName string, dataset DatasetRef) producerSchemaKey {
+	return producerSchemaKey{
+		jobAlias:    strings.TrimSpace(jobAlias),
+		stepName:    strings.TrimSpace(stepName),
+		datasetName: strings.TrimSpace(dataset.Name),
+	}
+}
+
+func sortDeclaredProducers(producers []declaredProducer) {
+	sort.Slice(producers, func(i, j int) bool {
+		if producers[i].job.Alias == producers[j].job.Alias {
+			if producers[i].step.Name == producers[j].step.Name {
+				return producers[i].dataset.Name < producers[j].dataset.Name
+			}
+			return producers[i].step.Name < producers[j].step.Name
+		}
+		return producers[i].job.Alias < producers[j].job.Alias
+	})
+}
+
+func sortDeclaredConsumers(consumers []declaredConsumer) {
+	sort.Slice(consumers, func(i, j int) bool {
+		if consumers[i].job.Alias == consumers[j].job.Alias {
+			if consumers[i].step.Name == consumers[j].step.Name {
+				return consumers[i].dataset.Name < consumers[j].dataset.Name
+			}
+			return consumers[i].step.Name < consumers[j].step.Name
+		}
+		return consumers[i].job.Alias < consumers[j].job.Alias
+	})
+}
+
+func sortProducerSchemaRecords(records []ProducerSchemaRecord) {
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].JobAlias == records[j].JobAlias {
+			if records[i].StepName == records[j].StepName {
+				return records[i].Dataset.Name < records[j].Dataset.Name
+			}
+			return records[i].StepName < records[j].StepName
+		}
+		return records[i].JobAlias < records[j].JobAlias
+	})
 }
 
 func deriveInferredEdges(builder *graphBuilder, jobs []Job) error {
@@ -937,6 +1404,16 @@ func mergeEdges(existing, incoming Edge) Edge {
 	}
 
 	existing.Findings = append(existing.Findings, incoming.Findings...)
+	existing.Findings = sortedFindings(existing.Findings)
+	if len(existing.ProducerSchema) == 0 && len(incoming.ProducerSchema) > 0 {
+		existing.ProducerSchema = cloneAnyMap(incoming.ProducerSchema)
+	}
+	if len(existing.PreviousProducerSchema) == 0 && len(incoming.PreviousProducerSchema) > 0 {
+		existing.PreviousProducerSchema = cloneAnyMap(incoming.PreviousProducerSchema)
+	}
+	if len(existing.ConsumerSchema) == 0 && len(incoming.ConsumerSchema) > 0 {
+		existing.ConsumerSchema = cloneAnyMap(incoming.ConsumerSchema)
+	}
 	if incoming.LastSeen != nil && (existing.LastSeen == nil || incoming.LastSeen.After(*existing.LastSeen)) {
 		lastSeen := *incoming.LastSeen
 		existing.LastSeen = &lastSeen

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -157,6 +157,11 @@ func (s GORMStore) ListContractProducerSchemas(ctx context.Context, incoming []s
 		if alias == "" {
 			return nil, fmt.Errorf("definition %d: metadata.alias is required", idx)
 		}
+		// Mirror ListContractJobs' duplicate guard so a direct call cannot
+		// silently pick an arbitrary definition for a repeated alias.
+		if _, exists := incomingAliases[alias]; exists {
+			return nil, fmt.Errorf("duplicate job alias %q", alias)
+		}
 		incomingAliases[alias] = struct{}{}
 	}
 

--- a/internal/contract/graph.go
+++ b/internal/contract/graph.go
@@ -54,23 +54,27 @@ type Node struct {
 
 // Edge is a derived relationship between two graph nodes.
 type Edge struct {
-	ID       string                 `json:"id"`
-	From     string                 `json:"from"`
-	To       string                 `json:"to"`
-	Class    EdgeClass              `json:"class"`
-	Verdict  schemacompat.Verdict   `json:"verdict,omitempty"`
-	Findings []schemacompat.Finding `json:"findings,omitempty"`
-	Dataset  *DatasetRef            `json:"dataset,omitempty"`
-	LastSeen *time.Time             `json:"lastSeen,omitempty"`
+	ID                     string                 `json:"id"`
+	From                   string                 `json:"from"`
+	To                     string                 `json:"to"`
+	Class                  EdgeClass              `json:"class"`
+	Verdict                schemacompat.Verdict   `json:"verdict,omitempty"`
+	Findings               []schemacompat.Finding `json:"findings,omitempty"`
+	Dataset                *DatasetRef            `json:"dataset,omitempty"`
+	ProducerSchema         map[string]any         `json:"producerSchema,omitempty"`
+	PreviousProducerSchema map[string]any         `json:"previousProducerSchema,omitempty"`
+	ConsumerSchema         map[string]any         `json:"consumerSchema,omitempty"`
+	LastSeen               *time.Time             `json:"lastSeen,omitempty"`
 }
 
-// Job is the compact job definition surface needed to derive B1 graph edges.
+// Job is the compact job definition surface needed to derive contract graph edges.
 type Job struct {
-	ID      uuid.UUID
-	Alias   string
-	Labels  map[string]string
-	Trigger Trigger
-	Steps   []Step
+	ID       uuid.UUID
+	Alias    string
+	Labels   map[string]string
+	Trigger  Trigger
+	Steps    []Step
+	Incoming bool
 }
 
 // Trigger is the compact trigger surface needed for trigger-chain inference.
@@ -79,10 +83,26 @@ type Trigger struct {
 	Configuration map[string]any
 }
 
-// Step is the compact step surface needed for output-schema path checks.
+// Step is the compact step surface needed for output-schema and dataset checks.
 type Step struct {
 	Name         string
 	OutputSchema map[string]any
+	Produces     []ProducedDataset
+	Consumes     []ConsumedDataset
+}
+
+// ProducedDataset is the compact produces declaration used by the contract graph.
+type ProducedDataset struct {
+	Name       string
+	Schema     map[string]any
+	SchemaFrom string
+	Version    int
+}
+
+// ConsumedDataset is the compact consumes declaration used by the contract graph.
+type ConsumedDataset struct {
+	Name   string
+	Schema map[string]any
 }
 
 // EvidenceRecord is one distinct lineage-observed producer/dataset/consumer edge.
@@ -95,9 +115,20 @@ type EvidenceRecord struct {
 	LastSeen         time.Time
 }
 
+// ProducerSchemaRecord captures a persisted producer's resolved dataset schema
+// before an incoming definition replaces it.
+type ProducerSchemaRecord struct {
+	JobAlias    string
+	StepName    string
+	Dataset     DatasetRef
+	Schema      map[string]any
+	SchemaKnown bool
+}
+
 // DeriveInput is the pure input surface for graph derivation. Callers that
 // already have the merged job world can use DeriveGraph directly.
 type DeriveInput struct {
-	Jobs     []Job
-	Evidence []EvidenceRecord
+	Jobs                    []Job
+	Evidence                []EvidenceRecord
+	PreviousProducerSchemas []ProducerSchemaRecord
 }

--- a/internal/contract/graph_test.go
+++ b/internal/contract/graph_test.go
@@ -2,6 +2,7 @@ package contract
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -280,6 +281,276 @@ func TestDeriveGraphInferredEdgeResolvesJobIDFilter(t *testing.T) {
 	require.Empty(t, edge.Findings)
 }
 
+func TestDeriveGraphDeclaredEdgeResolvesSchemaFromOutput(t *testing.T) {
+	producer := Job{
+		Alias: "producer",
+		Steps: []Step{{
+			Name:         "export",
+			OutputSchema: objectSchemaWithRequired("customer_id", "row_count"),
+			Produces: []ProducedDataset{{
+				Name:       "lake.customers",
+				SchemaFrom: schema.DatasetSchemaFromOutput,
+			}},
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Steps: []Step{{
+			Name: "load",
+			Consumes: []ConsumedDataset{{
+				Name:   "lake.customers",
+				Schema: objectSchemaWithRequired("customer_id"),
+			}},
+		}},
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictCompatible, edge.Verdict)
+	require.Empty(t, edge.Findings)
+	require.Contains(t, edge.ProducerSchema["properties"], "customer_id")
+	require.Contains(t, edge.ConsumerSchema["properties"], "customer_id")
+	requireDatasetNode(t, graph, "/lake.customers")
+}
+
+func TestDeriveGraphDeclaredEdgeUsesInlineProducerSchema(t *testing.T) {
+	producer := Job{
+		Alias: "producer",
+		Steps: []Step{{
+			Name: "export",
+			Produces: []ProducedDataset{{
+				Name:   "lake.customers",
+				Schema: objectSchemaWithRequired("customer_id"),
+			}},
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Steps: []Step{{
+			Name: "load",
+			Consumes: []ConsumedDataset{{
+				Name:   "lake.customers",
+				Schema: objectSchemaWithRequired("customer_id"),
+			}},
+		}},
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictCompatible, edge.Verdict)
+	require.Empty(t, edge.Findings)
+	require.Contains(t, edge.ProducerSchema["properties"], "customer_id")
+}
+
+func TestDeriveGraphDeclaredNameLevelEdgeWithoutSchemas(t *testing.T) {
+	producer := Job{
+		Alias: "producer",
+		Steps: []Step{{
+			Name:     "export",
+			Produces: []ProducedDataset{{Name: "lake.customers"}},
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Steps: []Step{{
+			Name:     "load",
+			Consumes: []ConsumedDataset{{Name: "lake.customers"}},
+		}},
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictCompatible, edge.Verdict)
+	require.Empty(t, edge.Findings)
+	require.Empty(t, edge.ProducerSchema)
+	require.Empty(t, edge.ConsumerSchema)
+}
+
+func TestDeriveGraphDeclaredConsumerRequirementReportsBreaking(t *testing.T) {
+	producer := Job{
+		Alias: "producer",
+		Steps: []Step{{
+			Name:         "export",
+			OutputSchema: objectSchemaWithRequired("row_count"),
+			Produces: []ProducedDataset{{
+				Name:       "lake.customers",
+				SchemaFrom: schema.DatasetSchemaFromOutput,
+			}},
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Steps: []Step{{
+			Name: "load",
+			Consumes: []ConsumedDataset{{
+				Name:   "lake.customers",
+				Schema: objectSchemaWithRequired("customer_id"),
+			}},
+		}},
+	}
+
+	graph, err := DeriveGraph(DeriveInput{Jobs: []Job{producer, consumer}})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictBreaking, edge.Verdict)
+	require.Len(t, edge.Findings, 2)
+	require.Equal(t, schemacompat.FindingKindRequirementUnsatisfied, edge.Findings[0].Kind)
+	require.Contains(t, edge.Findings[0].Path, "datasets.consumes.lake.customers.schema")
+	require.Contains(t, edge.Findings[0].Detail, "customer_id")
+}
+
+func TestDeriveGraphDeclaredSchemaLessConsumerUsesProducerComparison(t *testing.T) {
+	producer := Job{
+		Alias:    "producer",
+		Incoming: true,
+		Steps: []Step{{
+			Name:         "export",
+			OutputSchema: objectSchemaWithRequired("row_count"),
+			Produces: []ProducedDataset{{
+				Name:       "lake.customers",
+				SchemaFrom: schema.DatasetSchemaFromOutput,
+			}},
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Steps: []Step{{
+			Name:     "load",
+			Consumes: []ConsumedDataset{{Name: "lake.customers"}},
+		}},
+	}
+
+	graph, err := DeriveGraph(DeriveInput{
+		Jobs: []Job{producer, consumer},
+		PreviousProducerSchemas: []ProducerSchemaRecord{{
+			JobAlias:    "producer",
+			StepName:    "export",
+			Dataset:     DatasetRef{Name: "lake.customers"},
+			Schema:      objectSchemaWithRequired("customer_id", "row_count"),
+			SchemaKnown: true,
+		}},
+	})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictBreaking, edge.Verdict)
+	require.NotEmpty(t, edge.PreviousProducerSchema)
+	require.Len(t, edge.Findings, 1)
+	require.Equal(t, schemacompat.FindingKindRequiredRemoved, edge.Findings[0].Kind)
+	require.Contains(t, edge.Findings[0].Detail, "customer_id")
+}
+
+func TestDeriveGraphDeclaredBatchConsumerRequirementCanMigrate(t *testing.T) {
+	producer := Job{
+		Alias:    "producer",
+		Incoming: true,
+		Steps: []Step{{
+			Name:         "export",
+			OutputSchema: objectSchemaWithRequired("row_count"),
+			Produces: []ProducedDataset{{
+				Name:       "lake.customers",
+				SchemaFrom: schema.DatasetSchemaFromOutput,
+			}},
+		}},
+	}
+	consumer := Job{
+		Alias:    "consumer",
+		Incoming: true,
+		Steps: []Step{{
+			Name: "load",
+			Consumes: []ConsumedDataset{{
+				Name:   "lake.customers",
+				Schema: objectSchemaWithRequired("row_count"),
+			}},
+		}},
+	}
+
+	graph, err := DeriveGraph(DeriveInput{
+		Jobs: []Job{producer, consumer},
+		PreviousProducerSchemas: []ProducerSchemaRecord{{
+			JobAlias:    "producer",
+			StepName:    "export",
+			Dataset:     DatasetRef{Name: "lake.customers"},
+			Schema:      objectSchemaWithRequired("customer_id", "row_count"),
+			SchemaKnown: true,
+		}},
+	})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictCompatible, edge.Verdict)
+	require.Empty(t, edge.Findings)
+}
+
+func TestDeriveGraphDeclaredUnknownPreviousProducerSchemaWarns(t *testing.T) {
+	producer := Job{
+		Alias:    "producer",
+		Incoming: true,
+		Steps: []Step{{
+			Name:         "export",
+			OutputSchema: objectSchemaWithRequired("customer_id"),
+			Produces: []ProducedDataset{{
+				Name:       "lake.customers",
+				SchemaFrom: schema.DatasetSchemaFromOutput,
+			}},
+		}},
+	}
+	consumer := Job{
+		Alias: "consumer",
+		Steps: []Step{{
+			Name:     "load",
+			Consumes: []ConsumedDataset{{Name: "lake.customers"}},
+		}},
+	}
+
+	graph, err := DeriveGraph(DeriveInput{
+		Jobs: []Job{producer, consumer},
+		PreviousProducerSchemas: []ProducerSchemaRecord{{
+			JobAlias: "producer",
+			StepName: "export",
+			Dataset:  DatasetRef{Name: "lake.customers"},
+		}},
+	})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictUnknown, edge.Verdict)
+	require.Len(t, edge.Findings, 1)
+	require.Equal(t, schemacompat.FindingKindRequirementUnknown, edge.Findings[0].Kind)
+	require.Contains(t, edge.Findings[0].Detail, "persisted producer schema")
+}
+
+func TestGORMStoreListContractProducerSchemasUsesTaskOutputSchema(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	createContractJobTables(t, db)
+
+	jobID := uuid.New()
+	triggerID := uuid.New()
+	insertContractTrigger(t, db, triggerID)
+	insertContractJob(t, db, jobID, triggerID, "producer")
+	insertContractTask(t, db, jobID, "export", objectSchemaWithRequired("customer_id"))
+	insertDatasetDeclaration(t, db, jobID, "producer", "export", "lake.customers", "produces")
+
+	records, err := (GORMStore{DB: db}).ListContractProducerSchemas(context.Background(), []schema.Definition{{
+		Metadata: schema.Metadata{Alias: "producer"},
+	}})
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, "producer", records[0].JobAlias)
+	require.Equal(t, "export", records[0].StepName)
+	require.Equal(t, DatasetRef{Name: "lake.customers"}, records[0].Dataset)
+	require.True(t, records[0].SchemaKnown)
+	require.Contains(t, records[0].Schema["properties"], "customer_id")
+}
+
 func outputSchemaWithProperties(keys ...string) map[string]any {
 	properties := make(map[string]any, len(keys))
 	for _, key := range keys {
@@ -289,6 +560,12 @@ func outputSchemaWithProperties(keys ...string) map[string]any {
 		"type":       "object",
 		"properties": properties,
 	}
+}
+
+func objectSchemaWithRequired(keys ...string) map[string]any {
+	schema := outputSchemaWithProperties(keys...)
+	schema["required"] = append([]string(nil), keys...)
+	return schema
 }
 
 func eventTrigger(sourceAlias string, mapping map[string]string) Trigger {
@@ -382,4 +659,55 @@ func insertEvidenceDataset(t *testing.T, db *gorm.DB, jobID uuid.UUID, namespace
 		direction,
 		createdAt,
 	).Error)
+}
+
+func createContractJobTables(t *testing.T, db *gorm.DB) {
+	t.Helper()
+	require.NoError(t, db.Exec("CREATE TABLE jobs (id text PRIMARY KEY, alias text NOT NULL, trigger_id text NOT NULL, labels json, deleted_at datetime)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE triggers (id text PRIMARY KEY, type text NOT NULL, configuration text NOT NULL, deleted_at datetime)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE tasks (id text PRIMARY KEY, job_id text NOT NULL, name text NOT NULL, position integer NOT NULL, output_schema json, deleted_at datetime, created_at datetime)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE dataset_declarations (id text PRIMARY KEY, job_id text NOT NULL, job_alias text NOT NULL, step_name text NOT NULL, name text NOT NULL, direction text NOT NULL)").Error)
+}
+
+func insertContractTrigger(t *testing.T, db *gorm.DB, triggerID uuid.UUID) {
+	t.Helper()
+	require.NoError(t, db.Exec("INSERT INTO triggers (id, type, configuration, deleted_at) VALUES (?, ?, ?, NULL)", triggerID, schema.TriggerCron, `{}`).Error)
+}
+
+func insertContractJob(t *testing.T, db *gorm.DB, jobID, triggerID uuid.UUID, alias string) {
+	t.Helper()
+	require.NoError(t, db.Exec("INSERT INTO jobs (id, alias, trigger_id, labels, deleted_at) VALUES (?, ?, ?, '{}', NULL)", jobID, alias, triggerID).Error)
+}
+
+func insertContractTask(t *testing.T, db *gorm.DB, jobID uuid.UUID, name string, outputSchema map[string]any) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		"INSERT INTO tasks (id, job_id, name, position, output_schema, deleted_at, created_at) VALUES (?, ?, ?, ?, ?, NULL, ?)",
+		uuid.New(),
+		jobID,
+		name,
+		0,
+		mustJSON(t, outputSchema),
+		time.Now().UTC(),
+	).Error)
+}
+
+func insertDatasetDeclaration(t *testing.T, db *gorm.DB, jobID uuid.UUID, jobAlias, stepName, name, direction string) {
+	t.Helper()
+	require.NoError(t, db.Exec(
+		"INSERT INTO dataset_declarations (id, job_id, job_alias, step_name, name, direction) VALUES (?, ?, ?, ?, ?, ?)",
+		uuid.New(),
+		jobID,
+		jobAlias,
+		stepName,
+		name,
+		direction,
+	).Error)
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(data)
 }


### PR DESCRIPTION
## Summary
B2 of the contract-enforcement plan — the declared edge class:

- Declared edges match `datasets.produces`/`consumes` on dataset name across the merged world; producer schema resolves from inline `schema` or `schemaFrom: output` (that step's `outputSchema`).
- Each declared edge carries checker verdicts: producer old-vs-new `Compare` + per-consumer `Satisfies`; schema-less consumers form name-level edges with producer-evolution verdicts only.
- **Coordinated-batch semantics**: producer + consumers updated in one apply batch are checked as a set (incoming consumer requirements are the target), so a coordinated migration passes without an ack.
- Additive API only (`Edge.ProducerSchema/PreviousProducerSchema/ConsumerSchema`, `DeriveInput.PreviousProducerSchemas`, optional `ProducerSchemaReader`) — the in-flight W2-γ/δ consumers are unaffected.
- **Known gap (flagged for W3)**: persisted `dataset_declarations` rows don't carry inline schema metadata, so previous-producer schemas resolve from persisted task `output_schema` when available and honestly report `unknown` otherwise.

## Test plan
- [x] Host `go vet` + `go test ./internal/contract/` (agent + orchestrator independently).
- [ ] Full matrix — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
