### PR TITLE
Add the caesium reproduce CLI with local execution (reproduce W2-β)

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -13,6 +13,7 @@ import (
 	"github.com/caesium-cloud/caesium/cmd/incident"
 	"github.com/caesium-cloud/caesium/cmd/job"
 	"github.com/caesium-cloud/caesium/cmd/receipt"
+	"github.com/caesium-cloud/caesium/cmd/reproduce"
 	"github.com/caesium-cloud/caesium/cmd/run"
 	"github.com/caesium-cloud/caesium/cmd/start"
 	"github.com/caesium-cloud/caesium/cmd/test"
@@ -29,6 +30,7 @@ var cmds = []*cobra.Command{
 	blame.Cmd,
 	cache.Cmd,
 	contract.Cmd,
+	reproduce.Cmd,
 	dataset.Cmd,
 	dev.Cmd,
 	event.Cmd,

--- a/cmd/reproduce/reproduce.go
+++ b/cmd/reproduce/reproduce.go
@@ -258,6 +258,20 @@ func (dockerPuller) Pull(ctx context.Context, imageRef, platform string) error {
 	return err
 }
 
+// ExistsLocally reports whether the image is already present in the local
+// daemon, letting Execute skip the registry pull (and survive private-registry
+// auth failures when the operator pulled or built the image themselves).
+func (dockerPuller) ExistsLocally(ctx context.Context, imageRef string) bool {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return false
+	}
+	defer func() { _ = cli.Close() }()
+
+	_, err = cli.ImageInspect(ctx, imageRef)
+	return err == nil
+}
+
 type localRunner struct{}
 
 func (localRunner) Run(ctx context.Context, def *pkgjobdef.Definition, taskTimeout time.Duration) (*ireproduce.RunResult, error) {

--- a/cmd/reproduce/reproduce.go
+++ b/cmd/reproduce/reproduce.go
@@ -1,0 +1,334 @@
+// Package reproduce implements the caesium reproduce CLI.
+package reproduce
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/caesium-cloud/caesium/internal/localrun"
+	ireproduce "github.com/caesium-cloud/caesium/internal/reproduce"
+	pkgjobdef "github.com/caesium-cloud/caesium/pkg/jobdef"
+	"github.com/docker/docker/api/types/image"
+	"github.com/docker/docker/client"
+	"github.com/spf13/cobra"
+)
+
+var (
+	reproduceJobID    string
+	reproduceTask     string
+	reproduceServer   string
+	reproduceAPIKey   string
+	reproduceDryRun   bool
+	reproduceJSON     bool
+	reproduceSet      []string
+	reproduceSetEnv   []string
+	reproduceMounts   []string
+	reproduceTimeout  time.Duration
+	reproducePlatform string
+)
+
+var httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
+
+// Cmd is the top-level reproduce command.
+var Cmd = &cobra.Command{
+	Use:           "reproduce <run-id> --job-id <job-id> --task <task>",
+	Short:         "Re-execute a historical task locally",
+	Args:          cobra.ExactArgs(1),
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE:          runReproduce,
+}
+
+type descriptorResponse struct {
+	TaskRunID  string          `json:"task_run_id"`
+	Status     string          `json:"status"`
+	Result     string          `json:"result"`
+	Output     json.RawMessage `json:"output"`
+	ReplaySafe bool            `json:"replay_safe"`
+	LogExcerpt struct {
+		Path string `json:"path"`
+	} `json:"log_excerpt"`
+	Descriptor json.RawMessage `json:"descriptor"`
+}
+
+type dryRunEnvelope struct {
+	RunID      string `json:"run_id"`
+	JobID      string `json:"job_id"`
+	TaskRunID  string `json:"task_run_id,omitempty"`
+	Status     string `json:"recorded_status,omitempty"`
+	Result     string `json:"recorded_result,omitempty"`
+	LogExcerpt string `json:"log_excerpt,omitempty"`
+	*ireproduce.Envelope
+}
+
+type runJSONResult struct {
+	RunID          string          `json:"run_id"`
+	JobID          string          `json:"job_id"`
+	TaskRunID      string          `json:"task_run_id,omitempty"`
+	RecordedStatus string          `json:"recorded_status,omitempty"`
+	RecordedResult string          `json:"recorded_result,omitempty"`
+	RecordedOutput json.RawMessage `json:"recorded_output,omitempty"`
+	*ireproduce.ExecutionResult
+}
+
+func init() {
+	Cmd.Flags().StringVar(&reproduceJobID, "job-id", "", "Job ID that owns the run (required)")
+	Cmd.Flags().StringVar(&reproduceTask, "task", "", "Task name or ID within the run (required)")
+	Cmd.Flags().StringVar(&reproduceServer, "server", "http://localhost:8080", "Caesium server base URL")
+	Cmd.Flags().StringVar(&reproduceAPIKey, "api-key", "", "API key for authentication (prefer "+cliutil.APIKeyEnvVar+"; --api-key is visible in process listings)")
+	Cmd.Flags().BoolVar(&reproduceDryRun, "dry-run", false, "Print the reconstructed envelope as JSON without executing")
+	Cmd.Flags().BoolVar(&reproduceJSON, "json", false, "Emit machine-readable JSON")
+	Cmd.Flags().StringArrayVar(&reproduceSet, "set", nil, "Override a run param as key=value (repeatable)")
+	Cmd.Flags().StringArrayVar(&reproduceSetEnv, "set-env", nil, "Override or add a container env var as KEY=VALUE (repeatable)")
+	Cmd.Flags().StringArrayVar(&reproduceMounts, "mount", nil, "Remap a recorded bind mount source as old=new (repeatable)")
+	Cmd.Flags().DurationVar(&reproduceTimeout, "timeout", 0, "Local task timeout (default: recorded task timeout)")
+	Cmd.Flags().StringVar(&reproducePlatform, "platform", "", "Platform to use when pulling the image (for example linux/amd64)")
+}
+
+func runReproduce(cmd *cobra.Command, args []string) error {
+	runID := strings.TrimSpace(args[0])
+	if strings.TrimSpace(reproduceJobID) == "" {
+		return fmt.Errorf("--job-id is required")
+	}
+	if strings.TrimSpace(reproduceTask) == "" {
+		return fmt.Errorf("--task is required")
+	}
+
+	setParams, err := parseAssignments(reproduceSet, "--set")
+	if err != nil {
+		return err
+	}
+	setEnv, err := parseAssignments(reproduceSetEnv, "--set-env")
+	if err != nil {
+		return err
+	}
+	mounts, err := parseMountRemaps(reproduceMounts)
+	if err != nil {
+		return err
+	}
+
+	stderr := cmd.ErrOrStderr()
+	server := strings.TrimRight(reproduceServer, "/")
+	if !reproduceDryRun || !reproduceJSON {
+		_, _ = fmt.Fprintf(stderr, "fetching descriptor from %s\n", server)
+	}
+	resp, err := fetchDescriptor(cmd.Context(), cmd, server, reproduceJobID, runID, reproduceTask)
+	if err != nil {
+		exitWithMessage(stderr, 2, err.Error())
+	}
+
+	desc, err := ireproduce.DecodeDescriptor(resp.Descriptor)
+	if err != nil {
+		exitWithMessage(stderr, 2, err.Error())
+	}
+	env, err := ireproduce.Reconstruct(desc, ireproduce.ReconstructOptions{
+		SetParams:  setParams,
+		SetEnv:     setEnv,
+		Mounts:     mounts,
+		Timeout:    reproduceTimeout,
+		Platform:   reproducePlatform,
+		ReplaySafe: resp.ReplaySafe,
+	})
+	if err != nil {
+		exitWithMessage(stderr, 2, err.Error())
+	}
+	printWarnings(stderr, env.Warnings)
+
+	envelopeOut := dryRunEnvelope{
+		RunID:      runID,
+		JobID:      reproduceJobID,
+		TaskRunID:  resp.TaskRunID,
+		Status:     resp.Status,
+		Result:     resp.Result,
+		LogExcerpt: resp.LogExcerpt.Path,
+		Envelope:   env,
+	}
+	if reproduceDryRun {
+		if err := writeJSON(cmd, envelopeOut); err != nil {
+			exitWithMessage(stderr, 2, err.Error())
+		}
+		return nil
+	}
+
+	result, err := ireproduce.Execute(cmd.Context(), desc, env, ireproduce.ExecuteOptions{
+		Puller:   dockerPuller{},
+		Runner:   localRunner{},
+		Timeout:  reproduceTimeout,
+		Platform: reproducePlatform,
+	})
+	if err != nil {
+		exitWithMessage(stderr, 2, err.Error())
+	}
+
+	if reproduceJSON {
+		if err := writeJSON(cmd, runJSONResult{
+			RunID:           runID,
+			JobID:           reproduceJobID,
+			TaskRunID:       resp.TaskRunID,
+			RecordedStatus:  resp.Status,
+			RecordedResult:  resp.Result,
+			RecordedOutput:  resp.Output,
+			ExecutionResult: result,
+		}); err != nil {
+			exitWithMessage(stderr, 2, err.Error())
+		}
+		os.Exit(result.ExitCode)
+	}
+
+	ireproduce.CopyLog(cmd.OutOrStdout(), result)
+	if result.ExitCode == 0 {
+		_, _ = fmt.Fprintf(stderr, "%s exited 0\n", env.TaskName)
+		return nil
+	}
+	_, _ = fmt.Fprintf(stderr, "%s failed", env.TaskName)
+	if result.Error != "" {
+		_, _ = fmt.Fprintf(stderr, ": %s", result.Error)
+	}
+	_, _ = fmt.Fprintln(stderr)
+	os.Exit(1)
+	return nil
+}
+
+func fetchDescriptor(ctx context.Context, cmd *cobra.Command, server, jobID, runID, task string) (*descriptorResponse, error) {
+	reqURL := fmt.Sprintf(
+		"%s/v1/jobs/%s/runs/%s/tasks/%s/descriptor",
+		server,
+		url.PathEscape(jobID),
+		url.PathEscape(runID),
+		url.PathEscape(task),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if apiKey := cliutil.ResolveAPIKey(cmd, reproduceAPIKey, cliutil.APIKeyEnvVar); apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch descriptor: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, readErr := io.ReadAll(resp.Body)
+	if resp.StatusCode >= http.StatusBadRequest {
+		if resp.StatusCode == http.StatusNotFound && strings.Contains(string(body), "descriptor unavailable") {
+			return nil, fmt.Errorf("descriptor unavailable for run %s task %s", runID, task)
+		}
+		return nil, fmt.Errorf("fetch descriptor failed (%d): %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	if readErr != nil {
+		return nil, fmt.Errorf("read descriptor response: %w", readErr)
+	}
+
+	var out descriptorResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decode descriptor response: %w", err)
+	}
+	if len(out.Descriptor) == 0 {
+		return nil, fmt.Errorf("descriptor unavailable for run %s task %s", runID, task)
+	}
+	return &out, nil
+}
+
+type dockerPuller struct{}
+
+func (dockerPuller) Pull(ctx context.Context, imageRef, platform string) error {
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return err
+	}
+	defer func() { _ = cli.Close() }()
+
+	reader, err := cli.ImagePull(ctx, imageRef, image.PullOptions{Platform: platform})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = reader.Close() }()
+	_, err = io.Copy(io.Discard, reader)
+	return err
+}
+
+type localRunner struct{}
+
+func (localRunner) Run(ctx context.Context, def *pkgjobdef.Definition, taskTimeout time.Duration) (*ireproduce.RunResult, error) {
+	result, err := localrun.New(localrun.Config{TaskTimeout: taskTimeout}).RunWithResult(ctx, def)
+	if result == nil {
+		return nil, err
+	}
+	out := &ireproduce.RunResult{
+		Status: result.Status,
+		Error:  result.Error,
+		Tasks:  make([]ireproduce.TaskResult, 0, len(result.Tasks)),
+	}
+	for _, task := range result.Tasks {
+		out.Tasks = append(out.Tasks, ireproduce.TaskResult{
+			Name:         task.Name,
+			Status:       task.Status,
+			Output:       task.Output,
+			LogText:      task.LogText,
+			LogTruncated: task.LogTruncated,
+			Error:        task.Error,
+		})
+	}
+	return out, err
+}
+
+func parseAssignments(values []string, flag string) ([]ireproduce.Assignment, error) {
+	out := make([]ireproduce.Assignment, 0, len(values))
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		if !ok {
+			return nil, fmt.Errorf("%s must be key=value: %s", flag, value)
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, fmt.Errorf("%s key cannot be empty", flag)
+		}
+		out = append(out, ireproduce.Assignment{Key: key, Value: val})
+	}
+	return out, nil
+}
+
+func parseMountRemaps(values []string) ([]ireproduce.MountRemap, error) {
+	out := make([]ireproduce.MountRemap, 0, len(values))
+	for _, value := range values {
+		from, to, ok := strings.Cut(value, "=")
+		if !ok {
+			return nil, fmt.Errorf("--mount must be old=new: %s", value)
+		}
+		from = strings.TrimSpace(from)
+		to = strings.TrimSpace(to)
+		if from == "" || to == "" {
+			return nil, fmt.Errorf("--mount old and new paths are required")
+		}
+		out = append(out, ireproduce.MountRemap{From: from, To: to})
+	}
+	return out, nil
+}
+
+func writeJSON(cmd *cobra.Command, value any) error {
+	encoder := json.NewEncoder(cmd.OutOrStdout())
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func printWarnings(w io.Writer, warnings []ireproduce.Warning) {
+	for _, warning := range warnings {
+		_, _ = fmt.Fprintf(w, "warning: %s\n", warning.Message)
+	}
+}
+
+func exitWithMessage(w io.Writer, code int, message string) {
+	_, _ = fmt.Fprintln(w, message)
+	os.Exit(code)
+}

--- a/docs/exec-plans/active/reproduce.md
+++ b/docs/exec-plans/active/reproduce.md
@@ -172,7 +172,7 @@ preferred, `--api-key` accepted with a visible-in-`ps` warning. This is the
 largest stream; B1 ships the inspection surface (fetch + reconstruct + print),
 B2 adds real local execution.
 
-- [ ] B1. Add the `cmd/reproduce/` command + `internal/reproduce/` reconstruction
+- [x] B1. Add the `cmd/reproduce/` command + `internal/reproduce/` reconstruction
       package + `--dry-run`/`--json` envelope output. Fetch the descriptor from
       Stream A's endpoint; reconstruct the container env in this order (later wins):
       recorded `ContainerSpec.Env` literals → `CAESIUM_PARAM_<KEY>` from recorded
@@ -188,7 +188,11 @@ B2 adds real local execution.
       Files: new `cmd/reproduce/reproduce.go`, new `internal/reproduce/reconstruct.go`
       (+ `reconstruct_test.go`), `cmd/execute.go`.
       Depends on: A1.
-- [ ] B2. Add run mode (default) with local execution + exit codes. Pull the image
+      Note: W2-beta added the top-level `caesium reproduce` command, descriptor
+      fetch/decode, stdout-clean `--dry-run`/`--json` envelope output, exact
+      env layering through `pkgtask.BuildOutputEnv`, secret omission warnings,
+      mount remap/skips, and focused reconstruction tests.
+- [x] B2. Add run mode (default) with local execution + exit codes. Pull the image
       by recorded `ResolvedImageDigest` (mutable tag → pull by tag, marked
       **DEGRADED**), execute the recorded command in the reconstructed environment,
       and parse `##caesium::output` markers from stdout via `pkgtask.ParseMarkers`.
@@ -210,6 +214,11 @@ B2 adds real local execution.
       Files: `cmd/reproduce/reproduce.go`, new `internal/reproduce/execute.go`
       (+ `execute_test.go`).
       Depends on: B1.
+      Note: W2-beta added Docker-SDK pre-pull with registry/`--image` guidance,
+      single-shot local execution via an injected `internal/localrun` adapter,
+      explicit exit codes 0/1/2 through the command layer, parsed marker output,
+      and integration coverage for dry-run JSON, run-mode JSON, and missing-run
+      exit 2.
 
 ### Stream C — Output-diff compare, fidelity summary, shell mode (P1)
 

--- a/internal/localrun/sqlite.go
+++ b/internal/localrun/sqlite.go
@@ -3,8 +3,14 @@ package localrun
 import (
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+
+	"github.com/caesium-cloud/caesium/pkg/db"
 )
 
 func openSQLite(dsn string) (*gorm.DB, error) {
-	return gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	// Use the repo's zap-backed GORM logger: gorm.Config{}'s default logger
+	// writes SQL traces (including routine record-not-found probes) straight
+	// to os.Stdout, which corrupts machine-readable CLI output — `caesium
+	// reproduce --json` and `caesium dev` both ride this runner.
+	return gorm.Open(sqlite.Open(dsn), &gorm.Config{Logger: db.NewLogger()})
 }

--- a/internal/reproduce/execute.go
+++ b/internal/reproduce/execute.go
@@ -1,0 +1,212 @@
+package reproduce
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	pkgjobdef "github.com/caesium-cloud/caesium/pkg/jobdef"
+	pkgtask "github.com/caesium-cloud/caesium/pkg/task"
+)
+
+// Puller pulls the image reference selected for local reproduction.
+type Puller interface {
+	Pull(ctx context.Context, imageRef, platform string) error
+}
+
+// Runner executes a synthesized one-step definition through the local runtime.
+type Runner interface {
+	Run(ctx context.Context, def *pkgjobdef.Definition, taskTimeout time.Duration) (*RunResult, error)
+}
+
+// RunResult is the localrun result subset used by this package.
+type RunResult struct {
+	Status string
+	Error  string
+	Tasks  []TaskResult
+}
+
+// TaskResult is the task-level localrun result subset used by this package.
+type TaskResult struct {
+	Name         string
+	Status       string
+	Output       map[string]string
+	LogText      string
+	LogTruncated bool
+	Error        string
+}
+
+// ExecuteOptions controls local execution.
+type ExecuteOptions struct {
+	Puller   Puller
+	Runner   Runner
+	Timeout  time.Duration
+	Platform string
+}
+
+// ExecutionResult is the machine-readable result for run mode.
+type ExecutionResult struct {
+	Status       string            `json:"status"`
+	ExitCode     int               `json:"exit_code"`
+	Task         string            `json:"task"`
+	Image        string            `json:"image"`
+	Output       map[string]string `json:"output,omitempty"`
+	Log          string            `json:"log,omitempty"`
+	LogTruncated bool              `json:"log_truncated,omitempty"`
+	Error        string            `json:"error,omitempty"`
+	Envelope     *Envelope         `json:"envelope"`
+	Warnings     []Warning         `json:"warnings,omitempty"`
+}
+
+// PullError is returned when the selected image cannot be pulled.
+type PullError struct {
+	ImageRef string
+	Registry string
+	Err      error
+}
+
+func (e *PullError) Error() string {
+	return fmt.Sprintf(
+		"pull image %s from registry %s failed: %v; authenticate with docker login %s or use --image <local-ref> when the image is available locally",
+		e.ImageRef,
+		e.Registry,
+		e.Err,
+		e.Registry,
+	)
+}
+
+func (e *PullError) Unwrap() error {
+	return e.Err
+}
+
+// Execute pulls the reconstructed image and runs the synthesized local task
+// exactly once.
+func Execute(ctx context.Context, desc *Descriptor, env *Envelope, opts ExecuteOptions) (*ExecutionResult, error) {
+	if desc == nil {
+		return nil, fmt.Errorf("descriptor is required")
+	}
+	if env == nil {
+		return nil, fmt.Errorf("envelope is required")
+	}
+	if opts.Puller == nil {
+		return nil, fmt.Errorf("image puller is required")
+	}
+	if opts.Runner == nil {
+		return nil, fmt.Errorf("local runner is required")
+	}
+
+	platform := firstNonEmpty(strings.TrimSpace(opts.Platform), env.Platform)
+	if err := opts.Puller.Pull(ctx, env.Image, platform); err != nil {
+		return nil, &PullError{
+			ImageRef: env.Image,
+			Registry: RegistryHost(env.Image),
+			Err:      err,
+		}
+	}
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = desc.Timing.TaskTimeout
+	}
+	def := BuildDefinition(desc, env, timeout)
+	runResult, runErr := opts.Runner.Run(ctx, def, timeout)
+	if runResult == nil {
+		if runErr != nil {
+			return nil, runErr
+		}
+		return nil, errors.New("local runner returned no result")
+	}
+
+	task := taskResult(runResult, env.TaskName)
+	if task == nil {
+		if runErr != nil {
+			return nil, runErr
+		}
+		return nil, fmt.Errorf("local runner returned no result for task %q", env.TaskName)
+	}
+
+	output := task.Output
+	if strings.TrimSpace(task.LogText) != "" {
+		markers, err := pkgtask.ParseMarkers(strings.NewReader(task.LogText))
+		if err != nil {
+			return nil, err
+		}
+		if markers != nil && len(markers.Output) > 0 {
+			output = markers.Output
+		}
+	}
+
+	result := &ExecutionResult{
+		Status:       task.Status,
+		Task:         env.TaskName,
+		Image:        env.Image,
+		Output:       output,
+		Log:          task.LogText,
+		LogTruncated: task.LogTruncated,
+		Error:        firstNonEmpty(task.Error, runResult.Error),
+		Envelope:     env,
+		Warnings:     env.Warnings,
+	}
+	if isSuccessfulStatus(task.Status) {
+		result.ExitCode = 0
+		return result, nil
+	}
+	result.ExitCode = 1
+	if result.Error == "" && runErr != nil {
+		result.Error = runErr.Error()
+	}
+	return result, nil
+}
+
+// RegistryHost returns the registry host component used in pull guidance.
+func RegistryHost(imageRef string) string {
+	ref := imageRef
+	if before, _, ok := strings.Cut(ref, "@"); ok {
+		ref = before
+	}
+	first := ref
+	if slash := strings.IndexByte(ref, '/'); slash >= 0 {
+		first = ref[:slash]
+	} else {
+		return "docker.io"
+	}
+	if strings.Contains(first, ".") || strings.Contains(first, ":") || first == "localhost" {
+		return first
+	}
+	return "docker.io"
+}
+
+func taskResult(result *RunResult, taskName string) *TaskResult {
+	for i := range result.Tasks {
+		if result.Tasks[i].Name == taskName {
+			return &result.Tasks[i]
+		}
+	}
+	if len(result.Tasks) == 1 {
+		return &result.Tasks[0]
+	}
+	return nil
+}
+
+func isSuccessfulStatus(status string) bool {
+	switch status {
+	case "succeeded", "cached":
+		return true
+	default:
+		return false
+	}
+}
+
+// CopyLog writes the reproduced task log when present.
+func CopyLog(w io.Writer, result *ExecutionResult) {
+	if w == nil || result == nil || result.Log == "" {
+		return
+	}
+	_, _ = io.WriteString(w, result.Log)
+	if !strings.HasSuffix(result.Log, "\n") {
+		_, _ = io.WriteString(w, "\n")
+	}
+}

--- a/internal/reproduce/execute.go
+++ b/internal/reproduce/execute.go
@@ -17,6 +17,13 @@ type Puller interface {
 	Pull(ctx context.Context, imageRef, platform string) error
 }
 
+// LocalImageChecker is optionally implemented by a Puller that can report
+// whether the image already exists in the local daemon, letting Execute skip
+// the registry pull (and survive registry-auth failures) when it does.
+type LocalImageChecker interface {
+	ExistsLocally(ctx context.Context, imageRef string) bool
+}
+
 // Runner executes a synthesized one-step definition through the local runtime.
 type Runner interface {
 	Run(ctx context.Context, def *pkgjobdef.Definition, taskTimeout time.Duration) (*RunResult, error)
@@ -70,7 +77,7 @@ type PullError struct {
 
 func (e *PullError) Error() string {
 	return fmt.Sprintf(
-		"pull image %s from registry %s failed: %v; authenticate with docker login %s or use --image <local-ref> when the image is available locally",
+		"pull image %s from registry %s failed: %v; authenticate with docker login %s and re-run, or make the image available in the local Docker daemon (docker pull/docker build) — reproduce uses a locally present image without pulling",
 		e.ImageRef,
 		e.Registry,
 		e.Err,
@@ -99,7 +106,13 @@ func Execute(ctx context.Context, desc *Descriptor, env *Envelope, opts ExecuteO
 	}
 
 	platform := firstNonEmpty(strings.TrimSpace(opts.Platform), env.Platform)
-	if err := opts.Puller.Pull(ctx, env.Image, platform); err != nil {
+	checker, canCheckLocal := opts.Puller.(LocalImageChecker)
+	if canCheckLocal && checker.ExistsLocally(ctx, env.Image) {
+		env.Warnings = append(env.Warnings, Warning{
+			Code:    "local_image_used",
+			Message: fmt.Sprintf("image %s already present in the local daemon; skipped registry pull", env.Image),
+		})
+	} else if err := opts.Puller.Pull(ctx, env.Image, platform); err != nil {
 		return nil, &PullError{
 			ImageRef: env.Image,
 			Registry: RegistryHost(env.Image),

--- a/internal/reproduce/execute.go
+++ b/internal/reproduce/execute.go
@@ -167,12 +167,11 @@ func RegistryHost(imageRef string) string {
 	if before, _, ok := strings.Cut(ref, "@"); ok {
 		ref = before
 	}
-	first := ref
-	if slash := strings.IndexByte(ref, '/'); slash >= 0 {
-		first = ref[:slash]
-	} else {
+	slash := strings.IndexByte(ref, '/')
+	if slash < 0 {
 		return "docker.io"
 	}
+	first := ref[:slash]
 	if strings.Contains(first, ".") || strings.Contains(first, ":") || first == "localhost" {
 		return first
 	}

--- a/internal/reproduce/execute_test.go
+++ b/internal/reproduce/execute_test.go
@@ -3,6 +3,7 @@ package reproduce
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -11,7 +12,7 @@ import (
 	pkgjobdef "github.com/caesium-cloud/caesium/pkg/jobdef"
 )
 
-func TestExecutePullFailureGuidanceNamesRegistryAndImageHint(t *testing.T) {
+func TestExecutePullFailureGuidanceNamesRegistryAndLocalFallback(t *testing.T) {
 	desc := basicDescriptor("registry.example.com/team/app:1")
 	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	env, err := Reconstruct(desc, ReconstructOptions{})
@@ -30,8 +31,53 @@ func TestExecutePullFailureGuidanceNamesRegistryAndImageHint(t *testing.T) {
 	if !strings.Contains(msg, "registry.example.com") {
 		t.Fatalf("pull error %q does not name registry", msg)
 	}
-	if !strings.Contains(msg, "--image <local-ref>") {
-		t.Fatalf("pull error %q does not include --image hint", msg)
+	if !strings.Contains(msg, "docker login registry.example.com") {
+		t.Fatalf("pull error %q does not include the docker login hint", msg)
+	}
+	if !strings.Contains(msg, "locally present image") {
+		t.Fatalf("pull error %q does not include the local-image guidance", msg)
+	}
+}
+
+type localPresentPuller struct{ pullCalled bool }
+
+func (p *localPresentPuller) Pull(context.Context, string, string) error {
+	p.pullCalled = true
+	return fmt.Errorf("must not pull when the image is local")
+}
+
+func (p *localPresentPuller) ExistsLocally(context.Context, string) bool { return true }
+
+// A locally present image short-circuits the registry pull entirely, so a
+// private-registry auth failure cannot block reproducing with a local image.
+func TestExecuteSkipsPullWhenImagePresentLocally(t *testing.T) {
+	desc := basicDescriptor("registry.example.com/team/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	env, err := Reconstruct(desc, ReconstructOptions{})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+	puller := &localPresentPuller{}
+	result, err := Execute(context.Background(), desc, env, ExecuteOptions{
+		Puller: puller,
+		Runner: fakeRunner{result: &RunResult{Tasks: []TaskResult{{
+			Name:   "transform",
+			Status: "succeeded",
+		}}}},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v, want success via local image", err)
+	}
+	if puller.pullCalled {
+		t.Fatal("Pull was called despite the image existing locally")
+	}
+	found := false
+	for _, w := range result.Envelope.Warnings {
+		if w.Code == "local_image_used" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected local_image_used warning, got %+v", result.Envelope.Warnings)
 	}
 }
 

--- a/internal/reproduce/execute_test.go
+++ b/internal/reproduce/execute_test.go
@@ -1,0 +1,158 @@
+package reproduce
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caesium-cloud/caesium/pkg/container"
+	pkgjobdef "github.com/caesium-cloud/caesium/pkg/jobdef"
+)
+
+func TestExecutePullFailureGuidanceNamesRegistryAndImageHint(t *testing.T) {
+	desc := basicDescriptor("registry.example.com/team/app:1")
+	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	env, err := Reconstruct(desc, ReconstructOptions{})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	_, err = Execute(context.Background(), desc, env, ExecuteOptions{
+		Puller: &fakePuller{err: errors.New("unauthorized: authentication required")},
+		Runner: fakeRunner{},
+	})
+	if err == nil {
+		t.Fatal("Execute() error = nil, want pull error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "registry.example.com") {
+		t.Fatalf("pull error %q does not name registry", msg)
+	}
+	if !strings.Contains(msg, "--image <local-ref>") {
+		t.Fatalf("pull error %q does not include --image hint", msg)
+	}
+}
+
+func TestExecuteUsesDegradedTagPullWhenDigestMissing(t *testing.T) {
+	desc := basicDescriptor("registry.example.com/team/app:latest")
+	env, err := Reconstruct(desc, ReconstructOptions{})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+	if env.ImagePullMode != "DEGRADED" {
+		t.Fatalf("ImagePullMode = %q, want DEGRADED", env.ImagePullMode)
+	}
+	if !hasWarning(env.Warnings, WarningDegradedImagePull) {
+		t.Fatalf("warnings = %#v, want degraded warning", env.Warnings)
+	}
+
+	puller := &fakePuller{}
+	result, err := Execute(context.Background(), desc, env, ExecuteOptions{
+		Puller: puller,
+		Runner: fakeRunner{result: &RunResult{Tasks: []TaskResult{{
+			Name:    "transform",
+			Status:  "succeeded",
+			LogText: `##caesium::output {"ok":"yes"}`,
+		}}}},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if puller.imageRef != "registry.example.com/team/app:latest" {
+		t.Fatalf("pulled image = %q, want mutable tag", puller.imageRef)
+	}
+	if result.ExitCode != 0 || result.Output["ok"] != "yes" {
+		t.Fatalf("result = %#v, want parsed success output", result)
+	}
+}
+
+func TestExecutePassesRemappedMountsToSynthesizedDefinition(t *testing.T) {
+	desc := basicDescriptor("alpine:3.23")
+	desc.ContainerSpec.Mounts = testBindMount("/recorded/data", "/data")
+	desc.ContainerSpec.ResolvedVolumeMounts = testPVCMount("claim", "/claim")
+	env, err := Reconstruct(desc, ReconstructOptions{
+		Mounts: []MountRemap{{From: "/recorded/data", To: "/local/data"}},
+	})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+	if !hasWarning(env.Warnings, WarningMountSkipped) {
+		t.Fatalf("warnings = %#v, want PVC skip warning", env.Warnings)
+	}
+
+	runner := &capturingRunner{result: &RunResult{Tasks: []TaskResult{{
+		Name:   "transform",
+		Status: "succeeded",
+	}}}}
+	_, err = Execute(context.Background(), desc, env, ExecuteOptions{
+		Puller:  &fakePuller{},
+		Runner:  runner,
+		Timeout: 45 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if runner.def == nil || len(runner.def.Steps) != 1 {
+		t.Fatalf("runner definition = %#v", runner.def)
+	}
+	mounts := runner.def.Steps[0].Mounts
+	if len(mounts) != 1 || mounts[0].Source != "/local/data" || mounts[0].Target != "/data" {
+		t.Fatalf("synthesized mounts = %#v, want remapped bind only", mounts)
+	}
+	if runner.timeout != 45*time.Second {
+		t.Fatalf("runner timeout = %s, want 45s", runner.timeout)
+	}
+}
+
+func basicDescriptor(image string) *Descriptor {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Baseline.JobAlias = "fixture"
+	desc.Runtime.Image = image
+	desc.Runtime.Command = []string{"sh", "-c", "echo ok"}
+	return desc
+}
+
+func testBindMount(source, target string) []container.Mount {
+	return []container.Mount{{Type: container.MountTypeBind, Source: source, Target: target}}
+}
+
+func testPVCMount(source, target string) []container.VolumeMount {
+	return []container.VolumeMount{{Type: container.VolumeMountTypePVC, Source: source, Target: target}}
+}
+
+type fakePuller struct {
+	imageRef string
+	platform string
+	err      error
+}
+
+func (p *fakePuller) Pull(_ context.Context, imageRef, platform string) error {
+	p.imageRef = imageRef
+	p.platform = platform
+	return p.err
+}
+
+type fakeRunner struct {
+	result *RunResult
+	err    error
+}
+
+func (r fakeRunner) Run(context.Context, *pkgjobdef.Definition, time.Duration) (*RunResult, error) {
+	return r.result, r.err
+}
+
+type capturingRunner struct {
+	def     *pkgjobdef.Definition
+	timeout time.Duration
+	result  *RunResult
+}
+
+func (r *capturingRunner) Run(_ context.Context, def *pkgjobdef.Definition, timeout time.Duration) (*RunResult, error) {
+	r.def = def
+	r.timeout = timeout
+	return r.result, nil
+}

--- a/internal/reproduce/reconstruct.go
+++ b/internal/reproduce/reconstruct.go
@@ -1,0 +1,561 @@
+// Package reproduce reconstructs and executes historical task descriptors for
+// the caesium reproduce CLI.
+package reproduce
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/caesium-cloud/caesium/pkg/container"
+	pkgjobdef "github.com/caesium-cloud/caesium/pkg/jobdef"
+	pkgtask "github.com/caesium-cloud/caesium/pkg/task"
+)
+
+const (
+	WarningSecretOmitted       = "secret_omitted"
+	WarningDegradedImagePull   = "degraded_image_pull"
+	WarningOutputRefUnresolved = "output_ref_unresolved"
+	WarningOutputMissingName   = "predecessor_output_missing_name"
+	WarningMountNotRemapped    = "mount_not_remapped"
+	WarningMountSkipped        = "mount_skipped"
+	WarningRetryNotApplied     = "retry_policy_not_applied"
+)
+
+// Assignment is a user-supplied KEY=VALUE override.
+type Assignment struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// MountRemap maps a recorded mount source to a local source.
+type MountRemap struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// Warning is included in machine-readable output and mirrored to stderr by the
+// command layer.
+type Warning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// SecretOmission records a secret env var that was deliberately not
+// reconstructed.
+type SecretOmission struct {
+	EnvKey string `json:"env_key"`
+	Ref    string `json:"ref,omitempty"`
+}
+
+// RetryPolicy records the historical retry knobs. Reproduce surfaces them but
+// runs a single local attempt.
+type RetryPolicy struct {
+	RetryCount   int    `json:"retry_count"`
+	RetryDelay   string `json:"retry_delay,omitempty"`
+	RetryBackoff bool   `json:"retry_backoff"`
+}
+
+// Envelope is the reconstructed local execution envelope.
+type Envelope struct {
+	TaskName            string            `json:"task"`
+	JobID               string            `json:"job_id,omitempty"`
+	JobAlias            string            `json:"job_alias,omitempty"`
+	BaselineRunID       string            `json:"baseline_run_id,omitempty"`
+	ReplaySafe          bool              `json:"replay_safe"`
+	CapturedAt          time.Time         `json:"captured_at,omitempty"`
+	Image               string            `json:"image"`
+	RecordedImage       string            `json:"recorded_image,omitempty"`
+	ResolvedImageDigest string            `json:"resolved_image_digest,omitempty"`
+	ImagePullMode       string            `json:"image_pull_mode"`
+	Command             []string          `json:"command,omitempty"`
+	WorkDir             string            `json:"workdir,omitempty"`
+	Env                 map[string]string `json:"env"`
+	Mounts              []container.Mount `json:"mounts,omitempty"`
+	Timeout             string            `json:"timeout,omitempty"`
+	Platform            string            `json:"platform,omitempty"`
+	RecordedRetryPolicy *RetryPolicy      `json:"recorded_retry_policy,omitempty"`
+	OmittedSecrets      []SecretOmission  `json:"omitted_secrets,omitempty"`
+	Warnings            []Warning         `json:"warnings,omitempty"`
+}
+
+// ReconstructOptions controls local envelope reconstruction.
+type ReconstructOptions struct {
+	SetParams  []Assignment
+	SetEnv     []Assignment
+	Mounts     []MountRemap
+	Timeout    time.Duration
+	Platform   string
+	ReplaySafe bool
+}
+
+// Descriptor mirrors descriptor schema v1 without importing internal/models.
+type Descriptor struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	CapturedAt    time.Time `json:"capturedAt"`
+
+	Baseline struct {
+		JobID         string `json:"jobId"`
+		JobAlias      string `json:"jobAlias"`
+		TaskID        string `json:"taskId"`
+		TaskName      string `json:"taskName"`
+		BaselineRunID string `json:"baselineRunId"`
+		ReplaySafe    bool   `json:"replaySafe"`
+	} `json:"baseline"`
+	DAG struct {
+		Predecessors       []EdgeRef                    `json:"predecessors,omitempty"`
+		PredecessorOutputs map[string]map[string]string `json:"predecessorOutputs,omitempty"`
+	} `json:"dag"`
+	Run struct {
+		Params map[string]string `json:"params,omitempty"`
+	} `json:"run"`
+	Runtime struct {
+		Engine              string            `json:"engine"`
+		Image               string            `json:"image"`
+		ResolvedImageDigest string            `json:"resolvedImageDigest,omitempty"`
+		Command             []string          `json:"command,omitempty"`
+		CommandRaw          string            `json:"commandRaw,omitempty"`
+		WorkDir             string            `json:"workdir,omitempty"`
+		TaskType            string            `json:"taskType,omitempty"`
+		NodeSelector        map[string]string `json:"nodeSelector,omitempty"`
+		RetryCount          int               `json:"retryCount"`
+		RetryDelay          time.Duration     `json:"retryDelay"`
+		RetryBackoff        bool              `json:"retryBackoff"`
+	} `json:"runtime"`
+	Timing struct {
+		TaskTimeout time.Duration `json:"taskTimeout"`
+		RunTimeout  time.Duration `json:"runTimeout"`
+	} `json:"timing"`
+	Schema struct {
+		InputSchema     map[string]map[string]any `json:"inputSchema,omitempty"`
+		OutputSchema    map[string]any            `json:"outputSchema,omitempty"`
+		ValidationMode  string                    `json:"validationMode,omitempty"`
+		RawInputSchema  json.RawMessage           `json:"-"`
+		RawOutputSchema json.RawMessage           `json:"-"`
+	} `json:"schema"`
+
+	ContainerSpec  container.Spec            `json:"containerSpec"`
+	KubernetesSpec *container.KubernetesSpec `json:"kubernetesSpec,omitempty"`
+	SecretRefs     []SecretRef               `json:"secretRefs,omitempty"`
+}
+
+// EdgeRef identifies a DAG predecessor or successor.
+type EdgeRef struct {
+	TaskID   string `json:"taskId"`
+	TaskName string `json:"taskName,omitempty"`
+}
+
+// SecretRef mirrors the descriptor's secret metadata relevant to local
+// omission warnings.
+type SecretRef struct {
+	Ref    string `json:"ref"`
+	EnvKey string `json:"envKey,omitempty"`
+}
+
+// DecodeDescriptor decodes raw descriptor JSON into the local mirror type.
+func DecodeDescriptor(raw []byte) (*Descriptor, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("descriptor is empty")
+	}
+	var desc Descriptor
+	if err := json.Unmarshal(raw, &desc); err != nil {
+		return nil, fmt.Errorf("decode descriptor: %w", err)
+	}
+	if desc.SchemaVersion != 1 {
+		return nil, fmt.Errorf("unsupported descriptor schemaVersion %d", desc.SchemaVersion)
+	}
+	if strings.TrimSpace(desc.Runtime.Image) == "" {
+		return nil, fmt.Errorf("descriptor runtime.image is required")
+	}
+	if strings.TrimSpace(desc.Baseline.TaskName) == "" {
+		desc.Baseline.TaskName = "task"
+	}
+	return &desc, nil
+}
+
+// Reconstruct builds the local envelope from a descriptor and CLI overrides.
+func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
+	if desc == nil {
+		return nil, fmt.Errorf("descriptor is required")
+	}
+
+	warnings := make([]Warning, 0)
+	env := make(map[string]string)
+	omitted := make([]SecretOmission, 0)
+	secretRefs := secretRefsByEnv(desc.SecretRefs)
+
+	for _, key := range sortedKeys(desc.ContainerSpec.Env) {
+		value := desc.ContainerSpec.Env[key]
+		if isSecretRef(value) {
+			omitted = appendSecretOmission(omitted, SecretOmission{EnvKey: key, Ref: firstNonEmpty(secretRefs[key], value)})
+			continue
+		}
+		env[key] = value
+	}
+	for _, ref := range desc.SecretRefs {
+		if ref.EnvKey == "" {
+			continue
+		}
+		if _, ok := desc.ContainerSpec.Env[ref.EnvKey]; !ok {
+			omitted = appendSecretOmission(omitted, SecretOmission{EnvKey: ref.EnvKey, Ref: ref.Ref})
+		}
+	}
+	if len(omitted) > 0 {
+		sort.Slice(omitted, func(i, j int) bool { return omitted[i].EnvKey < omitted[j].EnvKey })
+		warnings = append(warnings, Warning{
+			Code:    WarningSecretOmitted,
+			Message: fmt.Sprintf("secret refs omitted by default: %s", strings.Join(secretEnvKeys(omitted), ", ")),
+		})
+	}
+
+	for _, key := range sortedKeys(desc.Run.Params) {
+		env[paramEnvKey(key)] = desc.Run.Params[key]
+	}
+
+	outputEnv, outputWarnings := predecessorOutputEnv(desc)
+	warnings = append(warnings, outputWarnings...)
+	for _, key := range sortedKeys(outputEnv) {
+		env[key] = outputEnv[key]
+	}
+
+	for _, assignment := range opts.SetParams {
+		if strings.TrimSpace(assignment.Key) == "" {
+			return nil, fmt.Errorf("--set key cannot be empty")
+		}
+		env[paramEnvKey(assignment.Key)] = assignment.Value
+	}
+	for _, assignment := range opts.SetEnv {
+		if strings.TrimSpace(assignment.Key) == "" {
+			return nil, fmt.Errorf("--set-env key cannot be empty")
+		}
+		env[assignment.Key] = assignment.Value
+	}
+
+	image, pullMode, imageWarnings := imageReference(desc.Runtime.Image, desc.Runtime.ResolvedImageDigest)
+	warnings = append(warnings, imageWarnings...)
+
+	mounts, mountWarnings := reconstructMounts(desc.ContainerSpec, opts.Mounts)
+	warnings = append(warnings, mountWarnings...)
+
+	timeout := opts.Timeout
+	if timeout == 0 {
+		timeout = desc.Timing.TaskTimeout
+	}
+
+	command := slices.Clone(desc.Runtime.Command)
+	if len(command) == 0 && strings.TrimSpace(desc.Runtime.CommandRaw) != "" {
+		command = []string{desc.Runtime.CommandRaw}
+	}
+
+	workdir := desc.ContainerSpec.WorkDir
+	if workdir == "" {
+		workdir = desc.Runtime.WorkDir
+	}
+
+	var retryPolicy *RetryPolicy
+	if desc.Runtime.RetryCount > 0 || desc.Runtime.RetryDelay > 0 || desc.Runtime.RetryBackoff {
+		retryPolicy = &RetryPolicy{
+			RetryCount:   desc.Runtime.RetryCount,
+			RetryDelay:   durationString(desc.Runtime.RetryDelay),
+			RetryBackoff: desc.Runtime.RetryBackoff,
+		}
+		warnings = append(warnings, Warning{
+			Code:    WarningRetryNotApplied,
+			Message: "recorded retry policy is surfaced but not applied; reproduce runs one local attempt",
+		})
+	}
+
+	return &Envelope{
+		TaskName:            desc.Baseline.TaskName,
+		JobID:               desc.Baseline.JobID,
+		JobAlias:            desc.Baseline.JobAlias,
+		BaselineRunID:       desc.Baseline.BaselineRunID,
+		ReplaySafe:          opts.ReplaySafe || desc.Baseline.ReplaySafe,
+		CapturedAt:          desc.CapturedAt,
+		Image:               image,
+		RecordedImage:       desc.Runtime.Image,
+		ResolvedImageDigest: desc.Runtime.ResolvedImageDigest,
+		ImagePullMode:       pullMode,
+		Command:             command,
+		WorkDir:             workdir,
+		Env:                 env,
+		Mounts:              mounts,
+		Timeout:             durationString(timeout),
+		Platform:            strings.TrimSpace(opts.Platform),
+		RecordedRetryPolicy: retryPolicy,
+		OmittedSecrets:      omitted,
+		Warnings:            warnings,
+	}, nil
+}
+
+// BuildDefinition synthesizes the one-step definition consumed by localrun.
+func BuildDefinition(desc *Descriptor, env *Envelope, timeout time.Duration) *pkgjobdef.Definition {
+	alias := sanitizeAlias(firstNonEmpty(desc.Baseline.JobAlias, "reproduce-"+desc.Baseline.TaskName))
+	validationMode := desc.Schema.ValidationMode
+	if validationMode != pkgjobdef.SchemaValidationWarn && validationMode != pkgjobdef.SchemaValidationFail {
+		validationMode = ""
+	}
+	return &pkgjobdef.Definition{
+		APIVersion: pkgjobdef.APIVersionV1,
+		Kind:       pkgjobdef.KindJob,
+		Metadata: pkgjobdef.Metadata{
+			Alias:            alias,
+			TaskTimeout:      timeout,
+			SchemaValidation: validationMode,
+		},
+		Trigger: pkgjobdef.Trigger{
+			Type: pkgjobdef.TriggerCron,
+			Configuration: map[string]any{
+				"cron": "0 0 1 1 *",
+			},
+		},
+		Steps: []pkgjobdef.Step{{
+			Name:         firstNonEmpty(desc.Baseline.TaskName, "task"),
+			Engine:       pkgjobdef.EngineDocker,
+			Image:        env.Image,
+			Command:      slices.Clone(env.Command),
+			OutputSchema: cloneAnyMap(desc.Schema.OutputSchema),
+			Spec: container.Spec{
+				Env:     cloneStringMap(env.Env),
+				WorkDir: env.WorkDir,
+				Mounts:  slices.Clone(env.Mounts),
+			},
+		}},
+	}
+}
+
+func predecessorOutputEnv(desc *Descriptor) (map[string]string, []Warning) {
+	byName := make(map[string]map[string]string)
+	used := make(map[string]struct{})
+	warnings := make([]Warning, 0)
+	for _, pred := range desc.DAG.Predecessors {
+		outputs := desc.DAG.PredecessorOutputs[pred.TaskID]
+		if len(outputs) == 0 {
+			continue
+		}
+		name := firstNonEmpty(pred.TaskName, pred.TaskID)
+		byName[name] = cloneStringMap(outputs)
+		used[pred.TaskID] = struct{}{}
+	}
+	for id, outputs := range desc.DAG.PredecessorOutputs {
+		if len(outputs) == 0 {
+			continue
+		}
+		if _, ok := used[id]; ok {
+			continue
+		}
+		byName[id] = cloneStringMap(outputs)
+		warnings = append(warnings, Warning{
+			Code:    WarningOutputMissingName,
+			Message: fmt.Sprintf("predecessor output %s had no matching predecessor name; using UUID in CAESIUM_OUTPUT_* env", id),
+		})
+	}
+
+	env := pkgtask.BuildOutputEnv(byName)
+	for stepName, outputs := range byName {
+		for key, value := range outputs {
+			if ref, ok := pkgtask.DecodeOutputRef(value); ok {
+				envKey := "CAESIUM_OUTPUT_" + pkgtask.NormalizeStepName(stepName) + "_" + pkgtask.NormalizeStepName(key)
+				warnings = append(warnings, Warning{
+					Code:    WarningOutputRefUnresolved,
+					Message: fmt.Sprintf("output ref %s points at recorded path %s; ensure local storage is mounted or remapped", envKey, ref.Path),
+				})
+			}
+		}
+	}
+	sortWarnings(warnings)
+	return env, warnings
+}
+
+func reconstructMounts(spec container.Spec, remaps []MountRemap) ([]container.Mount, []Warning) {
+	remapBySource := make(map[string]string, len(remaps))
+	for _, remap := range remaps {
+		if strings.TrimSpace(remap.From) == "" || strings.TrimSpace(remap.To) == "" {
+			continue
+		}
+		remapBySource[remap.From] = remap.To
+	}
+
+	var mounts []container.Mount
+	var warnings []Warning
+	for _, mount := range spec.Mounts {
+		mounts = append(mounts, applyMountRemap(mount, remapBySource, &warnings))
+	}
+	for _, mount := range spec.ResolvedVolumeMounts {
+		switch mount.Type {
+		case container.VolumeMountTypeBind, container.VolumeMountTypeVolume, container.VolumeMountTypeTmpfs:
+			converted := container.Mount{
+				Type:     container.MountType(mount.Type),
+				Source:   mount.Source,
+				Target:   mount.Target,
+				ReadOnly: mount.ReadOnly,
+			}
+			mounts = append(mounts, applyMountRemap(converted, remapBySource, &warnings))
+		case container.VolumeMountTypePVC, container.VolumeMountTypeClaimTemplate, container.VolumeMountTypeVolumeSource:
+			warnings = append(warnings, Warning{
+				Code:    WarningMountSkipped,
+				Message: fmt.Sprintf("skipping Kubernetes-only volume mount %s at %s for local Docker reproduce", firstNonEmpty(mount.Name, string(mount.Type)), mount.Target),
+			})
+		default:
+			warnings = append(warnings, Warning{
+				Code:    WarningMountSkipped,
+				Message: fmt.Sprintf("skipping unsupported volume mount %s at %s for local Docker reproduce", firstNonEmpty(mount.Name, string(mount.Type)), mount.Target),
+			})
+		}
+	}
+	sortWarnings(warnings)
+	return mounts, warnings
+}
+
+func applyMountRemap(mount container.Mount, remapBySource map[string]string, warnings *[]Warning) container.Mount {
+	if mount.Type != container.MountTypeBind || strings.TrimSpace(mount.Source) == "" {
+		return mount
+	}
+	if replacement := remapBySource[mount.Source]; replacement != "" {
+		mount.Source = replacement
+		return mount
+	}
+	*warnings = append(*warnings, Warning{
+		Code:    WarningMountNotRemapped,
+		Message: fmt.Sprintf("bind mount %s -> %s was not remapped; pass --mount %s=<local-path> if the recorded source is not available", mount.Source, mount.Target, mount.Source),
+	})
+	return mount
+}
+
+func imageReference(recorded, digest string) (string, string, []Warning) {
+	recorded = strings.TrimSpace(recorded)
+	digest = strings.TrimSpace(digest)
+	if digest == "" {
+		return recorded, "DEGRADED", []Warning{{
+			Code:    WarningDegradedImagePull,
+			Message: fmt.Sprintf("no resolved image digest recorded for %s; pulling mutable tag is DEGRADED", recorded),
+		}}
+	}
+	base := recorded
+	if before, _, ok := strings.Cut(recorded, "@"); ok {
+		base = before
+	}
+	return base + "@" + digest, "DIGEST", nil
+}
+
+func paramEnvKey(key string) string {
+	return "CAESIUM_PARAM_" + strings.ToUpper(key)
+}
+
+func isSecretRef(value string) bool {
+	return strings.HasPrefix(strings.TrimSpace(value), "secret://")
+}
+
+func secretRefsByEnv(refs []SecretRef) map[string]string {
+	out := make(map[string]string, len(refs))
+	for _, ref := range refs {
+		if ref.EnvKey != "" {
+			out[ref.EnvKey] = ref.Ref
+		}
+	}
+	return out
+}
+
+func appendSecretOmission(omitted []SecretOmission, next SecretOmission) []SecretOmission {
+	for _, existing := range omitted {
+		if existing.EnvKey == next.EnvKey {
+			return omitted
+		}
+	}
+	return append(omitted, next)
+}
+
+func secretEnvKeys(omitted []SecretOmission) []string {
+	keys := make([]string, 0, len(omitted))
+	for _, omission := range omitted {
+		keys = append(keys, omission.EnvKey)
+	}
+	return keys
+}
+
+func sortedKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(values))
+	for k, v := range values {
+		out[k] = v
+	}
+	return out
+}
+
+func cloneAnyMap(values map[string]any) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(values))
+	for k, v := range values {
+		out[k] = v
+	}
+	return out
+}
+
+func durationString(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return d.String()
+}
+
+func sanitizeAlias(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '.':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	alias := strings.Trim(b.String(), "-.")
+	if alias == "" {
+		return "reproduce-task"
+	}
+	if !strings.HasPrefix(alias, "reproduce-") {
+		alias = "reproduce-" + alias
+	}
+	if len(alias) > 63 {
+		alias = strings.Trim(alias[:63], "-.")
+	}
+	return alias
+}
+
+func sortWarnings(warnings []Warning) {
+	sort.SliceStable(warnings, func(i, j int) bool {
+		if warnings[i].Code != warnings[j].Code {
+			return warnings[i].Code < warnings[j].Code
+		}
+		return warnings[i].Message < warnings[j].Message
+	})
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/reproduce/reconstruct.go
+++ b/internal/reproduce/reconstruct.go
@@ -313,7 +313,10 @@ func BuildDefinition(desc *Descriptor, env *Envelope, timeout time.Duration) *pk
 			},
 		},
 		Steps: []pkgjobdef.Step{{
-			Name:         firstNonEmpty(desc.Baseline.TaskName, "task"),
+			Name: firstNonEmpty(desc.Baseline.TaskName, "task"),
+			// Type must be set explicitly: the YAML unmarshaller defaults it,
+			// but this definition is constructed in Go and localrun validates.
+			Type:         pkgjobdef.StepTypeTask,
 			Engine:       pkgjobdef.EngineDocker,
 			Image:        env.Image,
 			Command:      slices.Clone(env.Command),

--- a/internal/reproduce/reconstruct_test.go
+++ b/internal/reproduce/reconstruct_test.go
@@ -1,0 +1,147 @@
+package reproduce
+
+import (
+	"testing"
+
+	"github.com/caesium-cloud/caesium/pkg/container"
+)
+
+func TestReconstructEnvLayeringAndSecretOmission(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Runtime.Image = "registry.example.com/etl/transform:1"
+	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	desc.ContainerSpec.Env = map[string]string{
+		"LITERAL_ENV":                 "fixture-literal",
+		"SECRET_ENV":                  "secret://vault/db-password",
+		"CAESIUM_PARAM_MODE":          "literal-param",
+		"CAESIUM_PARAM_OVERRIDE":      "literal-override",
+		"CAESIUM_OUTPUT_PRODUCE_ROWS": "literal-output",
+	}
+	desc.SecretRefs = []SecretRef{{EnvKey: "SECRET_ENV", Ref: "secret://vault/db-password"}}
+	desc.Run.Params = map[string]string{
+		"mode":     "recorded",
+		"override": "recorded-override",
+	}
+	desc.DAG.Predecessors = []EdgeRef{{TaskID: "11111111-1111-1111-1111-111111111111", TaskName: "produce"}}
+	desc.DAG.PredecessorOutputs = map[string]map[string]string{
+		"11111111-1111-1111-1111-111111111111": {
+			"rows": "7",
+		},
+	}
+
+	env, err := Reconstruct(desc, ReconstructOptions{
+		SetParams: []Assignment{{Key: "mode", Value: "manual"}},
+		SetEnv: []Assignment{
+			{Key: "CAESIUM_PARAM_OVERRIDE", Value: "env-final"},
+			{Key: "EXTRA_ENV", Value: "extra"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	want := map[string]string{
+		"LITERAL_ENV":                 "fixture-literal",
+		"CAESIUM_PARAM_MODE":          "manual",
+		"CAESIUM_PARAM_OVERRIDE":      "env-final",
+		"CAESIUM_OUTPUT_PRODUCE_ROWS": "7",
+		"EXTRA_ENV":                   "extra",
+	}
+	for key, value := range want {
+		if got := env.Env[key]; got != value {
+			t.Fatalf("env[%s] = %q, want %q in %#v", key, got, value, env.Env)
+		}
+	}
+	if _, ok := env.Env["SECRET_ENV"]; ok {
+		t.Fatalf("SECRET_ENV should be omitted by default: %#v", env.Env)
+	}
+	if len(env.OmittedSecrets) != 1 || env.OmittedSecrets[0].EnvKey != "SECRET_ENV" {
+		t.Fatalf("omitted secrets = %#v, want SECRET_ENV", env.OmittedSecrets)
+	}
+	if !hasWarning(env.Warnings, WarningSecretOmitted) {
+		t.Fatalf("warnings = %#v, want %s", env.Warnings, WarningSecretOmitted)
+	}
+	if env.ImagePullMode != "DIGEST" {
+		t.Fatalf("ImagePullMode = %q, want DIGEST", env.ImagePullMode)
+	}
+}
+
+func TestReconstructOutputRefUsesBuildOutputEnvShape(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "load"
+	desc.Runtime.Image = "alpine:3.23"
+	desc.DAG.Predecessors = []EdgeRef{{TaskID: "22222222-2222-2222-2222-222222222222", TaskName: "extract.step"}}
+	ref := containerOutputRef("/data/out.parquet")
+	desc.DAG.PredecessorOutputs = map[string]map[string]string{
+		"22222222-2222-2222-2222-222222222222": {
+			"frame-path": ref,
+		},
+	}
+
+	env, err := Reconstruct(desc, ReconstructOptions{})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	if got := env.Env["CAESIUM_OUTPUT_EXTRACT_STEP_FRAME_PATH"]; got != "/data/out.parquet" {
+		t.Fatalf("output ref env path = %q", got)
+	}
+	if got := env.Env["CAESIUM_OUTPUT_EXTRACT_STEP_FRAME_PATH_DIGEST"]; got == "" {
+		t.Fatalf("output ref digest companion missing in %#v", env.Env)
+	}
+	if !hasWarning(env.Warnings, WarningOutputRefUnresolved) {
+		t.Fatalf("warnings = %#v, want %s", env.Warnings, WarningOutputRefUnresolved)
+	}
+}
+
+func TestReconstructMountRemapAndKubernetesSkip(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Runtime.Image = "alpine:3.23"
+	desc.ContainerSpec.Mounts = []container.Mount{{
+		Type:   container.MountTypeBind,
+		Source: "/prod/data",
+		Target: "/data",
+	}}
+	desc.ContainerSpec.ResolvedVolumeMounts = []container.VolumeMount{
+		{Type: container.VolumeMountTypeBind, Source: "/prod/work", Target: "/work"},
+		{Type: container.VolumeMountTypePVC, Name: "shared", Source: "claim", Target: "/claim"},
+	}
+
+	env, err := Reconstruct(desc, ReconstructOptions{
+		Mounts: []MountRemap{
+			{From: "/prod/data", To: "/local/data"},
+			{From: "/prod/work", To: "/local/work"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	if len(env.Mounts) != 2 {
+		t.Fatalf("mounts = %#v, want two Docker-compatible mounts", env.Mounts)
+	}
+	if env.Mounts[0].Source != "/local/data" || env.Mounts[1].Source != "/local/work" {
+		t.Fatalf("mount sources = %#v, want remapped sources", env.Mounts)
+	}
+	if !hasWarning(env.Warnings, WarningMountSkipped) {
+		t.Fatalf("warnings = %#v, want PVC skip warning", env.Warnings)
+	}
+}
+
+func containerOutputRef(path string) string {
+	return `{"caesiumOutputRef":1,"path":"` + path + `","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}`
+}
+
+func hasWarning(warnings []Warning, code string) bool {
+	for _, warning := range warnings {
+		if warning.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/test/reproduce_cli_test.go
+++ b/test/reproduce_cli_test.go
@@ -1,0 +1,199 @@
+//go:build integration
+
+package test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
+	jobID, runID, taskRunID := s.createReproduceCLIFixture()
+	secretAssertionEnabled := s.engineType != "kubernetes"
+	if secretAssertionEnabled {
+		catalogDB := s.openIntegrationCatalogDB()
+		defer func() { s.Require().NoError(catalogDB.Close()) }()
+		s.Require().NoError(addSecretRefToDescriptor(s.T().Context(), catalogDB, taskRunID))
+	}
+
+	dryRunOut, err := s.runCLIStdout(
+		"reproduce", runID,
+		"--job-id", jobID,
+		"--task", "transform",
+		"--dry-run",
+		"--json",
+		"--server", s.caesiumURL,
+	)
+	s.Require().NoError(err)
+	var envelope reproduceCLIEnvelope
+	s.Require().NoError(json.Unmarshal([]byte(dryRunOut), &envelope))
+	s.Equal("transform", envelope.Task)
+	s.Equal("fixture-literal", envelope.Env["LITERAL_ENV"])
+	s.Equal("vanilla", envelope.Env["CAESIUM_PARAM_FLAVOR"])
+	s.Equal("7", envelope.Env["CAESIUM_OUTPUT_PRODUCE_ROWS"])
+	s.Equal("raw", envelope.Env["CAESIUM_OUTPUT_PRODUCE_SOURCE"])
+	if secretAssertionEnabled {
+		s.NotContains(envelope.Env, "SECRET_ENV")
+		s.True(reproduceHasOmittedSecret(envelope.OmittedSecrets, "SECRET_ENV"), "omitted secrets = %+v", envelope.OmittedSecrets)
+		s.True(reproduceHasWarning(envelope.Warnings, "secret_omitted"), "warnings = %+v", envelope.Warnings)
+	}
+
+	runOut, runErrOut, runErr := s.runCLISeparate(
+		"reproduce", runID,
+		"--job-id", jobID,
+		"--task", "transform",
+		"--json",
+		"--server", s.caesiumURL,
+	)
+	s.Require().NoError(runErr, "stderr: %s", runErrOut)
+	var result reproduceCLIRunResult
+	s.Require().NoError(json.Unmarshal([]byte(runOut), &result))
+	s.Equal(0, result.ExitCode)
+	s.Equal("succeeded", result.Status)
+	s.Equal("yes", result.Output["clean"])
+	s.Equal("7", result.Output["rows"])
+	s.Equal("raw", result.Output["source"])
+
+	missingOut, missingErrOut, missingErr := s.runCLISeparate(
+		"reproduce", uuid.NewString(),
+		"--job-id", jobID,
+		"--task", "transform",
+		"--server", s.caesiumURL,
+	)
+	s.Require().Error(missingErr)
+	s.Equal("", missingOut)
+	s.Equal(2, reproduceExitCode(missingErr), "stderr: %s", missingErrOut)
+	s.Contains(missingErrOut, "fetch descriptor failed")
+}
+
+func (s *IntegrationTestSuite) createReproduceCLIFixture() (jobID, runID, taskRunID string) {
+	alias := fmt.Sprintf("e2e-reproduce-cli-%d", time.Now().UnixNano())
+	manifest := fmt.Sprintf(`apiVersion: v1
+kind: Job
+metadata:
+  alias: %s
+  replaySafe: true
+trigger: { type: cron, configuration: { cron: "0 2 * * *" } }
+steps:
+  - name: produce
+    image: alpine:3.23
+    cache: { pinDigests: true }
+    command: ["sh","-c","echo '##caesium::output {\"rows\":\"7\",\"source\":\"raw\"}'"]
+    next: transform
+  - name: transform
+    image: alpine:3.23
+    cache: { pinDigests: true }
+    env:
+      LITERAL_ENV: fixture-literal
+    command: ["sh","-c","test \"$LITERAL_ENV\" = fixture-literal; test \"$CAESIUM_PARAM_FLAVOR\" = vanilla; test \"$CAESIUM_OUTPUT_PRODUCE_ROWS\" = 7; test \"$CAESIUM_OUTPUT_PRODUCE_SOURCE\" = raw; echo '##caesium::output {\"clean\":\"yes\",\"rows\":\"7\",\"source\":\"raw\"}'"]
+    dependsOn: produce
+`, alias)
+	dir := s.writeJobManifest(manifest)
+	defer os.RemoveAll(dir)
+
+	s.runCLI("job", "apply", "--path", dir, "--server", s.caesiumURL)
+	job := s.requireJobByAlias(alias)
+	s.Require().NotNil(job)
+
+	runID = s.triggerRunWithParams(job.ID, map[string]string{"flavor": "vanilla"})
+	s.Require().Equal("succeeded", s.awaitRun(job.ID, runID, runTimeout).Status)
+
+	status, body := s.getReproduceDescriptor(job.ID, runID, "transform")
+	s.Require().Equal(200, status, string(body))
+	var resp reproduceDescriptorResponse
+	s.Require().NoError(json.Unmarshal(body, &resp))
+	return job.ID, runID, resp.TaskRunID
+}
+
+type reproduceCLIEnvelope struct {
+	Task           string            `json:"task"`
+	Env            map[string]string `json:"env"`
+	OmittedSecrets []struct {
+		EnvKey string `json:"env_key"`
+		Ref    string `json:"ref"`
+	} `json:"omitted_secrets"`
+	Warnings []struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	} `json:"warnings"`
+}
+
+type reproduceCLIRunResult struct {
+	Status   string            `json:"status"`
+	ExitCode int               `json:"exit_code"`
+	Output   map[string]string `json:"output"`
+}
+
+func addSecretRefToDescriptor(ctx context.Context, conn *sql.DB, taskRunID string) error {
+	var raw string
+	if err := conn.QueryRowContext(ctx, `SELECT execution_descriptor FROM task_runs WHERE id = ?`, taskRunID).Scan(&raw); err != nil {
+		return err
+	}
+	var descriptor map[string]any
+	if err := json.Unmarshal([]byte(raw), &descriptor); err != nil {
+		return err
+	}
+	spec, _ := descriptor["containerSpec"].(map[string]any)
+	if spec == nil {
+		spec = map[string]any{}
+		descriptor["containerSpec"] = spec
+	}
+	env, _ := spec["env"].(map[string]any)
+	if env == nil {
+		env = map[string]any{}
+		spec["env"] = env
+	}
+	env["SECRET_ENV"] = "secret://fixture/db-password"
+	descriptor["secretRefs"] = []any{map[string]any{
+		"ref":        "secret://fixture/db-password",
+		"envKey":     "SECRET_ENV",
+		"provider":   "fixture",
+		"verifiable": false,
+	}}
+	updated, err := json.Marshal(descriptor)
+	if err != nil {
+		return err
+	}
+	_, err = conn.ExecContext(ctx, `UPDATE task_runs SET execution_descriptor = ? WHERE id = ?`, string(updated), taskRunID)
+	return err
+}
+
+func reproduceHasOmittedSecret(secrets []struct {
+	EnvKey string `json:"env_key"`
+	Ref    string `json:"ref"`
+}, envKey string) bool {
+	for _, secret := range secrets {
+		if secret.EnvKey == envKey {
+			return true
+		}
+	}
+	return false
+}
+
+func reproduceHasWarning(warnings []struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}, code string) bool {
+	for _, warning := range warnings {
+		if warning.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func reproduceExitCode(err error) int {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}

--- a/test/reproduce_cli_test.go
+++ b/test/reproduce_cli_test.go
@@ -46,6 +46,27 @@ func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 		s.True(reproduceHasWarning(envelope.Warnings, "secret_omitted"), "warnings = %+v", envelope.Warnings)
 	}
 
+	// The missing-descriptor exit-2 leg is daemon-free — run it on every lane
+	// before the docker-gated run-mode leg below.
+	missingOut, missingErrOut, missingErr := s.runCLISeparate(
+		"reproduce", uuid.NewString(),
+		"--job-id", jobID,
+		"--task", "transform",
+		"--server", s.caesiumURL,
+	)
+	s.Require().Error(missingErr)
+	s.Equal("", missingOut)
+	s.Equal(2, reproduceExitCode(missingErr), "stderr: %s", missingErrOut)
+	s.Contains(missingErrOut, "fetch descriptor failed")
+
+	// Run mode executes on the operator's LOCAL Docker daemon by design; the
+	// podman and kubernetes lanes' test-runners have no docker.sock, so only
+	// the daemon-free legs above run there.
+	if s.engineType != "" && s.engineType != "docker" {
+		s.T().Logf("skipping reproduce run-mode leg under CAESIUM_TEST_ENGINE=%s; local execution needs the harness Docker daemon (covered on the docker lanes)", s.engineType)
+		return
+	}
+
 	runOut, runErrOut, runErr := s.runCLISeparate(
 		"reproduce", runID,
 		"--job-id", jobID,
@@ -62,17 +83,6 @@ func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 	s.Equal("yes", result.Output["clean"])
 	s.Equal("7", result.Output["rows"])
 	s.Equal("raw", result.Output["source"])
-
-	missingOut, missingErrOut, missingErr := s.runCLISeparate(
-		"reproduce", uuid.NewString(),
-		"--job-id", jobID,
-		"--task", "transform",
-		"--server", s.caesiumURL,
-	)
-	s.Require().Error(missingErr)
-	s.Equal("", missingOut)
-	s.Equal(2, reproduceExitCode(missingErr), "stderr: %s", missingErrOut)
-	s.Contains(missingErrOut, "fetch descriptor failed")
 }
 
 func (s *IntegrationTestSuite) createReproduceCLIFixture() (jobID, runID, taskRunID string) {

--- a/test/reproduce_cli_test.go
+++ b/test/reproduce_cli_test.go
@@ -55,7 +55,8 @@ func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 	)
 	s.Require().NoError(runErr, "stderr: %s", runErrOut)
 	var result reproduceCLIRunResult
-	s.Require().NoError(json.Unmarshal([]byte(runOut), &result))
+	s.Require().NoError(json.Unmarshal([]byte(runOut), &result),
+		"run-mode --json stdout must be a single JSON document; raw stdout: %q; stderr: %q", runOut, runErrOut)
 	s.Equal(0, result.ExitCode)
 	s.Equal("succeeded", result.Status)
 	s.Equal("yes", result.Output["clean"])


### PR DESCRIPTION
## Summary
B1+B2 of the reproduce plan — the operator-facing CLI core:

- `caesium reproduce <run-id> --job-id <id> --task <name>`: fetches the W1 descriptor endpoint (API-key hygiene per `cmd/why`), reconstructs the envelope with the design's later-wins layering — recorded `ContainerSpec.Env` → `CAESIUM_PARAM_*` → `CAESIUM_OUTPUT_*` via the exact `pkgtask.BuildOutputEnv` mapping `internal/replay` uses → `--set` → `--set-env`; `secret://` refs omitted by default and named in warnings.
- `--dry-run`/`--json`: a single JSON document on stdout (envelope + `warnings: [{code,message}]` + `omitted_secrets` + `recorded_retry_policy`), everything else on stderr.
- Run mode rides `internal/localrun` with a synthesized one-step definition (design OQ#2), single-shot (OQ#3 — recorded retry surfaced, never applied): digest-first pull with DEGRADED mutable-tag fallback, `##caesium::output` marker parsing, `--mount old=new` remap (PVC/k8s sources warned + skipped), `--timeout` defaulting to the recorded value, `--platform` on the pre-pull.
- Exit codes: `0` succeeded / `1` ran-and-failed / `2` fetch-auth-reconstruction (registry-auth failures name the registry and point at `docker login` or `--image`).
- `internal/reproduce` is Cobra-free and pure-Go (host-tested: env layering, secret omission, pull guidance, DEGRADED marking, mount remap); integration scenarios drive the real binary via `runCLIStdout` (dry-run JSON purity + envelope equality, run-mode exit 0 against the harness daemon, missing-run exit 2), engine-tolerant on digest recording.

**Known scope note**: `--platform` applies to the explicit pre-pull; the shared localrun docker atom does not thread platform into `ContainerCreate` (untouched shared API — candidate for a follow-up if cross-arch reproduction demands it).

## Test plan
- [x] Host `go test ./internal/reproduce/` — green (agent + orchestrator independently).
- [ ] Full matrix + CLI integration scenarios — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
