### PR TITLE
Enable digest pinning on the integration servers (reproduce W1-η)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,7 @@ jobs:
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             -e CAESIUM_CONTRACT_DEPRECATION_WINDOW=5s \
+            -e CAESIUM_CACHE_PIN_DIGESTS=true \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -330,6 +331,7 @@ jobs:
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             -e CAESIUM_CONTRACT_DEPRECATION_WINDOW=5s \
+            -e CAESIUM_CACHE_PIN_DIGESTS=true \
             -e CAESIUM_AGENT_REMEDIATION_ENABLED=true \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
@@ -512,6 +514,7 @@ jobs:
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             -e CAESIUM_CONTRACT_DEPRECATION_WINDOW=5s \
+            -e CAESIUM_CACHE_PIN_DIGESTS=true \
             --user 0:0 \
             caesiumcloud/caesium:${{ env.IMAGE_TAG }}-amd64 start
       - name: Extract caesium CLI

--- a/docs/exec-plans/active/reproduce.md
+++ b/docs/exec-plans/active/reproduce.md
@@ -252,7 +252,7 @@ on the shared command file — see conflicts).
 
 ## Harness Strengthening
 
-- [ ] H-1. Ensure the integration server produces reproducible descriptors and the
+- [x] H-1. Ensure the integration server produces reproducible descriptors and the
       reproduce scenarios drive the **real CLI** against the harness Docker daemon:
       confirm the integration job runs with digest pinning on (so
       `ResolvedImageDigest` is recorded and pull-by-digest is faithful), that the
@@ -263,6 +263,17 @@ on the shared command file — see conflicts).
       is real. Reproduce needs no new `CAESIUM_*` server env (it reuses
       `CAESIUM_API_KEY`); if any harness gate is missing, add it here.
       Files: `justfile`, `.github/workflows/ci.yml`, `test/` harness helpers.
+      Note: W1-η found digest pinning was the one missing gate —
+      `CAESIUM_CACHE_PIN_DIGESTS` (default false) was set on NO server-boot site, so
+      descriptors recorded no `ResolvedImageDigest`. Now set `=true` on every site in
+      one sweep (all justfile lanes incl. podman/distributed/agent, the local
+      k8s-distributed helm `--set` list as `extraEnv[3]`, the CI helm values file,
+      and the three ci.yml server blocks) — degradation-safe because the imagecheck
+      resolver falls back to the tag on registry failure. Verified already-present:
+      the harness Docker daemon is reachable from the test-runner container (both
+      mount `docker.sock`), and `runCLIStdout`/`runCLISeparate` split-stream helpers
+      exist in `test/` (used by blame/agent-remediation scenarios). No new helper
+      code needed; A2/B scenarios consume the existing surface.
 
 ## Navigational / Organizational Improvements
 

--- a/helm/caesium/ci/test-values-k8s.yaml
+++ b/helm/caesium/ci/test-values-k8s.yaml
@@ -41,6 +41,11 @@ config:
     # deterministic here too (mirrors the justfile/ci.yml server blocks).
     - name: CAESIUM_CONTRACT_DEPRECATION_WINDOW
       value: 5s
+    # Pin image digests so descriptors record ResolvedImageDigest and the
+    # reproduce scenarios can pull-by-digest faithfully (falls back to tag on
+    # registry failure, so this cannot fail runs).
+    - name: CAESIUM_CACHE_PIN_DIGESTS
+      value: "true"
 
 kubernetes:
   engine:

--- a/justfile
+++ b/justfile
@@ -297,6 +297,7 @@ integration-test-podman: build
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
+        -e CAESIUM_CACHE_PIN_DIGESTS=true \
         --user 0:0 \
         {{ repo }}/{{ image }}:{{ tag }} start
     if docker run --rm --platform {{ platform }} \
@@ -340,6 +341,7 @@ integration-up: build-test
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
+        -e CAESIUM_CACHE_PIN_DIGESTS=true \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_RATE_LIMIT_PRUNER_ENABLED=true \
         -e CAESIUM_RATE_LIMIT_PRUNE_INTERVAL=500ms \
@@ -366,6 +368,7 @@ integration-up-distributed: build-test
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
+        -e CAESIUM_CACHE_PIN_DIGESTS=true \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         -e CAESIUM_EXECUTION_MODE=distributed \
         -e CAESIUM_NODE_ADDRESS=127.0.0.1:9001 \
@@ -414,6 +417,7 @@ integration-up-agent: build-test build-triage-agent
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
+        -e CAESIUM_CACHE_PIN_DIGESTS=true \
         -e CAESIUM_NOTIFICATION_WATCHER_INTERVAL=1s \
         {{ local_image_ref }}:{{ tag }}-test start
 
@@ -455,6 +459,7 @@ ui-e2e: build-release
             -e CAESIUM_FRESHNESS_ENABLED=true \
             -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
             -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
+            -e CAESIUM_CACHE_PIN_DIGESTS=true \
             -e CAESIUM_RUN_QUEUE_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUER_ENABLED=true \
             -e CAESIUM_RUN_QUEUE_DEQUEUE_INTERVAL=500ms \
@@ -494,6 +499,7 @@ ui-e2e-auth: build-release
         -e CAESIUM_FRESHNESS_ENABLED=true \
         -e CAESIUM_CONTRACT_ENFORCEMENT=fail \
         -e CAESIUM_CONTRACT_DEPRECATION_WINDOW={{ contract_deprecation_window }} \
+        -e CAESIUM_CACHE_PIN_DIGESTS=true \
         -e CAESIUM_AGENT_REMEDIATION_ENABLED=true \
         --user 0:0 {{ local_image_ref }}:{{ tag }} start >/dev/null
     tries=0
@@ -579,6 +585,8 @@ k8s-distributed: build-release k8s-registry-up
             --set-string config.extraEnv[1].value=true \
             --set config.extraEnv[2].name=CAESIUM_CONTRACT_ENFORCEMENT \
             --set-string config.extraEnv[2].value=fail \
+            --set config.extraEnv[3].name=CAESIUM_CACHE_PIN_DIGESTS \
+            --set-string config.extraEnv[3].value=true \
             --set kubernetes.engine.enabled=true \
             --set persistence.enabled=false \
             --wait


### PR DESCRIPTION
## Summary
H-1 of the reproduce plan — the one missing harness gate:

- `CAESIUM_CACHE_PIN_DIGESTS=true` on EVERY server-boot site in one sweep (all justfile lanes including podman/distributed/agent, the local k8s-distributed helm `--set` list, `helm/caesium/ci/test-values-k8s.yaml`, and the three ci.yml server blocks) — the fourth-site drift that bit the contract-enforcement waves twice is covered up front.
- Degradation-safe: the imagecheck resolver falls back to the tag (warn) on registry failure, so pinning cannot fail runs — it only enriches descriptors with `ResolvedImageDigest` for faithful pull-by-digest.
- Verified already present (no changes needed): the harness Docker daemon is reachable from the test-runner (both mount `docker.sock`), and the split-stream `runCLIStdout`/`runCLISeparate` helpers exist and are battle-tested.

## Test plan
- [x] `just --summary` parses; ci.yml + helm values YAML-parse.
- [ ] GHA CI — the integration lanes prove the env is accepted; W1-α's A2 scenario asserts recorded digests round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
