### PR TITLE
Add the caesium contract CLI group and server-mode lint (contract-enforcement W3-δ)

### DIFF
--- a/cmd/contract/check.go
+++ b/cmd/contract/check.go
@@ -1,0 +1,128 @@
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/caesium-cloud/caesium/cmd/job"
+	"github.com/spf13/cobra"
+)
+
+var (
+	checkPaths []string
+	checkJSON  bool
+)
+
+var checkCmd = &cobra.Command{
+	Use:   "check --path jobs/",
+	Short: "Check local job definitions against persisted contract state",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		defs, err := job.LoadDefinitions(checkPaths)
+		if err != nil {
+			return err
+		}
+		if len(defs) == 0 {
+			if checkJSON {
+				return writeContractJSON(cmd, job.ServerContractSummary{
+					Breaking: []job.ServerContractFinding{},
+					Warnings: []job.ServerContractFinding{},
+					Edges:    0,
+				})
+			}
+			_, err := fmt.Fprintln(cmd.OutOrStdout(), "No job definitions found.")
+			return err
+		}
+
+		apiKey := cliutil.ResolveAPIKey(cmd, apiKeyFlag, cliutil.APIKeyEnvVar)
+		if err := ensureContractEnforcementEnabled(cmd, apiKey); err != nil {
+			return err
+		}
+
+		lintResp, _, err := job.PostServerLint(cmd.Context(), serverBase(), apiKey, defs)
+		if err != nil {
+			return err
+		}
+		if len(lintResp.Errors) > 0 {
+			return fmt.Errorf("server lint failed: %s", lintErrorSummary(lintResp.Errors))
+		}
+		if lintResp.Contracts == nil {
+			return disabledError("server lint did not include contract findings")
+		}
+
+		if checkJSON {
+			if err := writeContractJSON(cmd, *lintResp.Contracts); err != nil {
+				return err
+			}
+		} else if err := renderContractSummary(cmd, lintResp.Contracts); err != nil {
+			return err
+		}
+		if len(lintResp.Contracts.Breaking) > 0 {
+			return fmt.Errorf("contract check failed: %d breaking finding(s)", len(lintResp.Contracts.Breaking))
+		}
+		return nil
+	},
+}
+
+func renderContractSummary(cmd *cobra.Command, summary *job.ServerContractSummary) error {
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "Contract findings: %d edge(s), %d breaking, %d warning(s)\n", summary.Edges, len(summary.Breaking), len(summary.Warnings)); err != nil {
+		return err
+	}
+	if len(summary.Breaking) > 0 {
+		if _, err := fmt.Fprintln(out, "Breaking:"); err != nil {
+			return err
+		}
+		if err := renderContractFindings(cmd, summary.Breaking); err != nil {
+			return err
+		}
+	}
+	if len(summary.Warnings) > 0 {
+		if _, err := fmt.Fprintln(out, "Warnings:"); err != nil {
+			return err
+		}
+		if err := renderContractFindings(cmd, summary.Warnings); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func renderContractFindings(cmd *cobra.Command, findings []job.ServerContractFinding) error {
+	out := cmd.OutOrStdout()
+	for _, finding := range findings {
+		if _, err := fmt.Fprintf(out, "  - %s -> %s [%s] %s %s: %s\n",
+			cleanCell(finding.From),
+			cleanCell(finding.To),
+			cleanCell(finding.EdgeClass),
+			cleanCell(finding.Kind),
+			cleanCell(finding.Path),
+			cleanCell(finding.Detail),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeContractJSON(cmd *cobra.Command, summary job.ServerContractSummary) error {
+	body, err := json.Marshal(summary)
+	if err != nil {
+		return err
+	}
+	return cliutil.WritePrettyJSON(cmd, body, "contract findings")
+}
+
+func lintErrorSummary(messages []job.ServerLintMessage) string {
+	parts := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		parts = append(parts, msg.Message)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func init() {
+	checkCmd.Flags().StringSliceVarP(&checkPaths, "path", "p", nil, "Paths to job definition files or directories (default: current directory)")
+	checkCmd.Flags().BoolVar(&checkJSON, "json", false, "Print contract findings JSON")
+}

--- a/cmd/contract/contract.go
+++ b/cmd/contract/contract.go
@@ -1,0 +1,23 @@
+package contract
+
+import (
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+)
+
+var (
+	serverFlag string
+	apiKeyFlag string
+)
+
+// Cmd is the root `caesium contract` command group.
+var Cmd = &cobra.Command{
+	Use:   "contract",
+	Short: "Inspect contract enforcement graph and findings",
+}
+
+func init() {
+	Cmd.PersistentFlags().StringVar(&serverFlag, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.PersistentFlags().StringVar(&apiKeyFlag, "api-key", "", "API key for authentication (prefer "+cliutil.APIKeyEnvVar+"; --api-key is visible in process listings)")
+	Cmd.AddCommand(graphCmd, checkCmd)
+}

--- a/cmd/contract/graph.go
+++ b/cmd/contract/graph.go
@@ -1,0 +1,148 @@
+package contract
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+)
+
+var (
+	graphDataset string
+	graphJSON    bool
+)
+
+var graphCmd = &cobra.Command{
+	Use:   "graph [--dataset ns/name]",
+	Short: "Fetch the contract graph from the server",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		apiKey := cliutil.ResolveAPIKey(cmd, apiKeyFlag, cliutil.APIKeyEnvVar)
+		if err := ensureContractEnforcementEnabled(cmd, apiKey); err != nil {
+			return err
+		}
+
+		reqURL := serverBase() + "/v1/contracts/graph"
+		if dataset := strings.TrimSpace(graphDataset); dataset != "" {
+			params := url.Values{}
+			params.Set("dataset", dataset)
+			reqURL += "?" + params.Encode()
+		}
+
+		body, status, err := request(cmd, apiKey, http.MethodGet, reqURL, nil, "contract graph")
+		if err != nil {
+			return err
+		}
+		if status == http.StatusNotFound {
+			return disabledError("GET /v1/contracts/graph is not registered")
+		}
+		if status >= http.StatusBadRequest {
+			return fmt.Errorf("contract graph failed (%d): %s", status, strings.TrimSpace(string(body)))
+		}
+		if graphJSON {
+			return cliutil.WritePrettyJSON(cmd, body, "contract graph")
+		}
+
+		var graph graphResponse
+		if err := decodeJSON(body, &graph, "contract graph"); err != nil {
+			return err
+		}
+		return renderGraph(cmd, graph)
+	},
+}
+
+func renderGraph(cmd *cobra.Command, graph graphResponse) error {
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "Contract graph: %d node(s), %d edge(s)\n", len(graph.Nodes), len(graph.Edges)); err != nil {
+		return err
+	}
+
+	if len(graph.Nodes) > 0 {
+		if _, err := fmt.Fprintln(out, "\nNodes:"); err != nil {
+			return err
+		}
+		tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "KIND\tID\tALIAS/DATASET\tLABELS")
+		for _, node := range graph.Nodes {
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n",
+				cleanCell(node.Kind),
+				cleanCell(node.ID),
+				cleanCell(nodeDisplay(node)),
+				cleanCell(formatLabels(node.Labels)),
+			)
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+	}
+
+	if len(graph.Edges) > 0 {
+		if _, err := fmt.Fprintln(out, "\nEdges:"); err != nil {
+			return err
+		}
+		tw := tabwriter.NewWriter(out, 0, 4, 2, ' ', 0)
+		_, _ = fmt.Fprintln(tw, "FROM\tTO\tCLASS\tVERDICT\tDATASET\tFINDINGS")
+		for _, edge := range graph.Edges {
+			_, _ = fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
+				cleanCell(edge.From),
+				cleanCell(edge.To),
+				cleanCell(edge.Class),
+				cleanCell(edge.Verdict),
+				cleanCell(datasetName(edge.Dataset)),
+				cleanCell(formatGraphFindings(edge.Findings)),
+			)
+		}
+		if err := tw.Flush(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nodeDisplay(node graphNode) string {
+	if node.Alias != "" {
+		return node.Alias
+	}
+	return datasetName(node.Dataset)
+}
+
+func formatLabels(labels map[string]string) string {
+	if len(labels) == 0 {
+		return "-"
+	}
+	keys := make([]string, 0, len(labels))
+	for key := range labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+labels[key])
+	}
+	return strings.Join(parts, ",")
+}
+
+func formatGraphFindings(findings []graphFinding) string {
+	if len(findings) == 0 {
+		return "-"
+	}
+	parts := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		parts = append(parts, fmt.Sprintf("%s:%s %s %s",
+			finding.Verdict,
+			finding.Kind,
+			finding.Path,
+			finding.Detail,
+		))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func init() {
+	graphCmd.Flags().StringVar(&graphDataset, "dataset", "", "Filter graph edges by dataset namespace/name")
+	graphCmd.Flags().BoolVar(&graphJSON, "json", false, "Print the raw graph JSON")
+}

--- a/cmd/contract/http.go
+++ b/cmd/contract/http.go
@@ -1,0 +1,72 @@
+package contract
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/spf13/cobra"
+)
+
+var httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
+
+type featuresResponse struct {
+	ContractEnforcementEnabled bool `json:"contract_enforcement_enabled"`
+}
+
+func serverBase() string {
+	return strings.TrimSuffix(serverFlag, "/")
+}
+
+func request(cmd *cobra.Command, apiKey, method, reqURL string, body io.Reader, label string) ([]byte, int, error) {
+	req, err := http.NewRequestWithContext(cmd.Context(), method, reqURL, body)
+	if err != nil {
+		return nil, 0, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("reading %s response: %w", label, err)
+	}
+	return data, resp.StatusCode, nil
+}
+
+func ensureContractEnforcementEnabled(cmd *cobra.Command, apiKey string) error {
+	body, status, err := request(cmd, apiKey, http.MethodGet, serverBase()+"/v1/system/features", nil, "system features")
+	if err != nil {
+		return err
+	}
+	if status == http.StatusNotFound {
+		return disabledError("contract enforcement feature status is unavailable")
+	}
+	if status >= http.StatusBadRequest {
+		return fmt.Errorf("system features failed (%d): %s", status, strings.TrimSpace(string(body)))
+	}
+
+	var features featuresResponse
+	if err := decodeJSON(body, &features, "system features"); err != nil {
+		return err
+	}
+	if !features.ContractEnforcementEnabled {
+		return disabledError("contract enforcement is disabled on the server")
+	}
+	return nil
+}
+
+func disabledError(prefix string) error {
+	return fmt.Errorf("%s; set CAESIUM_CONTRACT_ENFORCEMENT=fail (or warn) on the Caesium server and restart it", prefix)
+}

--- a/cmd/contract/types.go
+++ b/cmd/contract/types.go
@@ -1,0 +1,68 @@
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type graphResponse struct {
+	Nodes []graphNode `json:"nodes"`
+	Edges []graphEdge `json:"edges"`
+}
+
+type graphNode struct {
+	ID      string            `json:"id"`
+	Kind    string            `json:"kind"`
+	Alias   string            `json:"alias,omitempty"`
+	Labels  map[string]string `json:"labels,omitempty"`
+	Dataset *datasetRef       `json:"dataset,omitempty"`
+}
+
+type graphEdge struct {
+	ID       string         `json:"id"`
+	From     string         `json:"from"`
+	To       string         `json:"to"`
+	Class    string         `json:"class"`
+	Verdict  string         `json:"verdict,omitempty"`
+	Findings []graphFinding `json:"findings,omitempty"`
+	Dataset  *datasetRef    `json:"dataset,omitempty"`
+}
+
+type graphFinding struct {
+	Kind    string `json:"kind,omitempty"`
+	Path    string `json:"path,omitempty"`
+	Detail  string `json:"detail,omitempty"`
+	Verdict string `json:"verdict"`
+}
+
+type datasetRef struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+func decodeJSON(body []byte, target any, label string) error {
+	if err := json.Unmarshal(body, target); err != nil {
+		return fmt.Errorf("%s response was not valid JSON: %w", label, err)
+	}
+	return nil
+}
+
+func datasetName(ref *datasetRef) string {
+	if ref == nil {
+		return "-"
+	}
+	if strings.TrimSpace(ref.Namespace) == "" {
+		return ref.Name
+	}
+	return ref.Namespace + "/" + ref.Name
+}
+
+func cleanCell(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	replacer := strings.NewReplacer("\t", " ", "\n", " ", "\r", " ")
+	return replacer.Replace(value)
+}

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -6,6 +6,7 @@ import (
 	"github.com/caesium-cloud/caesium/cmd/backfill"
 	"github.com/caesium-cloud/caesium/cmd/blame"
 	"github.com/caesium-cloud/caesium/cmd/cache"
+	"github.com/caesium-cloud/caesium/cmd/contract"
 	"github.com/caesium-cloud/caesium/cmd/dataset"
 	"github.com/caesium-cloud/caesium/cmd/dev"
 	"github.com/caesium-cloud/caesium/cmd/event"
@@ -27,6 +28,7 @@ var cmds = []*cobra.Command{
 	backfill.Cmd,
 	blame.Cmd,
 	cache.Cmd,
+	contract.Cmd,
 	dataset.Cmd,
 	dev.Cmd,
 	event.Cmd,

--- a/cmd/job/lint.go
+++ b/cmd/job/lint.go
@@ -1,13 +1,18 @@
 package job
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
 
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
 	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
 	lintpkg "github.com/caesium-cloud/caesium/internal/jobdef/lint"
 	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
@@ -26,6 +31,11 @@ var (
 	lintVaultNamespace   string
 	lintVaultCACert      string
 	lintVaultSkipVerify  bool
+	lintServer           string
+	lintAPIKey           string
+	lintJSON             bool
+
+	lintHTTPClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
 )
 
 var lintCmd = &cobra.Command{
@@ -36,11 +46,19 @@ var lintCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		serverMode := cmd.Flags().Changed("server")
+		if lintJSON && !serverMode {
+			return fmt.Errorf("--json is only supported with --server")
+		}
 		if len(defs) == 0 {
 			if err := writeCmdOut(cmd, "No job definitions found.\n"); err != nil {
 				return err
 			}
 			return nil
+		}
+
+		if serverMode {
+			return runServerLint(cmd, defs)
 		}
 
 		for _, def := range defs {
@@ -114,8 +132,262 @@ func init() {
 	lintCmd.Flags().StringVar(&lintVaultNamespace, "vault-namespace", os.Getenv("VAULT_NAMESPACE"), "Vault namespace for secret resolution")
 	lintCmd.Flags().StringVar(&lintVaultCACert, "vault-ca-cert", os.Getenv("VAULT_CACERT"), "Vault CA certificate path")
 	lintCmd.Flags().BoolVar(&lintVaultSkipVerify, "vault-skip-verify", envBool("VAULT_SKIP_VERIFY", false), "Disable TLS verification when connecting to Vault")
+	lintCmd.Flags().StringVar(&lintServer, "server", "http://localhost:8080", "POST definitions to the Caesium server for persisted-world linting; pass without a value to use http://localhost:8080")
+	if flag := lintCmd.Flags().Lookup("server"); flag != nil {
+		flag.NoOptDefVal = "http://localhost:8080"
+	}
+	lintCmd.Flags().StringVar(&lintAPIKey, "api-key", "", "API key for authentication (prefer "+cliutil.APIKeyEnvVar+"; --api-key is visible in process listings)")
+	lintCmd.Flags().BoolVar(&lintJSON, "json", false, "Print server lint JSON (requires --server)")
 
 	Cmd.AddCommand(lintCmd)
+}
+
+// LoadDefinitions exposes the same manifest loader used by `caesium job lint`
+// for sibling CLI groups that need to lint the exact local path set.
+func LoadDefinitions(paths []string) ([]jobdef.Definition, error) {
+	return collectDefinitions(paths)
+}
+
+type ServerLintRequest struct {
+	Definitions []jobdef.Definition `json:"definitions"`
+}
+
+type ServerLintMessage struct {
+	Message string `json:"message"`
+	Line    int    `json:"line,omitempty"`
+}
+
+type ServerLintSummary struct {
+	Steps     int    `json:"steps"`
+	Contracts string `json:"contracts,omitempty"`
+}
+
+type ServerLintResponse struct {
+	Errors    []ServerLintMessage    `json:"errors"`
+	Warnings  []ServerLintMessage    `json:"warnings"`
+	Summary   ServerLintSummary      `json:"summary"`
+	Contracts *ServerContractSummary `json:"contracts,omitempty"`
+}
+
+type ServerContractSummary struct {
+	Breaking []ServerContractFinding `json:"breaking"`
+	Warnings []ServerContractFinding `json:"warnings"`
+	Edges    int                     `json:"edges"`
+}
+
+type ServerContractFinding struct {
+	EdgeID    string            `json:"edgeId,omitempty"`
+	EdgeClass string            `json:"edgeClass,omitempty"`
+	From      string            `json:"from,omitempty"`
+	To        string            `json:"to,omitempty"`
+	Dataset   *ServerDatasetRef `json:"dataset,omitempty"`
+	Kind      string            `json:"kind,omitempty"`
+	Path      string            `json:"path,omitempty"`
+	Detail    string            `json:"detail,omitempty"`
+	Verdict   string            `json:"verdict"`
+}
+
+type ServerDatasetRef struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+func runServerLint(cmd *cobra.Command, defs []jobdef.Definition) error {
+	server := strings.TrimSuffix(lintServer, "/")
+	apiKey := cliutil.ResolveAPIKey(cmd, lintAPIKey, cliutil.APIKeyEnvVar)
+	if err := ensureContractLintEnabled(cmd.Context(), server, apiKey); err != nil {
+		return err
+	}
+
+	resp, body, err := PostServerLint(cmd.Context(), server, apiKey, defs)
+	if err != nil {
+		return err
+	}
+	if lintJSON {
+		if err := cliutil.WritePrettyJSON(cmd, body, "job lint response"); err != nil {
+			return err
+		}
+	} else if err := renderServerLintResponse(cmd, resp); err != nil {
+		return err
+	}
+
+	if len(resp.Errors) > 0 {
+		return fmt.Errorf("server lint failed: %s", joinServerLintMessages(resp.Errors))
+	}
+	if resp.Contracts == nil {
+		return fmt.Errorf("server lint did not include contract findings; set CAESIUM_CONTRACT_ENFORCEMENT=fail (or warn) on the server")
+	}
+	if len(resp.Contracts.Breaking) > 0 {
+		return fmt.Errorf("server lint found %d breaking contract finding(s)", len(resp.Contracts.Breaking))
+	}
+	return nil
+}
+
+func PostServerLint(ctx context.Context, server, apiKey string, defs []jobdef.Definition) (*ServerLintResponse, []byte, error) {
+	payload, err := json.Marshal(ServerLintRequest{Definitions: defs})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(server, "/")+"/v1/jobdefs/lint", bytes.NewReader(payload))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := lintHTTPClient.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading job lint response: %w", err)
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return nil, nil, fmt.Errorf("job lint failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var lintResp ServerLintResponse
+	if err := json.Unmarshal(body, &lintResp); err != nil {
+		return nil, nil, fmt.Errorf("job lint response was not valid JSON: %w", err)
+	}
+	return &lintResp, body, nil
+}
+
+type serverFeaturesResponse struct {
+	ContractEnforcementEnabled bool `json:"contract_enforcement_enabled"`
+}
+
+func ensureContractLintEnabled(ctx context.Context, server, apiKey string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimSuffix(server, "/")+"/v1/system/features", nil)
+	if err != nil {
+		return err
+	}
+	if apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := lintHTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("reading system features response: %w", err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("contract enforcement feature status is unavailable; set CAESIUM_CONTRACT_ENFORCEMENT=fail (or warn) on the Caesium server and restart it")
+	}
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("system features failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var features serverFeaturesResponse
+	if err := json.Unmarshal(body, &features); err != nil {
+		return fmt.Errorf("system features response was not valid JSON: %w", err)
+	}
+	if !features.ContractEnforcementEnabled {
+		return fmt.Errorf("contract enforcement is disabled on the server; set CAESIUM_CONTRACT_ENFORCEMENT=fail (or warn) and restart it")
+	}
+	return nil
+}
+
+func renderServerLintResponse(cmd *cobra.Command, resp *ServerLintResponse) error {
+	if len(resp.Errors) > 0 {
+		if err := writeCmdOut(cmd, "Errors:\n"); err != nil {
+			return err
+		}
+		for _, msg := range resp.Errors {
+			if err := writeCmdOut(cmd, "  - %s\n", msg.Message); err != nil {
+				return err
+			}
+		}
+	}
+	if len(resp.Warnings) > 0 {
+		if err := writeCmdOut(cmd, "Warnings:\n"); err != nil {
+			return err
+		}
+		for _, msg := range resp.Warnings {
+			if err := writeCmdOut(cmd, "  - %s\n", msg.Message); err != nil {
+				return err
+			}
+		}
+	}
+	if len(resp.Errors) == 0 {
+		if err := writeCmdOut(cmd, "Validated %d step(s) against server state\n", resp.Summary.Steps); err != nil {
+			return err
+		}
+		if resp.Summary.Contracts != "" {
+			if err := writeCmdOut(cmd, "Declared data contracts: %s\n", resp.Summary.Contracts); err != nil {
+				return err
+			}
+		}
+	}
+	return renderServerContractSummary(cmd, resp.Contracts)
+}
+
+func renderServerContractSummary(cmd *cobra.Command, summary *ServerContractSummary) error {
+	if summary == nil {
+		return writeCmdOut(cmd, "Contracts: not reported; set CAESIUM_CONTRACT_ENFORCEMENT=fail (or warn) on the server.\n")
+	}
+	if err := writeCmdOut(cmd, "Contracts: %d edge(s), %d breaking, %d warning(s)\n", summary.Edges, len(summary.Breaking), len(summary.Warnings)); err != nil {
+		return err
+	}
+	if len(summary.Breaking) > 0 {
+		if err := writeCmdOut(cmd, "Breaking:\n"); err != nil {
+			return err
+		}
+		if err := writeServerContractFindings(cmd, summary.Breaking); err != nil {
+			return err
+		}
+	}
+	if len(summary.Warnings) > 0 {
+		if err := writeCmdOut(cmd, "Warnings:\n"); err != nil {
+			return err
+		}
+		if err := writeServerContractFindings(cmd, summary.Warnings); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeServerContractFindings(cmd *cobra.Command, findings []ServerContractFinding) error {
+	for _, finding := range findings {
+		if err := writeCmdOut(cmd, "  - %s -> %s [%s] %s %s: %s\n",
+			dashIfEmpty(finding.From),
+			dashIfEmpty(finding.To),
+			dashIfEmpty(finding.EdgeClass),
+			dashIfEmpty(finding.Kind),
+			dashIfEmpty(finding.Path),
+			dashIfEmpty(finding.Detail),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func joinServerLintMessages(messages []ServerLintMessage) string {
+	parts := make([]string, 0, len(messages))
+	for _, msg := range messages {
+		parts = append(parts, msg.Message)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func dashIfEmpty(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+	return value
 }
 
 func writeLintTriggerScopeNote(cmd *cobra.Command) error {

--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -309,7 +309,7 @@ Reuses the existing `api/rest/controller/jobdef/` controllers — do NOT fork th
       denial for `/v1/contracts/graph`, `caesium_contract_findings_total{verdict}`,
       and an integration scenario that applies a producer/consumer pair, reads the
       real graph endpoint, and verifies the feature flag.
-- [ ] D2. Add the `caesium contract` Cobra group — `caesium contract graph
+- [x] D2. Add the `caesium contract` Cobra group — `caesium contract graph
       [--dataset ns/name] [--json]` (GET `/v1/contracts/graph`) and `caesium contract
       check --path jobs/ [--json]` (server-mode contract lint) — appended to the
       `cmds` slice in `cmd/execute.go` (after `cache.Cmd`); add a `--server` flag to
@@ -320,6 +320,17 @@ Reuses the existing `api/rest/controller/jobdef/` controllers — do NOT fork th
       parseable output to **stdout** via `cmd.OutOrStdout()`.
       Files: new `cmd/contract/`, `cmd/execute.go`, `cmd/job/lint.go`.
       Depends on: D1.
+      Note: W3-delta added the `caesium contract` group with `graph` and `check`
+      verbs, feature-probing `GET /v1/system/features` and failing with
+      `CAESIUM_CONTRACT_ENFORCEMENT` guidance when the gate is off. `graph --json`
+      emits the raw graph response; human graph output renders nodes and edges with
+      classes/verdicts. `check --path ... [--json]` reuses the job lint manifest
+      loader, POSTs to `/v1/jobdefs/lint`, renders only the contract findings block,
+      and exits non-zero on breaking findings. `job lint --server[=<url>] [--json]`
+      now posts to server-side lint while offline lint remains the default nil-DB
+      path; JSON uses `cmd.OutOrStdout()`. Added split-stream integration scenarios in
+      `test/contract_cli_test.go` for graph JSON, server lint JSON, and breaking
+      contract-check exit behavior.
 
 ### Stream E — Datasets `schema`/`schemaFrom` declarations
 

--- a/test/contract_cli_test.go
+++ b/test/contract_cli_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func (s *IntegrationTestSuite) TestContractGraphCLIJSONReportsInferredEdge() {
+	suffix := time.Now().UnixNano()
+	producer := fmt.Sprintf("integration-contract-cli-producer-%d", suffix)
+	consumer := fmt.Sprintf("integration-contract-cli-consumer-%d", suffix)
+
+	dir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"customer_id", "row_count"}),
+		consumer: contractConsumerManifest(consumer, producer, "reporting", "customer", "customer_id"),
+	})
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	stdout, err := s.runCLIStdout("contract", "graph", "--json", "--server", s.caesiumURL)
+	s.Require().NoError(err)
+
+	var graph contractGraphResponse
+	s.Require().NoError(json.Unmarshal([]byte(stdout), &graph))
+	s.Require().NotNil(contractCLIInferredEdge(graph, producer, consumer))
+}
+
+func (s *IntegrationTestSuite) TestJobLintServerJSONReportsContractFinding() {
+	suffix := time.Now().UnixNano()
+	producer := fmt.Sprintf("integration-contract-lint-producer-%d", suffix)
+	consumer := fmt.Sprintf("integration-contract-lint-consumer-%d", suffix)
+
+	dir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"customer_id", "row_count"}),
+		consumer: contractConsumerManifest(consumer, producer, "reporting", "customer", "customer_id"),
+	})
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	brokenDir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"row_count"}),
+	})
+	defer os.RemoveAll(brokenDir)
+
+	stdout, err := s.runCLIStdout("job", "lint", "--path", brokenDir, "--server", s.caesiumURL, "--json")
+	s.Require().Error(err)
+
+	var lintResp contractCLILintResponse
+	s.Require().NoError(json.Unmarshal([]byte(stdout), &lintResp))
+	s.Require().NotNil(lintResp.Contracts)
+	s.True(contractCLIFindingsNameConsumer(lintResp.Contracts.Breaking, consumer), "expected breaking finding naming %s in %+v", consumer, lintResp.Contracts.Breaking)
+}
+
+func (s *IntegrationTestSuite) TestContractCheckFailsOnBreakingLocalChange() {
+	suffix := time.Now().UnixNano()
+	producer := fmt.Sprintf("integration-contract-check-producer-%d", suffix)
+	consumer := fmt.Sprintf("integration-contract-check-consumer-%d", suffix)
+
+	dir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"customer_id", "row_count"}),
+		consumer: contractConsumerManifest(consumer, producer, "reporting", "customer", "customer_id"),
+	})
+	defer os.RemoveAll(dir)
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+
+	brokenDir := s.writeContractManifests(map[string]string{
+		producer: contractProducerManifest(producer, []string{"row_count"}),
+	})
+	defer os.RemoveAll(brokenDir)
+
+	output, err := s.runCLIExpectError("contract", "check", "--path", brokenDir, "--server", s.caesiumURL)
+	s.Require().Error(err)
+	s.Contains(output, consumer)
+	s.Contains(output, "customer_id")
+}
+
+type contractCLILintResponse struct {
+	Contracts *contractCLIContractSummary `json:"contracts,omitempty"`
+}
+
+type contractCLIContractSummary struct {
+	Breaking []contractCLIContractFinding `json:"breaking"`
+	Warnings []contractCLIContractFinding `json:"warnings"`
+	Edges    int                          `json:"edges"`
+}
+
+type contractCLIContractFinding struct {
+	From    string `json:"from"`
+	To      string `json:"to"`
+	Detail  string `json:"detail"`
+	Verdict string `json:"verdict"`
+}
+
+func contractCLIInferredEdge(graph contractGraphResponse, producer, consumer string) *contractGraphEdge {
+	for i := range graph.Edges {
+		edge := &graph.Edges[i]
+		if edge.From == "job:"+producer && edge.To == "job:"+consumer && edge.Class == "inferred" {
+			return edge
+		}
+	}
+	return nil
+}
+
+func contractCLIFindingsNameConsumer(findings []contractCLIContractFinding, consumer string) bool {
+	for _, finding := range findings {
+		if strings.Contains(finding.To, consumer) || strings.Contains(finding.Detail, consumer) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
D2 of the contract-enforcement plan — the CLI operator surface:

- `caesium contract graph [--dataset ns/name] [--json]` — renders the derived graph (nodes + edges with class/verdict/findings); `--json` emits the raw endpoint response to a clean stdout.
- `caesium contract check --path jobs/ [--json]` — server-mode contract lint of local definitions; exits non-zero on breaking findings so CI can gate producer PRs.
- `caesium job lint --server` — POSTs to `/v1/jobdefs/lint` and reports contract findings against the persisted world; the offline nil-DB path stays the default.
- Enforcement-unset servers fail with actionable guidance naming `CAESIUM_CONTRACT_ENFORCEMENT` (feature-flag probe).
- Integration scenarios (`test/contract_cli_test.go`, reusing C1's fixtures): graph `--json` stdout parses + inferred edge present; `job lint --server --json` clean stdout with a persisted-world finding; `contract check` non-zero naming the consumer. All captured via `runCLIStdout` split-stream.

## Test plan
- [x] gofmt; host vet blocked at the known dqlite CGO boundary (cmd → server packages).
- [ ] Full matrix + CLI integration scenarios — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
