### PR TITLE
Add output diff, fidelity summary, and shell mode to reproduce (reproduce W3-γ)

### DIFF
--- a/caesium.go
+++ b/caesium.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/caesium-cloud/caesium/cmd"
 	"github.com/caesium-cloud/caesium/pkg/env"
 	"github.com/caesium-cloud/caesium/pkg/log"
@@ -12,6 +14,9 @@ func main() {
 	}
 
 	if err := cmd.Execute(); err != nil {
+		if code, ok := cmd.ExitCode(err); ok {
+			os.Exit(code)
+		}
 		log.Fatal("caesium failure", "error", err)
 	}
 }

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -60,3 +60,8 @@ func Execute() error {
 
 	return command.Execute()
 }
+
+// ExitCode extracts a command-requested process exit code from an Execute error.
+func ExitCode(err error) (int, bool) {
+	return reproduce.ExitCode(err)
+}

--- a/cmd/reproduce/reproduce.go
+++ b/cmd/reproduce/reproduce.go
@@ -4,17 +4,22 @@ package reproduce
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"os"
+	osexec "os/exec"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/caesium-cloud/caesium/cmd/cliutil"
 	"github.com/caesium-cloud/caesium/internal/localrun"
+	"github.com/caesium-cloud/caesium/internal/outputdiff"
 	ireproduce "github.com/caesium-cloud/caesium/internal/reproduce"
+	"github.com/caesium-cloud/caesium/pkg/container"
 	pkgjobdef "github.com/caesium-cloud/caesium/pkg/jobdef"
 	"github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
@@ -33,6 +38,8 @@ var (
 	reproduceMounts   []string
 	reproduceTimeout  time.Duration
 	reproducePlatform string
+	reproduceDiff     bool
+	reproduceShell    bool
 )
 
 var httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
@@ -41,7 +48,7 @@ var httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
 var Cmd = &cobra.Command{
 	Use:           "reproduce <run-id> --job-id <job-id> --task <task>",
 	Short:         "Re-execute a historical task locally",
-	Args:          cobra.ExactArgs(1),
+	Args:          cobra.ArbitraryArgs,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE:          runReproduce,
@@ -91,43 +98,52 @@ func init() {
 	Cmd.Flags().StringArrayVar(&reproduceMounts, "mount", nil, "Remap a recorded bind mount source as old=new (repeatable)")
 	Cmd.Flags().DurationVar(&reproduceTimeout, "timeout", 0, "Local task timeout (default: recorded task timeout)")
 	Cmd.Flags().StringVar(&reproducePlatform, "platform", "", "Platform to use when pulling the image (for example linux/amd64)")
+	Cmd.Flags().BoolVar(&reproduceDiff, "diff", false, "Compare reproduced output markers against recorded output")
+	Cmd.Flags().BoolVar(&reproduceShell, "shell", false, "Open an interactive shell in the reconstructed environment")
 }
 
 func runReproduce(cmd *cobra.Command, args []string) error {
+	stderr := cmd.ErrOrStderr()
+	if len(args) != 1 {
+		return exitWithMessage(stderr, 2, "reproduce requires exactly one run id")
+	}
+	if err := validateModeFlags(reproduceShell, reproduceDiff, reproduceDryRun, reproduceJSON); err != nil {
+		return printExitError(stderr, err)
+	}
+
 	runID := strings.TrimSpace(args[0])
 	if strings.TrimSpace(reproduceJobID) == "" {
-		return fmt.Errorf("--job-id is required")
+		return exitWithMessage(stderr, 2, "--job-id is required")
 	}
 	if strings.TrimSpace(reproduceTask) == "" {
-		return fmt.Errorf("--task is required")
+		return exitWithMessage(stderr, 2, "--task is required")
 	}
 
 	setParams, err := parseAssignments(reproduceSet, "--set")
 	if err != nil {
-		return err
+		return exitWithMessage(stderr, 2, err.Error())
 	}
 	setEnv, err := parseAssignments(reproduceSetEnv, "--set-env")
 	if err != nil {
-		return err
+		return exitWithMessage(stderr, 2, err.Error())
 	}
 	mounts, err := parseMountRemaps(reproduceMounts)
 	if err != nil {
-		return err
+		return exitWithMessage(stderr, 2, err.Error())
 	}
 
-	stderr := cmd.ErrOrStderr()
 	server := strings.TrimRight(reproduceServer, "/")
 	if !reproduceDryRun || !reproduceJSON {
 		_, _ = fmt.Fprintf(stderr, "fetching descriptor from %s\n", server)
 	}
 	resp, err := fetchDescriptor(cmd.Context(), cmd, server, reproduceJobID, runID, reproduceTask)
 	if err != nil {
-		exitWithMessage(stderr, 2, err.Error())
+		return exitWithMessage(stderr, 2, err.Error())
 	}
 
 	desc, err := ireproduce.DecodeDescriptor(resp.Descriptor)
 	if err != nil {
-		exitWithMessage(stderr, 2, err.Error())
+		return exitWithMessage(stderr, 2, err.Error())
 	}
 	env, err := ireproduce.Reconstruct(desc, ireproduce.ReconstructOptions{
 		SetParams:  setParams,
@@ -138,9 +154,17 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 		ReplaySafe: resp.ReplaySafe,
 	})
 	if err != nil {
-		exitWithMessage(stderr, 2, err.Error())
+		return exitWithMessage(stderr, 2, err.Error())
 	}
 	printWarnings(stderr, env.Warnings)
+
+	var recordedOutput map[string]string
+	if reproduceDiff {
+		recordedOutput, err = decodeRecordedOutput(resp.Output)
+		if err != nil {
+			return exitWithMessage(stderr, 2, err.Error())
+		}
+	}
 
 	envelopeOut := dryRunEnvelope{
 		RunID:      runID,
@@ -153,7 +177,23 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 	}
 	if reproduceDryRun {
 		if err := writeJSON(cmd, envelopeOut); err != nil {
-			exitWithMessage(stderr, 2, err.Error())
+			return exitWithMessage(stderr, 2, err.Error())
+		}
+		return nil
+	}
+
+	if reproduceShell {
+		result, err := ireproduce.ExecuteShell(cmd.Context(), env, ireproduce.ShellExecuteOptions{
+			Puller:      dockerPuller{},
+			ShellRunner: dockerShellRunner{},
+			Platform:    reproducePlatform,
+		})
+		if err != nil {
+			return exitWithMessage(stderr, 2, err.Error())
+		}
+		printFidelitySummary(stderr, result.Fidelity)
+		if result.ExitCode != 0 {
+			return exitWithCode(result.ExitCode)
 		}
 		return nil
 	}
@@ -165,7 +205,17 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 		Platform: reproducePlatform,
 	})
 	if err != nil {
-		exitWithMessage(stderr, 2, err.Error())
+		return exitWithMessage(stderr, 2, err.Error())
+	}
+
+	var diff *outputdiff.Diff
+	if reproduceDiff && result.ExitCode == 0 {
+		computed := outputdiff.Compare(recordedOutput, result.Output)
+		result.OutputDiff = &computed
+		diff = &computed
+		if !computed.Empty() {
+			result.ExitCode = 3
+		}
 	}
 
 	if reproduceJSON {
@@ -178,23 +228,35 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 			RecordedOutput:  resp.Output,
 			ExecutionResult: result,
 		}); err != nil {
-			exitWithMessage(stderr, 2, err.Error())
+			return exitWithMessage(stderr, 2, err.Error())
 		}
-		os.Exit(result.ExitCode)
+		if result.ExitCode != 0 {
+			return exitWithCode(result.ExitCode)
+		}
+		return nil
 	}
 
 	ireproduce.CopyLog(cmd.OutOrStdout(), result)
+	if diff != nil {
+		_, _ = io.WriteString(cmd.OutOrStdout(), diff.Render())
+	}
 	if result.ExitCode == 0 {
 		_, _ = fmt.Fprintf(stderr, "%s exited 0\n", env.TaskName)
+		printFidelitySummary(stderr, result.Fidelity)
 		return nil
+	}
+	if result.ExitCode == 3 {
+		_, _ = fmt.Fprintf(stderr, "%s exited 0; reproduced output differs from recorded output\n", env.TaskName)
+		printFidelitySummary(stderr, result.Fidelity)
+		return exitWithCode(3)
 	}
 	_, _ = fmt.Fprintf(stderr, "%s failed", env.TaskName)
 	if result.Error != "" {
 		_, _ = fmt.Fprintf(stderr, ": %s", result.Error)
 	}
 	_, _ = fmt.Fprintln(stderr)
-	os.Exit(1)
-	return nil
+	printFidelitySummary(stderr, result.Fidelity)
+	return exitWithCode(1)
 }
 
 func fetchDescriptor(ctx context.Context, cmd *cobra.Command, server, jobID, runID, task string) (*descriptorResponse, error) {
@@ -297,6 +359,87 @@ func (localRunner) Run(ctx context.Context, def *pkgjobdef.Definition, taskTimeo
 	return out, err
 }
 
+type dockerShellRunner struct{}
+
+func (dockerShellRunner) RunShell(ctx context.Context, req ireproduce.ShellRequest) error {
+	command := osexec.CommandContext(ctx, "docker", dockerRunShellArgs(req)...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		code := commandExitCode(err)
+		if code == 126 || code == 127 {
+			return &ireproduce.ShellUnavailableError{Image: req.Image, Shell: req.Shell, Err: err}
+		}
+		if code >= 0 {
+			return &ireproduce.ShellExitError{Code: code, Err: err}
+		}
+		return err
+	}
+	return nil
+}
+
+func dockerRunShellArgs(req ireproduce.ShellRequest) []string {
+	shell := strings.TrimSpace(req.Shell)
+	if shell == "" {
+		shell = ireproduce.DefaultShell
+	}
+	args := []string{"run", "--rm", "-it", "--entrypoint", shell}
+	if strings.TrimSpace(req.Platform) != "" {
+		args = append(args, "--platform", req.Platform)
+	}
+	if strings.TrimSpace(req.WorkDir) != "" {
+		args = append(args, "--workdir", req.WorkDir)
+	}
+	for _, key := range sortedMapKeys(req.Env) {
+		args = append(args, "-e", key+"="+req.Env[key])
+	}
+	for _, mount := range req.Mounts {
+		if arg := dockerMountArg(mount); arg != "" {
+			args = append(args, "--mount", arg)
+		}
+	}
+	args = append(args, req.Image)
+	return args
+}
+
+func dockerMountArg(mount container.Mount) string {
+	switch mount.Type {
+	case container.MountTypeBind:
+		if strings.TrimSpace(mount.Source) == "" || strings.TrimSpace(mount.Target) == "" {
+			return ""
+		}
+		return readonlySuffix(fmt.Sprintf("type=bind,source=%s,target=%s", mount.Source, mount.Target), mount.ReadOnly)
+	case container.MountTypeVolume:
+		if strings.TrimSpace(mount.Source) == "" || strings.TrimSpace(mount.Target) == "" {
+			return ""
+		}
+		return readonlySuffix(fmt.Sprintf("type=volume,source=%s,target=%s", mount.Source, mount.Target), mount.ReadOnly)
+	case container.MountTypeTmpfs:
+		if strings.TrimSpace(mount.Target) == "" {
+			return ""
+		}
+		return fmt.Sprintf("type=tmpfs,target=%s", mount.Target)
+	default:
+		return ""
+	}
+}
+
+func readonlySuffix(arg string, readonly bool) string {
+	if readonly {
+		return arg + ",readonly"
+	}
+	return arg
+}
+
+func commandExitCode(err error) int {
+	var exitErr *osexec.ExitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode()
+	}
+	return -1
+}
+
 func parseAssignments(values []string, flag string) ([]ireproduce.Assignment, error) {
 	out := make([]ireproduce.Assignment, 0, len(values))
 	for _, value := range values {
@@ -336,13 +479,106 @@ func writeJSON(cmd *cobra.Command, value any) error {
 	return encoder.Encode(value)
 }
 
+func decodeRecordedOutput(raw json.RawMessage) (map[string]string, error) {
+	if len(raw) == 0 || strings.TrimSpace(string(raw)) == "null" {
+		return nil, nil
+	}
+	var out map[string]string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode recorded output: %w", err)
+	}
+	return out, nil
+}
+
 func printWarnings(w io.Writer, warnings []ireproduce.Warning) {
 	for _, warning := range warnings {
 		_, _ = fmt.Fprintf(w, "warning: %s\n", warning.Message)
 	}
 }
 
-func exitWithMessage(w io.Writer, code int, message string) {
+func printFidelitySummary(w io.Writer, summary *ireproduce.FidelitySummary) {
+	if w == nil || summary == nil || len(summary.Dimensions) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(w, "fidelity summary:")
+	for _, dimension := range summary.Dimensions {
+		if len(dimension.Details) == 0 {
+			_, _ = fmt.Fprintf(w, "  %s: %s\n", dimension.Dimension, dimension.Status)
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "  %s: %s - %s\n", dimension.Dimension, dimension.Status, strings.Join(dimension.Details, "; "))
+	}
+}
+
+func sortedMapKeys(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func validateModeFlags(shellMode, diffMode, dryRunMode, jsonMode bool) error {
+	switch {
+	case shellMode && diffMode:
+		return usageError("--shell cannot be combined with --diff")
+	case shellMode && dryRunMode:
+		return usageError("--shell cannot be combined with --dry-run")
+	case shellMode && jsonMode:
+		return usageError("--shell cannot be combined with --json")
+	case diffMode && dryRunMode:
+		return usageError("--diff cannot be combined with --dry-run")
+	default:
+		return nil
+	}
+}
+
+type exitError struct {
+	code int
+	msg  string
+}
+
+func (e *exitError) Error() string {
+	if e.msg != "" {
+		return e.msg
+	}
+	return fmt.Sprintf("exit status %d", e.code)
+}
+
+func (e *exitError) ExitCode() int {
+	return e.code
+}
+
+func usageError(message string) error {
+	return &exitError{code: 2, msg: message}
+}
+
+// ExitCode extracts the process exit code requested by reproduce.
+func ExitCode(err error) (int, bool) {
+	var exitErr *exitError
+	if errors.As(err, &exitErr) {
+		return exitErr.ExitCode(), true
+	}
+	return 0, false
+}
+
+func printExitError(w io.Writer, err error) error {
+	var exitErr *exitError
+	if errors.As(err, &exitErr) && exitErr.msg != "" {
+		_, _ = fmt.Fprintln(w, exitErr.msg)
+	}
+	return err
+}
+
+func exitWithMessage(w io.Writer, code int, message string) error {
 	_, _ = fmt.Fprintln(w, message)
-	os.Exit(code)
+	return &exitError{code: code, msg: message}
+}
+
+func exitWithCode(code int) error {
+	if code == 0 {
+		return nil
+	}
+	return &exitError{code: code}
 }

--- a/cmd/reproduce/reproduce.go
+++ b/cmd/reproduce/reproduce.go
@@ -2,6 +2,7 @@
 package reproduce
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -216,6 +217,8 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 		if !computed.Empty() {
 			result.ExitCode = 3
 		}
+	} else if reproduceDiff {
+		_, _ = fmt.Fprintln(stderr, "diff skipped: the task exited non-zero, so there is no successful output to compare")
 	}
 
 	if reproduceJSON {
@@ -361,14 +364,38 @@ func (localRunner) Run(ctx context.Context, def *pkgjobdef.Definition, taskTimeo
 
 type dockerShellRunner struct{}
 
+// shellStderrTee mirrors docker's stderr to the operator while keeping a
+// bounded copy so exit 126/127 can be classified: only a docker/daemon
+// exec-failure (shell binary missing from the image) is "shell unavailable";
+// the same codes typed inside a WORKING shell (`exit 127`) must not be.
+type shellStderrTee struct {
+	dst io.Writer
+	buf bytes.Buffer
+}
+
+func (t *shellStderrTee) Write(p []byte) (int, error) {
+	if t.buf.Len() < 8192 {
+		t.buf.Write(p)
+	}
+	return t.dst.Write(p)
+}
+
+func (t *shellStderrTee) indicatesMissingShell() bool {
+	s := t.buf.String()
+	return strings.Contains(s, "Error response from daemon") ||
+		strings.Contains(s, "no such file or directory") ||
+		strings.Contains(s, "executable file not found")
+}
+
 func (dockerShellRunner) RunShell(ctx context.Context, req ireproduce.ShellRequest) error {
+	tee := &shellStderrTee{dst: os.Stderr}
 	command := osexec.CommandContext(ctx, "docker", dockerRunShellArgs(req)...)
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout
-	command.Stderr = os.Stderr
+	command.Stderr = tee
 	if err := command.Run(); err != nil {
 		code := commandExitCode(err)
-		if code == 126 || code == 127 {
+		if (code == 126 || code == 127) && tee.indicatesMissingShell() {
 			return &ireproduce.ShellUnavailableError{Image: req.Image, Shell: req.Shell, Err: err}
 		}
 		if code >= 0 {

--- a/cmd/reproduce/reproduce_test.go
+++ b/cmd/reproduce/reproduce_test.go
@@ -1,0 +1,74 @@
+package reproduce
+
+import (
+	"strings"
+	"testing"
+
+	ireproduce "github.com/caesium-cloud/caesium/internal/reproduce"
+	"github.com/caesium-cloud/caesium/pkg/container"
+)
+
+func TestValidateModeFlagsConflictsExitTwo(t *testing.T) {
+	tests := []struct {
+		name      string
+		shellMode bool
+		diffMode  bool
+		dryRun    bool
+		jsonMode  bool
+		want      string
+	}{
+		{name: "shell diff", shellMode: true, diffMode: true, want: "--shell cannot be combined with --diff"},
+		{name: "shell dry run", shellMode: true, dryRun: true, want: "--shell cannot be combined with --dry-run"},
+		{name: "shell json", shellMode: true, jsonMode: true, want: "--shell cannot be combined with --json"},
+		{name: "diff dry run", diffMode: true, dryRun: true, want: "--diff cannot be combined with --dry-run"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateModeFlags(tt.shellMode, tt.diffMode, tt.dryRun, tt.jsonMode)
+			if err == nil {
+				t.Fatal("validateModeFlags() error = nil, want conflict")
+			}
+			code, ok := ExitCode(err)
+			if !ok || code != 2 {
+				t.Fatalf("ExitCode(error) = %d, %t; want 2, true", code, ok)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %q, want %q", err.Error(), tt.want)
+			}
+		})
+	}
+}
+
+func TestDockerRunShellArgsUsesInteractiveEntrypointAndExactEnv(t *testing.T) {
+	args := dockerRunShellArgs(ireproduce.ShellRequest{
+		Image:    "alpine:3.23",
+		Shell:    ireproduce.DefaultShell,
+		Platform: "linux/amd64",
+		WorkDir:  "/work",
+		Env: map[string]string{
+			"B": "2",
+			"A": "1",
+		},
+		Mounts: []container.Mount{{
+			Type:     container.MountTypeBind,
+			Source:   "/host/data",
+			Target:   "/data",
+			ReadOnly: true,
+		}},
+	})
+	joined := strings.Join(args, "\x00")
+
+	for _, want := range []string{
+		"run\x00--rm\x00-it\x00--entrypoint\x00/bin/sh",
+		"--platform\x00linux/amd64",
+		"--workdir\x00/work",
+		"-e\x00A=1\x00-e\x00B=2",
+		"--mount\x00type=bind,source=/host/data,target=/data,readonly",
+		"alpine:3.23",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("docker args %q missing %q", joined, want)
+		}
+	}
+}

--- a/docs/exec-plans/active/reproduce.md
+++ b/docs/exec-plans/active/reproduce.md
@@ -257,7 +257,7 @@ faithful-vs-best-effort table, and drop into a shell inside the exact
 environment. C extends `cmd/reproduce/` and `internal/reproduce/`, so it
 sequences **after** Stream B.
 
-- [ ] C1. Add `--diff` output-compare as a **shared** package
+- [x] C1. Add `--diff` output-compare as a **shared** package
       (`internal/outputdiff/`) so the recorded-vs-reproduced `##caesium::output` map
       comparison is built once and reused by the N-run
       [backtesting](backtesting.md) sibling (design Interplay note: "build it once as
@@ -267,7 +267,13 @@ sequences **after** Stream B.
       Files: new `internal/outputdiff/outputdiff.go` (+ `outputdiff_test.go`),
       `cmd/reproduce/reproduce.go`.
       Depends on: B2.
-- [ ] C2. Add the per-run fidelity summary block derived from the design's
+      Note: W3-gamma added generic `internal/outputdiff.Compare(recorded,
+      reproduced map[string]string) Diff` with deterministic added/removed/changed
+      rendering, wired `caesium reproduce --diff` to recorded descriptor-wrapper
+      output, returns exit `3` only after a successful local task with mismatched
+      outputs, and extended the docker-gated CLI integration lane with match and
+      deliberate mismatch assertions.
+- [x] C2. Add the per-run fidelity summary block derived from the design's
       faithful-vs-best-effort table: emit explicit warnings (never silence) for a
       DEGRADED mutable-tag pull, unmounted output-refs / dangling BYO-storage paths,
       engine & workload-identity dimensions with no local equivalent
@@ -278,13 +284,25 @@ sequences **after** Stream B.
       Files: `internal/reproduce/reconstruct.go`, `internal/reproduce/execute.go`,
       `cmd/reproduce/reproduce.go`.
       Depends on: B2.
-- [ ] C3. Add `--shell` interactive mode: same fetch/pull/env reconstruction, but
+      Note: W3-gamma added a structured `fidelity.dimensions[]` block to dry-run and
+      run JSON plus compact human stderr rendering after local execution. The summary
+      covers faithful, degraded, not_reproduced, and listed_not_applied dimensions
+      from the design table, with warnings for mutable tags, output refs, workload
+      identity, platform emulation, resource limits, wall clock, external state, and
+      unsuppressed side effects.
+- [x] C3. Add `--shell` interactive mode: same fetch/pull/env reconstruction, but
       `docker run -it --entrypoint <shell>` inside the exact environment instead of
       the recorded command. Distroless images without a shell fail here with a clear
       guidance error (run mode still works); the `--shell-image` busybox:1.36.1 sidecar
       fallback (design Open Question #4) is **out of scope** — recorded as deferred.
       Files: `cmd/reproduce/reproduce.go`, `internal/reproduce/execute.go`.
       Depends on: B2.
+      Note: W3-gamma added `--shell` as an interactive Docker CLI runner using the
+      reconstructed image/env/workdir/mounts and inherited stdio, with conflicts
+      against `--diff`, `--dry-run`, and `--json` as exit-2 usage errors. Distroless
+      `/bin/sh` failures return guidance naming the deferred `--shell-image` Open
+      Question #4 fallback; unit coverage exercises shell request construction,
+      conflict handling, and the guidance path.
 
 ### Stream D — Fix-testing + local secret resolution (P2)
 

--- a/internal/outputdiff/outputdiff.go
+++ b/internal/outputdiff/outputdiff.go
@@ -1,0 +1,98 @@
+// Package outputdiff compares recorded and reproduced task output maps.
+package outputdiff
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Entry is a key/value output present on only one side of a comparison.
+type Entry struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Change is a key whose recorded and reproduced values differ.
+type Change struct {
+	Key        string `json:"key"`
+	Recorded   string `json:"recorded"`
+	Reproduced string `json:"reproduced"`
+}
+
+// Diff is the deterministic comparison of recorded vs reproduced outputs.
+type Diff struct {
+	Added   []Entry  `json:"added,omitempty"`
+	Removed []Entry  `json:"removed,omitempty"`
+	Changed []Change `json:"changed,omitempty"`
+}
+
+// Compare computes the output diff. Inputs are treated as immutable.
+func Compare(recorded, reproduced map[string]string) Diff {
+	keys := make(map[string]struct{}, len(recorded)+len(reproduced))
+	for key := range recorded {
+		keys[key] = struct{}{}
+	}
+	for key := range reproduced {
+		keys[key] = struct{}{}
+	}
+
+	ordered := make([]string, 0, len(keys))
+	for key := range keys {
+		ordered = append(ordered, key)
+	}
+	sort.Strings(ordered)
+
+	var diff Diff
+	for _, key := range ordered {
+		recordedValue, recordedOK := recorded[key]
+		reproducedValue, reproducedOK := reproduced[key]
+		switch {
+		case !recordedOK && reproducedOK:
+			diff.Added = append(diff.Added, Entry{Key: key, Value: reproducedValue})
+		case recordedOK && !reproducedOK:
+			diff.Removed = append(diff.Removed, Entry{Key: key, Value: recordedValue})
+		case recordedOK && reproducedOK && recordedValue != reproducedValue:
+			diff.Changed = append(diff.Changed, Change{
+				Key:        key,
+				Recorded:   recordedValue,
+				Reproduced: reproducedValue,
+			})
+		}
+	}
+	return diff
+}
+
+// Empty reports whether the two output maps matched exactly.
+func (d Diff) Empty() bool {
+	return len(d.Added) == 0 && len(d.Removed) == 0 && len(d.Changed) == 0
+}
+
+// Render returns deterministic human-readable diff text.
+func (d Diff) Render() string {
+	if d.Empty() {
+		return "Output diff vs recorded: match\n"
+	}
+
+	var b strings.Builder
+	b.WriteString("Output diff vs recorded:\n")
+	if len(d.Changed) > 0 {
+		b.WriteString("  changed:\n")
+		for _, change := range d.Changed {
+			_, _ = fmt.Fprintf(&b, "    %s: recorded %q -> reproduced %q\n", change.Key, change.Recorded, change.Reproduced)
+		}
+	}
+	if len(d.Removed) > 0 {
+		b.WriteString("  removed:\n")
+		for _, entry := range d.Removed {
+			_, _ = fmt.Fprintf(&b, "    %s: recorded %q, reproduced <missing>\n", entry.Key, entry.Value)
+		}
+	}
+	if len(d.Added) > 0 {
+		b.WriteString("  added:\n")
+		for _, entry := range d.Added {
+			_, _ = fmt.Fprintf(&b, "    %s: recorded <missing>, reproduced %q\n", entry.Key, entry.Value)
+		}
+	}
+	return b.String()
+}

--- a/internal/outputdiff/outputdiff_test.go
+++ b/internal/outputdiff/outputdiff_test.go
@@ -36,7 +36,7 @@ func TestCompareDetectsAddedRemovedAndChangedDeterministically(t *testing.T) {
 	firstChanged := strings.Index(rendered, "d_changed")
 	firstRemoved := strings.Index(rendered, "b_removed")
 	firstAdded := strings.Index(rendered, "a_added")
-	if !(firstChanged > 0 && firstRemoved > firstChanged && firstAdded > firstRemoved) {
+	if firstChanged <= 0 || firstRemoved <= firstChanged || firstAdded <= firstRemoved {
 		t.Fatalf("Render() order is not deterministic changed/removed/added:\n%s", rendered)
 	}
 }

--- a/internal/outputdiff/outputdiff_test.go
+++ b/internal/outputdiff/outputdiff_test.go
@@ -1,0 +1,56 @@
+package outputdiff
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCompareDetectsAddedRemovedAndChangedDeterministically(t *testing.T) {
+	diff := Compare(
+		map[string]string{
+			"b_removed": "old",
+			"c_same":    "same",
+			"d_changed": "before",
+		},
+		map[string]string{
+			"a_added":   "new",
+			"c_same":    "same",
+			"d_changed": "after",
+		},
+	)
+
+	if diff.Empty() {
+		t.Fatal("diff.Empty() = true, want false")
+	}
+	if got, want := diff.Added, []Entry{{Key: "a_added", Value: "new"}}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Added = %#v, want %#v", got, want)
+	}
+	if got, want := diff.Removed, []Entry{{Key: "b_removed", Value: "old"}}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Removed = %#v, want %#v", got, want)
+	}
+	if got, want := diff.Changed, []Change{{Key: "d_changed", Recorded: "before", Reproduced: "after"}}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Changed = %#v, want %#v", got, want)
+	}
+
+	rendered := diff.Render()
+	firstChanged := strings.Index(rendered, "d_changed")
+	firstRemoved := strings.Index(rendered, "b_removed")
+	firstAdded := strings.Index(rendered, "a_added")
+	if !(firstChanged > 0 && firstRemoved > firstChanged && firstAdded > firstRemoved) {
+		t.Fatalf("Render() order is not deterministic changed/removed/added:\n%s", rendered)
+	}
+}
+
+func TestCompareEmpty(t *testing.T) {
+	diff := Compare(
+		map[string]string{"rows": "7"},
+		map[string]string{"rows": "7"},
+	)
+
+	if !diff.Empty() {
+		t.Fatalf("diff.Empty() = false, diff = %#v", diff)
+	}
+	if got, want := diff.Render(), "Output diff vs recorded: match\n"; got != want {
+		t.Fatalf("Render() = %q, want %q", got, want)
+	}
+}

--- a/internal/reproduce/execute.go
+++ b/internal/reproduce/execute.go
@@ -5,12 +5,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 	"time"
 
+	"github.com/caesium-cloud/caesium/internal/outputdiff"
+	"github.com/caesium-cloud/caesium/pkg/container"
 	pkgjobdef "github.com/caesium-cloud/caesium/pkg/jobdef"
 	pkgtask "github.com/caesium-cloud/caesium/pkg/task"
 )
+
+const DefaultShell = "/bin/sh"
 
 // Puller pulls the image reference selected for local reproduction.
 type Puller interface {
@@ -27,6 +32,11 @@ type LocalImageChecker interface {
 // Runner executes a synthesized one-step definition through the local runtime.
 type Runner interface {
 	Run(ctx context.Context, def *pkgjobdef.Definition, taskTimeout time.Duration) (*RunResult, error)
+}
+
+// ShellRunner starts an interactive shell in the reconstructed environment.
+type ShellRunner interface {
+	RunShell(ctx context.Context, req ShellRequest) error
 }
 
 // RunResult is the localrun result subset used by this package.
@@ -54,6 +64,13 @@ type ExecuteOptions struct {
 	Platform string
 }
 
+// ShellExecuteOptions controls interactive shell execution.
+type ShellExecuteOptions struct {
+	Puller      Puller
+	ShellRunner ShellRunner
+	Platform    string
+}
+
 // ExecutionResult is the machine-readable result for run mode.
 type ExecutionResult struct {
 	Status       string            `json:"status"`
@@ -65,7 +82,30 @@ type ExecutionResult struct {
 	LogTruncated bool              `json:"log_truncated,omitempty"`
 	Error        string            `json:"error,omitempty"`
 	Envelope     *Envelope         `json:"envelope"`
+	Fidelity     *FidelitySummary  `json:"fidelity,omitempty"`
+	OutputDiff   *outputdiff.Diff  `json:"output_diff,omitempty"`
 	Warnings     []Warning         `json:"warnings,omitempty"`
+}
+
+// ShellRequest is the docker-run shape for interactive shell mode.
+type ShellRequest struct {
+	Image    string            `json:"image"`
+	Shell    string            `json:"shell"`
+	Env      map[string]string `json:"env,omitempty"`
+	Mounts   []container.Mount `json:"mounts,omitempty"`
+	WorkDir  string            `json:"workdir,omitempty"`
+	Platform string            `json:"platform,omitempty"`
+}
+
+// ShellResult reports the interactive shell process outcome.
+type ShellResult struct {
+	ExitCode int              `json:"exit_code"`
+	Task     string           `json:"task"`
+	Image    string           `json:"image"`
+	Error    string           `json:"error,omitempty"`
+	Envelope *Envelope        `json:"envelope"`
+	Fidelity *FidelitySummary `json:"fidelity,omitempty"`
+	Warnings []Warning        `json:"warnings,omitempty"`
 }
 
 // PullError is returned when the selected image cannot be pulled.
@@ -89,6 +129,43 @@ func (e *PullError) Unwrap() error {
 	return e.Err
 }
 
+// ShellUnavailableError is returned when the selected image has no shell at the
+// requested path, which is common for distroless images.
+type ShellUnavailableError struct {
+	Image string
+	Shell string
+	Err   error
+}
+
+func (e *ShellUnavailableError) Error() string {
+	return fmt.Sprintf(
+		"shell %s is unavailable in image %s; distroless images often omit a shell. The --shell-image sidecar fallback is deferred (design Open Question #4); use run mode or rebuild an image with a shell for interactive debugging",
+		e.Shell,
+		e.Image,
+	)
+}
+
+func (e *ShellUnavailableError) Unwrap() error {
+	return e.Err
+}
+
+// ShellExitError records a non-zero exit from the interactive shell process.
+type ShellExitError struct {
+	Code int
+	Err  error
+}
+
+func (e *ShellExitError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return fmt.Sprintf("shell exited with status %d", e.Code)
+}
+
+func (e *ShellExitError) Unwrap() error {
+	return e.Err
+}
+
 // Execute pulls the reconstructed image and runs the synthesized local task
 // exactly once.
 func Execute(ctx context.Context, desc *Descriptor, env *Envelope, opts ExecuteOptions) (*ExecutionResult, error) {
@@ -106,18 +183,8 @@ func Execute(ctx context.Context, desc *Descriptor, env *Envelope, opts ExecuteO
 	}
 
 	platform := firstNonEmpty(strings.TrimSpace(opts.Platform), env.Platform)
-	checker, canCheckLocal := opts.Puller.(LocalImageChecker)
-	if canCheckLocal && checker.ExistsLocally(ctx, env.Image) {
-		env.Warnings = append(env.Warnings, Warning{
-			Code:    "local_image_used",
-			Message: fmt.Sprintf("image %s already present in the local daemon; skipped registry pull", env.Image),
-		})
-	} else if err := opts.Puller.Pull(ctx, env.Image, platform); err != nil {
-		return nil, &PullError{
-			ImageRef: env.Image,
-			Registry: RegistryHost(env.Image),
-			Err:      err,
-		}
+	if err := ensureImageAvailable(ctx, env, opts.Puller, platform); err != nil {
+		return nil, err
 	}
 
 	timeout := opts.Timeout
@@ -161,6 +228,7 @@ func Execute(ctx context.Context, desc *Descriptor, env *Envelope, opts ExecuteO
 		LogTruncated: task.LogTruncated,
 		Error:        firstNonEmpty(task.Error, runResult.Error),
 		Envelope:     env,
+		Fidelity:     env.Fidelity,
 		Warnings:     env.Warnings,
 	}
 	if isSuccessfulStatus(task.Status) {
@@ -172,6 +240,80 @@ func Execute(ctx context.Context, desc *Descriptor, env *Envelope, opts ExecuteO
 		result.Error = runErr.Error()
 	}
 	return result, nil
+}
+
+// ExecuteShell pulls the reconstructed image and starts an interactive shell
+// inside the exact reconstructed environment.
+func ExecuteShell(ctx context.Context, env *Envelope, opts ShellExecuteOptions) (*ShellResult, error) {
+	if env == nil {
+		return nil, fmt.Errorf("envelope is required")
+	}
+	if opts.Puller == nil {
+		return nil, fmt.Errorf("image puller is required")
+	}
+	if opts.ShellRunner == nil {
+		return nil, fmt.Errorf("shell runner is required")
+	}
+
+	platform := firstNonEmpty(strings.TrimSpace(opts.Platform), env.Platform)
+	if err := ensureImageAvailable(ctx, env, opts.Puller, platform); err != nil {
+		return nil, err
+	}
+
+	req := BuildShellRequest(env, platform)
+	result := &ShellResult{
+		Task:     env.TaskName,
+		Image:    env.Image,
+		Envelope: env,
+		Fidelity: env.Fidelity,
+		Warnings: env.Warnings,
+	}
+	if err := opts.ShellRunner.RunShell(ctx, req); err != nil {
+		var shellExit *ShellExitError
+		if errors.As(err, &shellExit) {
+			result.ExitCode = shellExit.Code
+			result.Error = shellExit.Error()
+			return result, nil
+		}
+		return nil, err
+	}
+	return result, nil
+}
+
+// BuildShellRequest converts an envelope into the interactive docker-run
+// request. The default shell is /bin/sh, matching the design.
+func BuildShellRequest(env *Envelope, platform string) ShellRequest {
+	if env == nil {
+		return ShellRequest{Shell: DefaultShell}
+	}
+	return ShellRequest{
+		Image:    env.Image,
+		Shell:    DefaultShell,
+		Env:      cloneStringMap(env.Env),
+		Mounts:   slices.Clone(env.Mounts),
+		WorkDir:  env.WorkDir,
+		Platform: strings.TrimSpace(platform),
+	}
+}
+
+func ensureImageAvailable(ctx context.Context, env *Envelope, puller Puller, platform string) error {
+	checker, canCheckLocal := puller.(LocalImageChecker)
+	if canCheckLocal && checker.ExistsLocally(ctx, env.Image) {
+		env.Warnings = append(env.Warnings, Warning{
+			Code:    "local_image_used",
+			Message: fmt.Sprintf("image %s already present in the local daemon; skipped registry pull", env.Image),
+		})
+		sortWarnings(env.Warnings)
+		return nil
+	}
+	if err := puller.Pull(ctx, env.Image, platform); err != nil {
+		return &PullError{
+			ImageRef: env.Image,
+			Registry: RegistryHost(env.Image),
+			Err:      err,
+		}
+	}
+	return nil
 }
 
 // RegistryHost returns the registry host component used in pull guidance.

--- a/internal/reproduce/execute_test.go
+++ b/internal/reproduce/execute_test.go
@@ -152,6 +152,107 @@ func TestExecutePassesRemappedMountsToSynthesizedDefinition(t *testing.T) {
 	}
 }
 
+func TestBuildShellRequestUsesDefaultShellAndClonesEnvelope(t *testing.T) {
+	env := &Envelope{
+		TaskName: "transform",
+		Image:    "alpine:3.23",
+		Env:      map[string]string{"A": "1"},
+		Mounts:   testBindMount("/local/data", "/data"),
+		WorkDir:  "/work",
+	}
+
+	req := BuildShellRequest(env, "linux/amd64")
+	env.Env["A"] = "mutated"
+	env.Mounts[0].Source = "/mutated"
+
+	if req.Shell != DefaultShell {
+		t.Fatalf("Shell = %q, want %q", req.Shell, DefaultShell)
+	}
+	if req.Env["A"] != "1" {
+		t.Fatalf("request env was not cloned: %#v", req.Env)
+	}
+	if req.Mounts[0].Source != "/local/data" {
+		t.Fatalf("request mounts were not cloned: %#v", req.Mounts)
+	}
+	if req.WorkDir != "/work" || req.Platform != "linux/amd64" {
+		t.Fatalf("request = %#v, want workdir and platform", req)
+	}
+}
+
+func TestExecuteShellPullsImageAndRunsShellRequest(t *testing.T) {
+	desc := basicDescriptor("registry.example.com/team/app:1")
+	env, err := Reconstruct(desc, ReconstructOptions{})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+	puller := &fakePuller{}
+	runner := &fakeShellRunner{}
+
+	result, err := ExecuteShell(context.Background(), env, ShellExecuteOptions{
+		Puller:      puller,
+		ShellRunner: runner,
+		Platform:    "linux/amd64",
+	})
+	if err != nil {
+		t.Fatalf("ExecuteShell() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0", result.ExitCode)
+	}
+	if puller.imageRef != "registry.example.com/team/app:1" || puller.platform != "linux/amd64" {
+		t.Fatalf("puller = %#v, want image and platform", puller)
+	}
+	if runner.req.Shell != DefaultShell || runner.req.Image != env.Image {
+		t.Fatalf("shell request = %#v, want default shell and env image", runner.req)
+	}
+}
+
+func TestExecuteShellDistrolessGuidance(t *testing.T) {
+	desc := basicDescriptor("gcr.io/distroless/static:nonroot")
+	env, err := Reconstruct(desc, ReconstructOptions{})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	_, err = ExecuteShell(context.Background(), env, ShellExecuteOptions{
+		Puller: &fakePuller{},
+		ShellRunner: &fakeShellRunner{err: &ShellUnavailableError{
+			Image: env.Image,
+			Shell: DefaultShell,
+			Err:   errors.New("exit status 127"),
+		}},
+	})
+	if err == nil {
+		t.Fatal("ExecuteShell() error = nil, want shell unavailable guidance")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "--shell-image") || !strings.Contains(msg, "deferred") || !strings.Contains(msg, "distroless") {
+		t.Fatalf("shell unavailable error = %q, want distroless deferred --shell-image guidance", msg)
+	}
+}
+
+func TestExecuteShellReturnsInteractiveExitCode(t *testing.T) {
+	desc := basicDescriptor("alpine:3.23")
+	env, err := Reconstruct(desc, ReconstructOptions{})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	result, err := ExecuteShell(context.Background(), env, ShellExecuteOptions{
+		Puller: &fakePuller{},
+		ShellRunner: &fakeShellRunner{err: &ShellExitError{
+			Code: 7,
+			Err:  errors.New("exit status 7"),
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ExecuteShell() error = %v, want shell exit result", err)
+	}
+	if result.ExitCode != 7 || result.Error == "" {
+		t.Fatalf("result = %#v, want shell exit code and error", result)
+	}
+}
+
 func basicDescriptor(image string) *Descriptor {
 	desc := &Descriptor{}
 	desc.SchemaVersion = 1
@@ -201,4 +302,14 @@ func (r *capturingRunner) Run(_ context.Context, def *pkgjobdef.Definition, time
 	r.def = def
 	r.timeout = timeout
 	return r.result, nil
+}
+
+type fakeShellRunner struct {
+	req ShellRequest
+	err error
+}
+
+func (r *fakeShellRunner) RunShell(_ context.Context, req ShellRequest) error {
+	r.req = req
+	return r.err
 }

--- a/internal/reproduce/reconstruct.go
+++ b/internal/reproduce/reconstruct.go
@@ -5,6 +5,7 @@ package reproduce
 import (
 	"encoding/json"
 	"fmt"
+	"runtime"
 	"slices"
 	"sort"
 	"strings"
@@ -23,6 +24,19 @@ const (
 	WarningMountNotRemapped    = "mount_not_remapped"
 	WarningMountSkipped        = "mount_skipped"
 	WarningRetryNotApplied     = "retry_policy_not_applied"
+	WarningWorkloadIdentity    = "workload_identity_listed_not_applied"
+	WarningCrossArchEmulation  = "cross_arch_emulation"
+	WarningResourceLimits      = "resource_limits_not_reproduced"
+	WarningWallClock           = "wall_clock_not_reproduced"
+	WarningExternalState       = "external_state_not_reproduced"
+	WarningSideEffects         = "side_effects_not_suppressed"
+)
+
+const (
+	FidelityFaithful         = "faithful"
+	FidelityDegraded         = "degraded"
+	FidelityNotReproduced    = "not_reproduced"
+	FidelityListedNotApplied = "listed_not_applied"
 )
 
 // Assignment is a user-supplied KEY=VALUE override.
@@ -42,6 +56,20 @@ type MountRemap struct {
 type Warning struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
+}
+
+// FidelityDimension records how faithfully one descriptor dimension can be
+// reproduced on the operator's local Docker daemon.
+type FidelityDimension struct {
+	Dimension string   `json:"dimension"`
+	Status    string   `json:"status"`
+	Details   []string `json:"details,omitempty"`
+}
+
+// FidelitySummary is the structured machine-readable fidelity block emitted by
+// reproduce and mirrored in compact human output.
+type FidelitySummary struct {
+	Dimensions []FidelityDimension `json:"dimensions"`
 }
 
 // SecretOmission records a secret env var that was deliberately not
@@ -79,6 +107,7 @@ type Envelope struct {
 	Platform            string            `json:"platform,omitempty"`
 	RecordedRetryPolicy *RetryPolicy      `json:"recorded_retry_policy,omitempty"`
 	OmittedSecrets      []SecretOmission  `json:"omitted_secrets,omitempty"`
+	Fidelity            *FidelitySummary  `json:"fidelity,omitempty"`
 	Warnings            []Warning         `json:"warnings,omitempty"`
 }
 
@@ -268,7 +297,7 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 		})
 	}
 
-	return &Envelope{
+	envelope := &Envelope{
 		TaskName:            desc.Baseline.TaskName,
 		JobID:               desc.Baseline.JobID,
 		JobAlias:            desc.Baseline.JobAlias,
@@ -287,8 +316,13 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 		Platform:            strings.TrimSpace(opts.Platform),
 		RecordedRetryPolicy: retryPolicy,
 		OmittedSecrets:      omitted,
-		Warnings:            warnings,
-	}, nil
+	}
+	fidelity, fidelityWarnings := buildFidelitySummary(desc, envelope, opts, omitted)
+	warnings = append(warnings, fidelityWarnings...)
+	sortWarnings(warnings)
+	envelope.Fidelity = fidelity
+	envelope.Warnings = warnings
+	return envelope, nil
 }
 
 // BuildDefinition synthesizes the one-step definition consumed by localrun.
@@ -442,6 +476,243 @@ func imageReference(recorded, digest string) (string, string, []Warning) {
 		base = before
 	}
 	return base + "@" + digest, "DIGEST", nil
+}
+
+func buildFidelitySummary(desc *Descriptor, env *Envelope, opts ReconstructOptions, omitted []SecretOmission) (*FidelitySummary, []Warning) {
+	var dimensions []FidelityDimension
+	var warnings []Warning
+	add := func(dimension, status string, details ...string) {
+		dimensions = append(dimensions, FidelityDimension{
+			Dimension: dimension,
+			Status:    status,
+			Details:   cleanDetails(details),
+		})
+	}
+
+	if strings.TrimSpace(desc.Runtime.ResolvedImageDigest) == "" {
+		add("image_content", FidelityDegraded, fmt.Sprintf("no resolved digest recorded for %s; local pull uses the mutable tag", desc.Runtime.Image))
+	} else {
+		add("image_content", FidelityFaithful, fmt.Sprintf("image pulled by recorded digest %s", desc.Runtime.ResolvedImageDigest))
+	}
+	add("command_argv_workdir", FidelityFaithful, "recorded command, argv, and workdir are used verbatim")
+	add("literal_env_vars", FidelityFaithful, "recorded literal env vars are restored")
+	add("run_params", FidelityFaithful, "recorded run params are restored as CAESIUM_PARAM_*")
+
+	if details := outputRefFidelityDetails(desc); len(details) > 0 {
+		add("predecessor_outputs", FidelityDegraded, details...)
+	} else {
+		add("predecessor_outputs", FidelityFaithful, "recorded scalar predecessor outputs are restored as CAESIUM_OUTPUT_*")
+	}
+	add("schema_config", FidelityFaithful, "recorded output schema and validation mode are applied to the local run")
+
+	if len(omitted) > 0 {
+		add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs omitted by default: %s", strings.Join(secretEnvKeys(omitted), ", ")))
+	} else {
+		add("secret_values", FidelityFaithful, "no recorded secret refs were present")
+	}
+
+	if details := mountFidelityDetails(desc.ContainerSpec, opts.Mounts); len(details) > 0 {
+		add("host_mounts_volumes", FidelityNotReproduced, details...)
+	} else {
+		add("host_mounts_volumes", FidelityFaithful, "no recorded host mounts or volumes were present")
+	}
+
+	if details := workloadIdentityDetails(desc); len(details) > 0 {
+		add("engine_workload_identity", FidelityListedNotApplied, details...)
+		warnings = append(warnings, Warning{
+			Code:    WarningWorkloadIdentity,
+			Message: "engine and workload-identity fields have no local Docker equivalent; listed in fidelity summary and not applied",
+		})
+	} else {
+		add("engine_workload_identity", FidelityFaithful, "recorded task has no non-Docker engine or workload-identity fields")
+	}
+
+	if requestedArch := platformArch(firstNonEmpty(opts.Platform, env.Platform)); requestedArch != "" && requestedArch != runtime.GOARCH {
+		add("cpu_architecture", FidelityDegraded, fmt.Sprintf("requested platform %s differs from local architecture %s; Docker may use emulation", firstNonEmpty(opts.Platform, env.Platform), runtime.GOARCH))
+		warnings = append(warnings, Warning{
+			Code:    WarningCrossArchEmulation,
+			Message: fmt.Sprintf("requested platform %s differs from local architecture %s; cross-arch emulation is DEGRADED", firstNonEmpty(opts.Platform, env.Platform), runtime.GOARCH),
+		})
+	} else if platform := strings.TrimSpace(firstNonEmpty(opts.Platform, env.Platform)); platform != "" {
+		add("cpu_architecture", FidelityFaithful, fmt.Sprintf("requested platform %s matches local architecture %s", platform, runtime.GOARCH))
+	} else {
+		add("cpu_architecture", FidelityFaithful, "no explicit platform override requested; local Docker selects the native architecture")
+	}
+
+	add("resource_limits", FidelityNotReproduced, "descriptor schema v1 does not record resource limits")
+	warnings = append(warnings, Warning{
+		Code:    WarningResourceLimits,
+		Message: "resource limits are not reproduced because descriptor schema v1 does not record them",
+	})
+
+	add("wall_clock_time", FidelityNotReproduced, "task observes the current local wall clock")
+	warnings = append(warnings, Warning{
+		Code:    WarningWallClock,
+		Message: "wall clock is not reproduced; the task runs now",
+	})
+
+	add("external_system_state", FidelityNotReproduced, "databases, APIs, object stores, and other external systems are not rewound")
+	warnings = append(warnings, Warning{
+		Code:    WarningExternalState,
+		Message: "external system state is not reproduced; the task sees whatever is reachable now",
+	})
+
+	add("side_effects", FidelityNotReproduced, "side effects are not suppressed under local reproduce")
+	warnings = append(warnings, Warning{
+		Code:    WarningSideEffects,
+		Message: "side effects are not suppressed; the container can affect systems reachable from this machine",
+	})
+
+	return &FidelitySummary{Dimensions: dimensions}, warnings
+}
+
+func outputRefFidelityDetails(desc *Descriptor) []string {
+	byName := make(map[string]map[string]string)
+	used := make(map[string]struct{})
+	for _, pred := range desc.DAG.Predecessors {
+		if outputs := desc.DAG.PredecessorOutputs[pred.TaskID]; len(outputs) > 0 {
+			byName[firstNonEmpty(pred.TaskName, pred.TaskID)] = outputs
+			used[pred.TaskID] = struct{}{}
+		}
+	}
+	for id, outputs := range desc.DAG.PredecessorOutputs {
+		if len(outputs) == 0 {
+			continue
+		}
+		if _, ok := used[id]; ok {
+			continue
+		}
+		byName[id] = outputs
+	}
+
+	var details []string
+	for stepName, outputs := range byName {
+		for key, value := range outputs {
+			ref, ok := pkgtask.DecodeOutputRef(value)
+			if !ok {
+				continue
+			}
+			envKey := "CAESIUM_OUTPUT_" + pkgtask.NormalizeStepName(stepName) + "_" + pkgtask.NormalizeStepName(key)
+			details = append(details, fmt.Sprintf("%s points at recorded path %s with digest %s; local storage must be mounted or remapped", envKey, ref.Path, ref.Digest))
+		}
+	}
+	sort.Strings(details)
+	return details
+}
+
+func mountFidelityDetails(spec container.Spec, remaps []MountRemap) []string {
+	if len(spec.Mounts) == 0 && len(spec.ResolvedVolumeMounts) == 0 {
+		return nil
+	}
+	remapBySource := make(map[string]string, len(remaps))
+	for _, remap := range remaps {
+		if strings.TrimSpace(remap.From) != "" && strings.TrimSpace(remap.To) != "" {
+			remapBySource[remap.From] = remap.To
+		}
+	}
+
+	var details []string
+	for _, mount := range spec.Mounts {
+		details = append(details, mountDetail(container.Mount{
+			Type:     mount.Type,
+			Source:   mount.Source,
+			Target:   mount.Target,
+			ReadOnly: mount.ReadOnly,
+		}, remapBySource))
+	}
+	for _, mount := range spec.ResolvedVolumeMounts {
+		switch mount.Type {
+		case container.VolumeMountTypeBind, container.VolumeMountTypeVolume, container.VolumeMountTypeTmpfs:
+			details = append(details, mountDetail(container.Mount{
+				Type:     container.MountType(mount.Type),
+				Source:   mount.Source,
+				Target:   mount.Target,
+				ReadOnly: mount.ReadOnly,
+			}, remapBySource))
+		case container.VolumeMountTypePVC, container.VolumeMountTypeClaimTemplate, container.VolumeMountTypeVolumeSource:
+			details = append(details, fmt.Sprintf("Kubernetes-only %s mount %s at %s is skipped under local Docker", mount.Type, firstNonEmpty(mount.Name, mount.Source), mount.Target))
+		default:
+			details = append(details, fmt.Sprintf("unsupported %s mount %s at %s is skipped under local Docker", mount.Type, firstNonEmpty(mount.Name, mount.Source), mount.Target))
+		}
+	}
+	sort.Strings(details)
+	return details
+}
+
+func mountDetail(mount container.Mount, remapBySource map[string]string) string {
+	if mount.Type == container.MountTypeBind {
+		if replacement := remapBySource[mount.Source]; replacement != "" {
+			return fmt.Sprintf("bind mount %s -> %s is remapped to local source %s", mount.Source, mount.Target, replacement)
+		}
+		return fmt.Sprintf("bind mount %s -> %s uses the recorded host path unless remapped", mount.Source, mount.Target)
+	}
+	if mount.Type == container.MountTypeVolume {
+		return fmt.Sprintf("volume %s -> %s uses local Docker volume contents", mount.Source, mount.Target)
+	}
+	if mount.Type == container.MountTypeTmpfs {
+		return fmt.Sprintf("tmpfs mount at %s is recreated locally, not restored from baseline state", mount.Target)
+	}
+	return fmt.Sprintf("%s mount %s -> %s is best-effort under local Docker", mount.Type, mount.Source, mount.Target)
+}
+
+func workloadIdentityDetails(desc *Descriptor) []string {
+	var details []string
+	if engine := strings.TrimSpace(desc.Runtime.Engine); engine != "" && engine != "docker" {
+		details = append(details, fmt.Sprintf("recorded engine %q runs under local Docker", engine))
+	}
+	if len(desc.Runtime.NodeSelector) > 0 {
+		details = append(details, "node selector "+formatStringMap(desc.Runtime.NodeSelector))
+	}
+	if k8s := firstKubernetesSpec(desc); k8s != nil {
+		if k8s.ServiceAccountName != "" {
+			details = append(details, "serviceAccountName "+k8s.ServiceAccountName)
+		}
+		if len(k8s.PodAnnotations) > 0 {
+			details = append(details, "pod annotations "+formatStringMap(k8s.PodAnnotations))
+		}
+		if k8s.AutomountServiceAccountToken != nil {
+			details = append(details, fmt.Sprintf("automountServiceAccountToken %t", *k8s.AutomountServiceAccountToken))
+		}
+		if k8s.QueueName != "" {
+			details = append(details, "Kueue queue "+k8s.QueueName)
+		}
+	}
+	sort.Strings(details)
+	return details
+}
+
+func firstKubernetesSpec(desc *Descriptor) *container.KubernetesSpec {
+	if desc.KubernetesSpec != nil {
+		return desc.KubernetesSpec
+	}
+	return desc.ContainerSpec.Kubernetes
+}
+
+func platformArch(platform string) string {
+	parts := strings.Split(strings.ToLower(strings.TrimSpace(platform)), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[1]
+}
+
+func formatStringMap(values map[string]string) string {
+	keys := sortedKeys(values)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+"="+values[key])
+	}
+	return strings.Join(parts, ", ")
+}
+
+func cleanDetails(details []string) []string {
+	out := make([]string, 0, len(details))
+	for _, detail := range details {
+		if strings.TrimSpace(detail) != "" {
+			out = append(out, detail)
+		}
+	}
+	return out
 }
 
 func paramEnvKey(key string) string {

--- a/internal/reproduce/reconstruct.go
+++ b/internal/reproduce/reconstruct.go
@@ -690,10 +690,29 @@ func firstKubernetesSpec(desc *Descriptor) *container.KubernetesSpec {
 
 func platformArch(platform string) string {
 	parts := strings.Split(strings.ToLower(strings.TrimSpace(platform)), "/")
-	if len(parts) < 2 {
+	if len(parts) == 0 || parts[0] == "" {
 		return ""
 	}
-	return parts[1]
+	// linux/amd64 → amd64; linux/arm64/v8 → arm64; a bare "arm64" is an arch.
+	arch := parts[len(parts)-1]
+	if len(parts) >= 3 {
+		arch = parts[1]
+	}
+	return normalizeArch(arch)
+}
+
+// normalizeArch maps OCI/uname spellings onto Go's runtime.GOARCH vocabulary
+// so the cross-arch fidelity check compares like with like.
+func normalizeArch(arch string) string {
+	switch arch {
+	case "x86_64", "x86-64":
+		return "amd64"
+	case "aarch64":
+		return "arm64"
+	case "i386", "i686":
+		return "386"
+	}
+	return arch
 }
 
 func formatStringMap(values map[string]string) string {

--- a/internal/reproduce/reconstruct_test.go
+++ b/internal/reproduce/reconstruct_test.go
@@ -1,6 +1,8 @@
 package reproduce
 
 import (
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/caesium-cloud/caesium/pkg/container"
@@ -133,6 +135,57 @@ func TestReconstructMountRemapAndKubernetesSkip(t *testing.T) {
 	}
 }
 
+func TestReconstructFidelitySummaryListsBestEffortDimensions(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Runtime.Image = "registry.example.com/team/app:latest"
+	desc.Runtime.Engine = "kubernetes"
+	desc.Runtime.NodeSelector = map[string]string{"disk": "ssd"}
+	desc.KubernetesSpec = &container.KubernetesSpec{
+		ServiceAccountName: "pipeline-runner",
+		QueueName:          "batch",
+	}
+	desc.DAG.Predecessors = []EdgeRef{{TaskID: "33333333-3333-3333-3333-333333333333", TaskName: "extract"}}
+	desc.DAG.PredecessorOutputs = map[string]map[string]string{
+		"33333333-3333-3333-3333-333333333333": {
+			"frame": containerOutputRef("/byo/frame.parquet"),
+		},
+	}
+
+	env, err := Reconstruct(desc, ReconstructOptions{Platform: oppositePlatform()})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	assertFidelityStatus(t, env.Fidelity, "image_content", FidelityDegraded)
+	assertFidelityStatus(t, env.Fidelity, "predecessor_outputs", FidelityDegraded)
+	workload := assertFidelityStatus(t, env.Fidelity, "engine_workload_identity", FidelityListedNotApplied)
+	if !strings.Contains(strings.Join(workload.Details, "; "), "serviceAccountName pipeline-runner") ||
+		!strings.Contains(strings.Join(workload.Details, "; "), "Kueue queue batch") ||
+		!strings.Contains(strings.Join(workload.Details, "; "), "node selector disk=ssd") {
+		t.Fatalf("workload identity details = %#v, want service account, Kueue queue, and node selector", workload.Details)
+	}
+	assertFidelityStatus(t, env.Fidelity, "cpu_architecture", FidelityDegraded)
+	assertFidelityStatus(t, env.Fidelity, "wall_clock_time", FidelityNotReproduced)
+	assertFidelityStatus(t, env.Fidelity, "external_system_state", FidelityNotReproduced)
+	assertFidelityStatus(t, env.Fidelity, "side_effects", FidelityNotReproduced)
+
+	for _, code := range []string{
+		WarningDegradedImagePull,
+		WarningOutputRefUnresolved,
+		WarningWorkloadIdentity,
+		WarningCrossArchEmulation,
+		WarningWallClock,
+		WarningExternalState,
+		WarningSideEffects,
+	} {
+		if !hasWarning(env.Warnings, code) {
+			t.Fatalf("warnings = %#v, want %s", env.Warnings, code)
+		}
+	}
+}
+
 func containerOutputRef(path string) string {
 	return `{"caesiumOutputRef":1,"path":"` + path + `","digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}`
 }
@@ -144,4 +197,28 @@ func hasWarning(warnings []Warning, code string) bool {
 		}
 	}
 	return false
+}
+
+func assertFidelityStatus(t *testing.T, summary *FidelitySummary, dimension, status string) FidelityDimension {
+	t.Helper()
+	if summary == nil {
+		t.Fatalf("fidelity summary is nil")
+	}
+	for _, dim := range summary.Dimensions {
+		if dim.Dimension == dimension {
+			if dim.Status != status {
+				t.Fatalf("fidelity[%s] = %s, want %s (details %#v)", dimension, dim.Status, status, dim.Details)
+			}
+			return dim
+		}
+	}
+	t.Fatalf("fidelity dimension %s not found in %#v", dimension, summary.Dimensions)
+	return FidelityDimension{}
+}
+
+func oppositePlatform() string {
+	if runtime.GOARCH == "amd64" {
+		return "linux/arm64"
+	}
+	return "linux/amd64"
 }

--- a/test/reproduce_cli_test.go
+++ b/test/reproduce_cli_test.go
@@ -72,6 +72,7 @@ func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 		"--job-id", jobID,
 		"--task", "transform",
 		"--json",
+		"--diff",
 		"--server", s.caesiumURL,
 	)
 	s.Require().NoError(runErr, "stderr: %s", runErrOut)
@@ -83,6 +84,33 @@ func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 	s.Equal("yes", result.Output["clean"])
 	s.Equal("7", result.Output["rows"])
 	s.Equal("raw", result.Output["source"])
+	s.Equal("vanilla", result.Output["flavor"])
+	s.Require().NotNil(result.OutputDiff)
+	s.True(result.OutputDiff.Empty(), "output diff = %+v", result.OutputDiff)
+	s.Require().NotNil(result.Fidelity)
+	s.True(reproduceHasFidelity(result.Fidelity, "image_content", "faithful"), "fidelity = %+v", result.Fidelity)
+	s.True(reproduceHasFidelity(result.Fidelity, "wall_clock_time", "not_reproduced"), "fidelity = %+v", result.Fidelity)
+
+	diffOut, diffErrOut, diffErr := s.runCLISeparate(
+		"reproduce", runID,
+		"--job-id", jobID,
+		"--task", "transform",
+		"--json",
+		"--diff",
+		"--set", "flavor=chocolate",
+		"--server", s.caesiumURL,
+	)
+	s.Require().Error(diffErr)
+	s.Equal(3, reproduceExitCode(diffErr), "stderr: %s", diffErrOut)
+	var mismatch reproduceCLIRunResult
+	s.Require().NoError(json.Unmarshal([]byte(diffOut), &mismatch),
+		"mismatch --json stdout must be parseable; raw stdout: %q; stderr: %q", diffOut, diffErrOut)
+	s.Equal(3, mismatch.ExitCode)
+	s.Equal("succeeded", mismatch.Status)
+	s.Equal("chocolate", mismatch.Output["flavor"])
+	s.Require().NotNil(mismatch.OutputDiff)
+	s.True(reproduceDiffHasChanged(mismatch.OutputDiff, "flavor", "vanilla", "chocolate"),
+		"output diff = %+v", mismatch.OutputDiff)
 }
 
 func (s *IntegrationTestSuite) createReproduceCLIFixture() (jobID, runID, taskRunID string) {
@@ -104,7 +132,7 @@ steps:
     cache: { pinDigests: true }
     env:
       LITERAL_ENV: fixture-literal
-    command: ["sh","-c","test \"$LITERAL_ENV\" = fixture-literal; test \"$CAESIUM_PARAM_FLAVOR\" = vanilla; test \"$CAESIUM_OUTPUT_PRODUCE_ROWS\" = 7; test \"$CAESIUM_OUTPUT_PRODUCE_SOURCE\" = raw; echo '##caesium::output {\"clean\":\"yes\",\"rows\":\"7\",\"source\":\"raw\"}'"]
+    command: ["sh","-c","test \"$LITERAL_ENV\" = fixture-literal; test -n \"$CAESIUM_PARAM_FLAVOR\"; test \"$CAESIUM_OUTPUT_PRODUCE_ROWS\" = 7; test \"$CAESIUM_OUTPUT_PRODUCE_SOURCE\" = raw; printf '##caesium::output {\"clean\":\"yes\",\"rows\":\"%%s\",\"source\":\"%%s\",\"flavor\":\"%%s\"}\\n' \"$CAESIUM_OUTPUT_PRODUCE_ROWS\" \"$CAESIUM_OUTPUT_PRODUCE_SOURCE\" \"$CAESIUM_PARAM_FLAVOR\""]
     dependsOn: produce
 `, alias)
 	dir := s.writeJobManifest(manifest)
@@ -138,9 +166,39 @@ type reproduceCLIEnvelope struct {
 }
 
 type reproduceCLIRunResult struct {
-	Status   string            `json:"status"`
-	ExitCode int               `json:"exit_code"`
-	Output   map[string]string `json:"output"`
+	Status     string                  `json:"status"`
+	ExitCode   int                     `json:"exit_code"`
+	Output     map[string]string       `json:"output"`
+	OutputDiff *reproduceCLIOutputDiff `json:"output_diff"`
+	Fidelity   *reproduceCLIFidelity   `json:"fidelity"`
+}
+
+type reproduceCLIOutputDiff struct {
+	Added []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"added"`
+	Removed []struct {
+		Key   string `json:"key"`
+		Value string `json:"value"`
+	} `json:"removed"`
+	Changed []struct {
+		Key        string `json:"key"`
+		Recorded   string `json:"recorded"`
+		Reproduced string `json:"reproduced"`
+	} `json:"changed"`
+}
+
+func (d *reproduceCLIOutputDiff) Empty() bool {
+	return d != nil && len(d.Added) == 0 && len(d.Removed) == 0 && len(d.Changed) == 0
+}
+
+type reproduceCLIFidelity struct {
+	Dimensions []struct {
+		Dimension string   `json:"dimension"`
+		Status    string   `json:"status"`
+		Details   []string `json:"details"`
+	} `json:"dimensions"`
 }
 
 func addSecretRefToDescriptor(ctx context.Context, conn *sql.DB, taskRunID string) error {
@@ -195,6 +253,30 @@ func reproduceHasWarning(warnings []struct {
 }, code string) bool {
 	for _, warning := range warnings {
 		if warning.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func reproduceHasFidelity(fidelity *reproduceCLIFidelity, dimension, status string) bool {
+	if fidelity == nil {
+		return false
+	}
+	for _, dim := range fidelity.Dimensions {
+		if dim.Dimension == dimension && dim.Status == status {
+			return true
+		}
+	}
+	return false
+}
+
+func reproduceDiffHasChanged(diff *reproduceCLIOutputDiff, key, recorded, reproduced string) bool {
+	if diff == nil {
+		return false
+	}
+	for _, change := range diff.Changed {
+		if change.Key == key && change.Recorded == recorded && change.Reproduced == reproduced {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
C1+C2+C3 of the reproduce plan + the W2-review carry-in:

- **C1**: new generic `internal/outputdiff` (`Compare(recorded, reproduced) Diff` with Added/Removed/Changed, `Empty()`, deterministic `Render()` — zero reproduce-specific types, ready for the backtesting sibling); `--diff` compares parsed markers against the recorded output — exit `3` on a successful-but-mismatched run, `0` on match; `--diff --dry-run` is a usage error.
- **C2**: structured fidelity block (per-dimension `faithful | degraded | not_reproduced | listed_not_applied` with details) derived from the descriptor — DEGRADED tag pulls, unmounted output refs, ServiceAccountName/node-selector/Kueue listed-not-applied, cross-arch, wall-clock/external-state not-reproduced — compact stderr rendering in human mode, embedded in `--json`.
- **C3**: `--shell` drops into the exact env via the local docker CLI (`docker run --rm -it --entrypoint /bin/sh` with inherited stdio, reconstructed env/workdir/mounts, SDK pre-pull + local-image check); shell exit 126/127 maps to distroless guidance naming the deferred `--shell-image` (OQ#4); conflicts with `--diff`/`--dry-run`/`--json` are usage errors.
- **Carry-in**: `RunE` now returns typed exit errors; `caesium.go` is the single `os.Exit` boundary (`cmd.ExitCode`); codes preserved 0/1/2 + new 3; command paths are now in-process testable (new `cmd/reproduce/reproduce_test.go`).
- Integration: `--diff` match → 0 and mutated-`--set` mismatch → 3 on the docker lane (the plan's acceptance scenario); fidelity block shape asserted in `--json`; `--shell` covered by unit tests (interactive).

## Test plan
- [x] Host `go test ./internal/reproduce/ ./internal/outputdiff/` — green (agent + orchestrator independently).
- [ ] Full matrix + integration scenarios — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
