### PR TITLE
Add fix-testing and local secret resolution to reproduce (reproduce W4-δ)

### DIFF
--- a/cmd/reproduce/reproduce.go
+++ b/cmd/reproduce/reproduce.go
@@ -13,10 +13,12 @@ import (
 	"os"
 	osexec "os/exec"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/caesium-cloud/caesium/cmd/cliutil"
+	"github.com/caesium-cloud/caesium/internal/jobdef/secret"
 	"github.com/caesium-cloud/caesium/internal/localrun"
 	"github.com/caesium-cloud/caesium/internal/outputdiff"
 	ireproduce "github.com/caesium-cloud/caesium/internal/reproduce"
@@ -28,19 +30,21 @@ import (
 )
 
 var (
-	reproduceJobID    string
-	reproduceTask     string
-	reproduceServer   string
-	reproduceAPIKey   string
-	reproduceDryRun   bool
-	reproduceJSON     bool
-	reproduceSet      []string
-	reproduceSetEnv   []string
-	reproduceMounts   []string
-	reproduceTimeout  time.Duration
-	reproducePlatform string
-	reproduceDiff     bool
-	reproduceShell    bool
+	reproduceJobID          string
+	reproduceTask           string
+	reproduceServer         string
+	reproduceAPIKey         string
+	reproduceDryRun         bool
+	reproduceJSON           bool
+	reproduceSet            []string
+	reproduceSetEnv         []string
+	reproduceMounts         []string
+	reproduceTimeout        time.Duration
+	reproducePlatform       string
+	reproduceDiff           bool
+	reproduceShell          bool
+	reproduceImage          string
+	reproduceResolveSecrets bool
 )
 
 var httpClient = &http.Client{Timeout: cliutil.DefaultHTTPTimeout}
@@ -101,6 +105,8 @@ func init() {
 	Cmd.Flags().StringVar(&reproducePlatform, "platform", "", "Platform to use when pulling the image (for example linux/amd64)")
 	Cmd.Flags().BoolVar(&reproduceDiff, "diff", false, "Compare reproduced output markers against recorded output")
 	Cmd.Flags().BoolVar(&reproduceShell, "shell", false, "Open an interactive shell in the reconstructed environment")
+	Cmd.Flags().StringVar(&reproduceImage, "image", "", "Override the image for fix testing (marks output OVERRIDDEN)")
+	Cmd.Flags().BoolVar(&reproduceResolveSecrets, "resolve-secrets", false, "Resolve secret:// refs via local providers (default: omit and warn)")
 }
 
 func runReproduce(cmd *cobra.Command, args []string) error {
@@ -132,6 +138,13 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return exitWithMessage(stderr, 2, err.Error())
 	}
+	var secretResolver ireproduce.SecretResolver
+	if reproduceResolveSecrets {
+		secretResolver, err = buildReproduceSecretResolver()
+		if err != nil {
+			return exitWithMessage(stderr, 2, err.Error())
+		}
+	}
 
 	server := strings.TrimRight(reproduceServer, "/")
 	if !reproduceDryRun || !reproduceJSON {
@@ -147,12 +160,16 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 		return exitWithMessage(stderr, 2, err.Error())
 	}
 	env, err := ireproduce.Reconstruct(desc, ireproduce.ReconstructOptions{
-		SetParams:  setParams,
-		SetEnv:     setEnv,
-		Mounts:     mounts,
-		Timeout:    reproduceTimeout,
-		Platform:   reproducePlatform,
-		ReplaySafe: resp.ReplaySafe,
+		Context:        cmd.Context(),
+		SetParams:      setParams,
+		SetEnv:         setEnv,
+		Mounts:         mounts,
+		Timeout:        reproduceTimeout,
+		Platform:       reproducePlatform,
+		ReplaySafe:     resp.ReplaySafe,
+		ImageOverride:  reproduceImage,
+		ResolveSecrets: reproduceResolveSecrets,
+		SecretResolver: secretResolver,
 	})
 	if err != nil {
 		return exitWithMessage(stderr, 2, err.Error())
@@ -243,17 +260,18 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 	if diff != nil {
 		_, _ = io.WriteString(cmd.OutOrStdout(), diff.Render())
 	}
+	taskLabel := resultTaskLabel(env)
 	if result.ExitCode == 0 {
-		_, _ = fmt.Fprintf(stderr, "%s exited 0\n", env.TaskName)
+		_, _ = fmt.Fprintf(stderr, "%s exited 0\n", taskLabel)
 		printFidelitySummary(stderr, result.Fidelity)
 		return nil
 	}
 	if result.ExitCode == 3 {
-		_, _ = fmt.Fprintf(stderr, "%s exited 0; reproduced output differs from recorded output\n", env.TaskName)
+		_, _ = fmt.Fprintf(stderr, "%s exited 0; reproduced output differs from recorded output\n", taskLabel)
 		printFidelitySummary(stderr, result.Fidelity)
 		return exitWithCode(3)
 	}
-	_, _ = fmt.Fprintf(stderr, "%s failed", env.TaskName)
+	_, _ = fmt.Fprintf(stderr, "%s failed", taskLabel)
 	if result.Error != "" {
 		_, _ = fmt.Fprintf(stderr, ": %s", result.Error)
 	}
@@ -303,6 +321,69 @@ func fetchDescriptor(ctx context.Context, cmd *cobra.Command, server, jobID, run
 		return nil, fmt.Errorf("descriptor unavailable for run %s task %s", runID, task)
 	}
 	return &out, nil
+}
+
+type secretResolverAdapter struct {
+	resolver secret.Resolver
+}
+
+func (a secretResolverAdapter) ResolveWithIdentity(ctx context.Context, ref string) (string, ireproduce.SecretIdentity, error) {
+	value, identity, err := a.resolver.ResolveWithIdentity(ctx, ref)
+	if err != nil {
+		return "", ireproduce.SecretIdentity{}, err
+	}
+	return value, ireproduce.SecretIdentity{
+		Provider:           identity.Provider,
+		Ref:                identity.Ref,
+		Version:            identity.Version,
+		ResourceVersion:    identity.ResourceVersion,
+		Namespace:          identity.Namespace,
+		Name:               identity.Name,
+		Key:                identity.Key,
+		KeyID:              identity.KeyID,
+		HMACSHA256:         identity.HMACSHA256,
+		Verifiable:         identity.Verifiable,
+		UnverifiableReason: identity.UnverifiableReason,
+		Metadata:           identity.Metadata,
+	}, nil
+}
+
+func buildReproduceSecretResolver() (ireproduce.SecretResolver, error) {
+	cfg := secret.Config{
+		EnableEnv:           envBool("CAESIUM_JOBDEF_SECRETS_ENABLE_ENV", true),
+		IdentityHMACKeys:    os.Getenv("CAESIUM_JOBDEF_SECRETS_IDENTITY_HMAC_KEYS"),
+		IdentityHMACCurrent: os.Getenv("CAESIUM_JOBDEF_SECRETS_IDENTITY_HMAC_KEY_ID"),
+	}
+
+	kubeConfig := firstNonEmptyString(os.Getenv("CAESIUM_JOBDEF_SECRETS_KUBECONFIG"), os.Getenv("KUBECONFIG"))
+	kubeNamespaceRaw := os.Getenv("CAESIUM_JOBDEF_SECRETS_KUBE_NAMESPACE")
+	kubeNamespace := firstNonEmptyString(kubeNamespaceRaw, os.Getenv("KUBERNETES_NAMESPACE"), "default")
+	if envBool("CAESIUM_JOBDEF_SECRETS_ENABLE_KUBERNETES", false) ||
+		kubeConfig != "" ||
+		(strings.TrimSpace(kubeNamespaceRaw) != "" && kubeNamespace != "default") ||
+		os.Getenv("KUBERNETES_SERVICE_HOST") != "" {
+		cfg.Kubernetes = &secret.KubernetesConfig{
+			KubeConfigPath: kubeConfig,
+			Namespace:      kubeNamespace,
+		}
+	}
+
+	vaultAddress := firstNonEmptyString(os.Getenv("CAESIUM_JOBDEF_SECRETS_VAULT_ADDRESS"), os.Getenv("VAULT_ADDR"))
+	if vaultAddress != "" {
+		cfg.Vault = &secret.VaultConfig{
+			Address:       vaultAddress,
+			Token:         firstNonEmptyString(os.Getenv("CAESIUM_JOBDEF_SECRETS_VAULT_TOKEN"), os.Getenv("VAULT_TOKEN")),
+			Namespace:     firstNonEmptyString(os.Getenv("CAESIUM_JOBDEF_SECRETS_VAULT_NAMESPACE"), os.Getenv("VAULT_NAMESPACE")),
+			CACertPath:    firstNonEmptyString(os.Getenv("CAESIUM_JOBDEF_SECRETS_VAULT_CA_CERT"), os.Getenv("VAULT_CACERT")),
+			TLSSkipVerify: envBool("CAESIUM_JOBDEF_SECRETS_VAULT_SKIP_VERIFY", false) || envBool("VAULT_SKIP_VERIFY", false),
+		}
+	}
+
+	resolver, err := secret.NewConfiguredResolver(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build local secret resolver: %w", err)
+	}
+	return secretResolverAdapter{resolver: resolver}, nil
 }
 
 type dockerPuller struct{}
@@ -537,6 +618,16 @@ func printFidelitySummary(w io.Writer, summary *ireproduce.FidelitySummary) {
 	}
 }
 
+func resultTaskLabel(env *ireproduce.Envelope) string {
+	if env == nil {
+		return "task"
+	}
+	if env.ImagePullMode == "OVERRIDDEN" {
+		return fmt.Sprintf("%s (OVERRIDDEN image: %s)", env.TaskName, env.Image)
+	}
+	return env.TaskName
+}
+
 func sortedMapKeys(values map[string]string) []string {
 	keys := make([]string, 0, len(values))
 	for key := range values {
@@ -608,4 +699,25 @@ func exitWithCode(code int) error {
 		return nil
 	}
 	return &exitError{code: code}
+}
+
+func envBool(key string, fallback bool) bool {
+	value, ok := os.LookupEnv(key)
+	if !ok || strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/cmd/reproduce/reproduce.go
+++ b/cmd/reproduce/reproduce.go
@@ -159,8 +159,7 @@ func runReproduce(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return exitWithMessage(stderr, 2, err.Error())
 	}
-	env, err := ireproduce.Reconstruct(desc, ireproduce.ReconstructOptions{
-		Context:        cmd.Context(),
+	env, err := ireproduce.Reconstruct(cmd.Context(), desc, ireproduce.ReconstructOptions{
 		SetParams:      setParams,
 		SetEnv:         setEnv,
 		Mounts:         mounts,
@@ -715,8 +714,8 @@ func envBool(key string, fallback bool) bool {
 
 func firstNonEmptyString(values ...string) string {
 	for _, value := range values {
-		if strings.TrimSpace(value) != "" {
-			return value
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
 		}
 	}
 	return ""

--- a/docs/exec-plans/active/reproduce.md
+++ b/docs/exec-plans/active/reproduce.md
@@ -310,14 +310,20 @@ The last two modes from the design's phasing. Both extend `cmd/reproduce/` and
 `internal/reproduce/`, so D sequences **after** Stream B (and coordinates with C
 on the shared command file — see conflicts).
 
-- [ ] D1. Add `--image ref` fix-testing mode: override the image (e.g. a locally
+- [x] D1. Add `--image ref` fix-testing mode: override the image (e.g. a locally
       built candidate fix) while keeping the recorded env, params, and predecessor
       outputs — "does my patch produce the right output *given the exact inputs that
       broke prod*?". Prominently mark the run **OVERRIDDEN** in the output line and
       the `--json` document so it is never mistaken for a faithful reproduction.
       Files: `cmd/reproduce/reproduce.go`, `internal/reproduce/execute.go`.
       Depends on: B2.
-- [ ] D2. Add `--resolve-secrets`: resolve `secret://` refs via the operator's
+      Note: W4-delta added `--image` override wiring through the reconstructed
+      envelope, pull target, synthesized localrun step image, top-level run JSON
+      (`image_pull_mode: "OVERRIDDEN"`, `image_overridden: true`), human stderr
+      result labels, and the `image_content: overridden` fidelity dimension, with
+      unit coverage plus a docker-gated `--json --diff --image alpine:3.23`
+      integration assertion.
+- [x] D2. Add `--resolve-secrets`: resolve `secret://` refs via the operator's
       **local** `secret.Resolver` config (never fetched from the server), and emit a
       best-effort drift warning by comparing the recorded ref string + provider
       identity fields (Vault version / k8s resourceVersion) when the local provider
@@ -326,6 +332,13 @@ on the shared command file — see conflicts).
       opt-in described in the design's Security section.
       Files: `cmd/reproduce/reproduce.go`, `internal/reproduce/reconstruct.go`.
       Depends on: B2.
+      Note: W4-delta added local resolver construction from the existing
+      `internal/jobdef/secret` provider config, a small reproduce-layer resolver
+      interface for pure-Go tests, opt-in env injection before `--set-env`
+      overrides, per-ref omission warnings on local failure/provider mismatch,
+      Vault-version and k8s-resourceVersion drift warnings, and integration
+      coverage for `secret://env/...` default omission plus
+      `--resolve-secrets --dry-run --json` injection.
 
 #### Deferred — recorded, not in scope
 

--- a/internal/reproduce/execute.go
+++ b/internal/reproduce/execute.go
@@ -73,18 +73,20 @@ type ShellExecuteOptions struct {
 
 // ExecutionResult is the machine-readable result for run mode.
 type ExecutionResult struct {
-	Status       string            `json:"status"`
-	ExitCode     int               `json:"exit_code"`
-	Task         string            `json:"task"`
-	Image        string            `json:"image"`
-	Output       map[string]string `json:"output,omitempty"`
-	Log          string            `json:"log,omitempty"`
-	LogTruncated bool              `json:"log_truncated,omitempty"`
-	Error        string            `json:"error,omitempty"`
-	Envelope     *Envelope         `json:"envelope"`
-	Fidelity     *FidelitySummary  `json:"fidelity,omitempty"`
-	OutputDiff   *outputdiff.Diff  `json:"output_diff,omitempty"`
-	Warnings     []Warning         `json:"warnings,omitempty"`
+	Status          string            `json:"status"`
+	ExitCode        int               `json:"exit_code"`
+	Task            string            `json:"task"`
+	Image           string            `json:"image"`
+	ImagePullMode   string            `json:"image_pull_mode,omitempty"`
+	ImageOverridden bool              `json:"image_overridden,omitempty"`
+	Output          map[string]string `json:"output,omitempty"`
+	Log             string            `json:"log,omitempty"`
+	LogTruncated    bool              `json:"log_truncated,omitempty"`
+	Error           string            `json:"error,omitempty"`
+	Envelope        *Envelope         `json:"envelope"`
+	Fidelity        *FidelitySummary  `json:"fidelity,omitempty"`
+	OutputDiff      *outputdiff.Diff  `json:"output_diff,omitempty"`
+	Warnings        []Warning         `json:"warnings,omitempty"`
 }
 
 // ShellRequest is the docker-run shape for interactive shell mode.
@@ -99,13 +101,15 @@ type ShellRequest struct {
 
 // ShellResult reports the interactive shell process outcome.
 type ShellResult struct {
-	ExitCode int              `json:"exit_code"`
-	Task     string           `json:"task"`
-	Image    string           `json:"image"`
-	Error    string           `json:"error,omitempty"`
-	Envelope *Envelope        `json:"envelope"`
-	Fidelity *FidelitySummary `json:"fidelity,omitempty"`
-	Warnings []Warning        `json:"warnings,omitempty"`
+	ExitCode        int              `json:"exit_code"`
+	Task            string           `json:"task"`
+	Image           string           `json:"image"`
+	ImagePullMode   string           `json:"image_pull_mode,omitempty"`
+	ImageOverridden bool             `json:"image_overridden,omitempty"`
+	Error           string           `json:"error,omitempty"`
+	Envelope        *Envelope        `json:"envelope"`
+	Fidelity        *FidelitySummary `json:"fidelity,omitempty"`
+	Warnings        []Warning        `json:"warnings,omitempty"`
 }
 
 // PullError is returned when the selected image cannot be pulled.
@@ -220,16 +224,18 @@ func Execute(ctx context.Context, desc *Descriptor, env *Envelope, opts ExecuteO
 	}
 
 	result := &ExecutionResult{
-		Status:       task.Status,
-		Task:         env.TaskName,
-		Image:        env.Image,
-		Output:       output,
-		Log:          task.LogText,
-		LogTruncated: task.LogTruncated,
-		Error:        firstNonEmpty(task.Error, runResult.Error),
-		Envelope:     env,
-		Fidelity:     env.Fidelity,
-		Warnings:     env.Warnings,
+		Status:          task.Status,
+		Task:            env.TaskName,
+		Image:           env.Image,
+		ImagePullMode:   env.ImagePullMode,
+		ImageOverridden: env.ImageOverridden,
+		Output:          output,
+		Log:             task.LogText,
+		LogTruncated:    task.LogTruncated,
+		Error:           firstNonEmpty(task.Error, runResult.Error),
+		Envelope:        env,
+		Fidelity:        env.Fidelity,
+		Warnings:        env.Warnings,
 	}
 	if isSuccessfulStatus(task.Status) {
 		result.ExitCode = 0
@@ -262,11 +268,13 @@ func ExecuteShell(ctx context.Context, env *Envelope, opts ShellExecuteOptions) 
 
 	req := BuildShellRequest(env, platform)
 	result := &ShellResult{
-		Task:     env.TaskName,
-		Image:    env.Image,
-		Envelope: env,
-		Fidelity: env.Fidelity,
-		Warnings: env.Warnings,
+		Task:            env.TaskName,
+		Image:           env.Image,
+		ImagePullMode:   env.ImagePullMode,
+		ImageOverridden: env.ImageOverridden,
+		Envelope:        env,
+		Fidelity:        env.Fidelity,
+		Warnings:        env.Warnings,
 	}
 	if err := opts.ShellRunner.RunShell(ctx, req); err != nil {
 		var shellExit *ShellExitError

--- a/internal/reproduce/execute_test.go
+++ b/internal/reproduce/execute_test.go
@@ -114,6 +114,38 @@ func TestExecuteUsesDegradedTagPullWhenDigestMissing(t *testing.T) {
 	}
 }
 
+func TestExecuteUsesImageOverrideForPullAndSynthesizedDefinition(t *testing.T) {
+	desc := basicDescriptor("registry.example.com/team/app:prod")
+	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	env, err := Reconstruct(desc, ReconstructOptions{ImageOverride: "registry.example.com/team/app:candidate"})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+	puller := &fakePuller{}
+	runner := &capturingRunner{result: &RunResult{Tasks: []TaskResult{{
+		Name:   "transform",
+		Status: "succeeded",
+	}}}}
+
+	result, err := Execute(context.Background(), desc, env, ExecuteOptions{
+		Puller: puller,
+		Runner: runner,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if puller.imageRef != "registry.example.com/team/app:candidate" {
+		t.Fatalf("pulled image = %q, want override", puller.imageRef)
+	}
+	if runner.def == nil || len(runner.def.Steps) != 1 || runner.def.Steps[0].Image != "registry.example.com/team/app:candidate" {
+		t.Fatalf("synthesized definition = %#v, want override image", runner.def)
+	}
+	if result.ImagePullMode != "OVERRIDDEN" || !result.ImageOverridden {
+		t.Fatalf("result override markers = mode %q overridden %t", result.ImagePullMode, result.ImageOverridden)
+	}
+}
+
 func TestExecutePassesRemappedMountsToSynthesizedDefinition(t *testing.T) {
 	desc := basicDescriptor("alpine:3.23")
 	desc.ContainerSpec.Mounts = testBindMount("/recorded/data", "/data")

--- a/internal/reproduce/execute_test.go
+++ b/internal/reproduce/execute_test.go
@@ -15,7 +15,7 @@ import (
 func TestExecutePullFailureGuidanceNamesRegistryAndLocalFallback(t *testing.T) {
 	desc := basicDescriptor("registry.example.com/team/app:1")
 	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	env, err := Reconstruct(desc, ReconstructOptions{})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -52,7 +52,7 @@ func (p *localPresentPuller) ExistsLocally(context.Context, string) bool { retur
 // private-registry auth failure cannot block reproducing with a local image.
 func TestExecuteSkipsPullWhenImagePresentLocally(t *testing.T) {
 	desc := basicDescriptor("registry.example.com/team/app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-	env, err := Reconstruct(desc, ReconstructOptions{})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -83,7 +83,7 @@ func TestExecuteSkipsPullWhenImagePresentLocally(t *testing.T) {
 
 func TestExecuteUsesDegradedTagPullWhenDigestMissing(t *testing.T) {
 	desc := basicDescriptor("registry.example.com/team/app:latest")
-	env, err := Reconstruct(desc, ReconstructOptions{})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -117,7 +117,7 @@ func TestExecuteUsesDegradedTagPullWhenDigestMissing(t *testing.T) {
 func TestExecuteUsesImageOverrideForPullAndSynthesizedDefinition(t *testing.T) {
 	desc := basicDescriptor("registry.example.com/team/app:prod")
 	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-	env, err := Reconstruct(desc, ReconstructOptions{ImageOverride: "registry.example.com/team/app:candidate"})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{ImageOverride: "registry.example.com/team/app:candidate"})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -150,7 +150,7 @@ func TestExecutePassesRemappedMountsToSynthesizedDefinition(t *testing.T) {
 	desc := basicDescriptor("alpine:3.23")
 	desc.ContainerSpec.Mounts = testBindMount("/recorded/data", "/data")
 	desc.ContainerSpec.ResolvedVolumeMounts = testPVCMount("claim", "/claim")
-	env, err := Reconstruct(desc, ReconstructOptions{
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{
 		Mounts: []MountRemap{{From: "/recorded/data", To: "/local/data"}},
 	})
 	if err != nil {
@@ -213,7 +213,7 @@ func TestBuildShellRequestUsesDefaultShellAndClonesEnvelope(t *testing.T) {
 
 func TestExecuteShellPullsImageAndRunsShellRequest(t *testing.T) {
 	desc := basicDescriptor("registry.example.com/team/app:1")
-	env, err := Reconstruct(desc, ReconstructOptions{})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -241,7 +241,7 @@ func TestExecuteShellPullsImageAndRunsShellRequest(t *testing.T) {
 
 func TestExecuteShellDistrolessGuidance(t *testing.T) {
 	desc := basicDescriptor("gcr.io/distroless/static:nonroot")
-	env, err := Reconstruct(desc, ReconstructOptions{})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -265,7 +265,7 @@ func TestExecuteShellDistrolessGuidance(t *testing.T) {
 
 func TestExecuteShellReturnsInteractiveExitCode(t *testing.T) {
 	desc := basicDescriptor("alpine:3.23")
-	env, err := Reconstruct(desc, ReconstructOptions{})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}

--- a/internal/reproduce/reconstruct.go
+++ b/internal/reproduce/reconstruct.go
@@ -3,8 +3,10 @@
 package reproduce
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"runtime"
 	"slices"
 	"sort"
@@ -18,7 +20,11 @@ import (
 
 const (
 	WarningSecretOmitted       = "secret_omitted"
+	WarningSecretResolveFailed = "secret_resolution_failed"
+	WarningSecretProvider      = "secret_provider_mismatch"
+	WarningSecretDrift         = "secret_drift"
 	WarningDegradedImagePull   = "degraded_image_pull"
+	WarningImageOverridden     = "image_overridden"
 	WarningOutputRefUnresolved = "output_ref_unresolved"
 	WarningOutputMissingName   = "predecessor_output_missing_name"
 	WarningMountNotRemapped    = "mount_not_remapped"
@@ -35,6 +41,7 @@ const (
 const (
 	FidelityFaithful         = "faithful"
 	FidelityDegraded         = "degraded"
+	FidelityOverridden       = "overridden"
 	FidelityNotReproduced    = "not_reproduced"
 	FidelityListedNotApplied = "listed_not_applied"
 )
@@ -79,6 +86,37 @@ type SecretOmission struct {
 	Ref    string `json:"ref,omitempty"`
 }
 
+// SecretResolution records a locally resolved secret without exposing its
+// value outside Envelope.Env.
+type SecretResolution struct {
+	EnvKey   string `json:"env_key"`
+	Ref      string `json:"ref,omitempty"`
+	Provider string `json:"provider,omitempty"`
+}
+
+// SecretIdentity is the provider identity subset reproduce can compare without
+// importing provider implementations.
+type SecretIdentity struct {
+	Provider           string            `json:"provider,omitempty"`
+	Ref                string            `json:"ref,omitempty"`
+	Version            string            `json:"version,omitempty"`
+	ResourceVersion    string            `json:"resourceVersion,omitempty"`
+	Namespace          string            `json:"namespace,omitempty"`
+	Name               string            `json:"name,omitempty"`
+	Key                string            `json:"key,omitempty"`
+	KeyID              string            `json:"keyId,omitempty"`
+	HMACSHA256         string            `json:"hmacSha256,omitempty"`
+	Verifiable         bool              `json:"verifiable"`
+	UnverifiableReason string            `json:"unverifiableReason,omitempty"`
+	Metadata           map[string]string `json:"metadata,omitempty"`
+}
+
+// SecretResolver resolves local secret refs. The command layer adapts this to
+// internal/jobdef/secret so this package stays independent of provider deps.
+type SecretResolver interface {
+	ResolveWithIdentity(ctx context.Context, ref string) (string, SecretIdentity, error)
+}
+
 // RetryPolicy records the historical retry knobs. Reproduce surfaces them but
 // runs a single local attempt.
 type RetryPolicy struct {
@@ -89,36 +127,43 @@ type RetryPolicy struct {
 
 // Envelope is the reconstructed local execution envelope.
 type Envelope struct {
-	TaskName            string            `json:"task"`
-	JobID               string            `json:"job_id,omitempty"`
-	JobAlias            string            `json:"job_alias,omitempty"`
-	BaselineRunID       string            `json:"baseline_run_id,omitempty"`
-	ReplaySafe          bool              `json:"replay_safe"`
-	CapturedAt          time.Time         `json:"captured_at,omitempty"`
-	Image               string            `json:"image"`
-	RecordedImage       string            `json:"recorded_image,omitempty"`
-	ResolvedImageDigest string            `json:"resolved_image_digest,omitempty"`
-	ImagePullMode       string            `json:"image_pull_mode"`
-	Command             []string          `json:"command,omitempty"`
-	WorkDir             string            `json:"workdir,omitempty"`
-	Env                 map[string]string `json:"env"`
-	Mounts              []container.Mount `json:"mounts,omitempty"`
-	Timeout             string            `json:"timeout,omitempty"`
-	Platform            string            `json:"platform,omitempty"`
-	RecordedRetryPolicy *RetryPolicy      `json:"recorded_retry_policy,omitempty"`
-	OmittedSecrets      []SecretOmission  `json:"omitted_secrets,omitempty"`
-	Fidelity            *FidelitySummary  `json:"fidelity,omitempty"`
-	Warnings            []Warning         `json:"warnings,omitempty"`
+	TaskName            string             `json:"task"`
+	JobID               string             `json:"job_id,omitempty"`
+	JobAlias            string             `json:"job_alias,omitempty"`
+	BaselineRunID       string             `json:"baseline_run_id,omitempty"`
+	ReplaySafe          bool               `json:"replay_safe"`
+	CapturedAt          time.Time          `json:"captured_at,omitempty"`
+	Image               string             `json:"image"`
+	RecordedImage       string             `json:"recorded_image,omitempty"`
+	ResolvedImageDigest string             `json:"resolved_image_digest,omitempty"`
+	ImagePullMode       string             `json:"image_pull_mode"`
+	ImageOverride       string             `json:"image_override,omitempty"`
+	ImageOverridden     bool               `json:"image_overridden,omitempty"`
+	Command             []string           `json:"command,omitempty"`
+	WorkDir             string             `json:"workdir,omitempty"`
+	Env                 map[string]string  `json:"env"`
+	Mounts              []container.Mount  `json:"mounts,omitempty"`
+	Timeout             string             `json:"timeout,omitempty"`
+	Platform            string             `json:"platform,omitempty"`
+	RecordedRetryPolicy *RetryPolicy       `json:"recorded_retry_policy,omitempty"`
+	OmittedSecrets      []SecretOmission   `json:"omitted_secrets,omitempty"`
+	ResolvedSecrets     []SecretResolution `json:"resolved_secrets,omitempty"`
+	Fidelity            *FidelitySummary   `json:"fidelity,omitempty"`
+	Warnings            []Warning          `json:"warnings,omitempty"`
 }
 
 // ReconstructOptions controls local envelope reconstruction.
 type ReconstructOptions struct {
-	SetParams  []Assignment
-	SetEnv     []Assignment
-	Mounts     []MountRemap
-	Timeout    time.Duration
-	Platform   string
-	ReplaySafe bool
+	Context        context.Context
+	SetParams      []Assignment
+	SetEnv         []Assignment
+	Mounts         []MountRemap
+	Timeout        time.Duration
+	Platform       string
+	ReplaySafe     bool
+	ImageOverride  string
+	ResolveSecrets bool
+	SecretResolver SecretResolver
 }
 
 // Descriptor mirrors descriptor schema v1 without importing internal/models.
@@ -180,8 +225,12 @@ type EdgeRef struct {
 // SecretRef mirrors the descriptor's secret metadata relevant to local
 // omission warnings.
 type SecretRef struct {
-	Ref    string `json:"ref"`
-	EnvKey string `json:"envKey,omitempty"`
+	Ref                string         `json:"ref"`
+	EnvKey             string         `json:"envKey,omitempty"`
+	Provider           string         `json:"provider,omitempty"`
+	Identity           map[string]any `json:"identity,omitempty"`
+	Verifiable         bool           `json:"verifiable"`
+	UnverifiableReason string         `json:"unverifiableReason,omitempty"`
 }
 
 // DecodeDescriptor decodes raw descriptor JSON into the local mirror type.
@@ -214,30 +263,61 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 	warnings := make([]Warning, 0)
 	env := make(map[string]string)
 	omitted := make([]SecretOmission, 0)
+	resolvedSecrets := make([]SecretResolution, 0)
 	secretRefs := secretRefsByEnv(desc.SecretRefs)
+	processedSecretEnv := make(map[string]struct{})
+	ctx := opts.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 
 	for _, key := range sortedKeys(desc.ContainerSpec.Env) {
 		value := desc.ContainerSpec.Env[key]
 		if isSecretRef(value) {
-			omitted = appendSecretOmission(omitted, SecretOmission{EnvKey: key, Ref: firstNonEmpty(secretRefs[key], value)})
+			ref := secretRefs[key]
+			ref.EnvKey = key
+			ref.Ref = firstNonEmpty(ref.Ref, value)
+			processedSecretEnv[key] = struct{}{}
+			if resolved, resolutionWarnings, ok := resolveRecordedSecret(ctx, ref, opts); ok {
+				env[key] = resolved.Value
+				resolvedSecrets = appendSecretResolution(resolvedSecrets, resolved.Resolution)
+				warnings = append(warnings, resolutionWarnings...)
+				continue
+			} else {
+				warnings = append(warnings, resolutionWarnings...)
+			}
+			omitted = appendSecretOmission(omitted, SecretOmission{EnvKey: key, Ref: ref.Ref})
 			continue
 		}
 		env[key] = value
 	}
-	for _, ref := range desc.SecretRefs {
+	for _, ref := range sortedSecretRefs(desc.SecretRefs) {
 		if ref.EnvKey == "" {
 			continue
 		}
+		if _, ok := processedSecretEnv[ref.EnvKey]; ok {
+			continue
+		}
 		if _, ok := desc.ContainerSpec.Env[ref.EnvKey]; !ok {
+			if resolved, resolutionWarnings, ok := resolveRecordedSecret(ctx, ref, opts); ok {
+				env[ref.EnvKey] = resolved.Value
+				resolvedSecrets = appendSecretResolution(resolvedSecrets, resolved.Resolution)
+				warnings = append(warnings, resolutionWarnings...)
+				continue
+			} else {
+				warnings = append(warnings, resolutionWarnings...)
+			}
 			omitted = appendSecretOmission(omitted, SecretOmission{EnvKey: ref.EnvKey, Ref: ref.Ref})
 		}
 	}
-	if len(omitted) > 0 {
+	if len(omitted) > 0 && !opts.ResolveSecrets {
 		sort.Slice(omitted, func(i, j int) bool { return omitted[i].EnvKey < omitted[j].EnvKey })
 		warnings = append(warnings, Warning{
 			Code:    WarningSecretOmitted,
 			Message: fmt.Sprintf("secret refs omitted by default: %s", strings.Join(secretEnvKeys(omitted), ", ")),
 		})
+	} else if len(omitted) > 0 {
+		sort.Slice(omitted, func(i, j int) bool { return omitted[i].EnvKey < omitted[j].EnvKey })
 	}
 
 	for _, key := range sortedKeys(desc.Run.Params) {
@@ -263,7 +343,7 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 		env[assignment.Key] = assignment.Value
 	}
 
-	image, pullMode, imageWarnings := imageReference(desc.Runtime.Image, desc.Runtime.ResolvedImageDigest)
+	image, pullMode, imageWarnings := imageReference(desc.Runtime.Image, desc.Runtime.ResolvedImageDigest, opts.ImageOverride)
 	warnings = append(warnings, imageWarnings...)
 
 	mounts, mountWarnings := reconstructMounts(desc.ContainerSpec, opts.Mounts)
@@ -308,6 +388,8 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 		RecordedImage:       desc.Runtime.Image,
 		ResolvedImageDigest: desc.Runtime.ResolvedImageDigest,
 		ImagePullMode:       pullMode,
+		ImageOverride:       strings.TrimSpace(opts.ImageOverride),
+		ImageOverridden:     pullMode == "OVERRIDDEN",
 		Command:             command,
 		WorkDir:             workdir,
 		Env:                 env,
@@ -316,8 +398,9 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 		Platform:            strings.TrimSpace(opts.Platform),
 		RecordedRetryPolicy: retryPolicy,
 		OmittedSecrets:      omitted,
+		ResolvedSecrets:     resolvedSecrets,
 	}
-	fidelity, fidelityWarnings := buildFidelitySummary(desc, envelope, opts, omitted)
+	fidelity, fidelityWarnings := buildFidelitySummary(desc, envelope, opts, omitted, resolvedSecrets)
 	warnings = append(warnings, fidelityWarnings...)
 	sortWarnings(warnings)
 	envelope.Fidelity = fidelity
@@ -462,9 +545,16 @@ func applyMountRemap(mount container.Mount, remapBySource map[string]string, war
 	return mount
 }
 
-func imageReference(recorded, digest string) (string, string, []Warning) {
+func imageReference(recorded, digest, override string) (string, string, []Warning) {
 	recorded = strings.TrimSpace(recorded)
 	digest = strings.TrimSpace(digest)
+	override = strings.TrimSpace(override)
+	if override != "" {
+		return override, "OVERRIDDEN", []Warning{{
+			Code:    WarningImageOverridden,
+			Message: fmt.Sprintf("OVERRIDDEN: using image override %s instead of recorded image %s", override, recorded),
+		}}
+	}
 	if digest == "" {
 		return recorded, "DEGRADED", []Warning{{
 			Code:    WarningDegradedImagePull,
@@ -478,7 +568,7 @@ func imageReference(recorded, digest string) (string, string, []Warning) {
 	return base + "@" + digest, "DIGEST", nil
 }
 
-func buildFidelitySummary(desc *Descriptor, env *Envelope, opts ReconstructOptions, omitted []SecretOmission) (*FidelitySummary, []Warning) {
+func buildFidelitySummary(desc *Descriptor, env *Envelope, opts ReconstructOptions, omitted []SecretOmission, resolved []SecretResolution) (*FidelitySummary, []Warning) {
 	var dimensions []FidelityDimension
 	var warnings []Warning
 	add := func(dimension, status string, details ...string) {
@@ -489,7 +579,13 @@ func buildFidelitySummary(desc *Descriptor, env *Envelope, opts ReconstructOptio
 		})
 	}
 
-	if strings.TrimSpace(desc.Runtime.ResolvedImageDigest) == "" {
+	if env.ImagePullMode == "OVERRIDDEN" {
+		details := []string{fmt.Sprintf("OVERRIDDEN: local run uses image override %s instead of recorded image %s", env.Image, desc.Runtime.Image)}
+		if strings.TrimSpace(desc.Runtime.ResolvedImageDigest) != "" {
+			details = append(details, fmt.Sprintf("recorded digest %s is not used for the override image", desc.Runtime.ResolvedImageDigest))
+		}
+		add("image_content", FidelityOverridden, details...)
+	} else if strings.TrimSpace(desc.Runtime.ResolvedImageDigest) == "" {
 		add("image_content", FidelityDegraded, fmt.Sprintf("no resolved digest recorded for %s; local pull uses the mutable tag", desc.Runtime.Image))
 	} else {
 		add("image_content", FidelityFaithful, fmt.Sprintf("image pulled by recorded digest %s", desc.Runtime.ResolvedImageDigest))
@@ -506,7 +602,13 @@ func buildFidelitySummary(desc *Descriptor, env *Envelope, opts ReconstructOptio
 	add("schema_config", FidelityFaithful, "recorded output schema and validation mode are applied to the local run")
 
 	if len(omitted) > 0 {
-		add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs omitted by default: %s", strings.Join(secretEnvKeys(omitted), ", ")))
+		if opts.ResolveSecrets {
+			add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs unresolved locally and omitted: %s", strings.Join(secretEnvKeys(omitted), ", ")))
+		} else {
+			add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs omitted by default: %s", strings.Join(secretEnvKeys(omitted), ", ")))
+		}
+	} else if len(resolved) > 0 {
+		add("secret_values", FidelityDegraded, fmt.Sprintf("secret refs resolved from local providers for %s; local values may differ from the recorded baseline", strings.Join(resolvedSecretEnvKeys(resolved), ", ")))
 	} else {
 		add("secret_values", FidelityFaithful, "no recorded secret refs were present")
 	}
@@ -724,6 +826,121 @@ func formatStringMap(values map[string]string) string {
 	return strings.Join(parts, ", ")
 }
 
+type resolvedSecret struct {
+	Value      string
+	Resolution SecretResolution
+}
+
+func resolveRecordedSecret(ctx context.Context, ref SecretRef, opts ReconstructOptions) (resolvedSecret, []Warning, bool) {
+	if !opts.ResolveSecrets {
+		return resolvedSecret{}, nil, false
+	}
+	if opts.SecretResolver == nil {
+		return resolvedSecret{}, []Warning{secretResolutionWarning(ref, "local secret resolver is not configured")}, false
+	}
+	value, identity, err := opts.SecretResolver.ResolveWithIdentity(ctx, ref.Ref)
+	if err != nil {
+		return resolvedSecret{}, []Warning{secretResolutionWarning(ref, err.Error())}, false
+	}
+
+	recordedProvider := recordedSecretProvider(ref)
+	localProvider := normalizeSecretProvider(identity.Provider)
+	if localProvider == "" || (recordedProvider != "" && recordedProvider != localProvider) {
+		return resolvedSecret{}, []Warning{{
+			Code: WarningSecretProvider,
+			Message: fmt.Sprintf(
+				"secret ref %s for %s resolved from local provider %q but recorded provider was %q; omitting env var",
+				ref.Ref,
+				ref.EnvKey,
+				firstNonEmpty(localProvider, "unknown"),
+				firstNonEmpty(recordedProvider, "unknown"),
+			),
+		}}, false
+	}
+
+	warnings := secretDriftWarnings(ref, identity)
+	return resolvedSecret{
+		Value: value,
+		Resolution: SecretResolution{
+			EnvKey:   ref.EnvKey,
+			Ref:      ref.Ref,
+			Provider: localProvider,
+		},
+	}, warnings, true
+}
+
+func secretResolutionWarning(ref SecretRef, reason string) Warning {
+	return Warning{
+		Code:    WarningSecretResolveFailed,
+		Message: fmt.Sprintf("secret ref %s for %s could not be resolved locally; omitting env var: %s", ref.Ref, ref.EnvKey, reason),
+	}
+}
+
+func secretDriftWarnings(ref SecretRef, identity SecretIdentity) []Warning {
+	localProvider := normalizeSecretProvider(identity.Provider)
+	if recorded := recordedSecretProvider(ref); recorded != "" && recorded != localProvider {
+		return nil
+	}
+
+	var details []string
+	if recordedRef := strings.TrimSpace(ref.Ref); recordedRef != "" && strings.TrimSpace(identity.Ref) != "" && recordedRef != strings.TrimSpace(identity.Ref) {
+		details = append(details, fmt.Sprintf("recorded ref %s, local ref %s", recordedRef, strings.TrimSpace(identity.Ref)))
+	}
+	switch localProvider {
+	case "vault":
+		recordedVersion := secretIdentityValue(ref.Identity, "version")
+		if recordedVersion != "" && strings.TrimSpace(identity.Version) != "" && recordedVersion != strings.TrimSpace(identity.Version) {
+			details = append(details, fmt.Sprintf("recorded Vault version %s, local version %s", recordedVersion, strings.TrimSpace(identity.Version)))
+		}
+	case "k8s":
+		recordedResourceVersion := secretIdentityValue(ref.Identity, "resourceVersion")
+		if recordedResourceVersion != "" && strings.TrimSpace(identity.ResourceVersion) != "" && recordedResourceVersion != strings.TrimSpace(identity.ResourceVersion) {
+			details = append(details, fmt.Sprintf("recorded k8s resourceVersion %s, local resourceVersion %s", recordedResourceVersion, strings.TrimSpace(identity.ResourceVersion)))
+		}
+	}
+	if len(details) == 0 {
+		return nil
+	}
+	return []Warning{{
+		Code:    WarningSecretDrift,
+		Message: fmt.Sprintf("secret ref %s for %s may have drifted: %s", ref.Ref, ref.EnvKey, strings.Join(details, "; ")),
+	}}
+}
+
+func secretIdentityValue(identity map[string]any, key string) string {
+	if len(identity) == 0 {
+		return ""
+	}
+	value, ok := identity[key]
+	if !ok || value == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
+}
+
+func recordedSecretProvider(ref SecretRef) string {
+	if provider := normalizeSecretProvider(ref.Provider); provider != "" {
+		return provider
+	}
+	return normalizeSecretProvider(secretProviderFromRef(ref.Ref))
+}
+
+func secretProviderFromRef(ref string) string {
+	parsed, err := url.Parse(strings.TrimSpace(ref))
+	if err != nil || parsed.Scheme != "secret" {
+		return ""
+	}
+	return parsed.Host
+}
+
+func normalizeSecretProvider(provider string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "kubernetes" {
+		return "k8s"
+	}
+	return provider
+}
+
 func cleanDetails(details []string) []string {
 	out := make([]string, 0, len(details))
 	for _, detail := range details {
@@ -742,13 +959,24 @@ func isSecretRef(value string) bool {
 	return strings.HasPrefix(strings.TrimSpace(value), "secret://")
 }
 
-func secretRefsByEnv(refs []SecretRef) map[string]string {
-	out := make(map[string]string, len(refs))
+func secretRefsByEnv(refs []SecretRef) map[string]SecretRef {
+	out := make(map[string]SecretRef, len(refs))
 	for _, ref := range refs {
 		if ref.EnvKey != "" {
-			out[ref.EnvKey] = ref.Ref
+			out[ref.EnvKey] = ref
 		}
 	}
+	return out
+}
+
+func sortedSecretRefs(refs []SecretRef) []SecretRef {
+	out := slices.Clone(refs)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].EnvKey != out[j].EnvKey {
+			return out[i].EnvKey < out[j].EnvKey
+		}
+		return out[i].Ref < out[j].Ref
+	})
 	return out
 }
 
@@ -761,11 +989,29 @@ func appendSecretOmission(omitted []SecretOmission, next SecretOmission) []Secre
 	return append(omitted, next)
 }
 
+func appendSecretResolution(resolved []SecretResolution, next SecretResolution) []SecretResolution {
+	for _, existing := range resolved {
+		if existing.EnvKey == next.EnvKey {
+			return resolved
+		}
+	}
+	return append(resolved, next)
+}
+
 func secretEnvKeys(omitted []SecretOmission) []string {
 	keys := make([]string, 0, len(omitted))
 	for _, omission := range omitted {
 		keys = append(keys, omission.EnvKey)
 	}
+	return keys
+}
+
+func resolvedSecretEnvKeys(resolved []SecretResolution) []string {
+	keys := make([]string, 0, len(resolved))
+	for _, resolution := range resolved {
+		keys = append(keys, resolution.EnvKey)
+	}
+	sort.Strings(keys)
 	return keys
 }
 

--- a/internal/reproduce/reconstruct.go
+++ b/internal/reproduce/reconstruct.go
@@ -579,15 +579,16 @@ func buildFidelitySummary(desc *Descriptor, env *Envelope, opts ReconstructOptio
 		})
 	}
 
-	if env.ImagePullMode == "OVERRIDDEN" {
+	switch {
+	case env.ImagePullMode == "OVERRIDDEN":
 		details := []string{fmt.Sprintf("OVERRIDDEN: local run uses image override %s instead of recorded image %s", env.Image, desc.Runtime.Image)}
 		if strings.TrimSpace(desc.Runtime.ResolvedImageDigest) != "" {
 			details = append(details, fmt.Sprintf("recorded digest %s is not used for the override image", desc.Runtime.ResolvedImageDigest))
 		}
 		add("image_content", FidelityOverridden, details...)
-	} else if strings.TrimSpace(desc.Runtime.ResolvedImageDigest) == "" {
+	case strings.TrimSpace(desc.Runtime.ResolvedImageDigest) == "":
 		add("image_content", FidelityDegraded, fmt.Sprintf("no resolved digest recorded for %s; local pull uses the mutable tag", desc.Runtime.Image))
-	} else {
+	default:
 		add("image_content", FidelityFaithful, fmt.Sprintf("image pulled by recorded digest %s", desc.Runtime.ResolvedImageDigest))
 	}
 	add("command_argv_workdir", FidelityFaithful, "recorded command, argv, and workdir are used verbatim")
@@ -601,15 +602,14 @@ func buildFidelitySummary(desc *Descriptor, env *Envelope, opts ReconstructOptio
 	}
 	add("schema_config", FidelityFaithful, "recorded output schema and validation mode are applied to the local run")
 
-	if len(omitted) > 0 {
-		if opts.ResolveSecrets {
-			add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs unresolved locally and omitted: %s", strings.Join(secretEnvKeys(omitted), ", ")))
-		} else {
-			add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs omitted by default: %s", strings.Join(secretEnvKeys(omitted), ", ")))
-		}
-	} else if len(resolved) > 0 {
+	switch {
+	case len(omitted) > 0 && opts.ResolveSecrets:
+		add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs unresolved locally and omitted: %s", strings.Join(secretEnvKeys(omitted), ", ")))
+	case len(omitted) > 0:
+		add("secret_values", FidelityNotReproduced, fmt.Sprintf("secret refs omitted by default: %s", strings.Join(secretEnvKeys(omitted), ", ")))
+	case len(resolved) > 0:
 		add("secret_values", FidelityDegraded, fmt.Sprintf("secret refs resolved from local providers for %s; local values may differ from the recorded baseline", strings.Join(resolvedSecretEnvKeys(resolved), ", ")))
-	} else {
+	default:
 		add("secret_values", FidelityFaithful, "no recorded secret refs were present")
 	}
 

--- a/internal/reproduce/reconstruct.go
+++ b/internal/reproduce/reconstruct.go
@@ -154,7 +154,6 @@ type Envelope struct {
 
 // ReconstructOptions controls local envelope reconstruction.
 type ReconstructOptions struct {
-	Context        context.Context
 	SetParams      []Assignment
 	SetEnv         []Assignment
 	Mounts         []MountRemap
@@ -255,7 +254,10 @@ func DecodeDescriptor(raw []byte) (*Descriptor, error) {
 }
 
 // Reconstruct builds the local envelope from a descriptor and CLI overrides.
-func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
+func Reconstruct(ctx context.Context, desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	if desc == nil {
 		return nil, fmt.Errorf("descriptor is required")
 	}
@@ -266,10 +268,6 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 	resolvedSecrets := make([]SecretResolution, 0)
 	secretRefs := secretRefsByEnv(desc.SecretRefs)
 	processedSecretEnv := make(map[string]struct{})
-	ctx := opts.Context
-	if ctx == nil {
-		ctx = context.Background()
-	}
 
 	for _, key := range sortedKeys(desc.ContainerSpec.Env) {
 		value := desc.ContainerSpec.Env[key]
@@ -299,6 +297,7 @@ func Reconstruct(desc *Descriptor, opts ReconstructOptions) (*Envelope, error) {
 			continue
 		}
 		if _, ok := desc.ContainerSpec.Env[ref.EnvKey]; !ok {
+			processedSecretEnv[ref.EnvKey] = struct{}{}
 			if resolved, resolutionWarnings, ok := resolveRecordedSecret(ctx, ref, opts); ok {
 				env[ref.EnvKey] = resolved.Value
 				resolvedSecrets = appendSecretResolution(resolvedSecrets, resolved.Resolution)

--- a/internal/reproduce/reconstruct_test.go
+++ b/internal/reproduce/reconstruct_test.go
@@ -1,6 +1,8 @@
 package reproduce
 
 import (
+	"context"
+	"errors"
 	"runtime"
 	"strings"
 	"testing"
@@ -96,6 +98,200 @@ func TestReconstructOutputRefUsesBuildOutputEnvShape(t *testing.T) {
 	}
 	if !hasWarning(env.Warnings, WarningOutputRefUnresolved) {
 		t.Fatalf("warnings = %#v, want %s", env.Warnings, WarningOutputRefUnresolved)
+	}
+}
+
+func TestReconstructImageOverrideMarksEnvelopeAndFidelity(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Runtime.Image = "registry.example.com/team/app:prod"
+	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	env, err := Reconstruct(desc, ReconstructOptions{ImageOverride: "registry.example.com/team/app:candidate"})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	if env.Image != "registry.example.com/team/app:candidate" {
+		t.Fatalf("Image = %q, want override", env.Image)
+	}
+	if env.ImagePullMode != "OVERRIDDEN" || !env.ImageOverridden || env.ImageOverride != "registry.example.com/team/app:candidate" {
+		t.Fatalf("override markers = mode %q overridden %t override %q", env.ImagePullMode, env.ImageOverridden, env.ImageOverride)
+	}
+	if env.RecordedImage != "registry.example.com/team/app:prod" {
+		t.Fatalf("RecordedImage = %q, want original", env.RecordedImage)
+	}
+	if !hasWarning(env.Warnings, WarningImageOverridden) {
+		t.Fatalf("warnings = %#v, want %s", env.Warnings, WarningImageOverridden)
+	}
+	image := assertFidelityStatus(t, env.Fidelity, "image_content", FidelityOverridden)
+	details := strings.Join(image.Details, "; ")
+	if !strings.Contains(details, "OVERRIDDEN") || !strings.Contains(details, "candidate") {
+		t.Fatalf("image fidelity details = %#v, want override marker and ref", image.Details)
+	}
+}
+
+func TestReconstructResolveSecretsInjectsLocalValueBeforeSetEnvOverride(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Runtime.Image = "alpine:3.23"
+	desc.ContainerSpec.Env = map[string]string{
+		"SECRET_ENV": "secret://env/DB_PASSWORD",
+	}
+	desc.SecretRefs = []SecretRef{{
+		EnvKey:   "SECRET_ENV",
+		Ref:      "secret://env/DB_PASSWORD",
+		Provider: "env",
+	}}
+	resolver := &fakeSecretResolver{values: map[string]fakeSecretValue{
+		"secret://env/DB_PASSWORD": {
+			value: "local-db-password",
+			identity: SecretIdentity{
+				Provider: "env",
+				Ref:      "secret://env/DB_PASSWORD",
+			},
+		},
+	}}
+
+	env, err := Reconstruct(desc, ReconstructOptions{
+		ResolveSecrets: true,
+		SecretResolver: resolver,
+		SetEnv:         []Assignment{{Key: "SECRET_ENV", Value: "manual-final"}},
+	})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	if env.Env["SECRET_ENV"] != "manual-final" {
+		t.Fatalf("SECRET_ENV = %q, want --set-env override after local resolution", env.Env["SECRET_ENV"])
+	}
+	if len(env.OmittedSecrets) != 0 {
+		t.Fatalf("omitted secrets = %#v, want none", env.OmittedSecrets)
+	}
+	if len(env.ResolvedSecrets) != 1 || env.ResolvedSecrets[0].EnvKey != "SECRET_ENV" || env.ResolvedSecrets[0].Provider != "env" {
+		t.Fatalf("resolved secrets = %#v, want SECRET_ENV env metadata", env.ResolvedSecrets)
+	}
+	assertFidelityStatus(t, env.Fidelity, "secret_values", FidelityDegraded)
+	if resolver.refs[0] != "secret://env/DB_PASSWORD" {
+		t.Fatalf("resolver refs = %#v", resolver.refs)
+	}
+	for _, warning := range env.Warnings {
+		if strings.Contains(warning.Message, "local-db-password") || strings.Contains(warning.Message, "manual-final") {
+			t.Fatalf("warning leaked secret value: %#v", warning)
+		}
+	}
+}
+
+func TestReconstructResolveSecretsOmitOnFailureOrProviderMismatch(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Runtime.Image = "alpine:3.23"
+	desc.ContainerSpec.Env = map[string]string{
+		"MISSING_SECRET":  "secret://env/MISSING",
+		"MISMATCH_SECRET": "secret://vault/secret/data/db?field=password",
+	}
+	desc.SecretRefs = []SecretRef{
+		{EnvKey: "MISSING_SECRET", Ref: "secret://env/MISSING", Provider: "env"},
+		{EnvKey: "MISMATCH_SECRET", Ref: "secret://vault/secret/data/db?field=password", Provider: "vault"},
+	}
+	resolver := &fakeSecretResolver{
+		values: map[string]fakeSecretValue{
+			"secret://vault/secret/data/db?field=password": {
+				value:    "wrong-provider-value",
+				identity: SecretIdentity{Provider: "env", Ref: "secret://vault/secret/data/db?field=password"},
+			},
+		},
+		errs: map[string]error{
+			"secret://env/MISSING": errors.New("environment variable MISSING not set"),
+		},
+	}
+
+	env, err := Reconstruct(desc, ReconstructOptions{ResolveSecrets: true, SecretResolver: resolver})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	if _, ok := env.Env["MISSING_SECRET"]; ok {
+		t.Fatalf("MISSING_SECRET should be omitted: %#v", env.Env)
+	}
+	if _, ok := env.Env["MISMATCH_SECRET"]; ok {
+		t.Fatalf("MISMATCH_SECRET should be omitted on provider mismatch: %#v", env.Env)
+	}
+	if len(env.OmittedSecrets) != 2 {
+		t.Fatalf("omitted secrets = %#v, want two", env.OmittedSecrets)
+	}
+	if !hasWarning(env.Warnings, WarningSecretResolveFailed) {
+		t.Fatalf("warnings = %#v, want resolve failure", env.Warnings)
+	}
+	if !hasWarning(env.Warnings, WarningSecretProvider) {
+		t.Fatalf("warnings = %#v, want provider mismatch", env.Warnings)
+	}
+}
+
+func TestReconstructResolveSecretsWarnsOnComparableDrift(t *testing.T) {
+	desc := &Descriptor{}
+	desc.SchemaVersion = 1
+	desc.Baseline.TaskName = "transform"
+	desc.Runtime.Image = "alpine:3.23"
+	desc.ContainerSpec.Env = map[string]string{
+		"VAULT_SECRET": "secret://vault/secret/data/db?field=password",
+		"K8S_SECRET":   "secret://k8s/default/db/password",
+	}
+	desc.SecretRefs = []SecretRef{
+		{
+			EnvKey:   "VAULT_SECRET",
+			Ref:      "secret://vault/secret/data/db?field=password",
+			Provider: "vault",
+			Identity: map[string]any{"version": "1", "hmacSha256": "server-keyed"},
+		},
+		{
+			EnvKey:   "K8S_SECRET",
+			Ref:      "secret://k8s/default/db/password",
+			Provider: "k8s",
+			Identity: map[string]any{"resourceVersion": "11"},
+		},
+	}
+	resolver := &fakeSecretResolver{values: map[string]fakeSecretValue{
+		"secret://vault/secret/data/db?field=password": {
+			value: "vault-local-value",
+			identity: SecretIdentity{
+				Provider: "vault",
+				Ref:      "secret://vault/secret/data/db?field=password",
+				Version:  "2",
+			},
+		},
+		"secret://k8s/default/db/password": {
+			value: "k8s-local-value",
+			identity: SecretIdentity{
+				Provider:        "k8s",
+				Ref:             "secret://k8s/default/db/password",
+				ResourceVersion: "12",
+			},
+		},
+	}}
+
+	env, err := Reconstruct(desc, ReconstructOptions{ResolveSecrets: true, SecretResolver: resolver})
+	if err != nil {
+		t.Fatalf("Reconstruct() error = %v", err)
+	}
+
+	if env.Env["VAULT_SECRET"] != "vault-local-value" || env.Env["K8S_SECRET"] != "k8s-local-value" {
+		t.Fatalf("resolved env = %#v", env.Env)
+	}
+	driftCount := 0
+	for _, warning := range env.Warnings {
+		if warning.Code == WarningSecretDrift {
+			driftCount++
+			if strings.Contains(warning.Message, "vault-local-value") || strings.Contains(warning.Message, "k8s-local-value") || strings.Contains(warning.Message, "server-keyed") {
+				t.Fatalf("drift warning leaked secret or HMAC value: %#v", warning)
+			}
+		}
+	}
+	if driftCount != 2 {
+		t.Fatalf("warnings = %#v, want two drift warnings", env.Warnings)
 	}
 }
 
@@ -221,4 +417,27 @@ func oppositePlatform() string {
 		return "linux/arm64"
 	}
 	return "linux/amd64"
+}
+
+type fakeSecretValue struct {
+	value    string
+	identity SecretIdentity
+}
+
+type fakeSecretResolver struct {
+	values map[string]fakeSecretValue
+	errs   map[string]error
+	refs   []string
+}
+
+func (r *fakeSecretResolver) ResolveWithIdentity(_ context.Context, ref string) (string, SecretIdentity, error) {
+	r.refs = append(r.refs, ref)
+	if err := r.errs[ref]; err != nil {
+		return "", SecretIdentity{}, err
+	}
+	value, ok := r.values[ref]
+	if !ok {
+		return "", SecretIdentity{}, errors.New("secret not found")
+	}
+	return value.value, value.identity, nil
 }

--- a/internal/reproduce/reconstruct_test.go
+++ b/internal/reproduce/reconstruct_test.go
@@ -35,7 +35,7 @@ func TestReconstructEnvLayeringAndSecretOmission(t *testing.T) {
 		},
 	}
 
-	env, err := Reconstruct(desc, ReconstructOptions{
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{
 		SetParams: []Assignment{{Key: "mode", Value: "manual"}},
 		SetEnv: []Assignment{
 			{Key: "CAESIUM_PARAM_OVERRIDE", Value: "env-final"},
@@ -85,7 +85,7 @@ func TestReconstructOutputRefUsesBuildOutputEnvShape(t *testing.T) {
 		},
 	}
 
-	env, err := Reconstruct(desc, ReconstructOptions{})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -108,7 +108,7 @@ func TestReconstructImageOverrideMarksEnvelopeAndFidelity(t *testing.T) {
 	desc.Runtime.Image = "registry.example.com/team/app:prod"
 	desc.Runtime.ResolvedImageDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-	env, err := Reconstruct(desc, ReconstructOptions{ImageOverride: "registry.example.com/team/app:candidate"})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{ImageOverride: "registry.example.com/team/app:candidate"})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -155,7 +155,7 @@ func TestReconstructResolveSecretsInjectsLocalValueBeforeSetEnvOverride(t *testi
 		},
 	}}
 
-	env, err := Reconstruct(desc, ReconstructOptions{
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{
 		ResolveSecrets: true,
 		SecretResolver: resolver,
 		SetEnv:         []Assignment{{Key: "SECRET_ENV", Value: "manual-final"}},
@@ -209,7 +209,7 @@ func TestReconstructResolveSecretsOmitOnFailureOrProviderMismatch(t *testing.T) 
 		},
 	}
 
-	env, err := Reconstruct(desc, ReconstructOptions{ResolveSecrets: true, SecretResolver: resolver})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{ResolveSecrets: true, SecretResolver: resolver})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -273,7 +273,7 @@ func TestReconstructResolveSecretsWarnsOnComparableDrift(t *testing.T) {
 		},
 	}}
 
-	env, err := Reconstruct(desc, ReconstructOptions{ResolveSecrets: true, SecretResolver: resolver})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{ResolveSecrets: true, SecretResolver: resolver})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}
@@ -310,7 +310,7 @@ func TestReconstructMountRemapAndKubernetesSkip(t *testing.T) {
 		{Type: container.VolumeMountTypePVC, Name: "shared", Source: "claim", Target: "/claim"},
 	}
 
-	env, err := Reconstruct(desc, ReconstructOptions{
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{
 		Mounts: []MountRemap{
 			{From: "/prod/data", To: "/local/data"},
 			{From: "/prod/work", To: "/local/work"},
@@ -349,7 +349,7 @@ func TestReconstructFidelitySummaryListsBestEffortDimensions(t *testing.T) {
 		},
 	}
 
-	env, err := Reconstruct(desc, ReconstructOptions{Platform: oppositePlatform()})
+	env, err := Reconstruct(context.Background(), desc, ReconstructOptions{Platform: oppositePlatform()})
 	if err != nil {
 		t.Fatalf("Reconstruct() error = %v", err)
 	}

--- a/test/reproduce_cli_test.go
+++ b/test/reproduce_cli_test.go
@@ -15,10 +15,16 @@ import (
 	"github.com/google/uuid"
 )
 
+const (
+	reproduceCLISecretEnvName = "CAESIUM_REPRODUCE_CLI_SECRET_ENV"
+	reproduceCLISecretValue   = "local-reproduce-secret"
+)
+
 func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 	jobID, runID, taskRunID := s.createReproduceCLIFixture()
 	secretAssertionEnabled := s.engineType != "kubernetes"
 	if secretAssertionEnabled {
+		s.T().Setenv(reproduceCLISecretEnvName, reproduceCLISecretValue)
 		catalogDB := s.openIntegrationCatalogDB()
 		defer func() { s.Require().NoError(catalogDB.Close()) }()
 		s.Require().NoError(addSecretRefToDescriptor(s.T().Context(), catalogDB, taskRunID))
@@ -44,6 +50,23 @@ func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 		s.NotContains(envelope.Env, "SECRET_ENV")
 		s.True(reproduceHasOmittedSecret(envelope.OmittedSecrets, "SECRET_ENV"), "omitted secrets = %+v", envelope.OmittedSecrets)
 		s.True(reproduceHasWarning(envelope.Warnings, "secret_omitted"), "warnings = %+v", envelope.Warnings)
+	}
+	if secretAssertionEnabled {
+		resolveOut, err := s.runCLIStdout(
+			"reproduce", runID,
+			"--job-id", jobID,
+			"--task", "transform",
+			"--dry-run",
+			"--json",
+			"--resolve-secrets",
+			"--server", s.caesiumURL,
+		)
+		s.Require().NoError(err)
+		var resolvedEnvelope reproduceCLIEnvelope
+		s.Require().NoError(json.Unmarshal([]byte(resolveOut), &resolvedEnvelope))
+		s.Equal(reproduceCLISecretValue, resolvedEnvelope.Env["SECRET_ENV"])
+		s.False(reproduceHasOmittedSecret(resolvedEnvelope.OmittedSecrets, "SECRET_ENV"), "omitted secrets = %+v", resolvedEnvelope.OmittedSecrets)
+		s.True(reproduceHasResolvedSecret(resolvedEnvelope.ResolvedSecrets, "SECRET_ENV"), "resolved secrets = %+v", resolvedEnvelope.ResolvedSecrets)
 	}
 
 	// The missing-descriptor exit-2 leg is daemon-free — run it on every lane
@@ -90,6 +113,27 @@ func (s *IntegrationTestSuite) TestReproduceCLIDryRunAndRunMode() {
 	s.Require().NotNil(result.Fidelity)
 	s.True(reproduceHasFidelity(result.Fidelity, "image_content", "faithful"), "fidelity = %+v", result.Fidelity)
 	s.True(reproduceHasFidelity(result.Fidelity, "wall_clock_time", "not_reproduced"), "fidelity = %+v", result.Fidelity)
+
+	overrideOut, overrideErrOut, overrideErr := s.runCLISeparate(
+		"reproduce", runID,
+		"--job-id", jobID,
+		"--task", "transform",
+		"--json",
+		"--diff",
+		"--image", "alpine:3.23",
+		"--server", s.caesiumURL,
+	)
+	s.Require().NoError(overrideErr, "stderr: %s", overrideErrOut)
+	s.Contains(overrideOut, "OVERRIDDEN", "override --json should carry an OVERRIDDEN marker")
+	var overrideResult reproduceCLIRunResult
+	s.Require().NoError(json.Unmarshal([]byte(overrideOut), &overrideResult),
+		"override --json stdout must be parseable; raw stdout: %q; stderr: %q", overrideOut, overrideErrOut)
+	s.Equal(0, overrideResult.ExitCode)
+	s.Equal("OVERRIDDEN", overrideResult.ImagePullMode)
+	s.True(overrideResult.ImageOverridden)
+	s.True(reproduceHasFidelity(overrideResult.Fidelity, "image_content", "overridden"), "fidelity = %+v", overrideResult.Fidelity)
+	s.Require().NotNil(overrideResult.OutputDiff)
+	s.True(overrideResult.OutputDiff.Empty(), "output diff = %+v", overrideResult.OutputDiff)
 
 	diffOut, diffErrOut, diffErr := s.runCLISeparate(
 		"reproduce", runID,
@@ -153,12 +197,19 @@ steps:
 }
 
 type reproduceCLIEnvelope struct {
-	Task           string            `json:"task"`
-	Env            map[string]string `json:"env"`
-	OmittedSecrets []struct {
+	Task            string            `json:"task"`
+	ImagePullMode   string            `json:"image_pull_mode"`
+	ImageOverridden bool              `json:"image_overridden"`
+	Env             map[string]string `json:"env"`
+	OmittedSecrets  []struct {
 		EnvKey string `json:"env_key"`
 		Ref    string `json:"ref"`
 	} `json:"omitted_secrets"`
+	ResolvedSecrets []struct {
+		EnvKey   string `json:"env_key"`
+		Ref      string `json:"ref"`
+		Provider string `json:"provider"`
+	} `json:"resolved_secrets"`
 	Warnings []struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
@@ -166,11 +217,13 @@ type reproduceCLIEnvelope struct {
 }
 
 type reproduceCLIRunResult struct {
-	Status     string                  `json:"status"`
-	ExitCode   int                     `json:"exit_code"`
-	Output     map[string]string       `json:"output"`
-	OutputDiff *reproduceCLIOutputDiff `json:"output_diff"`
-	Fidelity   *reproduceCLIFidelity   `json:"fidelity"`
+	Status          string                  `json:"status"`
+	ExitCode        int                     `json:"exit_code"`
+	ImagePullMode   string                  `json:"image_pull_mode"`
+	ImageOverridden bool                    `json:"image_overridden"`
+	Output          map[string]string       `json:"output"`
+	OutputDiff      *reproduceCLIOutputDiff `json:"output_diff"`
+	Fidelity        *reproduceCLIFidelity   `json:"fidelity"`
 }
 
 type reproduceCLIOutputDiff struct {
@@ -220,11 +273,12 @@ func addSecretRefToDescriptor(ctx context.Context, conn *sql.DB, taskRunID strin
 		env = map[string]any{}
 		spec["env"] = env
 	}
-	env["SECRET_ENV"] = "secret://fixture/db-password"
+	ref := "secret://env/" + reproduceCLISecretEnvName
+	env["SECRET_ENV"] = ref
 	descriptor["secretRefs"] = []any{map[string]any{
-		"ref":        "secret://fixture/db-password",
+		"ref":        ref,
 		"envKey":     "SECRET_ENV",
-		"provider":   "fixture",
+		"provider":   "env",
 		"verifiable": false,
 	}}
 	updated, err := json.Marshal(descriptor)
@@ -253,6 +307,19 @@ func reproduceHasWarning(warnings []struct {
 }, code string) bool {
 	for _, warning := range warnings {
 		if warning.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func reproduceHasResolvedSecret(secrets []struct {
+	EnvKey   string `json:"env_key"`
+	Ref      string `json:"ref"`
+	Provider string `json:"provider"`
+}, envKey string) bool {
+	for _, secret := range secrets {
+		if secret.EnvKey == envKey {
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
D1+D2 — the reproduce plan's final code items:

- **`--image ref` fix-testing**: run a candidate image against the exact recorded env/params/predecessor outputs; marked **OVERRIDDEN** everywhere it could be mistaken for faithful (human output line, `image_pull_mode: OVERRIDDEN` + `image_overridden: true` in JSON, `image_content: overridden` in fidelity). Composes with `--diff` — the candidate-fix loop the design leads with.
- **`--resolve-secrets`**: resolves `secret://` refs through the operator's LOCAL `internal/jobdef/secret` resolver only (never server-fetched); per-ref omit+warn on failure; `secret_drift` warnings compare recorded Vault version / k8s resourceVersion when the local provider matches (the server-keyed HMAC stays unverifiable by design). Values never appear in warnings/fidelity/`resolved_secrets`; the printed envelope carries them only after this explicit opt-in (design §dry-run + §Security cited in-code).
- `internal/reproduce` stays pure-Go: the resolver is adapted behind a `SecretResolver` interface in the cmd layer, faked in unit tests.
- Integration: `--image` OVERRIDDEN assertion in `--json` on the docker lane; env-provider `--resolve-secrets` scenario asserting injection + an empty omitted list for the resolved ref.

## Test plan
- [x] Host `go test ./internal/reproduce/ ./internal/outputdiff/` — green (agent + orchestrator independently).
- [ ] Full matrix + integration — GHA CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiP4ZA51DgoU7YKbZhxEhR
