### PR TITLE
Add the intentional-break escape hatch with acks and notifications (contract-enforcement W3-γ)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,6 +264,7 @@ jobs:
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+            -e CAESIUM_CONTRACT_DEPRECATION_WINDOW=5s \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -328,6 +329,7 @@ jobs:
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+            -e CAESIUM_CONTRACT_DEPRECATION_WINDOW=5s \
             -e CAESIUM_AGENT_REMEDIATION_ENABLED=true \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
@@ -509,6 +511,7 @@ jobs:
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+            -e CAESIUM_CONTRACT_DEPRECATION_WINDOW=5s \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
       - name: Extract caesium CLI

--- a/api/rest/controller/jobdef/apply.go
+++ b/api/rest/controller/jobdef/apply.go
@@ -5,7 +5,9 @@ import (
 	"net/http"
 	"strings"
 
+	authmw "github.com/caesium-cloud/caesium/api/middleware"
 	jobdefsvc "github.com/caesium-cloud/caesium/api/rest/service/jobdef"
+	contractenforce "github.com/caesium-cloud/caesium/internal/contract"
 	internaljobdef "github.com/caesium-cloud/caesium/internal/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/db"
 	"github.com/labstack/echo/v5"
@@ -33,9 +35,16 @@ func Apply(c *echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
+	contractAck, err := allowBreakingFromRequest(req.AllowBreaking, applyActor(c))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+	}
+	contractWarnings := make([]contractenforce.ContractWarning, 0)
 	opts := &internaljobdef.ApplyOptions{
-		Force:      req.Force,
-		Provenance: prov,
+		Force:            req.Force,
+		Provenance:       prov,
+		ContractAck:      contractAck,
+		ContractWarnings: &contractWarnings,
 	}
 	if err := importer.ValidateBatch(ctx, req.Definitions); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
@@ -54,6 +63,9 @@ func Apply(c *echo.Context) error {
 					return c.JSON(http.StatusConflict, payload)
 				}
 				return echo.NewHTTPError(http.StatusConflict, err.Error())
+			}
+			if errors.Is(err, internaljobdef.ErrContractAck) {
+				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 			}
 			if errors.Is(err, internaljobdef.ErrDuplicateJob) || errors.Is(err, internaljobdef.ErrProvenanceConflict) || errors.Is(err, internaljobdef.ErrJobRunning) {
 				return echo.NewHTTPError(http.StatusConflict, err.Error())
@@ -75,7 +87,7 @@ func Apply(c *echo.Context) error {
 		pruned = count
 	}
 
-	return c.JSON(http.StatusOK, ApplyResponse{Applied: applied, Pruned: pruned})
+	return c.JSON(http.StatusOK, ApplyResponse{Applied: applied, Pruned: pruned, ContractWarnings: contractWarnings})
 }
 
 func applyProvenanceFromRequest(p *ApplyProvenance) (*internaljobdef.Provenance, error) {
@@ -101,4 +113,26 @@ func applyProvenanceFromRequest(p *ApplyProvenance) (*internaljobdef.Provenance,
 		return nil, errors.New("provenance.source_id is required when any other provenance field is set")
 	}
 	return prov, nil
+}
+
+func allowBreakingFromRequest(req *jobdefsvc.AllowBreakingRequest, actor string) (*contractenforce.AllowBreaking, error) {
+	if req == nil {
+		return nil, nil
+	}
+	dataset := strings.TrimSpace(req.Dataset)
+	if dataset == "" {
+		return nil, errors.New("allow_breaking.dataset is required")
+	}
+	return &contractenforce.AllowBreaking{
+		Dataset: dataset,
+		Reason:  strings.TrimSpace(req.Reason),
+		Actor:   actor,
+	}, nil
+}
+
+func applyActor(c *echo.Context) string {
+	if principal := authmw.GetPrincipal(c); principal != nil && strings.TrimSpace(principal.Subject) != "" {
+		return strings.TrimSpace(principal.Subject)
+	}
+	return "anonymous"
 }

--- a/api/rest/service/jobdef/apply.go
+++ b/api/rest/service/jobdef/apply.go
@@ -1,12 +1,16 @@
 package jobdef
 
-import schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+import (
+	contractenforce "github.com/caesium-cloud/caesium/internal/contract"
+	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+)
 
 type ApplyRequest struct {
-	Definitions []schema.Definition `json:"definitions"`
-	Force       bool                `json:"force,omitempty"`
-	Prune       bool                `json:"prune,omitempty"`
-	Provenance  *ApplyProvenance    `json:"provenance,omitempty"`
+	Definitions   []schema.Definition   `json:"definitions"`
+	Force         bool                  `json:"force,omitempty"`
+	Prune         bool                  `json:"prune,omitempty"`
+	Provenance    *ApplyProvenance      `json:"provenance,omitempty"`
+	AllowBreaking *AllowBreakingRequest `json:"allow_breaking,omitempty"`
 }
 
 // ApplyProvenance lets a non-git-sync apply (e.g. a CI/CD pipeline) record the
@@ -28,6 +32,14 @@ type ApplyProvenance struct {
 }
 
 type ApplyResponse struct {
-	Applied int `json:"applied"`
-	Pruned  int `json:"pruned,omitempty"`
+	Applied          int                               `json:"applied"`
+	Pruned           int                               `json:"pruned,omitempty"`
+	ContractWarnings []contractenforce.ContractWarning `json:"contract_warnings,omitempty"`
+}
+
+// AllowBreakingRequest requests a bounded contract-break acknowledgement for
+// one declared dataset or inferred producer.output.<key> subject.
+type AllowBreakingRequest struct {
+	Dataset string `json:"dataset"`
+	Reason  string `json:"reason,omitempty"`
 }

--- a/cmd/job/apply.go
+++ b/cmd/job/apply.go
@@ -28,6 +28,8 @@ var (
 	applyProvenanceRef      string
 	applyProvenanceCommit   string
 	applyProvenancePath     string
+	applyAllowBreaking      string
+	applyReason             string
 )
 
 var applyCmd = &cobra.Command{
@@ -45,8 +47,19 @@ var applyCmd = &cobra.Command{
 			return nil
 		}
 
-		if err := sendApplyRequest(cmd.Context(), strings.TrimSuffix(applyServer, "/"), defs, applyForce, applyPrune, applyProvenanceFromFlags()); err != nil {
+		allowBreaking, err := allowBreakingFromFlags()
+		if err != nil {
 			return err
+		}
+
+		resp, err := sendApplyRequest(cmd.Context(), strings.TrimSuffix(applyServer, "/"), defs, applyForce, applyPrune, applyProvenanceFromFlags(), allowBreaking)
+		if err != nil {
+			return err
+		}
+		for _, warning := range resp.ContractWarnings {
+			if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", warning.Message); err != nil {
+				return err
+			}
 		}
 
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Applied %d job definition(s)\n", len(defs)); err != nil {
@@ -66,6 +79,8 @@ func init() {
 	applyCmd.Flags().StringVar(&applyProvenanceRef, "provenance-ref", "", "Record the repository ref that produced the applied definitions")
 	applyCmd.Flags().StringVar(&applyProvenanceCommit, "provenance-commit", "", "Record the commit that produced the applied definitions")
 	applyCmd.Flags().StringVar(&applyProvenancePath, "provenance-path", "", "Record the manifest path that produced the applied definitions")
+	applyCmd.Flags().StringVar(&applyAllowBreaking, "allow-breaking", "", "Acknowledge an intentional breaking contract change (grammar: dataset=<name>)")
+	applyCmd.Flags().StringVar(&applyReason, "reason", "", "Reason recorded with --allow-breaking")
 	Cmd.AddCommand(applyCmd)
 }
 
@@ -148,38 +163,68 @@ func applyProvenanceFromFlags() *jobdefsvc.ApplyProvenance {
 	return prov
 }
 
-func sendApplyRequest(ctx context.Context, server string, defs []schema.Definition, force, prune bool, provenance *jobdefsvc.ApplyProvenance) error {
+func allowBreakingFromFlags() (*jobdefsvc.AllowBreakingRequest, error) {
+	raw := strings.TrimSpace(applyAllowBreaking)
+	reason := strings.TrimSpace(applyReason)
+	if raw == "" {
+		if reason != "" {
+			return nil, errors.New("--reason requires --allow-breaking dataset=<name>")
+		}
+		return nil, nil
+	}
+	key, value, ok := strings.Cut(raw, "=")
+	if !ok || strings.TrimSpace(key) != "dataset" || strings.TrimSpace(value) == "" {
+		return nil, errors.New(`--allow-breaking must use grammar dataset=<name>`)
+	}
+	return &jobdefsvc.AllowBreakingRequest{
+		Dataset: strings.TrimSpace(value),
+		Reason:  reason,
+	}, nil
+}
+
+func sendApplyRequest(ctx context.Context, server string, defs []schema.Definition, force, prune bool, provenance *jobdefsvc.ApplyProvenance, allowBreaking *jobdefsvc.AllowBreakingRequest) (*jobdefsvc.ApplyResponse, error) {
 	reqBody := jobdefsvc.ApplyRequest{
-		Definitions: defs,
-		Force:       force,
-		Prune:       prune,
-		Provenance:  provenance,
+		Definitions:   defs,
+		Force:         force,
+		Prune:         prune,
+		Provenance:    provenance,
+		AllowBreaking: allowBreaking,
 	}
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, server+"/v1/jobdefs/apply", bytes.NewReader(payload))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	if resp.StatusCode >= http.StatusBadRequest {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("apply failed: %s", strings.TrimSpace(string(body)))
+		return nil, fmt.Errorf("apply failed: %s", strings.TrimSpace(string(body)))
 	}
 
-	return nil
+	var applyResp jobdefsvc.ApplyResponse
+	if len(bytes.TrimSpace(body)) > 0 {
+		if err := json.Unmarshal(body, &applyResp); err != nil {
+			return nil, err
+		}
+	}
+
+	return &applyResp, nil
 }
 
 func isYAML(path string) bool {

--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -260,7 +260,7 @@ Plus the two-sided intentional-break escape hatch.
       `internal/metrics/metrics.go`.
       Depends on: A1 + B1.
       Note: W2-γ landed the catalog-only `ContractAck` model, `CAESIUM_CONTRACT_ENFORCEMENT`/`CAESIUM_CONTRACT_DEPRECATION_WINDOW`, fail/warn apply-time enforcement inside the importer transaction, the HTTP 409 payload, `caesium_contract_breaks_blocked_total{dataset}`, and the paramMapping + happy-path integration scenarios. The C1 edge-set digest is `sha256` hex over JSON `{version:1, subject, edges[]}`, with `edges[]` sorted by producer, consumer, edge ID, path, and detail and carrying edge class, dataset/output key, consumer team, path/detail, and verdict.
-- [ ] C2. Add the intentional-break escape hatch: `caesium job apply
+- [x] C2. Add the intentional-break escape hatch: `caesium job apply
       --allow-breaking dataset=<name> [--reason ...]` records a `ContractAck` row
       (actor, edge-set digest, `deprecationUntil`); during the window the enforcement
       check downgrades to `warn` for the acknowledged digest only, and consumers'
@@ -276,6 +276,7 @@ Plus the two-sided intentional-break escape hatch.
       `internal/contract/enforce.go`, `internal/notification/subscriber.go`,
       `api/rest/controller/jobdef/apply.go`.
       Depends on: C1.
+      Note: W3-gamma landed `--allow-breaking dataset=<name> [--reason ...]` through the CLI/apply API/importer transaction, digest-scoped `ContractAck` creation, active-window warnings for producer and consumer applies, expiry-by-check-time re-blocking, and `contract_break_declared` notification events for impacted consumers. The required hardening items also landed: digest v2 drops `ConsumerTeam`, `schemacompat.Finding.Key` replaces free-text output-key parsing with fallback compatibility, `caesium_contract_breaks_blocked_total` now labels `subject`, and `CAESIUM_CONTRACT_DEPRECATION_WINDOW` validation is scoped to enforcement-enabled configs.
 
 ### Stream D — REST + CLI operator surface
 

--- a/helm/caesium/ci/test-values-k8s.yaml
+++ b/helm/caesium/ci/test-values-k8s.yaml
@@ -37,6 +37,10 @@ config:
     # (mirrors the justfile lanes and the ci.yml docker-run server blocks).
     - name: CAESIUM_CONTRACT_ENFORCEMENT
       value: fail
+    # Short deprecation window so the ack-expiry lifecycle scenario is
+    # deterministic here too (mirrors the justfile/ci.yml server blocks).
+    - name: CAESIUM_CONTRACT_DEPRECATION_WINDOW
+      value: 5s
 
 kubernetes:
   engine:

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -213,10 +213,13 @@ func (s GORMStore) ListContractProducerSchemas(ctx context.Context, incoming []s
 				StepName: stepName,
 				Dataset:  datasetRefFromName(name),
 			}
-			if step, ok := stepsByName[stepName]; ok && len(step.OutputSchema) > 0 {
-				record.Schema = cloneAnyMap(step.OutputSchema)
-				record.SchemaKnown = true
+			step, _ := stepsByName[stepName]
+			producerSchema, schemaKnown, err := persistedProducerSchema(decl, step)
+			if err != nil {
+				return nil, fmt.Errorf("existing job %s step %s dataset %s schema: %w", alias, stepName, name, err)
 			}
+			record.Schema = producerSchema
+			record.SchemaKnown = schemaKnown
 			records = append(records, record)
 		}
 	}
@@ -475,7 +478,10 @@ func (s GORMStore) persistedContractJobs(ctx context.Context, incomingAliases ma
 		if err != nil {
 			return nil, fmt.Errorf("existing trigger %s configuration: %w", row.Alias, err)
 		}
-		steps := attachPersistedDatasetDeclarations(stepsByJobID[row.ID], declsByJobID[row.ID])
+		steps, err := attachPersistedDatasetDeclarations(stepsByJobID[row.ID], declsByJobID[row.ID])
+		if err != nil {
+			return nil, fmt.Errorf("existing job %s dataset declarations: %w", row.Alias, err)
+		}
 		jobs = append(jobs, Job{
 			ID:     row.ID,
 			Alias:  row.Alias,
@@ -613,9 +619,9 @@ func consumedDatasetsFromDefinition(datasets *schema.StepDatasets) []ConsumedDat
 	return out
 }
 
-func attachPersistedDatasetDeclarations(steps []Step, decls []models.DatasetDeclaration) []Step {
+func attachPersistedDatasetDeclarations(steps []Step, decls []models.DatasetDeclaration) ([]Step, error) {
 	if len(steps) == 0 || len(decls) == 0 {
-		return steps
+		return steps, nil
 	}
 
 	stepIndexByName := make(map[string]int, len(steps))
@@ -635,13 +641,26 @@ func attachPersistedDatasetDeclarations(steps []Step, decls []models.DatasetDecl
 		}
 		switch decl.Direction {
 		case models.DatasetDirectionProduces:
-			produced := ProducedDataset{Name: name}
-			if len(steps[idx].OutputSchema) > 0 {
-				produced.SchemaFrom = schema.DatasetSchemaFromOutput
+			inlineSchema, err := persistedInlineSchema(decl)
+			if err != nil {
+				return nil, fmt.Errorf("%s produces %s: %w", stepName, name, err)
+			}
+			produced := ProducedDataset{
+				Name:       name,
+				Schema:     inlineSchema,
+				SchemaFrom: strings.TrimSpace(decl.SchemaFrom),
+				Version:    decl.SchemaVersion,
 			}
 			steps[idx].Produces = append(steps[idx].Produces, produced)
 		case models.DatasetDirectionConsumes:
-			steps[idx].Consumes = append(steps[idx].Consumes, ConsumedDataset{Name: name})
+			inlineSchema, err := persistedInlineSchema(decl)
+			if err != nil {
+				return nil, fmt.Errorf("%s consumes %s: %w", stepName, name, err)
+			}
+			steps[idx].Consumes = append(steps[idx].Consumes, ConsumedDataset{
+				Name:   name,
+				Schema: inlineSchema,
+			})
 		}
 	}
 
@@ -653,7 +672,33 @@ func attachPersistedDatasetDeclarations(steps []Step, decls []models.DatasetDecl
 			return steps[idx].Consumes[i].Name < steps[idx].Consumes[j].Name
 		})
 	}
-	return steps
+	return steps, nil
+}
+
+func persistedProducerSchema(decl models.DatasetDeclaration, step Step) (map[string]any, bool, error) {
+	inlineSchema, err := persistedInlineSchema(decl)
+	if err != nil {
+		return nil, false, err
+	}
+	if strings.TrimSpace(decl.SchemaJSON) != "" {
+		return inlineSchema, true, nil
+	}
+	if strings.TrimSpace(decl.SchemaFrom) == schema.DatasetSchemaFromOutput && len(step.OutputSchema) > 0 {
+		return cloneAnyMap(step.OutputSchema), true, nil
+	}
+	return nil, false, nil
+}
+
+func persistedInlineSchema(decl models.DatasetDeclaration) (map[string]any, error) {
+	raw := strings.TrimSpace(decl.SchemaJSON)
+	if raw == "" {
+		return nil, nil
+	}
+	out, err := parseJSONMap(raw)
+	if err != nil {
+		return nil, fmt.Errorf("schema_json: %w", err)
+	}
+	return out, nil
 }
 
 type declaredProducer struct {

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -1220,6 +1220,7 @@ func inferredFindings(producer Job, refs []outputRef) []schemacompat.Finding {
 			findings = append(findings, schemacompat.Finding{
 				Kind:    schemacompat.FindingKindRequirementUnsatisfied,
 				Path:    paramMappingFindingPath(ref.paramName),
+				Key:     ref.key,
 				Detail:  fmt.Sprintf("paramMapping %q references %s output key %q from producer %s step %q, but that key is missing from the step outputSchema", ref.paramName, ref.jsonPath, ref.key, producer.Alias, step.Name),
 				Verdict: schemacompat.VerdictBreaking,
 			})
@@ -1236,6 +1237,7 @@ func inferredFindings(producer Job, refs []outputRef) []schemacompat.Finding {
 		findings = append(findings, schemacompat.Finding{
 			Kind:    kind,
 			Path:    paramMappingFindingPath(ref.paramName),
+			Key:     ref.key,
 			Detail:  detail,
 			Verdict: schemacompat.VerdictUnknown,
 		})
@@ -1256,6 +1258,7 @@ func unknownProducerFindings(producerAlias string, consumer Job, refs []outputRe
 		findings = append(findings, schemacompat.Finding{
 			Kind:    schemacompat.FindingKindRequirementUnknown,
 			Path:    paramMappingFindingPath(ref.paramName),
+			Key:     ref.key,
 			Detail:  fmt.Sprintf("paramMapping %q on %s references %s from producer %s, but that producer is not present in the merged job set; cannot prove the output key %q exists", ref.paramName, consumer.Alias, ref.jsonPath, producerAlias, ref.key),
 			Verdict: schemacompat.VerdictUnknown,
 		})

--- a/internal/contract/derive.go
+++ b/internal/contract/derive.go
@@ -213,7 +213,7 @@ func (s GORMStore) ListContractProducerSchemas(ctx context.Context, incoming []s
 				StepName: stepName,
 				Dataset:  datasetRefFromName(name),
 			}
-			step, _ := stepsByName[stepName]
+			step := stepsByName[stepName]
 			producerSchema, schemaKnown, err := persistedProducerSchema(decl, step)
 			if err != nil {
 				return nil, fmt.Errorf("existing job %s step %s dataset %s schema: %w", alias, stepName, name, err)

--- a/internal/contract/enforce.go
+++ b/internal/contract/enforce.go
@@ -208,7 +208,7 @@ func EvaluateGraphWithOptions(ctx context.Context, db *gorm.DB, graph Graph, mod
 		return EnforcementResult{}, fmt.Errorf("contract deprecation window must be greater than 0")
 	}
 
-	groups, err := breakingGroupsFromGraph(graph)
+	groups, err := breakingGroupsFromGraph(graph, opts.IncomingAliases)
 	if err != nil {
 		return EnforcementResult{}, err
 	}
@@ -290,7 +290,7 @@ func EvaluateGraphWithOptions(ctx context.Context, db *gorm.DB, graph Graph, mod
 	}
 }
 
-func breakingGroupsFromGraph(graph Graph) ([]breakingGroup, error) {
+func breakingGroupsFromGraph(graph Graph, incomingAliases map[string]struct{}) ([]breakingGroup, error) {
 	nodesByID := make(map[string]Node, len(graph.Nodes))
 	for _, node := range graph.Nodes {
 		nodesByID[node.ID] = node
@@ -306,6 +306,9 @@ func breakingGroupsFromGraph(graph Graph) ([]breakingGroup, error) {
 				continue
 			}
 			cf := contractFindingFromEdge(edge, finding, nodesByID)
+			if !contractFindingInIncomingScope(cf, incomingAliases) {
+				continue
+			}
 			key := cf.Producer + "\x00" + cf.Subject
 			group := grouped[key]
 			if group == nil {
@@ -336,6 +339,19 @@ func breakingGroupsFromGraph(graph Graph) ([]breakingGroup, error) {
 		return groups[i].subject < groups[j].subject
 	})
 	return groups, nil
+}
+
+func contractFindingInIncomingScope(finding ContractFinding, incomingAliases map[string]struct{}) bool {
+	if incomingAliases == nil {
+		return true
+	}
+	if _, ok := incomingAliases[strings.TrimSpace(finding.Producer)]; ok {
+		return true
+	}
+	if _, ok := incomingAliases[strings.TrimSpace(finding.Consumer)]; ok {
+		return true
+	}
+	return false
 }
 
 func contractFindingFromEdge(edge Edge, finding schemacompat.Finding, nodesByID map[string]Node) ContractFinding {

--- a/internal/contract/enforce.go
+++ b/internal/contract/enforce.go
@@ -12,11 +12,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
 	"github.com/caesium-cloud/caesium/pkg/log"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -28,6 +30,7 @@ const (
 
 var (
 	ErrContractBreakBlocked = errors.New("contract breaking change blocked")
+	ErrInvalidContractAck   = errors.New("invalid contract breaking acknowledgement")
 	outputKeyDetailPattern  = regexp.MustCompile(`(?:output key|key) "([^"]+)"`)
 )
 
@@ -56,6 +59,22 @@ type EnforcementResponse struct {
 	Findings []ContractFinding `json:"findings"`
 }
 
+// ContractWarning is returned on successful apply calls that rely on an active
+// deprecation acknowledgement.
+type ContractWarning struct {
+	Type              string    `json:"type"`
+	Message           string    `json:"message"`
+	Subject           string    `json:"subject"`
+	Dataset           string    `json:"dataset,omitempty"`
+	OutputKey         string    `json:"output_key,omitempty"`
+	Producer          string    `json:"producer"`
+	Consumer          string    `json:"consumer,omitempty"`
+	ConsumerTeam      string    `json:"consumer_team,omitempty"`
+	EdgeSetDigest     string    `json:"edge_set_digest"`
+	AcknowledgementID string    `json:"acknowledgement_id"`
+	DeprecationUntil  time.Time `json:"deprecation_until"`
+}
+
 // ContractFinding names one impacted consumer for a breaking contract edge.
 type ContractFinding struct {
 	Subject           string `json:"subject"`
@@ -77,8 +96,39 @@ type ContractFinding struct {
 
 type breakingGroup struct {
 	subject  string
+	producer string
 	findings []ContractFinding
 	digest   string
+}
+
+// AllowBreaking scopes one intentional break acknowledgement requested by an
+// apply caller. The CLI grammar is --allow-breaking dataset=<subject>, where
+// subject is a declared dataset name or an inferred producer.output.<key>
+// subject.
+type AllowBreaking struct {
+	Dataset string
+	Reason  string
+	Actor   string
+}
+
+// ApplyOptions controls acknowledgement creation and warning attribution.
+type ApplyOptions struct {
+	AllowBreaking      *AllowBreaking
+	DeprecationWindow  time.Duration
+	EventStore         EventAppender
+	IncomingAliases    map[string]struct{}
+	SuppressAckNoMatch bool
+}
+
+// EnforcementResult carries non-blocking warnings produced by enforcement.
+type EnforcementResult struct {
+	Warnings []ContractWarning
+}
+
+// EventAppender is the transactional subset of internal/event.Store used to
+// persist contract-break notifications without tying tests to the concrete type.
+type EventAppender interface {
+	AppendTx(*gorm.DB, *event.Event) error
 }
 
 type digestInput struct {
@@ -88,60 +138,82 @@ type digestInput struct {
 }
 
 type digestFinding struct {
-	EdgeID       string `json:"edge_id"`
-	EdgeClass    string `json:"edge_class"`
-	Dataset      string `json:"dataset,omitempty"`
-	OutputKey    string `json:"output_key,omitempty"`
-	Producer     string `json:"producer"`
-	Consumer     string `json:"consumer"`
-	ConsumerTeam string `json:"consumer_team,omitempty"`
-	Path         string `json:"path"`
-	Detail       string `json:"detail"`
-	Verdict      string `json:"verdict"`
+	EdgeID    string `json:"edge_id"`
+	EdgeClass string `json:"edge_class"`
+	Dataset   string `json:"dataset,omitempty"`
+	OutputKey string `json:"output_key,omitempty"`
+	Producer  string `json:"producer"`
+	Consumer  string `json:"consumer"`
+	Path      string `json:"path"`
+	Detail    string `json:"detail"`
+	Verdict   string `json:"verdict"`
 }
 
 // EnforceApply derives the merged contract graph for incoming definitions and
 // applies warn/fail enforcement. Off-mode returns before graph derivation so the
 // apply path is fully inert when CAESIUM_CONTRACT_ENFORCEMENT is unset.
 func EnforceApply(ctx context.Context, db *gorm.DB, incoming []schema.Definition, mode string, now time.Time) error {
+	_, err := EnforceApplyWithOptions(ctx, db, incoming, mode, now, ApplyOptions{})
+	return err
+}
+
+// EnforceApplyWithOptions derives the graph and applies enforcement, optionally
+// recording a bounded acknowledgement for one matching breaking subject.
+func EnforceApplyWithOptions(ctx context.Context, db *gorm.DB, incoming []schema.Definition, mode string, now time.Time, opts ApplyOptions) (EnforcementResult, error) {
 	mode = normalizeMode(mode)
 	if mode == EnforcementModeOff {
-		return nil
+		return EnforcementResult{}, nil
 	}
 	if mode != EnforcementModeWarn && mode != EnforcementModeFail {
-		return fmt.Errorf("unsupported contract enforcement mode %q", mode)
+		return EnforcementResult{}, fmt.Errorf("unsupported contract enforcement mode %q", mode)
 	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
+	if opts.IncomingAliases == nil {
+		opts.IncomingAliases = incomingAliasSet(incoming)
+	}
 
 	graph, err := NewGORMDeriver(db).DeriveGraph(ctx, incoming)
 	if err != nil {
-		return err
+		return EnforcementResult{}, err
 	}
-	return EvaluateGraph(ctx, db, graph, mode, now)
+	return EvaluateGraphWithOptions(ctx, db, graph, mode, now, opts)
 }
 
 // EvaluateGraph applies enforcement to an already-derived graph. It is split
 // out so tests and future lint/diff surfaces can reuse the exact digest logic.
 func EvaluateGraph(ctx context.Context, db *gorm.DB, graph Graph, mode string, now time.Time) error {
+	_, err := EvaluateGraphWithOptions(ctx, db, graph, mode, now, ApplyOptions{})
+	return err
+}
+
+// EvaluateGraphWithOptions applies enforcement and optionally writes an
+// acknowledgement for a matching breaking subject.
+func EvaluateGraphWithOptions(ctx context.Context, db *gorm.DB, graph Graph, mode string, now time.Time, opts ApplyOptions) (EnforcementResult, error) {
 	mode = normalizeMode(mode)
 	if mode == EnforcementModeOff {
-		return nil
+		return EnforcementResult{}, nil
 	}
 	if mode != EnforcementModeWarn && mode != EnforcementModeFail {
-		return fmt.Errorf("unsupported contract enforcement mode %q", mode)
+		return EnforcementResult{}, fmt.Errorf("unsupported contract enforcement mode %q", mode)
 	}
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
+	if opts.DeprecationWindow == 0 {
+		opts.DeprecationWindow = 14 * 24 * time.Hour
+	}
+	if opts.DeprecationWindow < 0 {
+		return EnforcementResult{}, fmt.Errorf("contract deprecation window must be greater than 0")
+	}
 
 	groups, err := breakingGroupsFromGraph(graph)
 	if err != nil {
-		return err
+		return EnforcementResult{}, err
 	}
 	if len(groups) == 0 {
-		return nil
+		return EnforcementResult{}, nil
 	}
 
 	if mode == EnforcementModeWarn {
@@ -152,26 +224,49 @@ func EvaluateGraph(ctx context.Context, db *gorm.DB, graph Graph, mode string, n
 				"findings", len(group.findings),
 			)
 		}
-		return nil
+		return EnforcementResult{}, nil
 	}
 
+	result := EnforcementResult{}
 	blocked := make([]ContractFinding, 0)
+	allowMatched := false
 	for _, group := range groups {
-		ackID, ok, err := validAckForDigest(ctx, db, group.digest, now)
+		ack, ok, err := validAckForDigest(ctx, db, group.digest, now)
 		if err != nil {
-			return err
+			return EnforcementResult{}, err
 		}
 		if ok {
 			for idx := range group.findings {
 				group.findings[idx].Acknowledged = true
-				group.findings[idx].AcknowledgementID = ackID
+				group.findings[idx].AcknowledgementID = ack.ID.String()
 			}
 			log.Warn("contract breaking change allowed by active acknowledgement",
 				"subject", group.subject,
 				"edge_set_digest", group.digest,
-				"acknowledgement_id", ackID,
+				"acknowledgement_id", ack.ID.String(),
 				"findings", len(group.findings),
 			)
+			if opts.AllowBreaking != nil && allowBreakingMatches(opts.AllowBreaking, group) {
+				allowMatched = true
+			}
+			result.Warnings = append(result.Warnings, warningsForAcknowledgedGroup(group, ack, opts.IncomingAliases)...)
+			continue
+		}
+
+		if opts.AllowBreaking != nil && allowBreakingMatches(opts.AllowBreaking, group) {
+			allowMatched = true
+			ack, err := createContractAck(ctx, db, group, opts.AllowBreaking, opts.DeprecationWindow, now)
+			if err != nil {
+				return EnforcementResult{}, err
+			}
+			for idx := range group.findings {
+				group.findings[idx].Acknowledged = true
+				group.findings[idx].AcknowledgementID = ack.ID.String()
+			}
+			if err := emitContractBreakDeclaredEvents(ctx, db, opts.EventStore, group, ack); err != nil {
+				return EnforcementResult{}, err
+			}
+			result.Warnings = append(result.Warnings, warningForDeclaredGroup(group, ack))
 			continue
 		}
 
@@ -179,10 +274,14 @@ func EvaluateGraph(ctx context.Context, db *gorm.DB, graph Graph, mode string, n
 		blocked = append(blocked, group.findings...)
 	}
 	if len(blocked) == 0 {
-		return nil
+		if opts.AllowBreaking != nil && !allowMatched && !opts.SuppressAckNoMatch {
+			return EnforcementResult{}, fmt.Errorf("%w: dataset %q did not match any breaking contract subject", ErrInvalidContractAck, strings.TrimSpace(opts.AllowBreaking.Dataset))
+		}
+		sortContractWarnings(result.Warnings)
+		return result, nil
 	}
 	sortContractFindings(blocked)
-	return &EnforcementError{
+	return EnforcementResult{}, &EnforcementError{
 		Response: EnforcementResponse{
 			Error:    "contract_breaking_change",
 			Message:  contractBreakMessage(blocked),
@@ -210,7 +309,7 @@ func breakingGroupsFromGraph(graph Graph) ([]breakingGroup, error) {
 			key := cf.Producer + "\x00" + cf.Subject
 			group := grouped[key]
 			if group == nil {
-				group = &breakingGroup{subject: cf.Subject}
+				group = &breakingGroup{subject: cf.Subject, producer: cf.Producer}
 				grouped[key] = group
 			}
 			group.findings = append(group.findings, cf)
@@ -249,10 +348,9 @@ func contractFindingFromEdge(edge Edge, finding schemacompat.Finding, nodesByID 
 	}
 
 	dataset := datasetKey(edge.Dataset)
-	outputKey := ""
+	outputKey := outputKeyFromFinding(finding)
 	subject := dataset
 	if subject == "" {
-		outputKey = outputKeyFromDetail(finding.Detail)
 		if outputKey != "" {
 			subject = producer + ".output." + outputKey
 		} else {
@@ -276,6 +374,13 @@ func contractFindingFromEdge(edge Edge, finding schemacompat.Finding, nodesByID 
 	}
 }
 
+func outputKeyFromFinding(finding schemacompat.Finding) string {
+	if key := strings.TrimSpace(finding.Key); key != "" {
+		return key
+	}
+	return outputKeyFromDetail(finding.Detail)
+}
+
 func outputKeyFromDetail(detail string) string {
 	matches := outputKeyDetailPattern.FindStringSubmatch(detail)
 	if len(matches) != 2 {
@@ -286,22 +391,21 @@ func outputKeyFromDetail(detail string) string {
 
 func edgeSetDigest(subject string, findings []ContractFinding) (string, error) {
 	input := digestInput{
-		Version: 1,
+		Version: 2,
 		Subject: subject,
 		Edges:   make([]digestFinding, 0, len(findings)),
 	}
 	for _, finding := range findings {
 		input.Edges = append(input.Edges, digestFinding{
-			EdgeID:       finding.EdgeID,
-			EdgeClass:    finding.EdgeClass,
-			Dataset:      finding.Dataset,
-			OutputKey:    finding.OutputKey,
-			Producer:     finding.Producer,
-			Consumer:     finding.Consumer,
-			ConsumerTeam: finding.ConsumerTeam,
-			Path:         finding.Path,
-			Detail:       finding.Detail,
-			Verdict:      finding.Verdict,
+			EdgeID:    finding.EdgeID,
+			EdgeClass: finding.EdgeClass,
+			Dataset:   finding.Dataset,
+			OutputKey: finding.OutputKey,
+			Producer:  finding.Producer,
+			Consumer:  finding.Consumer,
+			Path:      finding.Path,
+			Detail:    finding.Detail,
+			Verdict:   finding.Verdict,
 		})
 	}
 	sort.Slice(input.Edges, func(i, j int) bool {
@@ -332,9 +436,9 @@ func edgeSetDigest(subject string, findings []ContractFinding) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-func validAckForDigest(ctx context.Context, db *gorm.DB, digest string, now time.Time) (string, bool, error) {
+func validAckForDigest(ctx context.Context, db *gorm.DB, digest string, now time.Time) (*models.ContractAck, bool, error) {
 	if db == nil {
-		return "", false, nil
+		return nil, false, nil
 	}
 	var ack models.ContractAck
 	err := db.WithContext(ctx).
@@ -343,12 +447,286 @@ func validAckForDigest(ctx context.Context, db *gorm.DB, digest string, now time
 		Order("expires_at DESC").
 		First(&ack).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return "", false, nil
+		return nil, false, nil
 	}
 	if err != nil {
-		return "", false, err
+		return nil, false, err
 	}
-	return ack.ID.String(), true, nil
+	return &ack, true, nil
+}
+
+func createContractAck(ctx context.Context, db *gorm.DB, group breakingGroup, allow *AllowBreaking, window time.Duration, now time.Time) (*models.ContractAck, error) {
+	if db == nil {
+		return nil, errors.New("contract acknowledgement requires database connection")
+	}
+	if allow == nil {
+		return nil, errors.New("contract acknowledgement request is required")
+	}
+	actor := strings.TrimSpace(allow.Actor)
+	if actor == "" {
+		actor = "anonymous"
+	}
+	ack := &models.ContractAck{
+		ID:            uuid.New(),
+		Dataset:       ackDatasetForGroup(group, allow),
+		EdgeSetDigest: group.digest,
+		Actor:         actor,
+		Reason:        strings.TrimSpace(allow.Reason),
+		CreatedAt:     now,
+		ExpiresAt:     now.Add(window),
+	}
+	if err := db.WithContext(ctx).Create(ack).Error; err != nil {
+		return nil, err
+	}
+	return ack, nil
+}
+
+func emitContractBreakDeclaredEvents(ctx context.Context, db *gorm.DB, store EventAppender, group breakingGroup, ack *models.ContractAck) error {
+	if store == nil || ack == nil {
+		return nil
+	}
+	for _, consumer := range contractBreakConsumers(ctx, db, group) {
+		payload, err := json.Marshal(map[string]any{
+			"job_alias":           consumer.Alias,
+			"job_labels":          consumer.Labels,
+			"producer":            group.producer,
+			"dataset":             displayDatasetName(datasetForGroup(group)),
+			"subject":             group.subject,
+			"offending_keys":      offendingKeys(group.findings),
+			"window_end":          ack.ExpiresAt,
+			"deprecation_until":   ack.ExpiresAt,
+			"actor":               ack.Actor,
+			"reason":              ack.Reason,
+			"edge_set_digest":     group.digest,
+			"acknowledgement_id":  ack.ID.String(),
+			"consumer":            consumer.Alias,
+			"consumer_team":       consumer.Labels["team"],
+			"impacted_consumers":  impactedConsumers(group.findings),
+			"breaking_findings":   group.findings,
+			"notification_target": "consumer",
+		})
+		if err != nil {
+			return err
+		}
+		evt := event.Event{
+			Type:      event.TypeContractBreakDeclared,
+			JobID:     consumer.ID,
+			Timestamp: ack.CreatedAt,
+			Payload:   payload,
+		}
+		if err := store.AppendTx(db, &evt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type contractBreakConsumer struct {
+	ID     uuid.UUID
+	Alias  string
+	Labels map[string]string
+}
+
+func contractBreakConsumers(ctx context.Context, db *gorm.DB, group breakingGroup) []contractBreakConsumer {
+	byAlias := map[string]contractBreakConsumer{}
+	for _, finding := range group.findings {
+		alias := strings.TrimSpace(finding.Consumer)
+		if alias == "" {
+			continue
+		}
+		labels := map[string]string{}
+		if finding.ConsumerTeam != "" {
+			labels["team"] = finding.ConsumerTeam
+		}
+		byAlias[alias] = contractBreakConsumer{Alias: alias, Labels: labels}
+	}
+	if db == nil || len(byAlias) == 0 {
+		return sortedContractBreakConsumers(byAlias)
+	}
+
+	aliases := make([]string, 0, len(byAlias))
+	for alias := range byAlias {
+		aliases = append(aliases, alias)
+	}
+	var jobs []models.Job
+	if err := db.WithContext(ctx).Where("alias IN ?", aliases).Find(&jobs).Error; err != nil {
+		log.Warn("contract break declared event could not load consumer jobs", "error", err)
+		return sortedContractBreakConsumers(byAlias)
+	}
+	for _, job := range jobs {
+		consumer := byAlias[job.Alias]
+		consumer.ID = job.ID
+		if len(job.Labels) > 0 {
+			consumer.Labels = map[string]string{}
+			for key, value := range job.Labels {
+				if stringValue, ok := value.(string); ok {
+					consumer.Labels[key] = stringValue
+				}
+			}
+		}
+		byAlias[job.Alias] = consumer
+	}
+	return sortedContractBreakConsumers(byAlias)
+}
+
+func sortedContractBreakConsumers(byAlias map[string]contractBreakConsumer) []contractBreakConsumer {
+	aliases := make([]string, 0, len(byAlias))
+	for alias := range byAlias {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+	out := make([]contractBreakConsumer, 0, len(aliases))
+	for _, alias := range aliases {
+		out = append(out, byAlias[alias])
+	}
+	return out
+}
+
+func impactedConsumers(findings []ContractFinding) []map[string]string {
+	seen := map[string]map[string]string{}
+	for _, finding := range findings {
+		consumer := strings.TrimSpace(finding.Consumer)
+		if consumer == "" {
+			continue
+		}
+		seen[consumer] = map[string]string{
+			"alias": consumer,
+			"team":  finding.ConsumerTeam,
+		}
+	}
+	aliases := make([]string, 0, len(seen))
+	for alias := range seen {
+		aliases = append(aliases, alias)
+	}
+	sort.Strings(aliases)
+	out := make([]map[string]string, 0, len(aliases))
+	for _, alias := range aliases {
+		out = append(out, seen[alias])
+	}
+	return out
+}
+
+func offendingKeys(findings []ContractFinding) []string {
+	seen := map[string]struct{}{}
+	for _, finding := range findings {
+		key := strings.TrimSpace(finding.OutputKey)
+		if key != "" {
+			seen[key] = struct{}{}
+		}
+	}
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func datasetForGroup(group breakingGroup) string {
+	for _, finding := range group.findings {
+		if strings.TrimSpace(finding.Dataset) != "" {
+			return strings.TrimSpace(finding.Dataset)
+		}
+	}
+	return ""
+}
+
+func displayDatasetName(dataset string) string {
+	dataset = strings.TrimSpace(dataset)
+	if strings.HasPrefix(dataset, "/") && !strings.Contains(strings.TrimPrefix(dataset, "/"), "/") {
+		return strings.TrimPrefix(dataset, "/")
+	}
+	return dataset
+}
+
+func ackDatasetForGroup(group breakingGroup, allow *AllowBreaking) string {
+	if allow != nil && strings.TrimSpace(allow.Dataset) != "" {
+		return strings.TrimSpace(allow.Dataset)
+	}
+	if dataset := displayDatasetName(datasetForGroup(group)); dataset != "" {
+		return dataset
+	}
+	return group.subject
+}
+
+func warningsForAcknowledgedGroup(group breakingGroup, ack *models.ContractAck, incomingAliases map[string]struct{}) []ContractWarning {
+	if ack == nil {
+		return nil
+	}
+	warnings := make([]ContractWarning, 0, len(group.findings))
+	subject := warningSubjectForGroup(group)
+	for _, finding := range group.findings {
+		warningType := "contract_break_acknowledged"
+		message := fmt.Sprintf("breaking contract %s from %s is in a deprecation window until %s", subject, finding.Producer, ack.ExpiresAt.Format(time.RFC3339))
+		if _, ok := incomingAliases[finding.Consumer]; ok {
+			warningType = "deprecated_contract_consumed"
+			message = fmt.Sprintf("consuming a deprecated contract %s from %s; migrate before %s", subject, finding.Producer, ack.ExpiresAt.Format(time.RFC3339))
+		}
+		warnings = append(warnings, contractWarning(warningType, message, finding, ack))
+	}
+	return warnings
+}
+
+func warningForDeclaredGroup(group breakingGroup, ack *models.ContractAck) ContractWarning {
+	finding := group.findings[0]
+	keys := offendingKeys(group.findings)
+	keyDetail := ""
+	if len(keys) > 0 {
+		keyDetail = " for key(s) " + strings.Join(keys, ", ")
+	}
+	message := fmt.Sprintf("contract break declared for %s%s from %s until %s", warningSubjectForGroup(group), keyDetail, group.producer, ack.ExpiresAt.Format(time.RFC3339))
+	return contractWarning("contract_break_declared", message, finding, ack)
+}
+
+func contractWarning(warningType, message string, finding ContractFinding, ack *models.ContractAck) ContractWarning {
+	return ContractWarning{
+		Type:              warningType,
+		Message:           message,
+		Subject:           finding.Subject,
+		Dataset:           displayDatasetName(finding.Dataset),
+		OutputKey:         finding.OutputKey,
+		Producer:          finding.Producer,
+		Consumer:          finding.Consumer,
+		ConsumerTeam:      finding.ConsumerTeam,
+		EdgeSetDigest:     finding.EdgeSetDigest,
+		AcknowledgementID: ack.ID.String(),
+		DeprecationUntil:  ack.ExpiresAt,
+	}
+}
+
+func warningSubjectForGroup(group breakingGroup) string {
+	if dataset := displayDatasetName(datasetForGroup(group)); dataset != "" {
+		return dataset
+	}
+	return group.subject
+}
+
+func allowBreakingMatches(allow *AllowBreaking, group breakingGroup) bool {
+	if allow == nil {
+		return false
+	}
+	requested := strings.TrimSpace(allow.Dataset)
+	for _, candidate := range []string{
+		group.subject,
+		datasetForGroup(group),
+		displayDatasetName(datasetForGroup(group)),
+	} {
+		if requested != "" && requested == strings.TrimSpace(candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+func incomingAliasSet(incoming []schema.Definition) map[string]struct{} {
+	aliases := make(map[string]struct{}, len(incoming))
+	for _, def := range incoming {
+		alias := strings.TrimSpace(def.Metadata.Alias)
+		if alias != "" {
+			aliases[alias] = struct{}{}
+		}
+	}
+	return aliases
 }
 
 func contractBreakMessage(findings []ContractFinding) string {
@@ -359,7 +737,9 @@ func contractBreakMessage(findings []ContractFinding) string {
 			team = "team: " + finding.ConsumerTeam
 		}
 		subject := finding.Subject
-		if finding.OutputKey != "" {
+		if finding.Dataset != "" && finding.OutputKey != "" {
+			subject = displayDatasetName(finding.Dataset) + " key " + finding.OutputKey
+		} else if finding.OutputKey != "" {
 			subject = "output key " + finding.OutputKey
 		}
 		parts = append(parts, fmt.Sprintf("%s from %s consumed by %s (%s)", subject, finding.Producer, finding.Consumer, team))
@@ -378,6 +758,28 @@ func sortContractFindings(findings []ContractFinding) {
 			strings.Compare(left.Consumer, right.Consumer),
 			strings.Compare(left.Path, right.Path),
 			strings.Compare(left.Detail, right.Detail),
+		} {
+			if cmp < 0 {
+				return true
+			}
+			if cmp > 0 {
+				return false
+			}
+		}
+		return false
+	})
+}
+
+func sortContractWarnings(warnings []ContractWarning) {
+	sort.Slice(warnings, func(i, j int) bool {
+		left := warnings[i]
+		right := warnings[j]
+		for _, cmp := range []int{
+			strings.Compare(left.Subject, right.Subject),
+			strings.Compare(left.Type, right.Type),
+			strings.Compare(left.Producer, right.Producer),
+			strings.Compare(left.Consumer, right.Consumer),
+			strings.Compare(left.Message, right.Message),
 		} {
 			if cmp < 0 {
 				return true

--- a/internal/contract/enforce_test.go
+++ b/internal/contract/enforce_test.go
@@ -63,7 +63,7 @@ func TestEvaluateGraphAcknowledgementAllowsMatchingDigest(t *testing.T) {
 	require.NoError(t, EvaluateGraph(context.Background(), db, graph, EnforcementModeFail, now))
 }
 
-func TestAllowBreakingMatchesDeclaredDatasetName(t *testing.T) {
+func TestAllowBreakingAckLifecycleWarningsAndExpiry(t *testing.T) {
 	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
 	graph := breakingDeclaredDatasetGraph()
 
@@ -77,14 +77,36 @@ func TestAllowBreakingMatchesDeclaredDatasetName(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, result.Warnings, 1)
+	require.Equal(t, "contract_break_declared", result.Warnings[0].Type)
 	require.Equal(t, "lake.customers", result.Warnings[0].Dataset)
+	require.Equal(t, "customer_id", result.Warnings[0].OutputKey)
+	require.NotEmpty(t, result.Warnings[0].AcknowledgementID)
+	require.Equal(t, now.Add(time.Hour), result.Warnings[0].DeprecationUntil)
+	require.Contains(t, result.Warnings[0].Message, "contract break declared")
 	require.Contains(t, result.Warnings[0].Message, "lake.customers")
+	require.Contains(t, result.Warnings[0].Message, "customer_id")
 
 	var ack models.ContractAck
 	require.NoError(t, db.First(&ack).Error)
 	require.Equal(t, "lake.customers", ack.Dataset)
 	require.Equal(t, "operator@example.com", ack.Actor)
 	require.Equal(t, now.Add(time.Hour), ack.ExpiresAt)
+
+	result, err = EvaluateGraphWithOptions(context.Background(), db, graph, EnforcementModeFail, now.Add(time.Minute), ApplyOptions{})
+	require.NoError(t, err)
+	require.Len(t, result.Warnings, 1)
+	require.Equal(t, "contract_break_acknowledged", result.Warnings[0].Type)
+	require.Equal(t, "lake.customers", result.Warnings[0].Dataset)
+	require.Equal(t, "customer_id", result.Warnings[0].OutputKey)
+	require.Contains(t, result.Warnings[0].Message, "deprecation window")
+	require.Contains(t, result.Warnings[0].Message, "lake.customers")
+
+	_, err = EvaluateGraphWithOptions(context.Background(), db, graph, EnforcementModeFail, now.Add(2*time.Hour), ApplyOptions{})
+	var enforcementErr *EnforcementError
+	require.ErrorAs(t, err, &enforcementErr)
+	require.True(t, errors.Is(err, ErrContractBreakBlocked))
+	require.Contains(t, enforcementErr.Response.Message, "lake.customers")
+	require.Contains(t, enforcementErr.Response.Message, "customer_id")
 }
 
 func TestEdgeSetDigestV2IgnoresConsumerTeam(t *testing.T) {

--- a/internal/contract/enforce_test.go
+++ b/internal/contract/enforce_test.go
@@ -63,6 +63,66 @@ func TestEvaluateGraphAcknowledgementAllowsMatchingDigest(t *testing.T) {
 	require.NoError(t, EvaluateGraph(context.Background(), db, graph, EnforcementModeFail, now))
 }
 
+func TestAllowBreakingMatchesDeclaredDatasetName(t *testing.T) {
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	graph := breakingDeclaredDatasetGraph()
+
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&models.ContractAck{}))
+
+	result, err := EvaluateGraphWithOptions(context.Background(), db, graph, EnforcementModeFail, now, ApplyOptions{
+		AllowBreaking:     &AllowBreaking{Dataset: "lake.customers", Actor: "operator@example.com", Reason: "planned migration"},
+		DeprecationWindow: time.Hour,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Warnings, 1)
+	require.Equal(t, "lake.customers", result.Warnings[0].Dataset)
+	require.Contains(t, result.Warnings[0].Message, "lake.customers")
+
+	var ack models.ContractAck
+	require.NoError(t, db.First(&ack).Error)
+	require.Equal(t, "lake.customers", ack.Dataset)
+	require.Equal(t, "operator@example.com", ack.Actor)
+	require.Equal(t, now.Add(time.Hour), ack.ExpiresAt)
+}
+
+func TestEdgeSetDigestV2IgnoresConsumerTeam(t *testing.T) {
+	findings := []ContractFinding{{
+		Subject:      "producer.output.customer_id",
+		OutputKey:    "customer_id",
+		Producer:     "producer",
+		Consumer:     "consumer",
+		ConsumerTeam: "reporting",
+		EdgeClass:    "inferred",
+		Path:         "trigger.configuration.paramMapping.customer",
+		Detail:       "missing customer_id",
+		Verdict:      "breaking",
+		EdgeID:       "edge:1",
+	}}
+	first, err := edgeSetDigest(findings[0].Subject, findings)
+	require.NoError(t, err)
+
+	findings[0].ConsumerTeam = "analytics"
+	second, err := edgeSetDigest(findings[0].Subject, findings)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second)
+}
+
+func TestEvaluateGraphUsesStructuredFindingKey(t *testing.T) {
+	graph := breakingInferenceGraph()
+	graph.Edges[0].Findings[0].Key = "customer_id"
+	graph.Edges[0].Findings[0].Detail = "message without quoted key"
+
+	err := EvaluateGraph(context.Background(), nil, graph, EnforcementModeFail, time.Now().UTC())
+
+	var enforcementErr *EnforcementError
+	require.ErrorAs(t, err, &enforcementErr)
+	require.Equal(t, "producer.output.customer_id", enforcementErr.Response.Findings[0].Subject)
+	require.Equal(t, "customer_id", enforcementErr.Response.Findings[0].OutputKey)
+}
+
 func TestEvaluateGraphWarnModeDoesNotBlock(t *testing.T) {
 	require.NoError(t, EvaluateGraph(context.Background(), nil, breakingInferenceGraph(), EnforcementModeWarn, time.Now().UTC()))
 }
@@ -83,6 +143,32 @@ func breakingInferenceGraph() Graph {
 				Kind:    schemacompat.FindingKindRequirementUnsatisfied,
 				Path:    "trigger.configuration.paramMapping.customer",
 				Detail:  `paramMapping "customer" references $.tasks[0].output.customer_id output key "customer_id" from producer producer step "export", but that key is missing from the step outputSchema`,
+				Verdict: schemacompat.VerdictBreaking,
+			}},
+		}},
+	}
+}
+
+func breakingDeclaredDatasetGraph() Graph {
+	dataset := &DatasetRef{Name: "lake.customers"}
+	return Graph{
+		Nodes: []Node{
+			{ID: "job:producer", Kind: NodeKindJob, Alias: "producer"},
+			{ID: "job:consumer", Kind: NodeKindJob, Alias: "consumer", Labels: map[string]string{"team": "reporting"}},
+			{ID: "dataset:/lake.customers", Kind: NodeKindDataset, Dataset: dataset},
+		},
+		Edges: []Edge{{
+			ID:      "edge:declared:job:producer->job:consumer:/lake.customers",
+			From:    "job:producer",
+			To:      "job:consumer",
+			Class:   EdgeClassDeclared,
+			Verdict: schemacompat.VerdictBreaking,
+			Dataset: dataset,
+			Findings: []schemacompat.Finding{{
+				Kind:    schemacompat.FindingKindRequiredRemoved,
+				Path:    "datasets.produces.lake.customers.schema.properties.customer_id",
+				Key:     "customer_id",
+				Detail:  "required property removed",
 				Verdict: schemacompat.VerdictBreaking,
 			}},
 		}},

--- a/internal/contract/enforce_test.go
+++ b/internal/contract/enforce_test.go
@@ -149,6 +149,26 @@ func TestEvaluateGraphWarnModeDoesNotBlock(t *testing.T) {
 	require.NoError(t, EvaluateGraph(context.Background(), nil, breakingInferenceGraph(), EnforcementModeWarn, time.Now().UTC()))
 }
 
+func TestEvaluateGraphWithOptionsScopesFindingsToIncomingAliases(t *testing.T) {
+	graph := breakingDeclaredDatasetGraph()
+	graph.Nodes = append(graph.Nodes, Node{ID: "job:unrelated", Kind: NodeKindJob, Alias: "unrelated"})
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+
+	result, err := EvaluateGraphWithOptions(context.Background(), nil, graph, EnforcementModeFail, now, ApplyOptions{
+		IncomingAliases: map[string]struct{}{"unrelated": {}},
+	})
+	require.NoError(t, err)
+	require.Empty(t, result.Warnings)
+
+	_, err = EvaluateGraphWithOptions(context.Background(), nil, graph, EnforcementModeFail, now, ApplyOptions{
+		IncomingAliases: map[string]struct{}{"producer": {}},
+	})
+	var enforcementErr *EnforcementError
+	require.ErrorAs(t, err, &enforcementErr)
+	require.Contains(t, enforcementErr.Response.Message, "lake.customers")
+	require.Contains(t, enforcementErr.Response.Message, "customer_id")
+}
+
 func breakingInferenceGraph() Graph {
 	return Graph{
 		Nodes: []Node{

--- a/internal/contract/graph_test.go
+++ b/internal/contract/graph_test.go
@@ -537,7 +537,7 @@ func TestGORMStoreListContractProducerSchemasUsesTaskOutputSchema(t *testing.T) 
 	insertContractTrigger(t, db, triggerID)
 	insertContractJob(t, db, jobID, triggerID, "producer")
 	insertContractTask(t, db, jobID, "export", objectSchemaWithRequired("customer_id"))
-	insertDatasetDeclaration(t, db, jobID, "producer", "export", "lake.customers", "produces")
+	insertDatasetDeclarationWithSchema(t, db, jobID, "producer", "export", "lake.customers", "produces", "", schema.DatasetSchemaFromOutput, 2)
 
 	records, err := (GORMStore{DB: db}).ListContractProducerSchemas(context.Background(), []schema.Definition{{
 		Metadata: schema.Metadata{Alias: "producer"},
@@ -549,6 +549,75 @@ func TestGORMStoreListContractProducerSchemasUsesTaskOutputSchema(t *testing.T) 
 	require.Equal(t, DatasetRef{Name: "lake.customers"}, records[0].Dataset)
 	require.True(t, records[0].SchemaKnown)
 	require.Contains(t, records[0].Schema["properties"], "customer_id")
+}
+
+func TestGORMStoreListContractProducerSchemasUsesDeclarationInlineSchema(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	createContractJobTables(t, db)
+
+	jobID := uuid.New()
+	triggerID := uuid.New()
+	insertContractTrigger(t, db, triggerID)
+	insertContractJob(t, db, jobID, triggerID, "producer")
+	insertDatasetDeclarationWithSchema(t, db, jobID, "producer", "export", "lake.customers", "produces", mustJSON(t, objectSchemaWithRequired("customer_id")), "", 3)
+
+	records, err := (GORMStore{DB: db}).ListContractProducerSchemas(context.Background(), []schema.Definition{{
+		Metadata: schema.Metadata{Alias: "producer"},
+	}})
+	require.NoError(t, err)
+	require.Len(t, records, 1)
+	require.Equal(t, "producer", records[0].JobAlias)
+	require.Equal(t, "export", records[0].StepName)
+	require.Equal(t, DatasetRef{Name: "lake.customers"}, records[0].Dataset)
+	require.True(t, records[0].SchemaKnown)
+	require.Contains(t, records[0].Schema["properties"], "customer_id")
+}
+
+func TestGORMStoreDeriveGraphUsesPersistedConsumerSchemaRequirement(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	createContractJobTables(t, db)
+
+	consumerID := uuid.New()
+	triggerID := uuid.New()
+	insertContractTrigger(t, db, triggerID)
+	insertContractJob(t, db, consumerID, triggerID, "consumer")
+	insertContractTask(t, db, consumerID, "load", nil)
+	insertDatasetDeclarationWithSchema(t, db, consumerID, "consumer", "load", "lake.customers", "consumes", mustJSON(t, objectSchemaWithRequired("customer_id")), "", 0)
+
+	incomingProducer := schema.Definition{
+		APIVersion: schema.APIVersionV1,
+		Kind:       "Job",
+		Metadata:   schema.Metadata{Alias: "producer"},
+		Trigger: schema.Trigger{
+			Type:          schema.TriggerCron,
+			Configuration: map[string]any{"cron": "0 0 * * *"},
+		},
+		Steps: []schema.Step{{
+			Name:         "export",
+			Image:        "alpine:3.23",
+			OutputSchema: objectSchemaWithRequired("row_count"),
+			Datasets: &schema.StepDatasets{Produces: []schema.ProducedDataset{{
+				Name:       "lake.customers",
+				SchemaFrom: schema.DatasetSchemaFromOutput,
+				Version:    2,
+			}}},
+		}},
+	}
+
+	store := GORMStore{DB: db}
+	graph, err := (Deriver{Jobs: store, ProducerSchemas: store}).DeriveGraph(context.Background(), []schema.Definition{incomingProducer})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassDeclared, "job:producer", "job:consumer", "/lake.customers")
+	require.Equal(t, schemacompat.VerdictBreaking, edge.Verdict)
+	require.Contains(t, edge.ProducerSchema["properties"], "row_count")
+	require.Contains(t, edge.ConsumerSchema["properties"], "customer_id")
+	require.Len(t, edge.Findings, 2)
+	require.Equal(t, schemacompat.FindingKindRequirementUnsatisfied, edge.Findings[0].Kind)
+	require.Contains(t, edge.Findings[0].Path, "datasets.consumes.lake.customers.schema")
+	require.Contains(t, edge.Findings[0].Detail, "customer_id")
 }
 
 func outputSchemaWithProperties(keys ...string) map[string]any {
@@ -666,7 +735,7 @@ func createContractJobTables(t *testing.T, db *gorm.DB) {
 	require.NoError(t, db.Exec("CREATE TABLE jobs (id text PRIMARY KEY, alias text NOT NULL, trigger_id text NOT NULL, labels json, deleted_at datetime)").Error)
 	require.NoError(t, db.Exec("CREATE TABLE triggers (id text PRIMARY KEY, type text NOT NULL, configuration text NOT NULL, deleted_at datetime)").Error)
 	require.NoError(t, db.Exec("CREATE TABLE tasks (id text PRIMARY KEY, job_id text NOT NULL, name text NOT NULL, position integer NOT NULL, output_schema json, deleted_at datetime, created_at datetime)").Error)
-	require.NoError(t, db.Exec("CREATE TABLE dataset_declarations (id text PRIMARY KEY, job_id text NOT NULL, job_alias text NOT NULL, step_name text NOT NULL, name text NOT NULL, direction text NOT NULL)").Error)
+	require.NoError(t, db.Exec("CREATE TABLE dataset_declarations (id text PRIMARY KEY, job_id text NOT NULL, job_alias text NOT NULL, step_name text NOT NULL, name text NOT NULL, direction text NOT NULL, schema_json text, schema_from text, schema_version integer)").Error)
 }
 
 func insertContractTrigger(t *testing.T, db *gorm.DB, triggerID uuid.UUID) {
@@ -694,14 +763,22 @@ func insertContractTask(t *testing.T, db *gorm.DB, jobID uuid.UUID, name string,
 
 func insertDatasetDeclaration(t *testing.T, db *gorm.DB, jobID uuid.UUID, jobAlias, stepName, name, direction string) {
 	t.Helper()
+	insertDatasetDeclarationWithSchema(t, db, jobID, jobAlias, stepName, name, direction, "", "", 0)
+}
+
+func insertDatasetDeclarationWithSchema(t *testing.T, db *gorm.DB, jobID uuid.UUID, jobAlias, stepName, name, direction, schemaJSON, schemaFrom string, schemaVersion int) {
+	t.Helper()
 	require.NoError(t, db.Exec(
-		"INSERT INTO dataset_declarations (id, job_id, job_alias, step_name, name, direction) VALUES (?, ?, ?, ?, ?, ?)",
+		"INSERT INTO dataset_declarations (id, job_id, job_alias, step_name, name, direction, schema_json, schema_from, schema_version) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
 		uuid.New(),
 		jobID,
 		jobAlias,
 		stepName,
 		name,
 		direction,
+		schemaJSON,
+		schemaFrom,
+		schemaVersion,
 	).Error)
 }
 

--- a/internal/contract/graph_test.go
+++ b/internal/contract/graph_test.go
@@ -761,11 +761,6 @@ func insertContractTask(t *testing.T, db *gorm.DB, jobID uuid.UUID, name string,
 	).Error)
 }
 
-func insertDatasetDeclaration(t *testing.T, db *gorm.DB, jobID uuid.UUID, jobAlias, stepName, name, direction string) {
-	t.Helper()
-	insertDatasetDeclarationWithSchema(t, db, jobID, jobAlias, stepName, name, direction, "", "", 0)
-}
-
 func insertDatasetDeclarationWithSchema(t *testing.T, db *gorm.DB, jobID uuid.UUID, jobAlias, stepName, name, direction, schemaJSON, schemaFrom string, schemaVersion int) {
 	t.Helper()
 	require.NoError(t, db.Exec(

--- a/internal/event/bus.go
+++ b/internal/event/bus.go
@@ -58,6 +58,10 @@ const (
 	// manager would otherwise never see the violation. In "fail" mode the task
 	// failure already carries the violations, so no separate event is emitted.
 	TypeSchemaViolationRecorded Type = "schema_violation_recorded"
+	// TypeContractBreakDeclared is emitted when an operator intentionally
+	// acknowledges a breaking cross-job data contract for a bounded
+	// deprecation window.
+	TypeContractBreakDeclared Type = "contract_break_declared"
 
 	// Incident lifecycle events (agent-in-the-loop D2). Emitted on the existing
 	// /events stream so the Console incidents surface (Stream U) can live-update

--- a/internal/freshness/registry.go
+++ b/internal/freshness/registry.go
@@ -8,6 +8,7 @@ package freshness
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -84,6 +85,10 @@ func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string)
 			if name == "" {
 				continue
 			}
+			schemaJSON, err := marshalInlineSchema(p.Schema)
+			if err != nil {
+				return nil, fmt.Errorf("steps[%d].datasets.produces[%d].schema: %w", i, j, err)
+			}
 			watermarkKey := ""
 			if p.Watermark != nil {
 				watermarkKey = strings.TrimSpace(p.Watermark.Key)
@@ -95,16 +100,24 @@ func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string)
 				StepName:      step.Name,
 				Name:          name,
 				Direction:     models.DatasetDirectionProduces,
+				SchemaJSON:    schemaJSON,
+				SchemaFrom:    strings.TrimSpace(p.SchemaFrom),
+				SchemaVersion: p.Version,
 				Freshness:     strings.TrimSpace(p.Freshness),
 				MaxStaleness:  strings.TrimSpace(p.MaxStaleness),
 				WatermarkKey:  watermarkKey,
 				SkipWhenFresh: skipWhenFreshPtr,
 			})
 		}
-		for _, consumed := range step.Datasets.Consumes {
+		for j := range step.Datasets.Consumes {
+			consumed := &step.Datasets.Consumes[j]
 			name := strings.TrimSpace(consumed.Name)
 			if name == "" {
 				continue
+			}
+			schemaJSON, err := marshalInlineSchema(consumed.Schema)
+			if err != nil {
+				return nil, fmt.Errorf("steps[%d].datasets.consumes[%d].schema: %w", i, j, err)
 			}
 			decls = append(decls, models.DatasetDeclaration{
 				ID:            uuid.New(),
@@ -113,12 +126,24 @@ func BuildDeclarations(def *schema.Definition, jobID uuid.UUID, jobAlias string)
 				StepName:      step.Name,
 				Name:          name,
 				Direction:     models.DatasetDirectionConsumes,
+				SchemaJSON:    schemaJSON,
 				SkipWhenFresh: skipWhenFreshPtr,
 			})
 		}
 	}
 
 	return decls, nil
+}
+
+func marshalInlineSchema(value map[string]any) (string, error) {
+	if len(value) == 0 {
+		return "", nil
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func boolPtr(value bool) *bool {

--- a/internal/freshness/registry_test.go
+++ b/internal/freshness/registry_test.go
@@ -111,6 +111,84 @@ func TestBuildDeclarations(t *testing.T) {
 	}
 }
 
+const registrySchemaJob = `
+apiVersion: v1
+kind: Job
+metadata:
+  alias: contract-datasets
+trigger:
+  type: cron
+  configuration: {expression: "0 */6 * * *"}
+steps:
+  - name: transform
+    image: etl:1.4
+    outputSchema:
+      type: object
+      required: [customer_id]
+      properties:
+        customer_id:
+          type: string
+    datasets:
+      consumes:
+        - name: raw.customers
+          schema:
+            type: object
+            required: [legacy_id]
+            properties:
+              legacy_id:
+                type: string
+      produces:
+        - name: lake.customers
+          schemaFrom: output
+          version: 2
+        - name: lake.orders
+          schema:
+            type: object
+            required: [order_id]
+            properties:
+              order_id:
+                type: string
+          version: 5
+`
+
+func TestBuildDeclarationsPersistsSchemaMetadata(t *testing.T) {
+	def, err := schema.Parse([]byte(registrySchemaJob))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	jobID := uuid.New()
+	decls, err := BuildDeclarations(def, jobID, def.Metadata.Alias)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	db := openRegistryDB(t)
+	if err := ReplaceForJobTx(db, jobID, decls); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	got, err := NewRegistry(db).ListByJob(context.Background(), jobID)
+	if err != nil {
+		t.Fatalf("list by job: %v", err)
+	}
+
+	consume := findDeclaration(t, got, models.DatasetDirectionConsumes, "raw.customers")
+	if consume.SchemaFrom != "" || consume.SchemaVersion != 0 {
+		t.Fatalf("unexpected consume schema source metadata: %+v", consume)
+	}
+	requireSchemaJSONRequired(t, consume.SchemaJSON, "legacy_id")
+
+	output := findDeclaration(t, got, models.DatasetDirectionProduces, "lake.customers")
+	if output.SchemaJSON != "" || output.SchemaFrom != schema.DatasetSchemaFromOutput || output.SchemaVersion != 2 {
+		t.Fatalf("unexpected schemaFrom declaration metadata: %+v", output)
+	}
+
+	inline := findDeclaration(t, got, models.DatasetDirectionProduces, "lake.orders")
+	if inline.SchemaFrom != "" || inline.SchemaVersion != 5 {
+		t.Fatalf("unexpected inline declaration metadata: %+v", inline)
+	}
+	requireSchemaJSONRequired(t, inline.SchemaJSON, "order_id")
+}
+
 func TestBuildDeclarationsCarriesSkipWhenFreshOptOut(t *testing.T) {
 	src := strings.Replace(registrySampleJob, "  datasets:\n    sources:", "  datasets:\n    skipWhenFresh: false\n    sources:", 1)
 	def, err := schema.Parse([]byte(src))
@@ -126,6 +204,38 @@ func TestBuildDeclarationsCarriesSkipWhenFreshOptOut(t *testing.T) {
 			t.Fatalf("declaration %s skipWhenFresh = %v, want false", decl.Name, decl.SkipWhenFresh)
 		}
 	}
+}
+
+func findDeclaration(t *testing.T, decls []models.DatasetDeclaration, direction, name string) models.DatasetDeclaration {
+	t.Helper()
+	for _, decl := range decls {
+		if decl.Direction == direction && decl.Name == name {
+			return decl
+		}
+	}
+	t.Fatalf("declaration %s %s not found in %+v", direction, name, decls)
+	return models.DatasetDeclaration{}
+}
+
+func requireSchemaJSONRequired(t *testing.T, raw, required string) {
+	t.Helper()
+	if raw == "" {
+		t.Fatalf("schema_json is empty, want required key %q", required)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		t.Fatalf("schema_json is not valid JSON: %v", err)
+	}
+	values, ok := parsed["required"].([]any)
+	if !ok {
+		t.Fatalf("schema_json required = %#v, want list containing %q", parsed["required"], required)
+	}
+	for _, value := range values {
+		if value == required {
+			return
+		}
+	}
+	t.Fatalf("schema_json required = %#v, want %q", values, required)
 }
 
 func TestReplaceForJobTxRebuildsAndPrunes(t *testing.T) {

--- a/internal/jobdef/importer.go
+++ b/internal/jobdef/importer.go
@@ -197,14 +197,6 @@ func ContractBreakResponse(err error) (any, bool) {
 	return enforcementErr.Response, true
 }
 
-func (i *Importer) enforceContractsTx(ctx context.Context, tx *gorm.DB, def *schema.Definition) error {
-	mode := env.Variables().ContractEnforcement
-	if strings.TrimSpace(mode) == "" {
-		return nil
-	}
-	return i.enforceContractsWithOptionsTx(ctx, tx, def, nil)
-}
-
 func (i *Importer) enforceContractsWithOptionsTx(ctx context.Context, tx *gorm.DB, def *schema.Definition, opts *ApplyOptions) error {
 	vars := env.Variables()
 	mode := vars.ContractEnforcement

--- a/internal/jobdef/importer.go
+++ b/internal/jobdef/importer.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	contractenforce "github.com/caesium-cloud/caesium/internal/contract"
+	"github.com/caesium-cloud/caesium/internal/event"
 	"github.com/caesium-cloud/caesium/internal/freshness"
 	"github.com/caesium-cloud/caesium/internal/metrics"
 	"github.com/caesium-cloud/caesium/internal/models"
@@ -35,6 +36,7 @@ var (
 	ErrProvenanceConflict = errors.New("job definition provenance conflict")
 	ErrJobRunning         = errors.New("job has a running run")
 	ErrContractBreak      = contractenforce.ErrContractBreakBlocked
+	ErrContractAck        = contractenforce.ErrInvalidContractAck
 
 	importerBusyRetryBackoffs = []time.Duration{
 		10 * time.Millisecond,
@@ -92,8 +94,10 @@ func (i *Importer) Apply(ctx context.Context, def *schema.Definition) (*models.J
 
 // ApplyOptions control optional behaviors for ApplyWithOptions.
 type ApplyOptions struct {
-	Provenance *Provenance
-	Force      bool
+	Provenance       *Provenance
+	Force            bool
+	ContractAck      *contractenforce.AllowBreaking
+	ContractWarnings *[]contractenforce.ContractWarning
 }
 
 // PruneOptions scope the set of jobs that should be retired when pruning.
@@ -159,7 +163,7 @@ func (i *Importer) ApplyWithOptions(ctx context.Context, def *schema.Definition,
 			if err := i.reconcileDatasetDeclarationsTx(tx, jobModel, def); err != nil {
 				return err
 			}
-			if err := i.enforceContractsTx(ctx, tx, def); err != nil {
+			if err := i.enforceContractsWithOptionsTx(ctx, tx, def, opts); err != nil {
 				return err
 			}
 			if err := i.softDeleteAtomsTx(tx, retiredAtomIDs); err != nil {
@@ -198,7 +202,30 @@ func (i *Importer) enforceContractsTx(ctx context.Context, tx *gorm.DB, def *sch
 	if strings.TrimSpace(mode) == "" {
 		return nil
 	}
-	return contractenforce.EnforceApply(ctx, tx, []schema.Definition{*def}, mode, time.Now().UTC())
+	return i.enforceContractsWithOptionsTx(ctx, tx, def, nil)
+}
+
+func (i *Importer) enforceContractsWithOptionsTx(ctx context.Context, tx *gorm.DB, def *schema.Definition, opts *ApplyOptions) error {
+	vars := env.Variables()
+	mode := vars.ContractEnforcement
+	if strings.TrimSpace(mode) == "" {
+		return nil
+	}
+	enforceOpts := contractenforce.ApplyOptions{
+		DeprecationWindow: vars.ContractDeprecationWindow,
+		EventStore:        event.NewStore(i.db),
+	}
+	if opts != nil {
+		enforceOpts.AllowBreaking = opts.ContractAck
+	}
+	result, err := contractenforce.EnforceApplyWithOptions(ctx, tx, []schema.Definition{*def}, mode, time.Now().UTC(), enforceOpts)
+	if err != nil {
+		return err
+	}
+	if opts != nil && opts.ContractWarnings != nil && len(result.Warnings) > 0 {
+		*opts.ContractWarnings = append(*opts.ContractWarnings, result.Warnings...)
+	}
+	return nil
 }
 
 // PruneMissing retires active jobs that are absent from the desired alias set.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -282,7 +282,7 @@ var (
 			Name: "caesium_contract_breaks_blocked_total",
 			Help: "Total apply-time contract breaks blocked by dataset or output-key subject.",
 		},
-		[]string{"dataset"},
+		[]string{"subject"},
 	)
 
 	// Auth metrics

--- a/internal/models/dataset_declaration.go
+++ b/internal/models/dataset_declaration.go
@@ -63,6 +63,20 @@ type DatasetDeclaration struct {
 	// advance the dataset. Empty in degraded mode (no declared watermark).
 	WatermarkKey string `gorm:"type:text;not null;default:''" json:"watermark_key,omitempty"`
 
+	// SchemaJSON is the marshaled inline JSON Schema declared on
+	// produces[].schema or consumes[].schema. Empty when no inline schema was
+	// declared.
+	SchemaJSON string `gorm:"type:text" json:"schema_json,omitempty"`
+
+	// SchemaFrom is the producing step-local schema source (currently "output").
+	// Empty for consumed declarations and produced declarations without
+	// schemaFrom.
+	SchemaFrom string `gorm:"type:text" json:"schema_from,omitempty"`
+
+	// SchemaVersion carries produces[].version for intentional dataset contract
+	// breaks. It is zero when unset and unused for consumed/source declarations.
+	SchemaVersion int `json:"schema_version,omitempty"`
+
 	// SkipWhenFresh carries metadata.datasets.skipWhenFresh after defaulting.
 	// It is evaluated at the cron scheduling seam only and never affects a task's
 	// cache identity. Pointer form preserves an explicit false across GORM's

--- a/internal/notification/notification_test.go
+++ b/internal/notification/notification_test.go
@@ -201,6 +201,7 @@ func TestValidEventTypes(t *testing.T) {
 		event.TypeSLAMissed,
 		event.TypeRunCompleted,
 		event.TypeTaskSucceeded,
+		event.TypeContractBreakDeclared,
 	}
 
 	for _, et := range expected {
@@ -277,11 +278,11 @@ func TestIsTimeoutError(t *testing.T) {
 
 func TestParseSLA(t *testing.T) {
 	tests := []struct {
-		name        string
-		input       json.RawMessage
-		wantNil     bool
-		wantDur     time.Duration
-		wantCompBy  string
+		name       string
+		input      json.RawMessage
+		wantNil    bool
+		wantDur    time.Duration
+		wantCompBy string
 	}{
 		{
 			name:    "nil input",
@@ -429,9 +430,9 @@ func TestRunMetSLA_BoundaryConditions(t *testing.T) {
 	windowStart := deadline.Add(-24 * time.Hour)
 
 	tests := []struct {
-		name     string
-		complAt  time.Time
-		want     bool
+		name    string
+		complAt time.Time
+		want    bool
 	}{
 		{"exactly at deadline", deadline, true},
 		{"exactly at window start", windowStart, true},

--- a/internal/notification/subscriber.go
+++ b/internal/notification/subscriber.go
@@ -20,6 +20,7 @@ var notifiableTypes = []event.Type{
 	event.TypeSLAMissed,
 	event.TypeRunCompleted,
 	event.TypeTaskSucceeded,
+	event.TypeContractBreakDeclared,
 }
 
 // Subscriber listens to the event bus and dispatches notifications

--- a/justfile
+++ b/justfile
@@ -33,6 +33,7 @@ sock := env("CAESIUM_SOCK", default_sock)
 port := env("CAESIUM_PORT", "8080")
 auth_mode := env("CAESIUM_AUTH_MODE", "none")
 event_ingest_api_key := env("CAESIUM_EVENT_INGEST_API_KEY", "integration-test-key")
+contract_deprecation_window := env("CAESIUM_CONTRACT_DEPRECATION_WINDOW", "5s")
 agent_integration_run := env("CAESIUM_AGENT_INTEGRATION_RUN", "TestIntegrationTestSuite/TestAgent")
 agent_api_external_url := env("CAESIUM_AGENT_API_EXTERNAL_URL", "http://172.17.0.1:" + port)
 
@@ -295,6 +296,7 @@ integration-test-podman: build
         -e CAESIUM_LOG_LEVEL=debug \
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+        -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
     if docker run --rm --platform {{ platform }} \
@@ -337,6 +339,7 @@ integration-up: build-test
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+        -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_RATE_LIMIT_PRUNER_ENABLED=true \
         -e CAESIUM_RATE_LIMIT_PRUNE_INTERVAL=500ms \
@@ -362,6 +365,7 @@ integration-up-distributed: build-test
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+        -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_EXECUTION_MODE=distributed \
         -e CAESIUM_NODE_ADDRESS=127.0.0.1:9001 \
@@ -409,6 +413,7 @@ integration-up-agent: build-test build-triage-agent
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+        -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         {{ local_image_ref }}:{{ tag }}-test start
 
@@ -449,6 +454,7 @@ ui-e2e: build-release
             -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+            -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -487,6 +493,7 @@ ui-e2e-auth: build-release
         -e CAESIUM_OPEN_LINEAGE_TRANSPORT=console \
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
+        -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
         -e CAESIUM_AGENT_REMEDIATION_ENABLED=true \
         --user 0:0 {{ local_image_ref }}:{{ tag }} start >/dev/null
     tries=0

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -54,12 +54,13 @@ func validate() error {
 	default:
 		return fmt.Errorf("CAESIUM_WAKEUP_FANOUT_MODE must be one of: full, gossip")
 	}
-	switch strings.ToLower(strings.TrimSpace(variables.ContractEnforcement)) {
+	contractMode := strings.ToLower(strings.TrimSpace(variables.ContractEnforcement))
+	switch contractMode {
 	case "", "warn", "fail":
 	default:
 		return fmt.Errorf("CAESIUM_CONTRACT_ENFORCEMENT must be one of: \"\", warn, fail")
 	}
-	if variables.ContractDeprecationWindow <= 0 {
+	if contractMode != "" && variables.ContractDeprecationWindow <= 0 {
 		return fmt.Errorf("CAESIUM_CONTRACT_DEPRECATION_WINDOW must be greater than 0")
 	}
 

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -150,6 +150,16 @@ func (s *EnvTestSuite) TestAgentRemediationSatisfiedBySSO() {
 	assert.NoError(s.T(), Process())
 }
 
+func (s *EnvTestSuite) TestContractDeprecationWindowValidatedOnlyWhenEnforcementEnabled() {
+	s.T().Setenv("CAESIUM_CONTRACT_DEPRECATION_WINDOW", "0s")
+	assert.NoError(s.T(), Process())
+
+	s.T().Setenv("CAESIUM_CONTRACT_ENFORCEMENT", "fail")
+	err := Process()
+	s.Require().Error(err)
+	assert.Contains(s.T(), err.Error(), "CAESIUM_CONTRACT_DEPRECATION_WINDOW")
+}
+
 func (s *EnvTestSuite) TestProcessInvalidTypeFailure() {
 	s.T().Setenv("CAESIUM_PORT", "not_a_port")
 	assert.NotNil(s.T(), Process())

--- a/pkg/jobdef/schemacompat/compat.go
+++ b/pkg/jobdef/schemacompat/compat.go
@@ -64,6 +64,9 @@ type Finding struct {
 	Kind FindingKind `json:"kind"`
 	// Path is the dotted JSON path to the relevant schema node.
 	Path string `json:"path"`
+	// Key is the concrete offending object property/output key when the walker
+	// can identify one.
+	Key string `json:"key,omitempty"`
 	// Detail is a human-readable explanation of the finding.
 	Detail string `json:"detail"`
 	// Verdict is the tri-state compatibility decision for this finding.
@@ -906,10 +909,20 @@ func (p schemaPath) string() string {
 	return strings.Join(p, ".")
 }
 
+func (p schemaPath) key() string {
+	for i := len(p) - 2; i >= 0; i-- {
+		if p[i] == "properties" {
+			return p[i+1]
+		}
+	}
+	return ""
+}
+
 func finding(kind FindingKind, path schemaPath, verdict Verdict, format string, args ...any) Finding {
 	return Finding{
 		Kind:    kind,
 		Path:    path.string(),
+		Key:     path.key(),
 		Detail:  fmt.Sprintf(format, args...),
 		Verdict: verdict,
 	}

--- a/pkg/jobdef/schemacompat/compat_test.go
+++ b/pkg/jobdef/schemacompat/compat_test.go
@@ -315,6 +315,26 @@ func TestCompareBothAdditionalPropertiesFalse(t *testing.T) {
 	require.Empty(t, findings)
 }
 
+func TestFindingKeyIsPopulatedForConcreteProperties(t *testing.T) {
+	findings := Compare(
+		objectSchema(
+			[]any{"customer_id"},
+			map[string]any{"customer_id": map[string]any{"type": "string"}},
+		),
+		objectSchema(
+			nil,
+			map[string]any{"customer_id": map[string]any{"type": "string"}},
+		),
+	)
+	requireContainsFindingKey(t, findings, FindingKindRequiredRemoved, "properties.customer_id", "customer_id")
+
+	findings = Compare(
+		objectSchema(nil, map[string]any{"tier": map[string]any{"type": "string", "enum": []any{"free", "pro"}}}),
+		objectSchema(nil, map[string]any{"tier": map[string]any{"type": "string", "enum": []any{"pro"}}}),
+	)
+	requireContainsFindingKey(t, findings, FindingKindEnumValuesRemoved, "properties.tier.enum", "tier")
+}
+
 func TestSatisfies(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -441,4 +461,16 @@ func requireContainsFinding(t *testing.T, findings []Finding, kind FindingKind, 
 		}
 	}
 	require.Failf(t, "missing finding", "kind=%s path=%s verdict=%s findings=%#v", kind, path, verdict, findings)
+}
+
+func requireContainsFindingKey(t *testing.T, findings []Finding, kind FindingKind, path, key string) {
+	t.Helper()
+
+	for _, finding := range findings {
+		if finding.Kind == kind && finding.Path == path {
+			require.Equal(t, key, finding.Key)
+			return
+		}
+	}
+	require.Failf(t, "missing finding", "kind=%s path=%s key=%s findings=%#v", kind, path, key, findings)
 }

--- a/test/contract_enforcement_test.go
+++ b/test/contract_enforcement_test.go
@@ -4,6 +4,8 @@ package test
 
 import (
 	"bytes"
+	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -63,6 +65,78 @@ func (s *IntegrationTestSuite) TestContractEnforcementAllowsNonBreakingProducerA
 	status, body := s.postContractApplyManifest(contractProducerManifest(producer, []string{"customer_id", "row_count", "customer_segment"}))
 	s.Equal(http.StatusOK, status, string(body))
 	s.Require().NotNil(s.requireJobByAlias(producer))
+}
+
+func (s *IntegrationTestSuite) TestContractEnforcementAllowBreakingAckLifecycle() {
+	suffix := time.Now().UnixNano()
+	dataset := fmt.Sprintf("lake.contract_customers_%d", suffix)
+	producer := fmt.Sprintf("integration-contract-ack-producer-%d", suffix)
+	consumer := fmt.Sprintf("integration-contract-ack-consumer-%d", suffix)
+	reason := "planned customer_id migration"
+
+	initialDir := s.writeContractManifests(map[string]string{
+		producer: contractDatasetProducerManifest(producer, dataset, []string{"customer_id", "row_count"}, 1),
+		consumer: contractDatasetConsumerManifest(consumer, dataset, "reporting"),
+	})
+	defer os.RemoveAll(initialDir)
+	s.runCLI("job", "apply", "--path", initialDir, "--server", s.caesiumURL)
+
+	consumerJob := s.requireJobByAlias(consumer)
+	s.Require().NotNil(consumerJob)
+
+	var notifications *replayWebhookCapture
+	if s.engineType == "podman" || s.engineType == "kubernetes" {
+		s.T().Logf("skipping contract notification webhook assertion under CAESIUM_TEST_ENGINE=%s; webhook host reachability is covered on the docker lane", s.engineType)
+	} else {
+		notifications = newReplayWebhookCapture(s.T().Context())
+		defer notifications.Close()
+		channelID := s.createWebhookNotificationChannel("contract-break-"+fmt.Sprint(suffix), notifications.URL())
+		s.createNotificationPolicy("contract-break-"+fmt.Sprint(suffix), channelID, []string{"contract_break_declared"}, consumerJob.ID)
+	}
+
+	breakingDir := s.writeContractManifests(map[string]string{
+		producer: contractDatasetProducerManifest(producer, dataset, []string{"row_count"}, 2),
+	})
+	defer os.RemoveAll(breakingDir)
+
+	stdout, stderr, err := s.runCLISeparate(
+		"job", "apply",
+		"--path", breakingDir,
+		"--server", s.caesiumURL,
+		"--allow-breaking", "dataset="+dataset,
+		"--reason", reason,
+	)
+	s.Require().NoError(err, stderr)
+	s.Contains(stdout, "Applied 1 job definition")
+	s.Contains(stderr, "contract break declared")
+	s.Contains(stderr, dataset)
+	s.Contains(stderr, "customer_id")
+	s.requireContractAckRecorded(dataset, reason)
+	s.requireContractBreakNotification(notifications, producer, dataset, "customer_id", reason)
+
+	stdout, stderr, err = s.runCLISeparate("job", "apply", "--path", breakingDir, "--server", s.caesiumURL)
+	s.Require().NoError(err, stderr)
+	s.Contains(stdout, "Applied 1 job definition")
+	s.Contains(stderr, "deprecation window")
+	s.Contains(stderr, dataset)
+
+	consumerDir := s.writeContractManifests(map[string]string{
+		consumer: contractDatasetConsumerManifest(consumer, dataset, "reporting"),
+	})
+	defer os.RemoveAll(consumerDir)
+
+	stdout, stderr, err = s.runCLISeparate("job", "apply", "--path", consumerDir, "--server", s.caesiumURL)
+	s.Require().NoError(err, stderr)
+	s.Contains(stdout, "Applied 1 job definition")
+	s.Contains(stderr, "consuming a deprecated contract")
+	s.Contains(stderr, dataset)
+
+	time.Sleep(6 * time.Second)
+	output, err := s.runCLIExpectError("job", "apply", "--path", consumerDir, "--server", s.caesiumURL)
+	s.Require().Error(err)
+	s.Contains(output, "contract_breaking_change")
+	s.Contains(output, dataset)
+	s.Contains(output, "customer_id")
 }
 
 func (s *IntegrationTestSuite) writeContractManifests(files map[string]string) string {
@@ -147,4 +221,108 @@ steps:
     image: alpine:3.23
     command: ["sh", "-c", "echo contract consumer"]
 `, alias, team, producerAlias, paramName, outputKey)
+}
+
+func contractDatasetProducerManifest(alias, dataset string, outputKeys []string, version int) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  labels:
+    team: producer-team
+trigger:
+  type: cron
+  configuration:
+    cron: "0 0 1 1 *"
+steps:
+  - name: export
+    image: alpine:3.23
+    command: ["sh", "-c", "echo contract dataset producer"]
+    outputSchema:
+      type: object
+      required: [%s]
+      properties:
+%s
+    datasets:
+      produces:
+        - name: %s
+          schemaFrom: output
+          version: %d
+`, alias, strings.Join(outputKeys, ", "), contractOutputSchemaProperties(outputKeys), dataset, version)
+}
+
+func contractDatasetConsumerManifest(alias, dataset, team string) string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  labels:
+    team: %s
+trigger:
+  type: cron
+  configuration:
+    cron: "0 0 1 1 *"
+steps:
+  - name: consume
+    image: alpine:3.23
+    command: ["sh", "-c", "echo contract dataset consumer"]
+    datasets:
+      consumes:
+        - name: %s
+          schema:
+            type: object
+            required: [customer_id]
+            properties:
+              customer_id:
+                type: string
+`, alias, team, dataset)
+}
+
+func (s *IntegrationTestSuite) requireContractAckRecorded(dataset, reason string) {
+	s.T().Helper()
+	if s.engineType == "kubernetes" {
+		s.T().Logf("skipping direct contract_acks DB assertion under CAESIUM_TEST_ENGINE=%s; dqlite is not port-forward-reachable", s.engineType)
+		return
+	}
+
+	catalogDB := s.openIntegrationCatalogDB()
+	defer func() { s.Require().NoError(catalogDB.Close()) }()
+
+	var actor, digest string
+	var readErr error
+	s.Require().Eventually(func() bool {
+		actor, digest, readErr = readContractAck(s.T().Context(), catalogDB, dataset, reason)
+		return readErr == nil
+	}, 10*time.Second, 250*time.Millisecond, "contract_acks should record the intentional break")
+	s.Require().NoError(readErr)
+	s.Equal("anonymous", actor)
+	s.NotEmpty(digest)
+}
+
+func readContractAck(ctx context.Context, db *sql.DB, dataset, reason string) (string, string, error) {
+	var actor, digest string
+	err := db.QueryRowContext(ctx, `
+SELECT actor, edge_set_digest
+FROM contract_acks
+WHERE dataset = ? AND reason = ?
+ORDER BY created_at DESC
+LIMIT 1
+`, dataset, reason).Scan(&actor, &digest)
+	return actor, digest, err
+}
+
+func (s *IntegrationTestSuite) requireContractBreakNotification(c *replayWebhookCapture, producer, dataset, key, reason string) {
+	s.T().Helper()
+	if c == nil {
+		return
+	}
+	s.Require().Eventually(func() bool {
+		return c.Count() > 0
+	}, 30*time.Second, 250*time.Millisecond, "contract_break_declared notification should be delivered")
+	body := strings.Join(c.Drain(), "\n")
+	s.Contains(body, "contract_break_declared")
+	s.Contains(body, producer)
+	s.Contains(body, dataset)
+	s.Contains(body, key)
+	s.Contains(body, reason)
 }


### PR DESCRIPTION
## Summary
C2 of the contract-enforcement plan + four review-deferred hardening items:

- `caesium job apply --allow-breaking dataset=<name> [--reason ...]` records a `ContractAck` (actor, digest, deprecationUntil) inside the same apply transaction; the value matches a declared dataset name or an inferred `producer.output.<key>` subject.
- During the window the acknowledged digest downgrades to warn; consumers applying against a deprecated contract get a named warning; at expiry the ack is spent at CHECK time (no reaper) and the next apply re-blocks 409.
- `contract_break_declared` (new bus event type) routes through the existing NotificationPolicy matching, carrying producer, subject, offending keys, window end, actor, reason — asserted end-to-end via webhook capture in the integration scenarios.
- **Hardening (from W2 review):** digest v2 drops `ConsumerTeam` (team is attribution, not identity); `schemacompat.Finding` gains a structured `Key` populated by the walker, replacing the fragile Detail-text parse; `caesium_contract_breaks_blocked_total`'s label renamed to `subject`; window validation scoped to enforcement-enabled configs.
- Integration servers (all justfile lanes, ci.yml blocks, helm values) boot with `CAESIUM_CONTRACT_DEPRECATION_WINDOW=5s` for a deterministic ack-lifecycle scenario (ack → warn → expiry re-block).

## Test plan
- [x] Host `go test`: pkg/jobdef(+schemacompat), internal/contract, internal/metrics, pkg/env — green (agent + orchestrator independently).
- [ ] importer/notification/CLI + ack-lifecycle integration scenarios — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
