### PR TITLE
Add the Console contract graph view (contract-enforcement W3-ζ)

### DIFF
--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -353,7 +353,7 @@ The Console surface, shipped after the REST reads (mirrors the data-plane-memory
 precedent: backend REST/CLI first, UI consumes it). New feature dir gated by the
 `ContractEnforcementEnabled` feature flag.
 
-- [ ] F1. Add the contract graph view rendering `GET /v1/contracts/graph`, reusing
+- [x] F1. Add the contract graph view rendering `GET /v1/contracts/graph`, reusing
       the existing `ui/src/features/jobs/LineageGraph.tsx` renderer (nodes:
       jobs/datasets; edge styling by class: declared / inferred / evidence); add the
       route in `ui/src/router.tsx`, the API method in `ui/src/lib/api.ts`, a nav
@@ -362,6 +362,12 @@ precedent: backend REST/CLI first, UI consumes it). New feature dir gated by the
       Files: new `ui/src/features/contracts/`, `ui/src/router.tsx`,
       `ui/src/lib/api.ts`, `ui/src/components/layout/Sidebar.tsx`.
       Depends on: D1.
+      Note: W3-ζ added the `/contracts` Console route, `Contracts` sidebar nav,
+      typed `getContractGraph({dataset})` API, feature-off not-found handling,
+      empty-state copy, class/verdict legend and edge styling, job-node SPA links
+      resolved through `/jobs`, vitest coverage, and `ui/e2e/contracts.spec.ts`.
+      Local proof: `npm run lint`, `npm run build`, and focused `npx vitest run`
+      for the contracts component plus API tests pass.
 - [ ] F2. Add contract badges to the JobDefs diff tab: extend
       `ui/src/features/jobdefs/JobDefsPage.tsx` (which already lints then diffs pasted
       YAML) so its diff tab renders breaking/compatible/unknown badges per edge from

--- a/ui/e2e/contracts.spec.ts
+++ b/ui/e2e/contracts.spec.ts
@@ -1,0 +1,176 @@
+import { expect, test, type APIRequestContext } from "@playwright/test";
+import { applyDefinitions, findJobByAlias, type FixtureDefinition } from "./helpers/fixtures";
+
+type ContractFixtureDefinition = Omit<FixtureDefinition, "trigger"> & {
+  apiVersion: string;
+  kind: string;
+  trigger: {
+    type: string;
+    configuration: Record<string, unknown>;
+  };
+  steps: Array<{
+    name: string;
+    engine: string;
+    image: string;
+    command: string[];
+    outputSchema?: Record<string, unknown>;
+  }>;
+};
+
+type ContractGraphResponse = {
+  nodes: Array<{
+    id: string;
+    kind: string;
+    alias?: string;
+  }>;
+  edges: ContractGraphEdge[];
+};
+
+type ContractGraphEdge = {
+  id: string;
+  from: string;
+  to: string;
+  class: string;
+  verdict?: string;
+};
+
+const shellImage = "alpine:3.23";
+
+test("operator can inspect the feature-gated contract graph", async ({ page, request }) => {
+  const suffix = Date.now().toString(36);
+  const producerAlias = `contract-ui-producer-${suffix}`;
+  const consumerAlias = `contract-ui-consumer-${suffix}`;
+
+  await applyDefinitions(
+    request,
+    buildProducerDefinition(producerAlias),
+    buildConsumerDefinition(consumerAlias, producerAlias),
+  );
+  const producer = await findJobByAlias(request, producerAlias);
+  const consumer = await findJobByAlias(request, consumerAlias);
+  const edge = await waitForContractEdge(request, producerAlias, consumerAlias);
+
+  await page.goto("/contracts");
+
+  await expect(page.locator("aside").getByRole("link", { name: /^Contracts\b/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Contract graph", exact: true })).toBeVisible();
+  await expect(page.getByTestId(`contract-node:job:${producerAlias}`)).toContainText(producerAlias);
+  await expect(page.getByTestId(`contract-node:job:${producerAlias}`)).toHaveAttribute("href", `/jobs/${producer.id}`);
+  await expect(page.getByTestId(`contract-node:job:${consumerAlias}`)).toContainText(consumerAlias);
+  await expect(page.getByTestId(`contract-node:job:${consumerAlias}`)).toHaveAttribute("href", `/jobs/${consumer.id}`);
+
+  const edgeLabel = page.getByTestId(contractEdgeTestId(edge));
+  await expect(edgeLabel).toBeVisible();
+  await expect(edgeLabel).toHaveAttribute("data-edge-class", "inferred");
+  await expect(edgeLabel).toHaveAttribute("data-edge-verdict", "compatible");
+});
+
+function buildProducerDefinition(alias: string): ContractFixtureDefinition {
+  return {
+    apiVersion: "v1",
+    kind: "Job",
+    metadata: {
+      alias,
+    },
+    trigger: {
+      type: "cron",
+      configuration: {
+        cron: "0 2 * * *",
+        timezone: "UTC",
+      },
+    },
+    steps: [
+      {
+        name: "export",
+        engine: "docker",
+        image: shellImage,
+        outputSchema: {
+          type: "object",
+          required: ["row_count"],
+          properties: {
+            row_count: { type: "integer" },
+          },
+        },
+        command: ["sh", "-c", "echo export"],
+      },
+    ],
+  };
+}
+
+function buildConsumerDefinition(alias: string, producerAlias: string): ContractFixtureDefinition {
+  return {
+    apiVersion: "v1",
+    kind: "Job",
+    metadata: {
+      alias,
+    },
+    trigger: {
+      type: "event",
+      configuration: {
+        events: [
+          {
+            type: "run_completed",
+            source: "caesium",
+            filter: {
+              job_alias: producerAlias,
+            },
+          },
+        ],
+        paramMapping: {
+          upstream_rows: "$.tasks[0].output.row_count",
+        },
+      },
+    },
+    steps: [
+      {
+        name: "load",
+        engine: "docker",
+        image: shellImage,
+        command: ["sh", "-c", "echo load"],
+      },
+    ],
+  };
+}
+
+async function waitForContractEdge(
+  request: APIRequestContext,
+  producerAlias: string,
+  consumerAlias: string,
+): Promise<ContractGraphEdge> {
+  let latest: ContractGraphResponse | undefined;
+  const expected = `job:${producerAlias}|job:${consumerAlias}|inferred|compatible`;
+
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get("/v1/contracts/graph");
+        if (!response.ok()) {
+          return "";
+        }
+        latest = (await response.json()) as ContractGraphResponse;
+        return latest.edges
+          .map((edge) => `${edge.from}|${edge.to}|${edge.class}|${edge.verdict ?? ""}`)
+          .join("\n");
+      },
+      {
+        timeout: 15_000,
+        intervals: [500, 1_000, 2_000],
+      },
+    )
+    .toContain(expected);
+
+  const edge = latest?.edges.find(
+    (candidate) =>
+      candidate.from === `job:${producerAlias}` &&
+      candidate.to === `job:${consumerAlias}` &&
+      candidate.class === "inferred",
+  );
+  if (!edge) {
+    throw new Error(`contract graph did not return edge ${expected}`);
+  }
+  return edge;
+}
+
+function contractEdgeTestId(edge: ContractGraphEdge): string {
+  return `contract-edge:${edge.class}:${edge.id}`;
+}

--- a/ui/e2e/contracts.spec.ts
+++ b/ui/e2e/contracts.spec.ts
@@ -163,7 +163,8 @@ async function waitForContractEdge(
     (candidate) =>
       candidate.from === `job:${producerAlias}` &&
       candidate.to === `job:${consumerAlias}` &&
-      candidate.class === "inferred",
+      candidate.class === "inferred" &&
+      candidate.verdict === "compatible",
   );
   if (!edge) {
     throw new Error(`contract graph did not return edge ${expected}`);

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   LayoutDashboard,
   Radio,
   Server,
+  ShieldCheck,
   Siren,
   type LucideIcon,
 } from "lucide-react";
@@ -82,6 +83,7 @@ export function Sidebar() {
   });
   const incidentsEnabled = features?.agent_remediation_enabled === true;
   const freshnessEnabled = features?.freshness_enabled === true;
+  const contractEnforcementEnabled = features?.contract_enforcement_enabled === true;
 
   const { data: incidentNav } = useQuery({
     queryKey: ["incidents", "nav"],
@@ -117,6 +119,9 @@ export function Sidebar() {
     { to: "/atoms", label: "Atoms", icon: Database, count: counts.atoms },
     ...(freshnessEnabled
       ? [{ to: "/datasets", label: "Datasets", icon: GitBranch, count: null }]
+      : []),
+    ...(contractEnforcementEnabled
+      ? [{ to: "/contracts", label: "Contracts", icon: ShieldCheck, count: null }]
       : []),
     ...(incidentsEnabled
       ? [{ to: "/incidents", label: "Incidents", icon: Siren, count: activeIncidentCount }]

--- a/ui/src/features/contracts/ContractGraphPage.tsx
+++ b/ui/src/features/contracts/ContractGraphPage.tsx
@@ -1,0 +1,537 @@
+import { type FormEvent, memo, useMemo, useState } from "react";
+import { Link, useNavigate, useSearch } from "@tanstack/react-router";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import ReactFlow, {
+  Background,
+  BaseEdge,
+  Controls,
+  EdgeLabelRenderer,
+  Handle,
+  Position,
+  getSmoothStepPath,
+  type EdgeProps,
+  type NodeProps,
+} from "reactflow";
+import "reactflow/dist/style.css";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Database,
+  GitBranch,
+  RefreshCw,
+  Search,
+  ShieldAlert,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/empty-state";
+import { NotFoundState } from "@/components/not-found-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ApiError, api } from "@/lib/api";
+import { cn, formatUTCTimestamp, shortId } from "@/lib/utils";
+import {
+  buildContractFlow,
+  cleanDatasetFilter,
+  contractNodeTestId,
+  type ContractFlowEdgeData,
+  type ContractFlowNodeData,
+} from "./contractGraphModel";
+
+type ContractSearch = {
+  dataset?: string;
+};
+
+export function ContractGraphPage() {
+  const navigate = useNavigate();
+  const search = useSearch({ strict: false }) as ContractSearch;
+  const dataset = typeof search.dataset === "string" ? search.dataset : "";
+
+  return (
+    <ContractGraph
+      key={dataset}
+      initialDataset={dataset}
+      onDatasetSubmit={(nextDataset) => {
+        void navigate({
+          to: "/contracts",
+          search: { dataset: cleanDatasetFilter(nextDataset) },
+        });
+      }}
+    />
+  );
+}
+
+export function ContractGraph({
+  initialDataset,
+  onDatasetSubmit,
+}: {
+  initialDataset: string;
+  onDatasetSubmit: (dataset: string) => void;
+}) {
+  const queryClient = useQueryClient();
+  const datasetFilter = cleanDatasetFilter(initialDataset);
+  const [datasetInput, setDatasetInput] = useState(initialDataset);
+
+  const featuresQuery = useQuery({
+    queryKey: ["system-features"],
+    queryFn: api.getSystemFeatures,
+    staleTime: 60_000,
+  });
+  const contractEnabled = featuresQuery.data?.contract_enforcement_enabled === true;
+
+  const graphQuery = useQuery({
+    queryKey: ["contracts", "graph", datasetFilter ?? ""],
+    queryFn: () => api.getContractGraph({ dataset: datasetFilter }),
+    enabled: contractEnabled,
+  });
+
+  const jobsQuery = useQuery({
+    queryKey: ["jobs"],
+    queryFn: api.getJobs,
+    enabled: contractEnabled,
+    staleTime: 30_000,
+  });
+
+  const jobIdsByAlias = useMemo(() => {
+    const map = new Map<string, string>();
+    (jobsQuery.data ?? []).forEach((job) => {
+      map.set(job.alias, job.id);
+    });
+    return map;
+  }, [jobsQuery.data]);
+
+  const graph = useMemo(() => {
+    if (!graphQuery.data) {
+      return { nodes: [], edges: [] };
+    }
+    return buildContractFlow(graphQuery.data, jobIdsByAlias);
+  }, [graphQuery.data, jobIdsByAlias]);
+
+  const findingCount = useMemo(
+    () => (graphQuery.data?.edges ?? []).reduce((total, edge) => total + (edge.findings?.length ?? 0), 0),
+    [graphQuery.data?.edges],
+  );
+
+  function applyDatasetFilter(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    onDatasetSubmit(datasetInput);
+  }
+
+  if (featuresQuery.isLoading) {
+    return <ContractGraphSkeleton />;
+  }
+
+  if (featuresQuery.error) {
+    return (
+      <EmptyState
+        title="Contract features unavailable"
+        subtitle={featuresQuery.error instanceof Error ? featuresQuery.error.message : "The system feature endpoint returned an error."}
+        icon={<AlertTriangle className="h-12 w-12 text-danger" />}
+      />
+    );
+  }
+
+  if (!contractEnabled) {
+    return (
+      <NotFoundState
+        title="Contracts disabled"
+        subtitle="Contract enforcement is not enabled on this Caesium server."
+      />
+    );
+  }
+
+  if (graphQuery.error) {
+    if (graphQuery.error instanceof ApiError && graphQuery.error.status === 404) {
+      return (
+        <NotFoundState
+          title="Contracts disabled"
+          subtitle="The contract graph endpoint is not available on this Caesium server."
+        />
+      );
+    }
+
+    return (
+      <div className="space-y-5" data-testid="contracts-page">
+        <ContractBreadcrumb />
+        <ContractHeader onRefresh={() => queryClient.invalidateQueries({ queryKey: ["contracts"] })} />
+        <DatasetFilterForm
+          datasetInput={datasetInput}
+          onDatasetInput={setDatasetInput}
+          onSubmit={applyDatasetFilter}
+        />
+        <EmptyState
+          title="Contract graph unavailable"
+          subtitle={graphQuery.error instanceof Error ? graphQuery.error.message : "The contract graph endpoint returned an error."}
+          icon={<AlertTriangle className="h-12 w-12 text-danger" />}
+        />
+      </div>
+    );
+  }
+
+  const hasEdges = (graphQuery.data?.edges.length ?? 0) > 0;
+
+  return (
+    <div className="space-y-5" data-testid="contracts-page">
+      <ContractBreadcrumb />
+      <ContractHeader onRefresh={() => queryClient.invalidateQueries({ queryKey: ["contracts"] })} />
+      <DatasetFilterForm
+        datasetInput={datasetInput}
+        onDatasetInput={setDatasetInput}
+        onSubmit={applyDatasetFilter}
+      />
+
+      {graphQuery.isLoading ? (
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-[260px]" />
+          <Skeleton className="h-[560px] w-full" />
+        </div>
+      ) : null}
+
+      {graphQuery.data && !hasEdges ? (
+        <div data-testid="contracts-empty-state">
+          <EmptyState
+            title="No contract edges yet"
+            subtitle="Contracts appear when job definitions declare dataset schemas or when lifecycle paramMapping chains infer producer and consumer relationships."
+            icon={<ShieldAlert className="h-12 w-12 text-text-3" />}
+          />
+        </div>
+      ) : null}
+
+      {graphQuery.data && hasEdges ? (
+        <>
+          <div className="grid gap-3 md:grid-cols-4">
+            <MetadataCell label="Nodes" value={String(graphQuery.data.nodes.length)} />
+            <MetadataCell label="Edges" value={String(graphQuery.data.edges.length)} />
+            <MetadataCell label="Findings" value={String(findingCount)} />
+            <MetadataCell label="Filter" value={datasetFilter ?? "all datasets"} />
+          </div>
+          <ContractLegend />
+          <div
+            className="relative h-[620px] min-h-[520px] w-full overflow-hidden rounded-lg bg-dag-bg"
+            data-testid="contracts-graph"
+          >
+            <ReactFlow
+              nodes={graph.nodes}
+              edges={graph.edges}
+              nodeTypes={nodeTypes}
+              edgeTypes={edgeTypes}
+              fitView
+              fitViewOptions={{ padding: 0.2 }}
+              minZoom={0.1}
+              maxZoom={1.5}
+            >
+              <Background gap={20} />
+              <Controls />
+            </ReactFlow>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function ContractGraphSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-5 w-32" />
+      <Skeleton className="h-10 w-80" />
+      <Skeleton className="h-24 w-full" />
+      <Skeleton className="h-[560px] w-full" />
+    </div>
+  );
+}
+
+function ContractHeader({ onRefresh }: { onRefresh: () => void }) {
+  return (
+    <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+      <div className="min-w-0">
+        <div className="mb-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-text-3">
+          Contracts
+        </div>
+        <h1 className="text-xl font-semibold tracking-tight text-text-1">Contract graph</h1>
+      </div>
+      <Button type="button" variant="outline" size="sm" onClick={onRefresh}>
+        <RefreshCw className="h-3.5 w-3.5" />
+        Refresh
+      </Button>
+    </div>
+  );
+}
+
+function ContractBreadcrumb() {
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-text-3">
+      <Link
+        to="/jobs"
+        className="flex items-center gap-1 transition-colors hover:text-text-2"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        Jobs
+      </Link>
+      <span className="text-text-4">/</span>
+      <span>Contracts</span>
+    </div>
+  );
+}
+
+function DatasetFilterForm({
+  datasetInput,
+  onDatasetInput,
+  onSubmit,
+}: {
+  datasetInput: string;
+  onDatasetInput: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <Card className="border-graphite/40 bg-midnight/30">
+      <CardHeader className="border-b border-border/50 pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm">
+          <Search className="h-4 w-4 text-cyan-glow" />
+          Dataset filter
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-4">
+        <form className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]" onSubmit={onSubmit}>
+          <label htmlFor="contract-dataset-filter" className="space-y-1.5">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-text-3">
+              Dataset
+            </span>
+            <input
+              id="contract-dataset-filter"
+              value={datasetInput}
+              placeholder="lake/customers"
+              data-testid="contract-dataset-filter"
+              onChange={(event) => onDatasetInput(event.target.value)}
+              className="h-9 w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm text-foreground shadow-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-primary focus:ring-1 focus:ring-ring"
+            />
+          </label>
+          <div className="flex items-end">
+            <Button type="submit" size="sm" className="h-9 w-full md:w-auto" data-testid="contract-filter-submit">
+              <Search className="h-3.5 w-3.5" />
+              Apply
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function MetadataCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-border/60 bg-card px-3 py-2">
+      <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-text-3">
+        {label}
+      </div>
+      <div className="mt-1 truncate font-mono text-xs text-text-1" title={value}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function ContractLegend() {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-3 rounded-md border border-border/60 bg-card/70 px-3 py-2 text-xs text-text-3"
+      data-testid="contract-legend"
+    >
+      <LegendLine label="Declared" className="border-success" />
+      <LegendLine label="Inferred" className="border-warning border-dashed" />
+      <LegendLine label="Evidence" className="border-text-4 border-dotted opacity-70" />
+      <span className="hidden h-4 w-px bg-border/70 sm:inline-block" aria-hidden="true" />
+      <LegendVerdict label="Breaking" className="border-danger/35 bg-danger/10 text-danger" />
+      <LegendVerdict label="Unknown" className="border-warning/35 bg-warning/10 text-warning" />
+      <LegendVerdict label="Compatible" className="border-success/35 bg-success/10 text-success" />
+    </div>
+  );
+}
+
+function LegendLine({ label, className }: { label: string; className: string }) {
+  return (
+    <span className="inline-flex items-center gap-2">
+      <span className={cn("inline-block w-10 border-t-2", className)} />
+      {label}
+    </span>
+  );
+}
+
+function LegendVerdict({ label, className }: { label: string; className: string }) {
+  return <span className={cn("rounded border px-2 py-0.5 text-[10px] font-semibold", className)}>{label}</span>;
+}
+
+const ContractNode = memo(({ data }: NodeProps<ContractFlowNodeData>) => {
+  const isJob = data.kind === "job";
+  const testId = contractNodeTestId(data);
+  const className = cn(
+    "relative block h-[138px] w-[300px] overflow-hidden rounded-lg border-2 px-4 py-3 text-left shadow-sm transition-colors",
+    isJob
+      ? "border-caesium-cyan/45 bg-[linear-gradient(155deg,hsl(var(--caesium-cyan)/0.16),hsl(var(--node-surface)/0.96)_62%)]"
+      : "border-gold/45 bg-[linear-gradient(155deg,hsl(var(--gold)/0.16),hsl(var(--node-surface)/0.96)_62%)]",
+    isJob && data.jobId ? "cursor-pointer hover:border-caesium-cyan/80" : "",
+  );
+  const body = (
+    <>
+      <Handle
+        type="target"
+        position={Position.Left}
+        className={cn("h-3 w-3 border-2 border-dag-bg", isJob ? "bg-caesium-cyan" : "bg-gold")}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className={cn("h-3 w-3 border-2 border-dag-bg", isJob ? "bg-caesium-cyan" : "bg-gold")}
+      />
+      <div className="flex h-full flex-col justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            {isJob ? (
+              <GitBranch className="h-4 w-4 shrink-0 text-running" />
+            ) : (
+              <Database className="h-4 w-4 shrink-0 text-gold" />
+            )}
+            <Badge variant="outline" className="text-[10px]">
+              {isJob ? "Job" : "Dataset"}
+            </Badge>
+          </div>
+          <div className="mt-3 truncate font-mono text-sm font-semibold text-text-1" title={data.label}>
+            {data.label}
+          </div>
+          <div className="mt-1 truncate text-[11px] text-text-3" title={data.detail}>
+            {data.detail}
+          </div>
+        </div>
+        <div className="truncate font-mono text-[10px] text-text-4" title={data.id}>
+          {shortId(data.id, 28)}
+        </div>
+      </div>
+    </>
+  );
+
+  if (isJob && data.jobId) {
+    return (
+      <Link
+        to="/jobs/$jobId"
+        params={{ jobId: data.jobId }}
+        data-testid={testId}
+        data-node-kind={data.kind}
+        data-job-alias={data.alias ?? data.label}
+        data-job-id={data.jobId}
+        className={className}
+        title={`Open job ${data.label}`}
+      >
+        {body}
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      data-testid={testId}
+      data-node-kind={data.kind}
+      data-job-alias={data.alias}
+      data-dataset-name={data.dataset?.name}
+      data-dataset-namespace={data.dataset?.namespace}
+      className={className}
+      title={data.label}
+    >
+      {body}
+    </div>
+  );
+});
+
+ContractNode.displayName = "ContractNode";
+
+const ContractEdge = memo(({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style,
+  markerEnd,
+  data,
+}: EdgeProps<ContractFlowEdgeData>) => {
+  const [edgePath, labelX, labelY] = getSmoothStepPath({
+    sourceX,
+    sourceY,
+    targetX,
+    targetY,
+    sourcePosition,
+    targetPosition,
+    borderRadius: 16,
+  });
+  const verdict = data?.verdict ?? "unknown";
+  const findingLabel = data?.findingCount ? `${data.findingCount} finding${data.findingCount === 1 ? "" : "s"}` : "no findings";
+
+  return (
+    <>
+      <BaseEdge id={id} path={edgePath} style={style} markerEnd={markerEnd} />
+      <EdgeLabelRenderer>
+        <div
+          data-testid={data?.testId ?? `contract-edge:${id}`}
+          data-edge-id={id}
+          data-edge-class={data?.edgeClass}
+          data-edge-verdict={verdict}
+          data-edge-source={data?.sourceLabel}
+          data-edge-target={data?.targetLabel}
+          className={cn(
+            "nodrag nopan max-w-[220px] rounded-full border bg-card/95 px-2 py-1 text-[10px] font-semibold shadow-sm",
+            edgeLabelClass(data?.edgeClass, verdict),
+          )}
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+          }}
+          title={edgeTitle(data, findingLabel)}
+        >
+          <span className="uppercase">{data?.edgeClass ?? "edge"}</span>
+          <span className="text-text-4"> · </span>
+          <span>{data?.edgeClass === "evidence" ? "observed" : verdict}</span>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+});
+
+ContractEdge.displayName = "ContractEdge";
+
+const nodeTypes = {
+  contract: ContractNode,
+};
+
+const edgeTypes = {
+  contract: ContractEdge,
+};
+
+function edgeLabelClass(edgeClass: string | undefined, verdict: string) {
+  if (edgeClass === "evidence") {
+    return "border-text-4/40 text-text-3";
+  }
+  switch (verdict) {
+    case "breaking":
+      return "border-danger/35 bg-danger/10 text-danger";
+    case "unknown":
+      return "border-warning/35 bg-warning/10 text-warning";
+    case "compatible":
+      return "border-success/35 bg-success/10 text-success";
+    default:
+      return "border-text-3/30 text-text-3";
+  }
+}
+
+function edgeTitle(data: ContractFlowEdgeData | undefined, findingLabel: string) {
+  if (!data) {
+    return findingLabel;
+  }
+  const parts = [
+    `${data.sourceLabel} -> ${data.targetLabel}`,
+    data.datasetLabel ? `dataset ${data.datasetLabel}` : undefined,
+    data.lastSeen ? `last seen ${formatUTCTimestamp(data.lastSeen, data.lastSeen)}` : undefined,
+    findingLabel,
+  ];
+  return parts.filter(Boolean).join(" | ");
+}

--- a/ui/src/features/contracts/__tests__/ContractGraphPage.test.tsx
+++ b/ui/src/features/contracts/__tests__/ContractGraphPage.test.tsx
@@ -1,0 +1,218 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ContractGraph } from "../ContractGraphPage";
+import { api } from "@/lib/api";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    params,
+    children,
+    ...props
+  }: {
+    to: string;
+    params?: Record<string, string>;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => {
+    const href = to === "/jobs/$jobId" && params?.jobId ? `/jobs/${params.jobId}` : to;
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  },
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({}),
+}));
+
+vi.mock("reactflow", () => {
+  const ReactFlow = ({
+    nodes = [],
+    edges = [],
+    nodeTypes = {},
+  }: {
+    nodes?: Array<Record<string, unknown>>;
+    edges?: Array<Record<string, unknown>>;
+    nodeTypes?: Record<string, React.ComponentType<{ data: Record<string, unknown> }>>;
+  }) => (
+    <div data-testid="reactflow-mock">
+      {nodes.map((node) => {
+        const data = (node.data ?? {}) as Record<string, unknown>;
+        const Component = nodeTypes[String(node.type)];
+        return Component ? (
+          <Component key={String(node.id)} data={data} />
+        ) : (
+          <div key={String(node.id)} data-testid={`node-${String(node.id)}`}>
+            {String(data.label ?? node.id)}
+          </div>
+        );
+      })}
+      {edges.map((edge) => {
+        const data = (edge.data ?? {}) as Record<string, unknown>;
+        const style = (edge.style ?? {}) as Record<string, unknown>;
+        return (
+          <div
+            key={String(edge.id)}
+            data-testid={String(data.testId)}
+            data-edge-class={String(data.edgeClass)}
+            data-edge-verdict={String(data.verdict)}
+            data-stroke={String(style.stroke)}
+            data-dasharray={String(style.strokeDasharray ?? "")}
+          >
+            {String(data.edgeClass)}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  return {
+    __esModule: true,
+    default: ReactFlow,
+    Background: () => null,
+    BaseEdge: () => null,
+    Controls: () => null,
+    EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Handle: () => null,
+    MarkerType: { ArrowClosed: "arrow-closed" },
+    Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+    getSmoothStepPath: () => ["M0,0L1,1", 0, 0],
+  };
+});
+
+vi.mock("dagre", () => {
+  class Graph {
+    private nodes = new Map<string, { x: number; y: number }>();
+
+    setDefaultEdgeLabel() {}
+    setGraph() {}
+    setNode(id: string) {
+      this.nodes.set(id, { x: 0, y: 0 });
+    }
+    setEdge() {}
+    node(id: string) {
+      return this.nodes.get(id) ?? { x: 0, y: 0 };
+    }
+  }
+
+  return {
+    __esModule: true,
+    default: {
+      graphlib: { Graph },
+      layout: () => undefined,
+    },
+  };
+});
+
+vi.mock("@/lib/api", () => {
+  class MockApiError extends Error {
+    status: number;
+    kind: string;
+    constructor(status: number, message: string, kind = "unknown") {
+      super(message);
+      this.status = status;
+      this.kind = kind;
+      this.name = "ApiError";
+    }
+  }
+
+  return {
+    ApiError: MockApiError,
+    api: {
+      getSystemFeatures: vi.fn(),
+      getContractGraph: vi.fn(),
+      getJobs: vi.fn(),
+    },
+  };
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function mockFeatures(contractEnabled: boolean) {
+  vi.mocked(api.getSystemFeatures).mockResolvedValue({
+    database_console_enabled: false,
+    log_console_enabled: false,
+    agent_remediation_enabled: false,
+    freshness_enabled: false,
+    contract_enforcement_enabled: contractEnabled,
+  });
+}
+
+describe("ContractGraph", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a not-found state and does not fetch the graph when disabled", async () => {
+    mockFeatures(false);
+    render(<ContractGraph initialDataset="" onDatasetSubmit={vi.fn()} />, { wrapper: createWrapper() });
+
+    await expect(screen.findByTestId("not-found-state")).resolves.toBeVisible();
+    expect(screen.getByText("Contracts disabled")).toBeInTheDocument();
+    expect(api.getContractGraph).not.toHaveBeenCalled();
+  });
+
+  it("renders the contract empty state for a graph with no edges", async () => {
+    mockFeatures(true);
+    vi.mocked(api.getContractGraph).mockResolvedValue({ nodes: [], edges: [] });
+    vi.mocked(api.getJobs).mockResolvedValue([]);
+
+    render(<ContractGraph initialDataset="" onDatasetSubmit={vi.fn()} />, { wrapper: createWrapper() });
+
+    await expect(screen.findByTestId("contracts-empty-state")).resolves.toBeVisible();
+    expect(screen.getByText("No contract edges yet")).toBeInTheDocument();
+    expect(screen.getByText(/declare dataset schemas/)).toBeInTheDocument();
+  });
+
+  it("renders classed edges, dataset nodes, and job links", async () => {
+    mockFeatures(true);
+    vi.mocked(api.getJobs).mockResolvedValue([
+      { id: "producer-id", alias: "producer", trigger_id: "", labels: {}, annotations: {}, paused: false, created_at: "", updated_at: "" },
+      { id: "consumer-id", alias: "consumer", trigger_id: "", labels: {}, annotations: {}, paused: false, created_at: "", updated_at: "" },
+    ]);
+    vi.mocked(api.getContractGraph).mockResolvedValue({
+      nodes: [
+        { id: "job:producer", kind: "job", alias: "producer" },
+        { id: "job:consumer", kind: "job", alias: "consumer" },
+        { id: "dataset:lake/customers", kind: "dataset", dataset: { namespace: "lake", name: "customers" } },
+      ],
+      edges: [
+        {
+          id: "declared:producer:consumer:lake/customers",
+          from: "job:producer",
+          to: "job:consumer",
+          class: "declared",
+          verdict: "breaking",
+          dataset: { namespace: "lake", name: "customers" },
+          findings: [{ verdict: "breaking", detail: "required field removed" }],
+        },
+      ],
+    });
+
+    render(<ContractGraph initialDataset="lake/customers" onDatasetSubmit={vi.fn()} />, { wrapper: createWrapper() });
+
+    await expect(screen.findByTestId("contracts-graph")).resolves.toBeVisible();
+    expect(screen.getByTestId("contract-legend")).toBeVisible();
+    expect(screen.getByTestId("contract-node:dataset:lake/customers")).toHaveTextContent("lake/customers");
+    expect(screen.getByTestId("contract-node:job:producer")).toHaveAttribute("href", "/jobs/producer-id");
+
+    const edge = screen.getByTestId("contract-edge:declared:declared:producer:consumer:lake/customers");
+    expect(edge).toHaveAttribute("data-edge-class", "declared");
+    expect(edge).toHaveAttribute("data-edge-verdict", "breaking");
+    expect(edge).toHaveAttribute("data-stroke", "hsl(var(--danger))");
+    expect(edge).toHaveAttribute("data-dasharray", "");
+
+    await waitFor(() => {
+      expect(api.getContractGraph).toHaveBeenCalledWith({ dataset: "lake/customers" });
+    });
+  });
+});

--- a/ui/src/features/contracts/contractGraphModel.ts
+++ b/ui/src/features/contracts/contractGraphModel.ts
@@ -1,0 +1,207 @@
+import dagre from "dagre";
+import type { CSSProperties } from "react";
+import { MarkerType, Position, type Edge, type Node } from "reactflow";
+import type {
+  ContractDatasetRef,
+  ContractEdgeClass,
+  ContractGraphEdge,
+  ContractGraphNode,
+  ContractGraphResponse,
+  ContractVerdict,
+} from "@/lib/api";
+
+export const contractNodeWidth = 300;
+export const contractNodeHeight = 138;
+
+export interface ContractFlowNodeData {
+  id: string;
+  kind: string;
+  alias?: string;
+  dataset?: ContractDatasetRef;
+  label: string;
+  detail: string;
+  jobId?: string;
+}
+
+export interface ContractFlowEdgeData {
+  edgeId: string;
+  edgeClass: ContractEdgeClass;
+  verdict?: ContractVerdict;
+  findingCount: number;
+  datasetLabel?: string;
+  lastSeen?: string;
+  sourceLabel: string;
+  targetLabel: string;
+  testId: string;
+}
+
+export function buildContractFlow(
+  graph: ContractGraphResponse,
+  jobIdsByAlias: Map<string, string>,
+): { nodes: Node<ContractFlowNodeData>[]; edges: Edge<ContractFlowEdgeData>[] } {
+  const nodeLabelById = new Map<string, string>();
+  const initialNodes: Node<ContractFlowNodeData>[] = graph.nodes.map((node) => {
+    const label = contractNodeLabel(node);
+    nodeLabelById.set(node.id, label);
+    return {
+      id: node.id,
+      type: "contract",
+      data: {
+        id: node.id,
+        kind: node.kind,
+        alias: node.alias,
+        dataset: node.dataset,
+        label,
+        detail: contractNodeDetail(node),
+        jobId: node.kind === "job" ? jobIdsByAlias.get(label) : undefined,
+      },
+      position: { x: 0, y: 0 },
+    };
+  });
+
+  const initialEdges: Edge<ContractFlowEdgeData>[] = graph.edges.map((edge) => {
+    const style = edgeVisualStyle(edge);
+    return {
+      id: edge.id,
+      source: edge.from,
+      target: edge.to,
+      type: "contract",
+      data: {
+        edgeId: edge.id,
+        edgeClass: edge.class,
+        verdict: edge.verdict,
+        findingCount: edge.findings?.length ?? 0,
+        datasetLabel: edge.dataset ? formatDatasetRef(edge.dataset) : undefined,
+        lastSeen: edge.lastSeen,
+        sourceLabel: nodeLabelById.get(edge.from) ?? edge.from,
+        targetLabel: nodeLabelById.get(edge.to) ?? edge.to,
+        testId: contractEdgeTestId(edge),
+      },
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        width: 20,
+        height: 20,
+        color: style.stroke,
+      },
+      style,
+    };
+  });
+
+  return getLayoutedElements(initialNodes, initialEdges);
+}
+
+export function contractEdgeTestId(edge: ContractGraphEdge): string {
+  return `contract-edge:${edge.class}:${edge.id}`;
+}
+
+export function formatDatasetRef(dataset: ContractDatasetRef): string {
+  const namespace = dataset.namespace.trim();
+  const name = dataset.name.trim();
+  return namespace ? `${namespace}/${name}` : `/${name}`;
+}
+
+export function cleanDatasetFilter(value: string): string | undefined {
+  const trimmed = value.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
+export function contractNodeTestId(data: ContractFlowNodeData): string {
+  return `contract-node:${data.id}`;
+}
+
+function contractNodeLabel(node: ContractGraphNode): string {
+  if (node.kind === "dataset" && node.dataset) {
+    return formatDatasetRef(node.dataset);
+  }
+  if (node.alias) {
+    return node.alias;
+  }
+  return node.id.startsWith("job:") ? node.id.slice("job:".length) : node.id;
+}
+
+function contractNodeDetail(node: ContractGraphNode): string {
+  if (node.kind === "dataset") {
+    return "Dataset";
+  }
+  return "Job";
+}
+
+function edgeVisualStyle(edge: ContractGraphEdge): CSSProperties {
+  const stroke = edgeStrokeColor(edge);
+  return {
+    stroke,
+    strokeWidth: edge.class === "evidence" ? 2 : 2.5,
+    strokeDasharray: edgeDashArray(edge.class),
+    strokeLinecap: edge.class === "evidence" ? "round" : undefined,
+    opacity: edge.class === "evidence" ? 0.58 : 1,
+  };
+}
+
+function edgeDashArray(edgeClass: ContractEdgeClass): string | undefined {
+  switch (edgeClass) {
+    case "inferred":
+      return "8 5";
+    case "evidence":
+      return "1 8";
+    default:
+      return undefined;
+  }
+}
+
+function edgeStrokeColor(edge: ContractGraphEdge): string {
+  if (edge.class === "evidence") {
+    return "hsl(var(--text-4))";
+  }
+  switch (edge.verdict) {
+    case "breaking":
+      return "hsl(var(--danger))";
+    case "unknown":
+      return "hsl(var(--warning))";
+    case "compatible":
+      return "hsl(var(--success))";
+    default:
+      return "hsl(var(--text-3))";
+  }
+}
+
+function getLayoutedElements(
+  nodes: Node<ContractFlowNodeData>[],
+  edges: Edge<ContractFlowEdgeData>[],
+  direction = "LR",
+) {
+  const dagreGraph = new dagre.graphlib.Graph();
+  dagreGraph.setDefaultEdgeLabel(() => ({}));
+  dagreGraph.setGraph({
+    rankdir: direction,
+    nodesep: 150,
+    ranksep: 200,
+    marginx: 50,
+    marginy: 50,
+    ranker: "network-simplex",
+  });
+
+  nodes.forEach((node) => {
+    dagreGraph.setNode(node.id, { width: contractNodeWidth, height: contractNodeHeight });
+  });
+  edges.forEach((edge) => {
+    dagreGraph.setEdge(edge.source, edge.target);
+  });
+
+  dagre.layout(dagreGraph);
+
+  return {
+    nodes: nodes.map((node) => {
+      const layoutNode = dagreGraph.node(node.id) ?? { x: 0, y: 0 };
+      return {
+        ...node,
+        targetPosition: direction === "LR" ? Position.Left : Position.Top,
+        sourcePosition: direction === "LR" ? Position.Right : Position.Bottom,
+        position: {
+          x: layoutNode.x - contractNodeWidth / 2,
+          y: layoutNode.y - contractNodeHeight / 2,
+        },
+      };
+    }),
+    edges,
+  };
+}

--- a/ui/src/features/stats/__tests__/StatsPage.test.tsx
+++ b/ui/src/features/stats/__tests__/StatsPage.test.tsx
@@ -63,6 +63,7 @@ describe('StatsPage', () => {
       log_console_enabled: false,
       agent_remediation_enabled: false,
       freshness_enabled: false,
+      contract_enforcement_enabled: false,
     });
   });
 

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -74,6 +74,25 @@ describe('api', () => {
     expect(mockFetch).toHaveBeenCalledWith('/v1/jobs/job-42/cache', expect.anything());
   });
 
+  it('getContractGraph encodes the optional dataset filter', async () => {
+    mockFetch.mockResolvedValue(okResponse({ nodes: [], edges: [] }));
+    await api.getContractGraph({ dataset: 'lake/customers' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/v1/contracts/graph?dataset=lake%2Fcustomers',
+      expect.anything(),
+    );
+  });
+
+  it('getContractGraph surfaces disabled-route 404 as ApiError', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve('Not found'),
+    });
+
+    await expect(api.getContractGraph()).rejects.toMatchObject({ status: 404 });
+  });
+
   it('getJobTasks normalizes task IDs from Go model casing', async () => {
     mockFetch.mockResolvedValue(okResponse([
       {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -414,6 +414,7 @@ export interface SystemFeatures {
   log_console_enabled: boolean;
   agent_remediation_enabled: boolean;
   freshness_enabled: boolean;
+  contract_enforcement_enabled: boolean;
   external_url?: string;
 }
 
@@ -861,6 +862,53 @@ export interface ImpactResult {
   downstream: ImpactNode[];
 }
 
+export type ContractNodeKind = "job" | "dataset" | string;
+export type ContractEdgeClass = "declared" | "inferred" | "evidence" | string;
+export type ContractVerdict = "breaking" | "compatible" | "unknown" | string;
+
+export interface ContractDatasetRef {
+  namespace: string;
+  name: string;
+}
+
+export interface ContractGraphNode {
+  id: string;
+  kind: ContractNodeKind;
+  alias?: string;
+  labels?: Record<string, string>;
+  dataset?: ContractDatasetRef;
+}
+
+export interface ContractFinding {
+  kind?: string;
+  path?: string;
+  detail?: string;
+  verdict: ContractVerdict;
+}
+
+export interface ContractGraphEdge {
+  id: string;
+  from: string;
+  to: string;
+  class: ContractEdgeClass;
+  verdict?: ContractVerdict;
+  findings?: ContractFinding[];
+  dataset?: ContractDatasetRef;
+  producerSchema?: Record<string, unknown>;
+  previousProducerSchema?: Record<string, unknown>;
+  consumerSchema?: Record<string, unknown>;
+  lastSeen?: string;
+}
+
+export interface ContractGraphResponse {
+  nodes: ContractGraphNode[];
+  edges: ContractGraphEdge[];
+}
+
+export interface ContractGraphQuery {
+  dataset?: string;
+}
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "/v1";
 
 export class ApiError extends Error {
@@ -1149,6 +1197,10 @@ export const api = {
   },
   getSystemNodes: () => request<Node[]>("/system/nodes"),
   getSystemFeatures: () => request<SystemFeatures>("/system/features"),
+  getContractGraph: (query: ContractGraphQuery = {}) => {
+    const params = queryString({ dataset: query.dataset });
+    return request<ContractGraphResponse>(`/contracts/graph${params ? `?${params}` : ""}`);
+  },
   getIncidents: (params: IncidentListParams = {}) => {
     const query = queryString({
       status: params.status,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -862,9 +862,9 @@ export interface ImpactResult {
   downstream: ImpactNode[];
 }
 
-export type ContractNodeKind = "job" | "dataset" | string;
-export type ContractEdgeClass = "declared" | "inferred" | "evidence" | string;
-export type ContractVerdict = "breaking" | "compatible" | "unknown" | string;
+export type ContractNodeKind = "job" | "dataset";
+export type ContractEdgeClass = "declared" | "inferred" | "evidence";
+export type ContractVerdict = "breaking" | "compatible" | "unknown";
 
 export interface ContractDatasetRef {
   namespace: string;

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -2,6 +2,7 @@ import { createRootRoute, createRoute, createRouter, redirect } from "@tanstack/
 import { AppShell } from "./components/layout/AppShell";
 import { ConsoleNotFound } from "./components/not-found-state";
 import { AtomsPage } from "./features/atoms/AtomsPage";
+import { ContractGraphPage } from "./features/contracts/ContractGraphPage";
 import { DatabaseConsolePage } from "./features/database/DatabaseConsolePage";
 import { DatasetsPage } from "./features/datasets/DatasetsPage";
 import { IncidentDetailPage } from "./features/incidents/IncidentDetailPage";
@@ -113,6 +114,15 @@ const lineageRoute = createRoute({
     name: typeof search.name === "string" ? search.name : undefined,
   }),
   component: LineageRoutePage,
+});
+
+const contractsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "contracts",
+  validateSearch: (search: Record<string, unknown>) => ({
+    dataset: typeof search.dataset === "string" ? search.dataset : undefined,
+  }),
+  component: ContractGraphPage,
 });
 
 async function requireFreshnessEnabled() {
@@ -238,6 +248,7 @@ const routeTree = rootRoute.addChildren([
   runDiffRoute,
   runDetailRoute,
   lineageRoute,
+  contractsRoute,
   datasetsRoute,
   incidentsRoute,
   incidentDetailRoute,


### PR DESCRIPTION
## Summary
F1 of the contract-enforcement plan — the Console contract graph:

- New `/contracts` route + sidebar entry, both hidden when `contract_enforcement_enabled` is false (direct visits render the shared NotFoundState; fetches disabled).
- React Flow canvas: job vs dataset nodes, edge styling by class (declared solid / inferred dashed / evidence faint) with verdict coloring (breaking/unknown/compatible) and a legend; job nodes SPA-link to job detail.
- Explanatory empty state for fresh servers; `?dataset=ns/name` filter supported by the typed api method.
- vitest coverage (16 new assertions) + Playwright e2e (`ui/e2e/contracts.spec.ts`) applying a producer+consumer pair and asserting nodes + a classed edge render.

## Test plan
- [x] `npm run lint` + `npm run build` + vitest — green (agent + orchestrator independently).
- [ ] ui-e2e (Playwright vs live backend) — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
