### PR TITLE
Add contract badges and ack-gated apply to the JobDefs diff (contract-enforcement W4-ζ)

### DIFF
--- a/api/rest/service/contract/contract.go
+++ b/api/rest/service/contract/contract.go
@@ -36,6 +36,7 @@ type Finding struct {
 	Dataset   *internalcontract.DatasetRef `json:"dataset,omitempty"`
 	Kind      schemacompat.FindingKind     `json:"kind,omitempty"`
 	Path      string                       `json:"path,omitempty"`
+	Key       string                       `json:"key,omitempty"`
 	Detail    string                       `json:"detail,omitempty"`
 	Verdict   schemacompat.Verdict         `json:"verdict"`
 }
@@ -142,6 +143,7 @@ func FindingsFromGraph(graph internalcontract.Graph) []Finding {
 				Dataset:   cloneDataset(edge.Dataset),
 				Kind:      edgeFinding.Kind,
 				Path:      edgeFinding.Path,
+				Key:       edgeFinding.Key,
 				Detail:    edgeFinding.Detail,
 				Verdict:   edgeFinding.Verdict,
 			})

--- a/api/rest/service/contract/contract_test.go
+++ b/api/rest/service/contract/contract_test.go
@@ -1,0 +1,35 @@
+package contract
+
+import (
+	"testing"
+
+	internalcontract "github.com/caesium-cloud/caesium/internal/contract"
+	"github.com/caesium-cloud/caesium/pkg/jobdef/schemacompat"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindingsFromGraphPreservesConcreteKey(t *testing.T) {
+	graph := internalcontract.Graph{
+		Edges: []internalcontract.Edge{{
+			ID:      "inferred:producer:consumer",
+			From:    internalcontract.JobNodeID("producer"),
+			To:      internalcontract.JobNodeID("consumer"),
+			Class:   internalcontract.EdgeClassInferred,
+			Verdict: schemacompat.VerdictBreaking,
+			Findings: []schemacompat.Finding{{
+				Kind:    schemacompat.FindingKindRequirementUnsatisfied,
+				Path:    "trigger.configuration.paramMapping.upstream_rows",
+				Key:     "row_count",
+				Detail:  "missing row_count",
+				Verdict: schemacompat.VerdictBreaking,
+			}},
+		}},
+	}
+
+	findings := FindingsFromGraph(graph)
+
+	require.Len(t, findings, 1)
+	require.Equal(t, "row_count", findings[0].Key)
+	require.Equal(t, "job:producer", findings[0].From)
+	require.Equal(t, "job:consumer", findings[0].To)
+}

--- a/docs/exec-plans/active/contract-enforcement.md
+++ b/docs/exec-plans/active/contract-enforcement.md
@@ -412,13 +412,20 @@ precedent: backend REST/CLI first, UI consumes it). New feature dir gated by the
       resolved through `/jobs`, vitest coverage, and `ui/e2e/contracts.spec.ts`.
       Local proof: `npm run lint`, `npm run build`, and focused `npx vitest run`
       for the contracts component plus API tests pass.
-- [ ] F2. Add contract badges to the JobDefs diff tab: extend
+- [x] F2. Add contract badges to the JobDefs diff tab: extend
       `ui/src/features/jobdefs/JobDefsPage.tsx` (which already lints then diffs pasted
       YAML) so its diff tab renders breaking/compatible/unknown badges per edge from
       the `contractFindings` in the diff response, with named consumers and teams
       inline, and disables Apply on breaking findings unless an ack reason is entered.
       Files: `ui/src/features/jobdefs/JobDefsPage.tsx`, `ui/src/lib/api.ts`.
       Depends on: D1 + C2 (the ack-reason path).
+      Note: W4-ζ added diff-tab contract finding badges, subject/consumer/team
+      labeling, ack-reason gated Apply, `allow_breaking` request threading, apply
+      `contract_warnings` toasts, vitest coverage for badge rendering and ack
+      threading, and a Playwright JobDefs diff scenario extending
+      `ui/e2e/contracts.spec.ts`. Local proof: `npm run lint`, `npm run build`, and
+      focused vitest for `src/features/jobdefs/__tests__/JobDefsPage.test.tsx` plus
+      `src/lib/__tests__/api.test.ts` pass.
 
 ## Harness Strengthening
 

--- a/internal/contract/graph_test.go
+++ b/internal/contract/graph_test.go
@@ -620,6 +620,76 @@ func TestGORMStoreDeriveGraphUsesPersistedConsumerSchemaRequirement(t *testing.T
 	require.Contains(t, edge.Findings[0].Detail, "customer_id")
 }
 
+func TestGORMStoreDeriveGraphReportsIncomingProducerRemovedMappedOutput(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	createContractJobTables(t, db)
+
+	producerAlias := "contract-diff-producer"
+	consumerAlias := "contract-diff-consumer"
+
+	producerID := uuid.New()
+	producerTriggerID := uuid.New()
+	insertContractTriggerWithConfig(t, db, producerTriggerID, schema.TriggerCron, map[string]any{
+		"cron":     "0 2 * * *",
+		"timezone": "UTC",
+	})
+	insertContractJob(t, db, producerID, producerTriggerID, producerAlias)
+	insertContractTask(t, db, producerID, "export", integerOutputSchemaWithRequired("row_count"))
+
+	consumerID := uuid.New()
+	consumerTriggerID := uuid.New()
+	insertContractTriggerWithConfig(t, db, consumerTriggerID, schema.TriggerEvent, map[string]any{
+		"events": []any{
+			map[string]any{
+				"type":   "run_completed",
+				"source": "caesium",
+				"filter": map[string]any{
+					"job_alias": producerAlias,
+				},
+			},
+		},
+		"paramMapping": map[string]any{
+			"upstream_rows": "$.tasks[0].output.row_count",
+		},
+	})
+	insertContractJob(t, db, consumerID, consumerTriggerID, consumerAlias)
+	insertContractTask(t, db, consumerID, "load", nil)
+
+	incomingProducer := schema.Definition{
+		APIVersion: schema.APIVersionV1,
+		Kind:       "Job",
+		Metadata:   schema.Metadata{Alias: producerAlias},
+		Trigger: schema.Trigger{
+			Type: schema.TriggerCron,
+			Configuration: map[string]any{
+				"cron":     "0 2 * * *",
+				"timezone": "UTC",
+			},
+		},
+		Steps: []schema.Step{{
+			Name:         "export",
+			Engine:       "docker",
+			Image:        "alpine:3.23",
+			Command:      []string{"sh", "-c", "echo export"},
+			OutputSchema: integerOutputSchemaWithRequired(),
+		}},
+	}
+
+	graph, err := (Deriver{Jobs: GORMStore{DB: db}}).DeriveGraph(context.Background(), []schema.Definition{incomingProducer})
+	require.NoError(t, err)
+
+	edge := requireEdge(t, graph, EdgeClassInferred, JobNodeID(producerAlias), JobNodeID(consumerAlias), "")
+	require.Equal(t, JobNodeID(producerAlias), edge.From)
+	require.Equal(t, schemacompat.VerdictBreaking, edge.Verdict)
+	require.Len(t, edge.Findings, 1)
+	require.Equal(t, schemacompat.FindingKindRequirementUnsatisfied, edge.Findings[0].Kind)
+	require.Equal(t, schemacompat.VerdictBreaking, edge.Findings[0].Verdict)
+	require.Equal(t, "row_count", edge.Findings[0].Key)
+	require.Equal(t, "trigger.configuration.paramMapping.upstream_rows", edge.Findings[0].Path)
+	require.Contains(t, edge.Findings[0].Detail, "row_count")
+}
+
 func outputSchemaWithProperties(keys ...string) map[string]any {
 	properties := make(map[string]any, len(keys))
 	for _, key := range keys {
@@ -635,6 +705,18 @@ func objectSchemaWithRequired(keys ...string) map[string]any {
 	schema := outputSchemaWithProperties(keys...)
 	schema["required"] = append([]string(nil), keys...)
 	return schema
+}
+
+func integerOutputSchemaWithRequired(keys ...string) map[string]any {
+	properties := make(map[string]any, len(keys))
+	for _, key := range keys {
+		properties[key] = map[string]any{"type": "integer"}
+	}
+	return map[string]any{
+		"type":       "object",
+		"required":   append([]string(nil), keys...),
+		"properties": properties,
+	}
 }
 
 func eventTrigger(sourceAlias string, mapping map[string]string) Trigger {
@@ -740,7 +822,12 @@ func createContractJobTables(t *testing.T, db *gorm.DB) {
 
 func insertContractTrigger(t *testing.T, db *gorm.DB, triggerID uuid.UUID) {
 	t.Helper()
-	require.NoError(t, db.Exec("INSERT INTO triggers (id, type, configuration, deleted_at) VALUES (?, ?, ?, NULL)", triggerID, schema.TriggerCron, `{}`).Error)
+	insertContractTriggerWithConfig(t, db, triggerID, schema.TriggerCron, map[string]any{})
+}
+
+func insertContractTriggerWithConfig(t *testing.T, db *gorm.DB, triggerID uuid.UUID, triggerType string, configuration map[string]any) {
+	t.Helper()
+	require.NoError(t, db.Exec("INSERT INTO triggers (id, type, configuration, deleted_at) VALUES (?, ?, ?, NULL)", triggerID, triggerType, mustJSON(t, configuration)).Error)
 }
 
 func insertContractJob(t *testing.T, db *gorm.DB, jobID, triggerID uuid.UUID, alias string) {

--- a/internal/jobdef/diff/diff_test.go
+++ b/internal/jobdef/diff/diff_test.go
@@ -2,12 +2,17 @@ package diff
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
-	"github.com/caesium-cloud/caesium/internal/jobdef"
-	"github.com/caesium-cloud/caesium/internal/jobdef/testutil"
+	"github.com/caesium-cloud/caesium/internal/models"
 	schema "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"gorm.io/datatypes"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
 )
 
 func TestCompareProducesCreatesUpdatesDeletes(t *testing.T) {
@@ -42,21 +47,204 @@ func TestCompareProducesCreatesUpdatesDeletes(t *testing.T) {
 }
 
 func TestLoadDatabaseSpecsMatchesDefinition(t *testing.T) {
-	db := testutil.OpenTestDB(t)
-	defer testutil.CloseDB(db)
+	db := openDiffTestDB(t)
+	defer closeDiffTestDB(db)
 
-	def, err := schema.Parse([]byte(testutil.SampleJob))
-	require.NoError(t, err)
-
-	importer := jobdef.NewImporter(db)
-	_, err = importer.Apply(context.Background(), def)
-	require.NoError(t, err)
+	def := schema.Definition{
+		APIVersion: schema.APIVersionV1,
+		Kind:       schema.KindJob,
+		Metadata: schema.Metadata{
+			Alias:       "csv-to-parquet",
+			Labels:      map[string]string{"team": "data"},
+			Annotations: map[string]string{"owner": "etl"},
+		},
+		Trigger: schema.Trigger{
+			Type: schema.TriggerCron,
+			Configuration: map[string]any{
+				"cron":     "0 * * * *",
+				"timezone": "UTC",
+			},
+		},
+		Callbacks: []schema.Callback{{
+			Type:          schema.CallbackNotification,
+			Configuration: map[string]any{"url": "https://example"},
+		}},
+		Steps: []schema.Step{{
+			Name:    "list",
+			Engine:  schema.EngineDocker,
+			Image:   "busybox:1.36.1",
+			Command: []string{"sh", "-c", "echo list"},
+		}},
+	}
+	insertDiffDefinition(t, db, def)
 
 	actual, err := LoadDatabaseSpecs(context.Background(), db)
 	require.NoError(t, err)
 
-	desired := map[string]JobSpec{def.Metadata.Alias: FromDefinition(def)}
+	desired := map[string]JobSpec{def.Metadata.Alias: FromDefinition(&def)}
 
 	diff := Compare(desired, actual)
 	require.True(t, diff.Empty())
+}
+
+func TestCompareReportsOutputSchemaOnlyUpdates(t *testing.T) {
+	db := openDiffTestDB(t)
+	defer closeDiffTestDB(db)
+
+	persisted := schema.Definition{
+		APIVersion: schema.APIVersionV1,
+		Kind:       schema.KindJob,
+		Metadata:   schema.Metadata{Alias: "contract-producer"},
+		Trigger: schema.Trigger{
+			Type: schema.TriggerCron,
+			Configuration: map[string]any{
+				"cron":     "0 2 * * *",
+				"timezone": "UTC",
+			},
+		},
+		Steps: []schema.Step{{
+			Name:    "export",
+			Engine:  schema.EngineDocker,
+			Image:   "alpine:3.23",
+			Command: []string{"sh", "-c", "echo export"},
+			OutputSchema: map[string]any{
+				"type":       "object",
+				"required":   []any{"row_count"},
+				"properties": map[string]any{"row_count": map[string]any{"type": "integer"}},
+			},
+		}},
+	}
+	insertDiffDefinition(t, db, persisted)
+
+	actual, err := LoadDatabaseSpecs(context.Background(), db)
+	require.NoError(t, err)
+
+	desiredDef := persisted
+	desiredDef.Steps = append([]schema.Step(nil), persisted.Steps...)
+	desiredDef.Steps[0].OutputSchema = map[string]any{
+		"type":       "object",
+		"required":   []any{},
+		"properties": map[string]any{},
+	}
+	desired := map[string]JobSpec{desiredDef.Metadata.Alias: FromDefinition(&desiredDef)}
+
+	diff := Compare(desired, actual)
+	require.Len(t, diff.Updates, 1)
+	require.Equal(t, "contract-producer", diff.Updates[0].Alias)
+	require.Contains(t, diff.Updates[0].Diff, "OutputSchema")
+	require.Contains(t, diff.Updates[0].Diff, "row_count")
+}
+
+func openDiffTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+	sqlDB.SetMaxIdleConns(1)
+	require.NoError(t, db.AutoMigrate(
+		&models.Trigger{},
+		&models.Job{},
+		&models.Atom{},
+		&models.Task{},
+		&models.Callback{},
+	))
+	return db
+}
+
+func closeDiffTestDB(db *gorm.DB) {
+	if db == nil {
+		return
+	}
+	if sqlDB, err := db.DB(); err == nil {
+		_ = sqlDB.Close()
+	}
+}
+
+func insertDiffDefinition(t *testing.T, db *gorm.DB, def schema.Definition) {
+	t.Helper()
+	now := time.Now().UTC()
+	triggerID := uuid.New()
+	jobID := uuid.New()
+	require.NoError(t, db.Create(&models.Trigger{
+		ID:            triggerID,
+		Type:          models.TriggerType(def.Trigger.Type),
+		Configuration: mustJSONString(t, def.Trigger.Configuration),
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}).Error)
+	require.NoError(t, db.Create(&models.Job{
+		ID:          jobID,
+		Alias:       def.Metadata.Alias,
+		TriggerID:   triggerID,
+		Labels:      stringMapToJSONMap(def.Metadata.Labels),
+		Annotations: stringMapToJSONMap(def.Metadata.Annotations),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}).Error)
+
+	for idx, step := range def.Steps {
+		atomID := uuid.New()
+		require.NoError(t, db.Create(&models.Atom{
+			ID:        atomID,
+			Engine:    models.AtomEngine(step.Engine),
+			Image:     step.Image,
+			Command:   mustJSONString(t, step.Command),
+			CreatedAt: now,
+			UpdatedAt: now,
+		}).Error)
+		require.NoError(t, db.Create(&models.Task{
+			ID:           uuid.New(),
+			JobID:        jobID,
+			AtomID:       atomID,
+			Name:         step.Name,
+			Position:     idx,
+			Type:         schema.StepTypeTask,
+			TriggerRule:  schema.TriggerRuleAllSuccess,
+			OutputSchema: mustOptionalJSON(t, step.OutputSchema),
+			CreatedAt:    now.Add(time.Duration(idx) * time.Millisecond),
+			UpdatedAt:    now.Add(time.Duration(idx) * time.Millisecond),
+		}).Error)
+	}
+
+	for idx, callback := range def.Callbacks {
+		require.NoError(t, db.Create(&models.Callback{
+			ID:            uuid.New(),
+			JobID:         jobID,
+			Type:          models.CallbackType(callback.Type),
+			Configuration: mustJSONString(t, callback.Configuration),
+			Position:      idx,
+			CreatedAt:     now.Add(time.Duration(idx) * time.Millisecond),
+			UpdatedAt:     now.Add(time.Duration(idx) * time.Millisecond),
+		}).Error)
+	}
+}
+
+func stringMapToJSONMap(in map[string]string) datatypes.JSONMap {
+	out := make(datatypes.JSONMap, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}
+
+func mustOptionalJSON(t *testing.T, value any) datatypes.JSON {
+	t.Helper()
+	if value == nil {
+		return nil
+	}
+	return datatypes.JSON(mustJSONBytes(t, value))
+}
+
+func mustJSONString(t *testing.T, value any) string {
+	t.Helper()
+	return string(mustJSONBytes(t, value))
+}
+
+func mustJSONBytes(t *testing.T, value any) []byte {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return data
 }

--- a/internal/jobdef/diff/spec.go
+++ b/internal/jobdef/diff/spec.go
@@ -43,9 +43,10 @@ type CallbackSpec struct {
 }
 
 type StepSpec struct {
-	Engine  string   `json:"engine"`
-	Image   string   `json:"image"`
-	Command []string `json:"command"`
+	Engine       string         `json:"engine"`
+	Image        string         `json:"image"`
+	Command      []string       `json:"command"`
+	OutputSchema map[string]any `json:"outputSchema"`
 }
 
 // FromDefinition normalises a job definition into a JobSpec.
@@ -184,10 +185,15 @@ func loadSteps(ctx context.Context, db *gorm.DB, jobID uuid.UUID) ([]StepSpec, e
 		if atom == nil {
 			return nil, fmt.Errorf("atom %s not found", task.AtomID)
 		}
+		outputSchema, err := parseJSONConfigBytes(task.OutputSchema)
+		if err != nil {
+			return nil, fmt.Errorf("task %s output_schema: %w", task.ID, err)
+		}
 		steps = append(steps, StepSpec{
-			Engine:  string(atom.Engine),
-			Image:   atom.Image,
-			Command: slices.Clone(atom.Cmd()),
+			Engine:       string(atom.Engine),
+			Image:        atom.Image,
+			Command:      slices.Clone(atom.Cmd()),
+			OutputSchema: outputSchema,
 		})
 	}
 	return steps, nil
@@ -285,20 +291,26 @@ func copySteps(steps []schema.Step) []StepSpec {
 	result := make([]StepSpec, 0, len(steps))
 	for _, step := range steps {
 		result = append(result, StepSpec{
-			Engine:  step.Engine,
-			Image:   step.Image,
-			Command: slices.Clone(step.Command),
+			Engine:       step.Engine,
+			Image:        step.Image,
+			Command:      slices.Clone(step.Command),
+			OutputSchema: cloneAnyMap(step.OutputSchema),
 		})
 	}
 	return result
 }
 
 func parseJSONConfig(raw string) (map[string]any, error) {
-	if strings.TrimSpace(raw) == "" {
+	return parseJSONConfigBytes([]byte(raw))
+}
+
+func parseJSONConfigBytes(raw []byte) (map[string]any, error) {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 || bytes.Equal(raw, []byte("null")) {
 		return map[string]any{}, nil
 	}
 	var result map[string]any
-	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+	if err := json.Unmarshal(raw, &result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/ui/e2e/contracts.spec.ts
+++ b/ui/e2e/contracts.spec.ts
@@ -79,7 +79,9 @@ test("operator can acknowledge a breaking contract finding from the JobDefs diff
   await waitForContractEdge(request, producerAlias, consumerAlias);
 
   await page.goto("/jobdefs");
-  await page.locator(".cm-content[contenteditable='true']").fill(stringify(buildProducerDefinition(producerAlias, [])));
+  const editedProducerYaml = stringify(buildProducerDefinition(producerAlias, []));
+  await page.locator(".cm-content[contenteditable='true']").fill(editedProducerYaml);
+  await expect(page.getByText("1 step")).toBeVisible();
   await page.getByRole("tab", { name: /Diff vs server/i }).click();
 
   const breakingBadge = page.getByTestId("contract-finding-badge").filter({ hasText: "breaking" }).first();

--- a/ui/e2e/contracts.spec.ts
+++ b/ui/e2e/contracts.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type APIRequestContext } from "@playwright/test";
+import { stringify } from "yaml";
 import { applyDefinitions, findJobByAlias, type FixtureDefinition } from "./helpers/fixtures";
 
 type ContractFixtureDefinition = Omit<FixtureDefinition, "trigger"> & {
@@ -65,7 +66,37 @@ test("operator can inspect the feature-gated contract graph", async ({ page, req
   await expect(edgeLabel).toHaveAttribute("data-edge-verdict", "compatible");
 });
 
-function buildProducerDefinition(alias: string): ContractFixtureDefinition {
+test("operator can acknowledge a breaking contract finding from the JobDefs diff", async ({ page, request }) => {
+  const suffix = Date.now().toString(36);
+  const producerAlias = `contract-diff-producer-${suffix}`;
+  const consumerAlias = `contract-diff-consumer-${suffix}`;
+
+  await applyDefinitions(
+    request,
+    buildProducerDefinition(producerAlias),
+    buildConsumerDefinition(consumerAlias, producerAlias),
+  );
+  await waitForContractEdge(request, producerAlias, consumerAlias);
+
+  await page.goto("/jobdefs");
+  await page.locator(".cm-content[contenteditable='true']").fill(stringify(buildProducerDefinition(producerAlias, [])));
+  await page.getByRole("tab", { name: /Diff vs server/i }).click();
+
+  const breakingBadge = page.getByTestId("contract-finding-badge").filter({ hasText: "breaking" }).first();
+  await expect(breakingBadge).toBeVisible();
+  await expect(breakingBadge).toContainText(`${producerAlias}.output.row_count`);
+  await expect(breakingBadge).toContainText(`consumer: ${consumerAlias}`);
+
+  const applyButton = page.getByRole("button", { name: /Apply definition/i });
+  await expect(applyButton).toBeDisabled();
+
+  await page.getByLabel("Breaking change acknowledgement reason").fill("accepted during contract migration");
+  await expect(applyButton).toBeEnabled();
+  await applyButton.click();
+  await expect(page.getByText(/Applied successfully/)).toBeVisible();
+});
+
+function buildProducerDefinition(alias: string, outputKeys = ["row_count"]): ContractFixtureDefinition {
   return {
     apiVersion: "v1",
     kind: "Job",
@@ -84,16 +115,18 @@ function buildProducerDefinition(alias: string): ContractFixtureDefinition {
         name: "export",
         engine: "docker",
         image: shellImage,
-        outputSchema: {
-          type: "object",
-          required: ["row_count"],
-          properties: {
-            row_count: { type: "integer" },
-          },
-        },
+        outputSchema: outputSchemaForKeys(outputKeys),
         command: ["sh", "-c", "echo export"],
       },
     ],
+  };
+}
+
+function outputSchemaForKeys(keys: string[]) {
+  return {
+    type: "object",
+    required: keys,
+    properties: Object.fromEntries(keys.map((key) => [key, { type: "integer" }])),
   };
 }
 

--- a/ui/e2e/contracts.spec.ts
+++ b/ui/e2e/contracts.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type APIRequestContext } from "@playwright/test";
+import { expect, test, type APIRequestContext, type APIResponse } from "@playwright/test";
 import { stringify } from "yaml";
 import { applyDefinitions, findJobByAlias, type FixtureDefinition } from "./helpers/fixtures";
 
@@ -66,7 +66,7 @@ test("operator can inspect the feature-gated contract graph", async ({ page, req
   await expect(edgeLabel).toHaveAttribute("data-edge-verdict", "compatible");
 });
 
-test("operator can acknowledge a breaking contract finding from the JobDefs diff", async ({ page, request }) => {
+test("operator can acknowledge a breaking contract finding from the JobDefs diff", async ({ page, request }, testInfo) => {
   const suffix = Date.now().toString(36);
   const producerAlias = `contract-diff-producer-${suffix}`;
   const consumerAlias = `contract-diff-consumer-${suffix}`;
@@ -82,10 +82,30 @@ test("operator can acknowledge a breaking contract finding from the JobDefs diff
   const editedProducerYaml = stringify(buildProducerDefinition(producerAlias, []));
   await page.locator(".cm-content[contenteditable='true']").fill(editedProducerYaml);
   await expect(page.getByText("1 step")).toBeVisible();
+  const diffResponsePromise = page.waitForResponse(
+    (response) => response.url().includes("/v1/jobdefs/diff") && response.request().method() === "POST",
+  );
   await page.getByRole("tab", { name: /Diff vs server/i }).click();
+  const diffResponse = await diffResponsePromise;
+  const diffResponseBody = await diffResponseBodyForDiagnostics(diffResponse);
+  await testInfo.attach("jobdefs-diff-response.json", {
+    body: diffResponseBody,
+    contentType: "application/json",
+  });
 
   const breakingBadge = page.getByTestId("contract-finding-badge").filter({ hasText: "breaking" }).first();
-  await expect(breakingBadge).toBeVisible();
+  try {
+    await expect(breakingBadge).toBeVisible();
+  } catch (error) {
+    throw new Error(
+      [
+        "expected JobDefs diff to render a breaking contract finding badge",
+        `POST /v1/jobdefs/diff returned ${diffResponse.status()} ${diffResponse.statusText()}`,
+        truncateForDiagnostics(diffResponseBody),
+        error instanceof Error ? error.message : String(error),
+      ].join("\n\n"),
+    );
+  }
   await expect(breakingBadge).toContainText(`${producerAlias}.output.row_count`);
   await expect(breakingBadge).toContainText(`consumer: ${consumerAlias}`);
 
@@ -209,4 +229,21 @@ async function waitForContractEdge(
 
 function contractEdgeTestId(edge: ContractGraphEdge): string {
   return `contract-edge:${edge.class}:${edge.id}`;
+}
+
+async function diffResponseBodyForDiagnostics(response: APIResponse): Promise<string> {
+  const body = await response.text();
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    return body;
+  }
+}
+
+function truncateForDiagnostics(value: string, limit = 12_000): string {
+  if (value.length <= limit) {
+    return value;
+  }
+  const omitted = value.length - limit;
+  return `${value.slice(0, limit)}\n... truncated ${omitted} characters`;
 }

--- a/ui/src/features/jobdefs/JobDefsPage.tsx
+++ b/ui/src/features/jobdefs/JobDefsPage.tsx
@@ -2,8 +2,8 @@ import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { api, type DiffResponse, type LintResponse } from "@/lib/api";
-import { FileCode2, Play, CheckCircle2, XCircle, Upload, GitBranch, FileWarning, Info, HardDrive, ShieldCheck } from "lucide-react";
+import { api, type AllowBreakingRequest, type ContractDiffFinding, type DiffResponse, type LintResponse } from "@/lib/api";
+import { FileCode2, Play, CheckCircle2, XCircle, Upload, GitBranch, FileWarning, Info, HardDrive, ShieldCheck, AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import CodeMirror from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
@@ -91,6 +91,104 @@ function contractStatusLabel(summary: string) {
   return detailStart === -1 ? summary : summary.slice(0, detailStart);
 }
 
+function collectContractFindings(diff: DiffResponse | null) {
+  if (!diff) return [];
+  return dedupeContractFindings([
+    ...(diff.added ?? []).flatMap((job) => job.contractFindings ?? []),
+    ...(diff.removed ?? []).flatMap((job) => job.contractFindings ?? []),
+    ...(diff.modified ?? []).flatMap((job) => job.contractFindings ?? []),
+  ]);
+}
+
+function dedupeContractFindings(findings: ContractDiffFinding[] | undefined) {
+  if (!findings?.length) return [];
+  const seen = new Set<string>();
+  const out: ContractDiffFinding[] = [];
+  for (const finding of findings) {
+    const key = [
+      finding.edgeId,
+      finding.edgeClass,
+      finding.from,
+      finding.to,
+      finding.verdict,
+      finding.path,
+      finding.key,
+      finding.detail,
+      contractDatasetLabel(finding.dataset),
+    ].join("|");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(finding);
+  }
+  return out;
+}
+
+function buildContractTeamLookup(diff: DiffResponse | null) {
+  const teams: Record<string, string> = {};
+  for (const job of [...(diff?.added ?? []), ...(diff?.removed ?? [])]) {
+    const alias = job.alias?.trim();
+    const team = job.labels?.team?.trim();
+    if (alias && team) {
+      teams[alias] = team;
+    }
+  }
+  return teams;
+}
+
+function contractDatasetLabel(dataset: ContractDiffFinding["dataset"] | undefined) {
+  const namespace = dataset?.namespace?.trim();
+  const name = dataset?.name?.trim();
+  if (namespace && name) return `${namespace}/${name}`;
+  return name || namespace || "";
+}
+
+function jobAliasFromNodeID(nodeID: string | undefined) {
+  const value = nodeID?.trim() ?? "";
+  return value.startsWith("job:") ? value.slice(4) : value;
+}
+
+function contractSubjectForFinding(finding: ContractDiffFinding) {
+  const dataset = contractDatasetLabel(finding.dataset);
+  if (dataset) return dataset;
+  const producer = jobAliasFromNodeID(finding.from) || "producer";
+  const key = finding.key?.trim();
+  if (key) return `${producer}.output.${key}`;
+  return `${producer}.contract`;
+}
+
+function contractConsumerLabel(finding: ContractDiffFinding) {
+  return jobAliasFromNodeID(finding.to) || "unknown consumer";
+}
+
+function contractTeamLabel(finding: ContractDiffFinding, contractTeams: Record<string, string>) {
+  const consumer = contractConsumerLabel(finding);
+  const team = finding.consumerTeam?.trim() || finding.consumer_team?.trim() || contractTeams[consumer];
+  if (team) return `team: ${team}`;
+  return "team not set";
+}
+
+function contractFindingTitle(finding: ContractDiffFinding, contractTeams: Record<string, string>) {
+  return [
+    `${finding.verdict}: ${contractSubjectForFinding(finding)}`,
+    `consumer: ${contractConsumerLabel(finding)}`,
+    contractTeamLabel(finding, contractTeams),
+    finding.detail,
+  ].filter(Boolean).join(" · ");
+}
+
+function contractBadgeClass(verdict: ContractDiffFinding["verdict"]) {
+  switch (verdict) {
+    case "breaking":
+      return "border-danger/35 bg-danger/10 text-danger";
+    case "unknown":
+      return "border-warning/35 bg-warning/10 text-warning";
+    case "compatible":
+      return "border-success/35 bg-success/10 text-success";
+    default:
+      return "border-text-3/30 text-text-3";
+  }
+}
+
 export function JobDefsPage() {
   const queryClient = useQueryClient();
   const [yaml, setYaml] = useState(EXAMPLE_YAML);
@@ -98,10 +196,12 @@ export function JobDefsPage() {
   const [lintResult, setLintResult] = useState<LintResponse>({ errors: [], warnings: [], summary: { steps: 0 } });
   const [diffResult, setDiffResult] = useState<DiffResponse | null>(null);
   const [isLinting, setIsLinting] = useState(false);
+  const [ackReason, setAckReason] = useState("");
   
   const handleYamlChange = (val: string) => {
     setYaml(val);
     setIsLinting(true);
+    setAckReason("");
   };
 
   // Debounced API calls
@@ -144,10 +244,24 @@ export function JobDefsPage() {
     };
   }, [yaml]);
 
+  const contractTeams = useMemo(() => buildContractTeamLookup(diffResult), [diffResult]);
+  const contractFindings = useMemo(() => collectContractFindings(diffResult), [diffResult]);
+  const breakingContractFindings = contractFindings.filter((finding) => finding.verdict === "breaking");
+  const hasBreakingContractFindings = breakingContractFindings.length > 0;
+  const ackSubject = breakingContractFindings[0] ? contractSubjectForFinding(breakingContractFindings[0]) : "";
+  const trimmedAckReason = ackReason.trim();
+  const allowBreaking: AllowBreakingRequest | undefined = hasBreakingContractFindings
+    ? { dataset: ackSubject, reason: trimmedAckReason }
+    : undefined;
+
   const applyMutation = useMutation({
-    mutationFn: () => api.applyJobDef(yaml),
+    mutationFn: () => api.applyJobDef(yaml, allowBreaking),
     onSuccess: (data) => {
       toast.success(`Applied successfully (${data.applied} jobs)`);
+      for (const warning of data.contract_warnings ?? []) {
+        toast.warning(warning.message || `Contract warning for ${warning.subject}`);
+      }
+      setAckReason("");
       queryClient.invalidateQueries({ queryKey: ["jobs"] });
       queryClient.invalidateQueries({ queryKey: ["atoms"] });
       queryClient.invalidateQueries({ queryKey: ["triggers"] });
@@ -196,7 +310,7 @@ export function JobDefsPage() {
             Lint, diff, and apply YAML manifests <span className="text-text-4">·</span> <code className="font-mono text-cyan-glow text-xs bg-cyan-glow/10 px-1 py-0.5 rounded">caesium job apply</code>
           </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
           <Button variant="outline" size="sm" className="bg-transparent border-graphite/50 text-text-2">
             <Upload className="h-3.5 w-3.5 mr-1.5" />
             Upload
@@ -205,11 +319,21 @@ export function JobDefsPage() {
             <GitBranch className="h-3.5 w-3.5 mr-1.5" />
             Git sync
           </Button>
+          {hasBreakingContractFindings && (
+            <input
+              aria-label="Breaking change acknowledgement reason"
+              data-testid="contract-ack-reason"
+              value={ackReason}
+              onChange={(event) => setAckReason(event.currentTarget.value)}
+              placeholder={`Reason for ${ackSubject}`}
+              className="h-8 w-full sm:w-64 rounded-md border border-danger/35 bg-danger/10 px-3 text-xs text-text-1 placeholder:text-danger/70 outline-none transition-colors focus:border-danger"
+            />
+          )}
           <Button 
             size="sm" 
             className="bg-cyan-glow text-midnight hover:bg-cyan-dim disabled:opacity-50"
             onClick={() => applyMutation.mutate()}
-            disabled={hasErrors || applyMutation.isPending || !yaml.trim() || isLinting}
+            disabled={hasErrors || applyMutation.isPending || !yaml.trim() || isLinting || (hasBreakingContractFindings && !trimmedAckReason)}
           >
             <Play className="h-3.5 w-3.5 mr-1.5" />
             {applyMutation.isPending ? "Applying..." : "Apply definition"}
@@ -345,7 +469,7 @@ export function JobDefsPage() {
               </Card>
             </>
           ) : (
-            <DiffView diff={diffResult} />
+            <DiffView diff={diffResult} contractTeams={contractTeams} />
           )}
         </div>
 
@@ -488,7 +612,7 @@ function formatIdentityDetail(hints: JobDefRuntimeHints) {
   return `Includes ${extras.join(" and ")}.`;
 }
 
-function DiffView({ diff }: { diff: DiffResponse | null }) {
+function DiffView({ diff, contractTeams }: { diff: DiffResponse | null; contractTeams: Record<string, string> }) {
   if (!diff) {
     return (
       <Card className="bg-midnight/30 border-graphite/50 p-8 text-center text-text-3 text-sm">
@@ -524,18 +648,24 @@ function DiffView({ diff }: { diff: DiffResponse | null }) {
         ) : (
           <div className="font-mono text-xs leading-relaxed overflow-x-auto bg-void p-4">
             {added.map((a, i) => (
-              <div key={`a-${i}`} className="flex gap-3 py-1.5">
-                <span className="text-success font-bold w-4 flex-shrink-0 text-center">+</span>
-                <span className="text-cyan-glow flex-shrink-0">{a.alias}</span>
-                <span className="text-success/80 text-[11px] truncate whitespace-nowrap">Job will be created</span>
+              <div key={`a-${i}`} className="py-1.5 border-b border-graphite/20 last:border-0">
+                <div className="flex gap-3">
+                  <span className="text-success font-bold w-4 flex-shrink-0 text-center">+</span>
+                  <span className="text-cyan-glow flex-shrink-0">{a.alias}</span>
+                  <span className="text-success/80 text-[11px] truncate whitespace-nowrap">Job will be created</span>
+                </div>
+                <ContractFindingsList findings={a.contractFindings} contractTeams={contractTeams} />
               </div>
             ))}
             
             {removed.map((r, i) => (
-              <div key={`r-${i}`} className="flex gap-3 py-1.5">
-                <span className="text-danger font-bold w-4 flex-shrink-0 text-center">-</span>
-                <span className="text-cyan-glow flex-shrink-0">{r.alias}</span>
-                <span className="text-danger/80 text-[11px] truncate whitespace-nowrap">Job will be deleted (if prune enabled)</span>
+              <div key={`r-${i}`} className="py-1.5 border-b border-graphite/20 last:border-0">
+                <div className="flex gap-3">
+                  <span className="text-danger font-bold w-4 flex-shrink-0 text-center">-</span>
+                  <span className="text-cyan-glow flex-shrink-0">{r.alias}</span>
+                  <span className="text-danger/80 text-[11px] truncate whitespace-nowrap">Job will be deleted (if prune enabled)</span>
+                </div>
+                <ContractFindingsList findings={r.contractFindings} contractTeams={contractTeams} />
               </div>
             ))}
             
@@ -545,6 +675,7 @@ function DiffView({ diff }: { diff: DiffResponse | null }) {
                   <span className="text-gold font-bold w-4 flex-shrink-0 text-center">~</span>
                   <span className="text-cyan-glow">{m.alias}</span>
                 </div>
+                <ContractFindingsList findings={m.contractFindings} contractTeams={contractTeams} />
                 <div className="pl-7 pr-2">
                   <pre className="text-[11px] font-mono text-text-3 overflow-x-auto bg-obsidian/30 p-2 rounded border border-graphite/20">
                     {m.diff}
@@ -556,6 +687,73 @@ function DiffView({ diff }: { diff: DiffResponse | null }) {
         )}
       </div>
     </Card>
+  );
+}
+
+function ContractFindingsList({
+  findings,
+  contractTeams,
+}: {
+  findings?: ContractDiffFinding[];
+  contractTeams: Record<string, string>;
+}) {
+  const visibleFindings = dedupeContractFindings(findings);
+  if (visibleFindings.length === 0) return null;
+
+  return (
+    <div className="pl-7 pr-2 pb-2 flex flex-col gap-1.5" data-testid="contract-findings">
+      {visibleFindings.map((finding) => (
+        <ContractFindingBadge
+          key={contractFindingTitle(finding, contractTeams)}
+          finding={finding}
+          contractTeams={contractTeams}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ContractFindingBadge({
+  finding,
+  contractTeams,
+}: {
+  finding: ContractDiffFinding;
+  contractTeams: Record<string, string>;
+}) {
+  const subject = contractSubjectForFinding(finding);
+  const consumer = contractConsumerLabel(finding);
+  const team = contractTeamLabel(finding, contractTeams);
+  const edgeClass = finding.edgeClass ?? "edge";
+
+  return (
+    <details className="group max-w-full">
+      <summary
+        title={contractFindingTitle(finding, contractTeams)}
+        data-testid="contract-finding-badge"
+        data-verdict={finding.verdict}
+        className={[
+          "flex w-fit max-w-full cursor-pointer list-none flex-wrap items-center gap-1.5 rounded-full border px-2 py-1 text-[10px] font-semibold leading-tight shadow-sm transition-colors [&::-webkit-details-marker]:hidden",
+          contractBadgeClass(finding.verdict),
+        ].join(" ")}
+      >
+        {finding.verdict === "breaking" && <AlertTriangle className="h-3 w-3 flex-shrink-0" />}
+        <span className="uppercase">{finding.verdict}</span>
+        <span className="text-text-4">·</span>
+        <span className="break-all">{subject}</span>
+        <span className="text-text-4">·</span>
+        <span>consumer: {consumer}</span>
+        <span className="text-text-4">·</span>
+        <span>{team}</span>
+      </summary>
+      <div className="mt-1 max-w-2xl rounded border border-graphite/30 bg-obsidian/40 p-2 text-[11px] leading-relaxed text-text-2">
+        <div className="flex flex-wrap gap-x-3 gap-y-1">
+          <span>{edgeClass}</span>
+          {finding.path && <span>path: {finding.path}</span>}
+          {finding.key && <span>key: {finding.key}</span>}
+        </div>
+        {finding.detail && <div className="mt-1 text-text-3">{finding.detail}</div>}
+      </div>
+    </details>
   );
 }
 

--- a/ui/src/features/jobdefs/JobDefsPage.tsx
+++ b/ui/src/features/jobdefs/JobDefsPage.tsx
@@ -1,4 +1,4 @@
-import { useDeferredValue, useEffect, useMemo, useState } from "react";
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -8,7 +8,7 @@ import { Button } from "@/components/ui/button";
 import CodeMirror from "@uiw/react-codemirror";
 import { yaml as yamlLang } from "@codemirror/lang-yaml";
 import { linter, type Diagnostic } from "@codemirror/lint";
-import { EditorView } from "@codemirror/view";
+import { EditorView, type ViewUpdate } from "@codemirror/view";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card } from "@/components/ui/card";
 import { getJobDefRuntimeHints, type JobDefRuntimeHints } from "./runtimeHints";
@@ -197,52 +197,105 @@ export function JobDefsPage() {
   const [diffResult, setDiffResult] = useState<DiffResponse | null>(null);
   const [isLinting, setIsLinting] = useState(false);
   const [ackReason, setAckReason] = useState("");
-  
-  const handleYamlChange = (val: string) => {
+  const latestYamlRef = useRef(EXAMPLE_YAML);
+  const yamlVersionRef = useRef(0);
+  const validationSeqRef = useRef(0);
+  const editorViewRef = useRef<EditorView | null>(null);
+
+  const syncLatestYaml = useCallback((value: string) => {
+    if (latestYamlRef.current !== value) {
+      latestYamlRef.current = value;
+      yamlVersionRef.current += 1;
+    }
+    return yamlVersionRef.current;
+  }, []);
+
+  const currentEditorYaml = useCallback(() => (
+    editorViewRef.current?.state.doc.toString() ?? latestYamlRef.current
+  ), []);
+
+  const runValidation = useCallback(async (sourceYaml: string, sourceVersion = yamlVersionRef.current) => {
+    const validationID = validationSeqRef.current + 1;
+    validationSeqRef.current = validationID;
+    const isCurrentValidation = () => (
+      validationID === validationSeqRef.current && sourceVersion === yamlVersionRef.current
+    );
+
+    setIsLinting(true);
+    try {
+      const lr = await api.lintJobDef(sourceYaml);
+      if (!isCurrentValidation()) return;
+      setLintResult(lr);
+
+      // Only get diff if lint passes
+      if (lr.errors && lr.errors.length === 0) {
+        const dr = await api.diffJobDef(sourceYaml);
+        if (!isCurrentValidation()) return;
+        setDiffResult(dr);
+      } else {
+        setDiffResult(null);
+      }
+    } catch (err) {
+      if (!isCurrentValidation()) return;
+      // Surface YAML parse errors or network failures
+      setLintResult({
+        errors: [{ message: err instanceof Error ? err.message : "Request failed", line: 1 }],
+        warnings: [],
+        summary: { steps: 0 },
+      });
+      setDiffResult(null);
+    } finally {
+      if (isCurrentValidation()) {
+        setIsLinting(false);
+      }
+    }
+  }, []);
+
+  const handleYamlChange = useCallback((val: string) => {
+    syncLatestYaml(val);
     setYaml(val);
     setIsLinting(true);
     setAckReason("");
-  };
+  }, [syncLatestYaml]);
+
+  const handleEditorUpdate = useCallback((update: ViewUpdate) => {
+    if (update.docChanged) {
+      syncLatestYaml(update.state.doc.toString());
+    }
+  }, [syncLatestYaml]);
+
+  const handleResetExample = useCallback(() => {
+    syncLatestYaml(EXAMPLE_YAML);
+    setYaml(EXAMPLE_YAML);
+    setIsLinting(true);
+    setAckReason("");
+  }, [syncLatestYaml]);
+
+  const handleTabChange = useCallback((value: string) => {
+    setTab(value);
+    if (value !== "diff") return;
+
+    const sourceYaml = currentEditorYaml();
+    const sourceVersion = syncLatestYaml(sourceYaml);
+    if (sourceYaml !== yaml) {
+      setYaml(sourceYaml);
+      setIsLinting(true);
+      setAckReason("");
+    }
+    void runValidation(sourceYaml, sourceVersion);
+  }, [currentEditorYaml, runValidation, syncLatestYaml, yaml]);
 
   // Debounced API calls
   useEffect(() => {
-    const ac = new AbortController();
-
+    const sourceVersion = yamlVersionRef.current;
     const timer = setTimeout(async () => {
-      try {
-        const lr = await api.lintJobDef(yaml);
-        if (ac.signal.aborted) return;
-        setLintResult(lr);
-        
-        // Only get diff if lint passes
-        if (lr.errors && lr.errors.length === 0) {
-          const dr = await api.diffJobDef(yaml);
-          if (ac.signal.aborted) return;
-          setDiffResult(dr);
-        } else {
-          setDiffResult(null);
-        }
-      } catch (err) {
-        if (ac.signal.aborted) return;
-        // Surface YAML parse errors or network failures
-        setLintResult({
-          errors: [{ message: err instanceof Error ? err.message : "Request failed", line: 1 }],
-          warnings: [],
-          summary: { steps: 0 },
-        });
-        setDiffResult(null);
-      } finally {
-        if (!ac.signal.aborted) {
-          setIsLinting(false);
-        }
-      }
+      await runValidation(yaml, sourceVersion);
     }, 300);
 
     return () => {
       clearTimeout(timer);
-      ac.abort();
     };
-  }, [yaml]);
+  }, [runValidation, yaml]);
 
   const contractTeams = useMemo(() => buildContractTeamLookup(diffResult), [diffResult]);
   const contractFindings = useMemo(() => collectContractFindings(diffResult), [diffResult]);
@@ -342,7 +395,7 @@ export function JobDefsPage() {
       </div>
 
       <div className="bg-obsidian border border-graphite/50 rounded-lg p-[3px] w-fit">
-        <Tabs value={tab} onValueChange={setTab}>
+        <Tabs value={tab} onValueChange={handleTabChange}>
           <TabsList className="bg-transparent h-auto p-0 space-x-1">
             <TabsTrigger 
               value="editor" 
@@ -392,8 +445,8 @@ export function JobDefsPage() {
                     <span className="font-mono text-[10px] text-text-4">
                       {lineCount} lines <span className="mx-1">·</span> {(yaml.length / 1024).toFixed(1)} KB
                     </span>
-                    <button 
-                      onClick={() => setYaml(EXAMPLE_YAML)} 
+                    <button
+                      onClick={handleResetExample}
                       className="text-[11px] text-text-3 hover:text-text-1 transition-colors"
                     >
                       Reset example
@@ -407,6 +460,11 @@ export function JobDefsPage() {
                     height="420px"
                     extensions={[yamlLang(), customTheme, customLinter]}
                     onChange={handleYamlChange}
+                    onCreateEditor={(view) => {
+                      editorViewRef.current = view;
+                      syncLatestYaml(view.state.doc.toString());
+                    }}
+                    onUpdate={handleEditorUpdate}
                     basicSetup={{
                       lineNumbers: true,
                       foldGutter: true,

--- a/ui/src/features/jobdefs/JobDefsPage.tsx
+++ b/ui/src/features/jobdefs/JobDefsPage.tsx
@@ -301,7 +301,12 @@ export function JobDefsPage() {
   const contractFindings = useMemo(() => collectContractFindings(diffResult), [diffResult]);
   const breakingContractFindings = contractFindings.filter((finding) => finding.verdict === "breaking");
   const hasBreakingContractFindings = breakingContractFindings.length > 0;
-  const ackSubject = breakingContractFindings[0] ? contractSubjectForFinding(breakingContractFindings[0]) : "";
+  // The allow_breaking request (like the CLI flag) acknowledges ONE subject per
+  // apply, so the in-page ack can only unlock single-subject breaking diffs;
+  // multi-subject breaks must be split into separate applies.
+  const breakingSubjects = [...new Set(breakingContractFindings.map(contractSubjectForFinding))];
+  const hasMultipleBreakingSubjects = breakingSubjects.length > 1;
+  const ackSubject = breakingSubjects[0] ?? "";
   const trimmedAckReason = ackReason.trim();
   const allowBreaking: AllowBreakingRequest | undefined = hasBreakingContractFindings
     ? { dataset: ackSubject, reason: trimmedAckReason }
@@ -372,7 +377,7 @@ export function JobDefsPage() {
             <GitBranch className="h-3.5 w-3.5 mr-1.5" />
             Git sync
           </Button>
-          {hasBreakingContractFindings && (
+          {hasBreakingContractFindings && !hasMultipleBreakingSubjects && (
             <input
               aria-label="Breaking change acknowledgement reason"
               data-testid="contract-ack-reason"
@@ -382,11 +387,21 @@ export function JobDefsPage() {
               className="h-8 w-full sm:w-64 rounded-md border border-danger/35 bg-danger/10 px-3 text-xs text-text-1 placeholder:text-danger/70 outline-none transition-colors focus:border-danger"
             />
           )}
-          <Button 
-            size="sm" 
+          {hasMultipleBreakingSubjects && (
+            <span
+              data-testid="contract-ack-multi-subject"
+              className="text-[11px] text-danger/90 max-w-xs"
+            >
+              {breakingSubjects.length} contracts break ({breakingSubjects.join(", ")}) — an
+              acknowledgement covers one subject per apply, so split this change into separate
+              applies (or use `caesium job apply --allow-breaking` per dataset).
+            </span>
+          )}
+          <Button
+            size="sm"
             className="bg-cyan-glow text-midnight hover:bg-cyan-dim disabled:opacity-50"
             onClick={() => applyMutation.mutate()}
-            disabled={hasErrors || applyMutation.isPending || !yaml.trim() || isLinting || (hasBreakingContractFindings && !trimmedAckReason)}
+            disabled={hasErrors || applyMutation.isPending || !yaml.trim() || isLinting || (hasBreakingContractFindings && !trimmedAckReason) || hasMultipleBreakingSubjects}
           >
             <Play className="h-3.5 w-3.5 mr-1.5" />
             {applyMutation.isPending ? "Applying..." : "Apply definition"}
@@ -762,7 +777,7 @@ function ContractFindingsList({
     <div className="pl-7 pr-2 pb-2 flex flex-col gap-1.5" data-testid="contract-findings">
       {visibleFindings.map((finding) => (
         <ContractFindingBadge
-          key={contractFindingTitle(finding, contractTeams)}
+          key={`${finding.edgeId ?? ""}:${finding.path ?? ""}:${finding.detail ?? ""}`}
           finding={finding}
           contractTeams={contractTeams}
         />

--- a/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
+++ b/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -9,6 +9,14 @@ vi.mock("@/lib/api", () => ({
     lintJobDef: vi.fn(),
     diffJobDef: vi.fn(),
     applyJobDef: vi.fn(),
+  },
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
   },
 }));
 
@@ -54,6 +62,31 @@ function createWrapper() {
   );
 }
 
+async function settleLintAndDiff() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(350);
+  });
+}
+
+function openDiffTab() {
+  const tab = screen.getByRole("tab", { name: /Diff vs server/i });
+  fireEvent.pointerDown(tab, { button: 0, ctrlKey: false });
+  fireEvent.click(tab);
+  fireEvent.keyDown(tab, { key: "Enter", code: "Enter" });
+}
+
+const breakingFinding = {
+  edgeId: "inferred:producer:consumer",
+  edgeClass: "inferred" as const,
+  from: "job:producer",
+  to: "job:consumer",
+  verdict: "breaking" as const,
+  key: "customer_id",
+  path: "trigger.configuration.paramMapping.customer",
+  detail: "paramMapping customer references output key customer_id, but that key is missing",
+  consumer_team: "reporting",
+};
+
 describe("JobDefsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -67,6 +100,10 @@ describe("JobDefsPage", () => {
       added: [],
       removed: [],
       modified: [],
+    });
+    vi.mocked(api.applyJobDef).mockResolvedValue({
+      applied: 1,
+      contract_warnings: [],
     });
   });
 
@@ -120,5 +157,83 @@ steps:
 
     expect(screen.getByText("No volumes declared")).toBeInTheDocument();
     expect(screen.getByText("No service account")).toBeInTheDocument();
+  });
+
+  it("renders contract finding badges from the diff response", async () => {
+    vi.mocked(api.diffJobDef).mockResolvedValue({
+      added: [],
+      removed: [],
+      modified: [
+        {
+          alias: "producer",
+          diff: "- old\n+ new",
+          contractFindings: [
+            breakingFinding,
+            {
+              ...breakingFinding,
+              edgeId: "declared:producer:consumer:lake/customers",
+              edgeClass: "declared",
+              verdict: "compatible",
+              dataset: { namespace: "lake", name: "customers" },
+              detail: "optional field added",
+            },
+            {
+              ...breakingFinding,
+              edgeId: "inferred:producer:consumer:unknown",
+              verdict: "unknown",
+              key: "order_id",
+              detail: "consumer requirement cannot be proven",
+            },
+          ],
+        },
+      ],
+    });
+
+    render(<JobDefsPage />, { wrapper: createWrapper() });
+    await settleLintAndDiff();
+    openDiffTab();
+
+    const badges = screen.getAllByTestId("contract-finding-badge");
+    expect(badges).toHaveLength(3);
+    expect(badges[0]).toHaveAttribute("data-verdict", "breaking");
+    expect(screen.getByText("producer.output.customer_id")).toBeInTheDocument();
+    expect(screen.getByText("lake/customers")).toBeInTheDocument();
+    expect(screen.getAllByText("consumer: consumer").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("team: reporting").length).toBeGreaterThan(0);
+    expect(badges[0].getAttribute("title")).toContain("missing");
+  });
+
+  it("requires an acknowledgement reason for breaking findings and passes it to apply", async () => {
+    vi.mocked(api.diffJobDef).mockResolvedValue({
+      added: [],
+      removed: [],
+      modified: [
+        {
+          alias: "producer",
+          diff: "- old\n+ new",
+          contractFindings: [breakingFinding],
+        },
+      ],
+    });
+
+    render(<JobDefsPage />, { wrapper: createWrapper() });
+    await settleLintAndDiff();
+
+    const applyButton = screen.getByRole("button", { name: /Apply definition/i });
+    expect(applyButton).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText("Breaking change acknowledgement reason"), {
+      target: { value: "customer migration accepted" },
+    });
+    expect(applyButton).toBeEnabled();
+
+    await act(async () => {
+      fireEvent.click(applyButton);
+      await Promise.resolve();
+    });
+    expect(api.applyJobDef).toHaveBeenCalledWith(expect.any(String), {
+      dataset: "producer.output.customer_id",
+      reason: "customer migration accepted",
+    });
   });
 });

--- a/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
+++ b/ui/src/features/jobdefs/__tests__/JobDefsPage.test.tsx
@@ -4,6 +4,26 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { JobDefsPage } from "../JobDefsPage";
 
+const codeMirrorHarness = vi.hoisted(() => {
+  const state: {
+    editorText: string;
+    delayOnChange: boolean;
+    pendingOnChange?: () => void;
+  } = {
+    editorText: "",
+    delayOnChange: false,
+    pendingOnChange: undefined,
+  };
+  const view = {
+    state: {
+      doc: {
+        toString: () => state.editorText,
+      },
+    },
+  };
+  return { state, view };
+});
+
 vi.mock("@/lib/api", () => ({
   api: {
     lintJobDef: vi.fn(),
@@ -24,16 +44,36 @@ vi.mock("@uiw/react-codemirror", () => ({
   default: ({
     value,
     onChange,
+    onCreateEditor,
+    onUpdate,
   }: {
     value: string;
     onChange?: (value: string) => void;
-  }) => (
-    <textarea
-      aria-label="job.yaml editor"
-      value={value}
-      onChange={(event) => onChange?.(event.currentTarget.value)}
-    />
-  ),
+    onCreateEditor?: (view: typeof codeMirrorHarness.view, state: typeof codeMirrorHarness.view.state) => void;
+    onUpdate?: (update: { docChanged: boolean; state: typeof codeMirrorHarness.view.state }) => void;
+  }) => {
+    codeMirrorHarness.state.editorText = value;
+    onCreateEditor?.(codeMirrorHarness.view, codeMirrorHarness.view.state);
+
+    return (
+      <textarea
+        aria-label="job.yaml editor"
+        value={value}
+        onChange={(event) => {
+          const nextValue = event.currentTarget.value;
+          codeMirrorHarness.state.editorText = nextValue;
+          onUpdate?.({ docChanged: true, state: codeMirrorHarness.view.state });
+
+          const emitChange = () => onChange?.(nextValue);
+          if (codeMirrorHarness.state.delayOnChange) {
+            codeMirrorHarness.state.pendingOnChange = emitChange;
+            return;
+          }
+          emitChange();
+        }}
+      />
+    );
+  },
 }));
 
 vi.mock("@codemirror/lang-yaml", () => ({
@@ -91,6 +131,9 @@ describe("JobDefsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    codeMirrorHarness.state.editorText = "";
+    codeMirrorHarness.state.delayOnChange = false;
+    codeMirrorHarness.state.pendingOnChange = undefined;
     vi.mocked(api.lintJobDef).mockResolvedValue({
       errors: [],
       warnings: [],
@@ -201,6 +244,41 @@ steps:
     expect(screen.getAllByText("consumer: consumer").length).toBeGreaterThan(0);
     expect(screen.getAllByText("team: reporting").length).toBeGreaterThan(0);
     expect(badges[0].getAttribute("title")).toContain("missing");
+  });
+
+  it("diffs the current editor document when the tab opens before onChange settles", async () => {
+    codeMirrorHarness.state.delayOnChange = true;
+    const nextYaml = `apiVersion: v1
+kind: Job
+metadata:
+  alias: race-producer
+trigger:
+  type: cron
+  configuration:
+    cron: "0 * * * *"
+steps:
+  - name: export
+    image: alpine:3.23
+`;
+
+    render(<JobDefsPage />, { wrapper: createWrapper() });
+    await settleLintAndDiff();
+    vi.mocked(api.lintJobDef).mockClear();
+    vi.mocked(api.diffJobDef).mockClear();
+
+    fireEvent.change(screen.getByLabelText("job.yaml editor"), {
+      target: { value: nextYaml },
+    });
+    openDiffTab();
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(codeMirrorHarness.state.pendingOnChange).toBeTypeOf("function");
+    expect(api.lintJobDef).toHaveBeenCalledWith(nextYaml);
+    expect(api.diffJobDef).toHaveBeenCalledWith(nextYaml);
   });
 
   it("requires an acknowledgement reason for breaking findings and passes it to apply", async () => {

--- a/ui/src/lib/__tests__/api.test.ts
+++ b/ui/src/lib/__tests__/api.test.ts
@@ -191,6 +191,33 @@ steps:
     });
   });
 
+  it('applyJobDef threads contract break acknowledgements', async () => {
+    mockFetch.mockResolvedValue(okResponse({ applied: 1 }));
+
+    await api.applyJobDef(`apiVersion: v1
+kind: Job
+metadata:
+  alias: contract-ack
+trigger:
+  type: cron
+  configuration:
+    cron: "0 * * * *"
+steps:
+  - name: run
+    image: alpine:3.23
+`, {
+      dataset: 'producer.output.customer_id',
+      reason: 'accepted by reporting',
+    });
+
+    const [, init] = mockFetch.mock.calls[0];
+    const payload = JSON.parse(String(init?.body));
+    expect(payload.allow_breaking).toEqual({
+      dataset: 'producer.output.customer_id',
+      reason: 'accepted by reporting',
+    });
+  });
+
   it('deleteTaskCache encodes the task name in the URL', async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -918,8 +918,6 @@ export interface ContractDiffFinding extends ContractFinding {
   dataset?: ContractDatasetRef;
   consumerTeam?: string;
   consumer_team?: string;
-  teamAttribution?: string;
-  team_attribution?: string;
 }
 
 export interface ContractGraphEdge {

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -447,11 +447,13 @@ export interface DiffJobSpec {
     configuration: Record<string, unknown>;
   };
   steps?: unknown[];
+  contractFindings?: ContractDiffFinding[];
 }
 
 export interface DiffUpdate {
   alias: string;
   diff: string;
+  contractFindings?: ContractDiffFinding[];
 }
 
 export interface DiffResponse {
@@ -460,8 +462,29 @@ export interface DiffResponse {
   modified: DiffUpdate[];
 }
 
+export interface AllowBreakingRequest {
+  dataset: string;
+  reason?: string;
+}
+
+export interface ContractWarning {
+  type: string;
+  message: string;
+  subject: string;
+  dataset?: string;
+  output_key?: string;
+  producer: string;
+  consumer?: string;
+  consumer_team?: string;
+  edge_set_digest: string;
+  acknowledgement_id: string;
+  deprecation_until: string;
+}
+
 export interface ApplyJobDefResponse {
   applied: number;
+  pruned?: number;
+  contract_warnings?: ContractWarning[];
 }
 
 export interface TriggerRunRequest {
@@ -883,7 +906,20 @@ export interface ContractFinding {
   kind?: string;
   path?: string;
   detail?: string;
+  key?: string;
   verdict: ContractVerdict;
+}
+
+export interface ContractDiffFinding extends ContractFinding {
+  edgeId?: string;
+  edgeClass?: ContractEdgeClass;
+  from?: string;
+  to?: string;
+  dataset?: ContractDatasetRef;
+  consumerTeam?: string;
+  consumer_team?: string;
+  teamAttribution?: string;
+  team_attribution?: string;
 }
 
 export interface ContractGraphEdge {
@@ -1309,10 +1345,13 @@ export const api = {
       method: "PUT",
       body: JSON.stringify(body),
     }),
-  applyJobDef: (yaml: string) =>
+  applyJobDef: (yaml: string, allowBreaking?: AllowBreakingRequest) =>
     request<ApplyJobDefResponse>("/jobdefs/apply", {
       method: "POST",
-      body: JSON.stringify({ definitions: parseJobDefinitions(yaml) }),
+      body: JSON.stringify({
+        definitions: parseJobDefinitions(yaml),
+        ...(allowBreaking ? { allow_breaking: allowBreaking } : {}),
+      }),
     }),
   getBackfills: (jobId: string) =>
     request<Backfill[]>(`/jobs/${jobId}/backfills`),


### PR DESCRIPTION
## Summary
F2 — the plan's final code item:

- The JobDefs diff tab renders verdict-colored badges per contract finding (dataset/subject, consumer + team, detail), reusing F1's verdict tokens.
- **Ack-gated Apply**: breaking findings disable Apply until a reason is entered; submission threads `allow_breaking: {dataset, reason}` through the apply request (C2's server path).
- Apply-response `contract_warnings` (declared-break confirmation, deprecation notices) surface as warning toasts.
- Enforcement-off servers: no contract chrome rendered at all.
- vitest coverage (badges, gating, ack threading) + Playwright e2e extending the contracts spec with a breaking-change acknowledgement flow.

## Test plan
- [x] `npm run lint` + `npm run build` + vitest — green (agent + orchestrator independently).
- [ ] ui-e2e — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
